### PR TITLE
Queue system + Stop and resume features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ logs
 
 
 tracker.db*
+dump.rdb*

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ uv run harness fetch-benchmark --benchmark-id <benchmark_id>
 uv run harness retrieve-results --benchmark-id <benchmark_id> --path ./results.json
 ```
 
+### Stop a benchmark
+
+```bash
+uv run harness harness stop-run --benchmark-id <benchmark_id>
+```
+
+### Resume a benchmark
+
+```bash
+uv run harness harness resume-run --benchmark-id <benchmark_id>
+```
+
 ### Supported Benchmarks
 
 - SWE-bench

--- a/cli/main.py
+++ b/cli/main.py
@@ -216,7 +216,13 @@ def stop_run(benchmark_id: UUID):
                 return
 
             _ = tracker.stop_run(benchmark_id)
-            click.echo(click.style("Run stopped successfully!", fg="green", bold=True))
+            click.echo(
+                click.style(
+                    "Run is currently being stopped. Will be stopped when all tasks in flight are finished.",
+                    fg="yellow",
+                    bold=True,
+                )
+            )
             click.echo(
                 click.style(
                     f"Retrieve results: harness retrieve-results --benchmark-id {benchmark_id} --path ./results.json",

--- a/cli/main.py
+++ b/cli/main.py
@@ -195,5 +195,69 @@ def retrieve_results(benchmark_id: UUID, path: Path):
         raise click.ClickException(str(e))
 
 
+@cli.command()
+@click.option(
+    "--benchmark-id",
+    type=UUID,
+    required=True,
+    help="Benchmark id (e.g., 123e4567-e89b-12d3-a456-426614174000)",
+)
+def stop_run(benchmark_id: UUID):
+    """
+    Stop a benchmark run by its benchmark id.
+
+    Example:
+        harness stop-run --benchmark-id 123e4567-e89b-12d3-a456-426614174000
+    """
+    click.echo(f"Stopping run for benchmark: {benchmark_id}")
+    try:
+        with TrackerService() as tracker:
+            if not check_tracker_service_health(tracker):
+                return
+
+            _ = tracker.stop_run(benchmark_id)
+            click.echo(click.style("Run stopped successfully!", fg="green", bold=True))
+            click.echo(
+                click.style(
+                    f"Retrieve results: harness retrieve-results --benchmark-id {benchmark_id} --path ./results.json",
+                    fg="cyan",
+                )
+            )
+    except TrackerServiceError as e:
+        raise click.ClickException(str(e))
+
+
+@cli.command()
+@click.option(
+    "--benchmark-id",
+    type=UUID,
+    required=True,
+    help="Benchmark id (e.g., 123e4567-e89b-12d3-a456-426614174000)",
+)
+def resume_run(benchmark_id: UUID):
+    """
+    Resume a benchmark run by its benchmark id.
+
+    Example:
+        harness resume-run --benchmark-id 123e4567-e89b-12d3-a456-426614174000
+    """
+    click.echo(f"Resuming run for benchmark: {benchmark_id}")
+    try:
+        with TrackerService() as tracker:
+            if not check_tracker_service_health(tracker):
+                return
+
+            _ = tracker.resume_run(benchmark_id)
+            click.echo(click.style("Run resumed successfully!", fg="green", bold=True))
+            click.echo(
+                click.style(
+                    f"Track progress: harness fetch-benchmark --benchmark-id {benchmark_id} --connect",
+                    fg="cyan",
+                )
+            )
+    except TrackerServiceError as e:
+        raise click.ClickException(str(e))
+
+
 if __name__ == "__main__":
     cli()

--- a/cli/tracker_service.py
+++ b/cli/tracker_service.py
@@ -6,7 +6,13 @@ from uuid import UUID
 
 import httpx
 from httpx._models import Response
-from tracker.types import FetchBenchmarkResponse, RetrieveResultsResponse, StartRunRequest
+from tracker.types import (
+    FetchBenchmarkResponse,
+    ResumeRunResponse,
+    RetrieveResultsResponse,
+    StartRunRequest,
+    StopRunResponse,
+)
 
 from cli.config import TRACKER_URL
 
@@ -192,3 +198,41 @@ class TrackerService:
             return RetrieveResultsResponse.model_validate(response.json())
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to retrieve results: {e}") from e
+
+    def stop_run(self, benchmark_id: UUID) -> StopRunResponse:
+        """
+        Stop a benchmark run by its benchmark id.
+
+        Args:
+            benchmark_id: Benchmark id
+
+        Returns:
+            StopRunResponse with status and message
+        """
+        try:
+            response = self._client.post(f"{self._base_url}/stop-run/{benchmark_id}")
+            if response.status_code != 200:
+                raise TrackerServiceError(f"Failed to stop run: {response.text}")
+
+            return StopRunResponse.model_validate(response.json())
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to stop run: {e}") from e
+
+    def resume_run(self, benchmark_id: UUID) -> ResumeRunResponse:
+        """
+        Resume a benchmark run by its benchmark id.
+
+        Args:
+            benchmark_id: Benchmark id
+
+        Returns:
+            ResumeRunResponse with status and message
+        """
+        try:
+            response = self._client.post(f"{self._base_url}/resume-run/{benchmark_id}")
+            if response.status_code != 200:
+                raise TrackerServiceError(f"Failed to resume run: {response.text}")
+
+            return ResumeRunResponse.model_validate(response.json())
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to resume run: {e}") from e

--- a/cli/tracker_service.py
+++ b/cli/tracker_service.py
@@ -139,7 +139,8 @@ class TrackerService:
             response = self._client.get(f"{self._base_url}/fetch-benchmark", params={"benchmark_id": str(benchmark_id)})
 
             if response.status_code != 200:
-                raise TrackerServiceError(f"Failed to fetch benchmark: {response.text}")
+                details = response.json().get("detail", response.text)
+                raise TrackerServiceError(f"Failed to fetch benchmark: {details}")
 
             return FetchBenchmarkResponse.model_validate(response.json())
         except httpx.HTTPError as e:
@@ -169,7 +170,8 @@ class TrackerService:
                 timeout=None,
             ) as response:
                 if response.status_code != 200:
-                    raise TrackerServiceError(f"Failed to stream benchmark: {response.status_code}")
+                    details = response.json().get("detail", response.text)
+                    raise TrackerServiceError(f"Failed to stream benchmark: {details}")
 
                 for line in response.iter_lines():
                     if line:
@@ -193,7 +195,8 @@ class TrackerService:
             )
 
             if response.status_code != 200:
-                raise TrackerServiceError(f"Failed to retrieve results: {response.text}")
+                details = response.json().get("detail", response.text)
+                raise TrackerServiceError(f"Failed to retrieve results: {details}")
 
             return RetrieveResultsResponse.model_validate(response.json())
         except httpx.HTTPError as e:
@@ -212,7 +215,8 @@ class TrackerService:
         try:
             response = self._client.post(f"{self._base_url}/stop-run/{benchmark_id}")
             if response.status_code != 200:
-                raise TrackerServiceError(f"Failed to stop run: {response.text}")
+                details = response.json().get("detail", response.text)
+                raise TrackerServiceError(f"Failed to stop run: {details}")
 
             return StopRunResponse.model_validate(response.json())
         except httpx.HTTPError as e:
@@ -231,7 +235,8 @@ class TrackerService:
         try:
             response = self._client.post(f"{self._base_url}/resume-run/{benchmark_id}")
             if response.status_code != 200:
-                raise TrackerServiceError(f"Failed to resume run: {response.text}")
+                details = response.json().get("detail", response.text)
+                raise TrackerServiceError(f"Failed to resume run: {details}")
 
             return ResumeRunResponse.model_validate(response.json())
         except httpx.HTTPError as e:

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -97,6 +97,18 @@ def format_start_run_response(start_run_response: StartRunResponse) -> None:
             fg="cyan",
         )
     )
+    click.echo(
+        click.style(
+            f"Stop run: harness stop-run --benchmark-id {start_run_response.benchmark_id}",
+            fg="cyan",
+        )
+    )
+    click.echo(
+        click.style(
+            f"Resume run: harness resume-run --benchmark-id {start_run_response.benchmark_id}",
+            fg="cyan",
+        )
+    )
     click.echo()
 
 

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -7,6 +7,32 @@ from tracker.types import FetchBenchmarkResponse, StartRunResponse
 from cli.main import TrackerService
 
 
+class BenchmarkFormatter:
+    @staticmethod
+    def get_status_color(status_value: str) -> str:
+        status_colors = {
+            "in_progress": "blue",
+            "stopping": "magenta",
+            "stopped": "cyan",
+            "finished": "cyan",
+            "error": "red",
+        }
+        return status_colors.get(status_value, "white")
+
+    @staticmethod
+    def create_progress_bar(finished_tasks: int, total_tasks: int, bar_width: int = 30) -> tuple[str, float]:
+        """
+        Create a progress bar string and percentage.
+
+        Returns:
+            tuple of (bar string, progress percentage)
+        """
+        progress_pct = (finished_tasks / total_tasks * 100) if total_tasks > 0 else 0
+        filled_width = int(bar_width * progress_pct / 100)
+        bar = "█" * filled_width + "░" * (bar_width - filled_width)
+        return bar, progress_pct
+
+
 def check_tracker_service_health(tracker: TrackerService) -> bool:
     """
     Re-usable utility to check the health of the tracker service.
@@ -42,29 +68,16 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     total_tasks = details.total_tasks
     finished_tasks = details.finished_tasks
 
-    progress_pct = (finished_tasks / total_tasks * 100) if total_tasks > 0 else 0
-
-    status_colors = {
-        "RUNNING": "blue",
-        "COMPLETED": "green",
-        "FAILED": "red",
-        "PENDING": "yellow",
-    }
-    status_color = status_colors.get(status, "white")
-
-    bar_width = 30
-    filled_width = int(bar_width * progress_pct / 100)
-    bar = "█" * filled_width + "░" * (bar_width - filled_width)
+    bar, progress_pct = BenchmarkFormatter.create_progress_bar(finished_tasks, total_tasks)
+    status_color = BenchmarkFormatter.get_status_color(status.value)
 
     click.echo(f"{click.style('Benchmark:', bold=True)} {benchmark_name}")
     click.echo(f"{click.style('Started at:', bold=True)} {started_at}")
     click.echo(f"{click.style('Benchmark ID:', bold=True)} {benchmark_id}")
     click.echo()
 
-    status_text = click.style(status, fg=status_color, bold=True)
-    click.echo(
-        f"[{bar}] {finished_tasks}/{total_tasks} ({progress_pct:.1f}%) • {status_text.replace('_', ' ').capitalize()}"
-    )
+    status_text = click.style(status.value.replace("_", " ").title(), fg=status_color, bold=True)
+    click.echo(f"[{bar}] {finished_tasks}/{total_tasks} ({progress_pct:.1f}%) • {status_text}")
 
 
 def format_start_run_response(start_run_response: StartRunResponse) -> None:
@@ -120,12 +133,6 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None
         tracker: TrackerService instance
         benchmark_id: Benchmark UUID to stream
     """
-    status_colors = {
-        "in_progress": "blue",
-        "finished": "green",
-        "error": "red",
-    }
-
     click.echo(click.style("Streaming benchmark updates (Ctrl+C to stop)...\n", fg="cyan"))
 
     try:
@@ -138,12 +145,8 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None
                 response = FetchBenchmarkResponse.model_validate_json(data_json)
                 details = response.details
 
-                progress_pct = (details.finished_tasks / details.total_tasks * 100) if details.total_tasks > 0 else 0
-                bar_width = 30
-                filled_width = int(bar_width * progress_pct / 100)
-                bar = "█" * filled_width + "░" * (bar_width - filled_width)
-
-                status_color = status_colors.get(details.status.value, "white")
+                bar, progress_pct = BenchmarkFormatter.create_progress_bar(details.finished_tasks, details.total_tasks)
+                status_color = BenchmarkFormatter.get_status_color(details.status.value)
                 status_text = click.style(details.status.value.replace("_", " ").title(), fg=status_color, bold=True)
 
                 click.echo(

--- a/services/tracker/Dockerfile
+++ b/services/tracker/Dockerfile
@@ -2,6 +2,11 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y \
+    supervisor \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pip install uv
 
 COPY pyproject.toml uv.lock ./
@@ -10,9 +15,10 @@ RUN uv sync --frozen --no-dev
 
 COPY src ./src
 COPY main.py ./
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 RUN uv run python src/tracker/database/session.py
 
 EXPOSE 8000
 
-CMD ["uv", "run", "fastapi", "run", "main.py", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/services/tracker/Makefile
+++ b/services/tracker/Makefile
@@ -17,7 +17,12 @@ build:
 	docker build -t $(IMAGE_NAME) .
 
 run:
-	@echo "Starting Docker container..."
+	@echo "Starting Redis container..."
+	@docker run -d \
+		--name tracker-redis \
+		-p 6379:6379 \
+		redis:7-alpine || echo "Redis container already running"
+	@echo "Starting tracker service container..."
 	@if [ ! -f .env ]; then \
 		echo "Error: .env file not found!"; \
 		exit 1; \
@@ -26,17 +31,20 @@ run:
 		--name $(CONTAINER_NAME) \
 		-p 8000:8000 \
 		--env-file .env \
+		-e REDIS_URL=redis://host.docker.internal:6379 \
 		-v ${HOME}/.aws:/root/.aws:ro \
 		$(IMAGE_NAME)
-	@echo "Container started successfully!"
+	@echo "Containers started successfully!"
 	@echo "Tracker service is running on http://localhost:8000"
 	@echo "Health check: http://localhost:8000/health"
 
 stop:
-	@echo "Stopping and removing container..."
+	@echo "Stopping and removing containers..."
 	@docker stop $(CONTAINER_NAME) 2>/dev/null || true
 	@docker rm $(CONTAINER_NAME) 2>/dev/null || true
-	@echo "Container stopped and removed."
+	@docker stop tracker-redis 2>/dev/null || true
+	@docker rm tracker-redis 2>/dev/null || true
+	@echo "Containers stopped and removed."
 
 clean: stop
 	@echo "Removing Docker image..."

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -9,10 +9,6 @@ DAYTONA_API_URL=https://app.daytona.io/api
 DAYTONA_TARGET=us
 ```
 
-### Broker setup
-
-Install redis `brew install redis`
-
 ### Docker Deployment
 
 Build and run the tracker service in a Docker container:

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -9,6 +9,10 @@ DAYTONA_API_URL=https://app.daytona.io/api
 DAYTONA_TARGET=us
 ```
 
+### Broker setup
+
+Install redis `brew install redis`
+
 ### Docker Deployment
 
 Build and run the tracker service in a Docker container:

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -17,8 +17,15 @@ from tracker.types import (
     StartRunErrorResponse,
     StartRunRequest,
     StartRunResponse,
+    StopRunResponse,
 )
-from tracker.utils import BenchmarkContext, commit_benchmark_error, process_benchmark, stream_benchmark_results
+from tracker.utils import (
+    BenchmarkContext,
+    commit_benchmark_error,
+    process_benchmark,
+    stop_benchmark,
+    stream_benchmark_results,
+)
 
 logger = get_logger(__name__)
 
@@ -218,4 +225,26 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
         benchmark_arguments=benchmark_row.arguments,
         final_evaluation=benchmark_row.final_evaluation,
         evaluation_results=benchmark_row.fetch_evaluation_results(session),
+    )
+
+
+@app.post("/stop-run")
+async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) -> StopRunResponse:
+    """
+    Stop a benchmark run by its id.
+
+    Usage:
+    curl -X POST http://<endpoint>/stop-run/<benchmark_id>
+
+    Returns:
+        StopRunResponse
+    """
+    benchmark_row = session.get(Benchmark, benchmark_id)
+    if not benchmark_row:
+        raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
+
+    await stop_benchmark(benchmark_row, session)
+
+    return StopRunResponse(
+        status="success",
     )

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -6,13 +6,14 @@ from sqlalchemy.orm import joinedload
 from sqlmodel import Session, select
 
 from tracker.benchmark_service import BenchmarkService
-from tracker.database.models import Benchmark
+from tracker.database.models import Benchmark, BenchmarkStatus
 from tracker.database.session import get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.s3 import get_contract_s3_key, upload_to_s3
 from tracker.types import (
     FetchBenchmarkResponse,
+    ResumeRunResponse,
     RetrieveResultsResponse,
     StartRunErrorResponse,
     StartRunRequest,
@@ -23,6 +24,7 @@ from tracker.utils import (
     BenchmarkContext,
     commit_benchmark_error,
     process_benchmark,
+    resume_benchmark,
     stop_benchmark,
     stream_benchmark_results,
 )
@@ -246,5 +248,44 @@ async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) 
     await stop_benchmark(benchmark_row, session)
 
     return StopRunResponse(
+        status="success",
+    )
+
+
+@app.post("/resume-run")
+async def resume_run(benchmark_id: UUID, session: Session = Depends(get_session)) -> ResumeRunResponse:
+    """
+    Resume a benchmark run by its id.
+
+    Usage:
+    curl -X POST http://<endpoint>/resume-run/<benchmark_id>
+
+    Returns:
+        ResumeRunResponse
+    """
+    benchmark_row = session.get(Benchmark, benchmark_id)
+    if not benchmark_row:
+        raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
+
+    if benchmark_row.status != BenchmarkStatus.STOPPED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the stopped state to resume.",
+        )
+
+    start_run_request = benchmark_row.start_run_request
+
+    # prepare benchmark and tasks to be resumed
+    verified_task_ids = await resume_benchmark(benchmark_row, session, start_run_request.benchmark_service)
+
+    # start the benchmark with the same args used to create it
+    # we will delegate inside what tasks we are running
+    await process_benchmark.kiq(
+        start_run_request_json=start_run_request.model_dump(),
+        benchmark_id_str=str(benchmark_row.id),
+        verified_task_ids=verified_task_ids,
+    )
+
+    return ResumeRunResponse(
         status="success",
     )

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -136,8 +136,10 @@ async def start_run(
 
         raise TrackerServiceError(error_response.model_dump_json()) from e
 
-    process_benchmark.apply_async(
-        args=(request, benchmark_row.id, verify_response.task_ids),
+    await process_benchmark.kiq(
+        start_run_request_json=request.model_dump(),
+        benchmark_id_str=str(benchmark_row.id),
+        verified_task_ids=verify_response.task_ids,
     )
 
     return StartRunResponse(

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import BackgroundTasks, Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
+from fastapi import Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import joinedload
 from sqlmodel import Session, select
@@ -92,7 +92,6 @@ async def upload_contract_to_s3(
 async def start_run(
     request: StartRunRequest,
     session: Session = Depends(get_session),
-    background_tasks: BackgroundTasks = BackgroundTasks(),
 ) -> StartRunResponse:
     """
     Start a benchmark run with the uploaded contract.
@@ -137,8 +136,8 @@ async def start_run(
 
         raise TrackerServiceError(error_response.model_dump_json()) from e
 
-    background_tasks.add_task(
-        process_benchmark, request, benchmark_row.id, verify_response.task_ids, benchmark_service, session
+    process_benchmark.apply_async(
+        args=(request, benchmark_row.id, verify_response.task_ids),
     )
 
     return StartRunResponse(

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -230,7 +230,7 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
     )
 
 
-@app.post("/stop-run")
+@app.post("/stop-run/{benchmark_id}")
 async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) -> StopRunResponse:
     """
     Stop a benchmark run by its id.
@@ -245,6 +245,13 @@ async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) 
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
+    # Can only pause a in progress benchmark
+    if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Benchmark {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress benchmark.",
+        )
+
     await stop_benchmark(benchmark_row, session)
 
     return StopRunResponse(
@@ -252,7 +259,7 @@ async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) 
     )
 
 
-@app.post("/resume-run")
+@app.post("/resume-run/{benchmark_id}")
 async def resume_run(benchmark_id: UUID, session: Session = Depends(get_session)) -> ResumeRunResponse:
     """
     Resume a benchmark run by its id.

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "daytona>=0.128.1",
     "sqlmodel>=0.0.31",
     "httpx>=0.28.1",
-    "celery[redis]>=5.6.2",
-    "celery-types>=0.24.0",
+    "taskiq>=0.12.1",
+    "taskiq-redis>=1.1.2",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "daytona>=0.128.1",
     "sqlmodel>=0.0.31",
     "httpx>=0.28.1",
+    "celery[redis]>=5.6.2",
+    "celery-types>=0.24.0",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "ruff",
     "basedpyright",
+    "pytest-env>=1.2.0",
 ]
 
 [build-system]
@@ -54,3 +55,6 @@ enableTypeIgnoreComments = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 pythonpath = ["."]
+env = [
+    "BROKER_ENVIRONMENT=testing"
+]

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -4,6 +4,7 @@ import os
 from typing import Any
 
 from dotenv import load_dotenv
+from taskiq import InMemoryBroker
 from taskiq_redis import RedisStreamBroker
 from taskiq_redis.redis_backend import RedisAsyncResultBackend
 
@@ -12,11 +13,15 @@ load_dotenv()
 BENCHMARK_SERVICE_URL = os.getenv("BENCHMARK_SERVICE_URL", "http://localhost:8002")
 S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "agentic-harness")
 REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+BROKER_ENVIRONMENT = os.environ.get("BROKER_ENVIRONMENT", "production")
 
 result_backend: RedisAsyncResultBackend[Any] = RedisAsyncResultBackend(
     redis_url=REDIS_URL,
 )
 
-broker = RedisStreamBroker(
-    url=REDIS_URL,
-).with_result_backend(result_backend)
+if BROKER_ENVIRONMENT == "testing":
+    broker = InMemoryBroker()
+else:
+    broker = RedisStreamBroker(
+        url=REDIS_URL,
+    ).with_result_backend(result_backend)

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -1,24 +1,22 @@
 """Configuration for the tracker service."""
 
 import os
+from typing import Any
 
-from celery import Celery
-from celery.app.task import Task
 from dotenv import load_dotenv
+from taskiq_redis import RedisStreamBroker
+from taskiq_redis.redis_backend import RedisAsyncResultBackend
 
 load_dotenv()
 
 BENCHMARK_SERVICE_URL = os.getenv("BENCHMARK_SERVICE_URL", "http://localhost:8002")
 S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "agentic-harness")
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
 
-
-# Monkey patch Task to allow generic params for celery-types https://pypi.org/project/celery-types/
-Task.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)  # type: ignore[attr-defined]
-
-# Celery configuration
-# NOTE: Using a local redis instance but needs to be changed to a cloud redis instance
-celery: Celery = Celery(
-    "tracker",
-    broker="redis://localhost:6379/0",
-    backend="redis://localhost:6379/0",
+result_backend: RedisAsyncResultBackend[Any] = RedisAsyncResultBackend(
+    redis_url=REDIS_URL,
 )
+
+broker = RedisStreamBroker(
+    url=REDIS_URL,
+).with_result_backend(result_backend)

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -2,9 +2,23 @@
 
 import os
 
+from celery import Celery
+from celery.app.task import Task
 from dotenv import load_dotenv
 
 load_dotenv()
 
 BENCHMARK_SERVICE_URL = os.getenv("BENCHMARK_SERVICE_URL", "http://localhost:8002")
 S3_BUCKET_NAME = os.getenv("S3_BUCKET_NAME", "agentic-harness")
+
+
+# Monkey patch Task to allow generic params for celery-types https://pypi.org/project/celery-types/
+Task.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)  # type: ignore[attr-defined]
+
+# Celery configuration
+# NOTE: Using a local redis instance but needs to be changed to a cloud redis instance
+celery: Celery = Celery(
+    "tracker",
+    broker="redis://localhost:6379/0",
+    backend="redis://localhost:6379/0",
+)

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -24,6 +24,8 @@ from tracker.database.utils import has_field_changed
 
 class BenchmarkStatus(str, Enum):
     IN_PROGRESS = "in_progress"
+    STOPPING = "stopping"
+    STOPPED = "stopped"
     FINISHED = "finished"
     ERROR = "error"
 
@@ -32,6 +34,7 @@ class TaskStatus(str, Enum):
     STARTING = "starting"
     IN_PROGRESS = "in_progress"
     EVALUATING = "evaluating"
+    STOPPED = "stopped"
     FINISHED = "finished"
     ERROR = "error"
 

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -20,6 +20,7 @@ from sqlmodel import (
 )
 
 from tracker.database.utils import has_field_changed
+from tracker.types import StartRunRequest
 
 
 class BenchmarkStatus(str, Enum):
@@ -114,6 +115,16 @@ class Benchmark(SQLModel, table=True):
         from tracker.utils import fetch_evaluation_results
 
         return fetch_evaluation_results(self.id, session)
+
+    @property
+    def start_run_request(self) -> StartRunRequest:
+        return StartRunRequest(
+            contract_name=self.arguments.contract_name,
+            benchmark_name=self.name,
+            concurrency=self.arguments.concurrency,
+            task_ids=self.arguments.task_ids,
+            slice_str=self.arguments.slice_str,
+        )
 
 
 @event.listens_for(Benchmark, "before_insert")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
@@ -20,7 +20,9 @@ from sqlmodel import (
 )
 
 from tracker.database.utils import has_field_changed
-from tracker.types import StartRunRequest
+
+if TYPE_CHECKING:
+    from tracker.types import StartRunRequest
 
 
 class BenchmarkStatus(str, Enum):
@@ -117,7 +119,9 @@ class Benchmark(SQLModel, table=True):
         return fetch_evaluation_results(self.id, session)
 
     @property
-    def start_run_request(self) -> StartRunRequest:
+    def start_run_request(self) -> "StartRunRequest":
+        from tracker.types import StartRunRequest
+
         return StartRunRequest(
             contract_name=self.arguments.contract_name,
             benchmark_name=self.name,

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -87,3 +87,7 @@ class RetrieveTaskResponse(BaseModel):
 
 class VerifyTaskIdsResponse(BaseModel):
     task_ids: list[str]
+
+
+class StopRunResponse(StatusResponse):
+    pass

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -91,3 +91,7 @@ class VerifyTaskIdsResponse(BaseModel):
 
 class StopRunResponse(StatusResponse):
     pass
+
+
+class ResumeRunResponse(StatusResponse):
+    pass

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -2,10 +2,12 @@ import asyncio
 import json
 from asyncio import Semaphore, gather
 from collections.abc import AsyncGenerator, Coroutine
+from datetime import datetime
 from enum import Enum
 from functools import cached_property
 from typing import Any, NamedTuple, Sequence
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 from sqlmodel import Session, case, col, func, select, update
 
@@ -565,7 +567,7 @@ async def resume_benchmark(
             update(Task)
             .where(col(Task.benchmark) == benchmark_row.id)
             .where(col(Task.status) == TaskStatus.STOPPED)
-            .values(status=TaskStatus.STARTING)
+            .values(status=TaskStatus.STARTING, started_at=datetime.now(ZoneInfo("UTC")))
         )
 
         session.commit()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -49,12 +49,19 @@ class TrackedTask:
         return self._task
 
     async def run(self, semaphore: asyncio.Semaphore, task_id: str) -> dict[str, dict[str, Any] | None]:
-        try:
+        async def _wrap_coro():
+            """Need to have a task created even if we are not running the coroutine so that we can cancel it before its running"""
             async with semaphore:
                 self._status = TrackedTaskStatus.RUNNING
-                self._task = asyncio.create_task(self._coro)
-                return await self._task
+                return await self._coro
+
+        try:
+            self._task = asyncio.create_task(_wrap_coro())
+            return await self._task
         except asyncio.CancelledError:
+            # Need to clean up the coroutine if we cancelled the task
+            self._coro.close()
+
             # When we cancel we return the task id still so that we can track the task when we create the final evaluation row
             return {task_id: None}
         finally:
@@ -73,7 +80,7 @@ class TaskMonitor:
         self._task_tracking = task_tracking
 
     def _fetch_task_row(self, task_id: str) -> Task:
-        task_row = self._session.get(Task, task_id)
+        task_row = self._session.exec(select(Task).where(Task.task_id == task_id).limit(1)).first()
         if not task_row:
             raise ValueError(f"Task with id {task_id} not found")
 
@@ -83,7 +90,7 @@ class TaskMonitor:
         """
         Runs while waiting to be aquired by the semaphore.
 
-        If the benchmark is stopping or the task status has been set to stopped we return False to exit the task early.
+        If the task status has been set to stopped we return False to exit the task early.
 
         Returns:
             True if the task should continue to be processed, False if the task should be stopped early
@@ -92,9 +99,7 @@ class TaskMonitor:
         self._session.expire_all()
         task_row = self._fetch_task_row(task_id)
 
-        benchmark_row = fetch_benchmark_row(task_row.benchmark, self._session)
-
-        if task_row.status == TaskStatus.STOPPED or benchmark_row.status == BenchmarkStatus.STOPPING:
+        if task_row.status == TaskStatus.STOPPED:
             return False
 
         return True
@@ -130,7 +135,9 @@ class TaskMonitor:
 
                 if not self._validate_task(task_id) and task.task:
                     task.task.cancel(f"Task {task_id} has been invalidated. Benchmark has been requested to stop")
-                    del self._task_tracking[task_id]
+
+                    if task_id in self._task_tracking:
+                        del self._task_tracking[task_id]
 
             if not self._task_tracking:
                 exit_condition_met = True
@@ -229,12 +236,7 @@ async def process_benchmark(
         # TODO: Delegate url since in the future this aspect can change
         benchmark_service = BenchmarkService(name=start_run_request.benchmark_name, url=BENCHMARK_SERVICE_URL)
 
-        benchmark_row = session.get(Benchmark, benchmark_id)
-
-        # NOTE: Benchmark row is created just before this task is called, so it should always be found
-        # This exists if we are testing an edge case with this method and to satisfy type checker
-        if not benchmark_row:
-            raise ValueError(f"Benchmark with id {benchmark_id} not found")
+        benchmark_row = fetch_benchmark_row(benchmark_id, session)
 
         try:
             # Create tasks inside of the database for each task id

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 from asyncio import Semaphore, gather
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Coroutine
+from enum import Enum
 from functools import cached_property
 from typing import Any, NamedTuple
 from uuid import UUID
@@ -9,6 +10,7 @@ from uuid import UUID
 from sqlmodel import Session, case, col, func, select
 
 from tracker.benchmark_service import BenchmarkService
+from tracker.config import BENCHMARK_SERVICE_URL, celery
 from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
 from tracker.logger import get_logger
@@ -22,127 +24,276 @@ from tracker.types import (
 logger = get_logger(__name__, stream=True)
 
 
+class TrackedTaskStatus(str, Enum):
+    WAITING = "waiting"
+    RUNNING = "running"
+    DONE = "done"
+
+
+class TrackedTask:
+    _coro: Coroutine[Any, Any, Any]
+    _status: str
+    _task: asyncio.Task[Any] | None
+
+    def __init__(self, coro: Coroutine[Any, Any, Any]):
+        self._coro = coro
+        self._status = TrackedTaskStatus.WAITING
+        self._task = None
+
+    @property
+    def status(self) -> str:
+        return self._status
+
+    @property
+    def task(self) -> asyncio.Task[Any] | None:
+        return self._task
+
+    async def run(self, semaphore: asyncio.Semaphore, task_id: str) -> dict[str, dict[str, Any] | None]:
+        try:
+            async with semaphore:
+                self._status = TrackedTaskStatus.RUNNING
+                self._task = asyncio.create_task(self._coro)
+                return await self._task
+        except asyncio.CancelledError:
+            # When we cancel we return the task id still so that we can track the task when we create the final evaluation row
+            return {task_id: None}
+        finally:
+            self._status = TrackedTaskStatus.DONE
+
+
+class TaskMonitor:
+    _benchmark_row: Benchmark
+    _session: Session
+    _task_tracking: dict[str, TrackedTask]
+    _TRACK_INTERVAL: int = 2
+
+    def __init__(self, benchmark_row: Benchmark, session: Session, task_tracking: dict[str, TrackedTask]):
+        self._benchmark_row = benchmark_row
+        self._session = session
+        self._task_tracking = task_tracking
+
+    def _fetch_task_row(self, task_id: str) -> Task:
+        task_row = self._session.get(Task, task_id)
+        if not task_row:
+            raise ValueError(f"Task with id {task_id} not found")
+
+        return task_row
+
+    def validate_task(self, task_id: str) -> bool:
+        """
+        Runs while waiting to be aquired by the semaphore.
+
+        If the benchmark is stopping or the task status has been set to stopped we return False to exit the task early.
+
+        Returns:
+            True if the task should continue to be processed, False if the task should be stopped early
+
+        """
+        self._session.expire_all()
+        task_row = self._fetch_task_row(task_id)
+
+        benchmark_row = fetch_benchmark_row(task_row.benchmark, self._session)
+
+        if task_row.status == TaskStatus.STOPPED or benchmark_row.status == BenchmarkStatus.STOPPING:
+            return False
+
+        return True
+
+    def check_is_waiting(self, task: TrackedTask) -> bool:
+        """
+        Checks if the task is waiting to be aquired by the semaphore.
+
+        Returns:
+            True if the task is waiting to be aquired by the semaphore, False if it has been aquired
+        """
+        if task.task is None or task.status == TrackedTaskStatus.WAITING:
+            return True
+
+        return False
+
+    async def track_tasks(self) -> None:
+        """
+        Tracks all the tasks and removes the tasks that are no longer waiting to be aquired by the semaphore.
+
+        Removes the tasks that are no longer waiting to be aquired by the semaphore.
+        """
+
+        exit_condition_met: bool = False
+
+        while not exit_condition_met:
+            tasks_to_check: list[str] = list(self._task_tracking.keys())
+            for task_id in tasks_to_check:
+                task = self._task_tracking[task_id]
+
+                if not self.check_is_waiting(task):
+                    del self._task_tracking[task_id]
+
+                if not self.validate_task(task_id) and task.task:
+                    task.task.cancel(f"Task {task_id} has been invalidated. Benchmark has been requested to stop")
+                    del self._task_tracking[task_id]
+
+            if not self._task_tracking:
+                exit_condition_met = True
+
+            await asyncio.sleep(self._TRACK_INTERVAL)
+
+
+def fetch_benchmark_row(benchmark_id: UUID, session: Session) -> Benchmark:
+    """Util to clean up pattern to fetch benchmark row"""
+    benchmark_row = session.get(Benchmark, benchmark_id)
+    if not benchmark_row:
+        raise ValueError(f"Benchmark with id {benchmark_id} not found")
+
+    return benchmark_row
+
+
+def handle_early_exit(task_row: Task, task_session: Session) -> None:
+    task_row.status = TaskStatus.STOPPED
+    task_session.add(task_row)
+    task_session.commit()
+
+
 async def process_task(
-    task_row_mapping: dict[str, Task],
+    task_row: Task,
     start_run_request: StartRunRequest,
-    semaphore: Semaphore,
     benchmark_service: BenchmarkService,
+    benchmark_id: UUID,
     task_id: str,
 ) -> dict[str, dict[str, Any] | None]:
-    async with semaphore:
-        with Session(bind=engine, expire_on_commit=False) as task_session:
-            task_row = task_row_mapping[task_id]
-            try:
-                task_data = await benchmark_service.request_retrieve_task(task_id=task_id)
+    with Session(bind=engine, expire_on_commit=False) as task_session:
+        benchmark_row = fetch_benchmark_row(benchmark_id, task_session)
 
-                task_row = task_session.merge(task_row)
-                task_row.status = TaskStatus.IN_PROGRESS
+        # If user has requested to stop the benchmark we exit before we process the task
+        if benchmark_row.status == BenchmarkStatus.STOPPING:
+            handle_early_exit(task_row, task_session)
+            return {task_id: None}
+
+        try:
+            task_data = await benchmark_service.request_retrieve_task(task_id=task_id)
+
+            task_row = task_session.merge(task_row)
+            task_row.status = TaskStatus.IN_PROGRESS
+            task_session.add(task_row)
+            task_session.commit()
+
+            async with create_sandbox(
+                benchmark_service.daytona_client, task_row.task_id, task_data.docker_image
+            ) as sandbox:
+                # Upload the contract to the sandbox after creating and install the dependencies
+                await upload_contract_to_sandbox(sandbox, start_run_request.contract_name)
+                await install_dependencies(sandbox, start_run_request.contract_name)
+
+                # Setup task if requested
+                if task_data.request_setup:
+                    _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
+
+                # Run the agent inside of the sandbox
+                # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
+                await run_agent(sandbox, start_run_request.contract_name, task_row.task_id, task_data.problem_statement)
+
+                # Update the status to evaluating once we finish running the agent
+                task_row.status = TaskStatus.EVALUATING
                 task_session.add(task_row)
                 task_session.commit()
 
-                async with create_sandbox(
-                    benchmark_service.daytona_client, task_row.task_id, task_data.docker_image
-                ) as sandbox:
-                    # Upload the contract to the sandbox after creating and install the dependencies
-                    await upload_contract_to_sandbox(sandbox, start_run_request.contract_name)
-                    await install_dependencies(sandbox, start_run_request.contract_name)
+                # Evaluate the instance
+                # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
+                evaluation_result = await benchmark_service.request_evaluate_instance(task_row.task_id, sandbox.id)
 
-                    # Setup task if requested
-                    if task_data.request_setup:
-                        _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
+                # Save the evaluation result to the database with the task row
+                evaluation_result_row = EvaluationResult(
+                    task=task_row.id, instance_id=sandbox.id, result=evaluation_result
+                )
+                task_session.add(evaluation_result_row)
 
-                    # Run the agent inside of the sandbox
-                    # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
-                    await run_agent(
-                        sandbox, start_run_request.contract_name, task_row.task_id, task_data.problem_statement
-                    )
+                # Mark the task status as finished since we have finished processing the task
+                task_row.status = TaskStatus.FINISHED
+                task_session.add(task_row)
+                task_session.commit()
 
-                    # Update the status to evaluating once we finish running the agent
-                    task_row.status = TaskStatus.EVALUATING
-                    task_session.add(task_row)
-                    task_session.commit()
-
-                    # Evaluate the instance
-                    # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
-                    evaluation_result = await benchmark_service.request_evaluate_instance(task_row.task_id, sandbox.id)
-
-                    # Save the evaluation result to the database with the task row
-                    evaluation_result_row = EvaluationResult(
-                        task=task_row.id, instance_id=sandbox.id, result=evaluation_result
-                    )
-                    task_session.add(evaluation_result_row)
-
-                    # Mark the task status as finished since we have finished processing the task
-                    task_row.status = TaskStatus.FINISHED
-                    task_session.add(task_row)
-                    task_session.commit()
-
-                    return {task_id: evaluation_result_row.result}
-            except Exception as e:
-                error_message = str(e)
-                commit_task_error(task_row, task_session, error_message)
-                return {task_id: None}
+                return {task_id: evaluation_result_row.result}
+        except Exception as e:
+            error_message = str(e)
+            commit_task_error(task_row, task_session, error_message)
+            return {task_id: None}
 
 
+@celery.task
 async def process_benchmark(
     start_run_request: StartRunRequest,
     benchmark_id: UUID,
     verified_task_ids: list[str],
-    benchmark_service: BenchmarkService,
-    session: Session,
 ) -> None:
-    benchmark_row = session.get(Benchmark, benchmark_id)
+    # NOTE: Will get ugly if we error on session create
+    with Session(bind=engine, expire_on_commit=False) as session:
+        # TODO: Delegate url since in the future this aspect can change
+        benchmark_service = BenchmarkService(name=start_run_request.benchmark_name, url=BENCHMARK_SERVICE_URL)
 
-    if not benchmark_row:
-        raise ValueError(f"Benchmark with id {benchmark_id} not found")
+        benchmark_row = session.get(Benchmark, benchmark_id)
 
-    try:
-        # Create tasks inside of the database for each task id
-        task_row_mapping: dict[str, Task] = {}
-        for task_id in verified_task_ids:
-            task_row = Task(task_id=task_id, benchmark=benchmark_row.id)
-            task_row_mapping[task_id] = task_row
+        # NOTE: Benchmark row is created just before this task is called, so it should always be found
+        # This exists if we are testing an edge case with this method and to satisfy type checker
+        if not benchmark_row:
+            raise ValueError(f"Benchmark with id {benchmark_id} not found")
 
-        session.add_all(list(task_row_mapping.values()))
-        session.commit()
+        try:
+            # Create tasks inside of the database for each task id
+            task_rows: dict[str, Task] = {}
+            for task_id in verified_task_ids:
+                task_row = Task(task_id=task_id, benchmark=benchmark_row.id)
+                task_rows[task_id] = task_row
 
-        semaphore = Semaphore(start_run_request.concurrency)
+            session.add_all(list(task_rows.values()))
+            session.commit()
 
-        evaluation_result_rows: list[dict[str, dict[str, Any] | None]] = await gather(
-            *[
-                process_task(task_row_mapping, start_run_request, semaphore, benchmark_service, task_id)
-                for task_id in verified_task_ids
-            ]
-        )
+            # Load the tasks we are going to be tracking
+            tracked_tasks: dict[str, TrackedTask] = {
+                task_id: TrackedTask(
+                    process_task(task_row, start_run_request, benchmark_service, benchmark_id, task_id)
+                )
+                for task_id, task_row in task_rows.items()
+            }
 
-        # NOTE: Tasks with errors will still need to be included inside of the final score calculation to ensure that they are accounted for
-        evaluation_results: dict[str, dict[str, Any] | None] = {
-            task_id: evaluation_result
-            for result_dict in evaluation_result_rows
-            for task_id, evaluation_result in result_dict.items()
-        }
+            # Start the monitor to track the state the tasks are in and cancel them when no longer valid
+            monitor = TaskMonitor(benchmark_row, session, tracked_tasks)
+            monitor_task = asyncio.create_task(monitor.track_tasks())
 
-        # Calculate the final score based off the tasks that were ran
-        final_score_response = await benchmark_service.request_final_score(evaluation_results=evaluation_results)
+            semaphore = Semaphore(start_run_request.concurrency)
 
-        # Create the final evaluation row and add it to the database
-        final_evaluation_row = FinalEvaluation(
-            benchmark=benchmark_row.id,
-            final_score=final_score_response.final_score,
-            properties=final_score_response.metadata,
-        )
+            evaluation_result_rows: list[dict[str, dict[str, Any] | None]] = await gather(
+                *[tracked_tasks[task_id].run(semaphore, task_id) for task_id in verified_task_ids]
+            )
 
-        session.add(final_evaluation_row)
-        session.commit()
+            await monitor_task
 
-        # Mark benchmark as completed
-        # NOTE: Finished at will be automatically set by an event when the status becomes finished
-        benchmark_row.status = BenchmarkStatus.FINISHED
-        session.add(benchmark_row)
-        session.commit()
-    except Exception as e:
-        error_message = str(e)
-        commit_benchmark_error(benchmark_row, session, error_message)
+            # NOTE: Tasks with errors will still need to be included inside of the final score calculation to ensure that they are accounted for
+            evaluation_results: dict[str, dict[str, Any] | None] = {
+                task_id: evaluation_result
+                for result_dict in evaluation_result_rows
+                for task_id, evaluation_result in result_dict.items()
+            }
+
+            # Calculate the final score based off the tasks that were ran
+            final_score_response = await benchmark_service.request_final_score(evaluation_results=evaluation_results)
+
+            # Create the final evaluation row and add it to the database
+            final_evaluation_row = FinalEvaluation(
+                benchmark=benchmark_row.id,
+                final_score=final_score_response.final_score,
+                properties=final_score_response.metadata,
+            )
+
+            session.add(final_evaluation_row)
+            session.commit()
+
+            # Mark benchmark as completed
+            # NOTE: Finished at will be automatically set by an event when the status becomes finished
+            benchmark_row.status = BenchmarkStatus.FINISHED
+            session.add(benchmark_row)
+            session.commit()
+        except Exception as e:
+            error_message = str(e)
+            commit_benchmark_error(benchmark_row, session, error_message)
 
 
 class TaskCounts(NamedTuple):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from sqlmodel import Session, case, col, func, select
 
 from tracker.benchmark_service import BenchmarkService
-from tracker.config import BENCHMARK_SERVICE_URL, celery
+from tracker.config import BENCHMARK_SERVICE_URL, broker
 from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
 from tracker.logger import get_logger
@@ -56,6 +56,7 @@ class TrackedTask:
                 return await self._coro
 
         try:
+            # TODO: Add session to handle catching non-cancelled execptions and committing the task to the database
             self._task = asyncio.create_task(_wrap_coro())
             return await self._task
         except asyncio.CancelledError:
@@ -225,12 +226,16 @@ async def process_task(
             return {task_id: None}
 
 
-@celery.task
+@broker.task
 async def process_benchmark(
-    start_run_request: StartRunRequest,
-    benchmark_id: UUID,
+    start_run_request_json: dict[str, Any],
+    benchmark_id_str: str,
     verified_task_ids: list[str],
 ) -> None:
+    # Was serialized to make it compatible with the broker
+    start_run_request: StartRunRequest = StartRunRequest(**start_run_request_json)
+    benchmark_id: UUID = UUID(benchmark_id_str)
+
     # NOTE: Will get ugly if we error on session create
     with Session(bind=engine, expire_on_commit=False) as session:
         # TODO: Delegate url since in the future this aspect can change

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -478,7 +478,7 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
 
                 yield f"{DATA_PREFIX} {response_data.model_dump_json()}\n\n"
 
-                if fresh_benchmark.status in [BenchmarkStatus.FINISHED, BenchmarkStatus.ERROR]:
+                if fresh_benchmark.status in [BenchmarkStatus.FINISHED, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPED]:
                     yield EVENT_COMPLETE
                     break
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -438,6 +438,7 @@ def commit_benchmark_error(benchmark_row: Benchmark, session: Session, error_mes
 
 
 def commit_task_error(task_row: Task, session: Session, error_message: str) -> None:
+    task_row = session.merge(task_row)
     task_row.status = TaskStatus.ERROR
     task_row.error_message = error_message
     session.add(task_row)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -4,13 +4,13 @@ from asyncio import Semaphore, gather
 from collections.abc import AsyncGenerator, Coroutine
 from enum import Enum
 from functools import cached_property
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, Sequence
 from uuid import UUID
 
 from sqlmodel import Session, case, col, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
-from tracker.config import BENCHMARK_SERVICE_URL, broker
+from tracker.config import broker
 from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
 from tracker.logger import get_logger
@@ -247,6 +247,41 @@ async def set_benchmark_final_status(benchmark_row: Benchmark, session: Session)
     session.commit()
 
 
+def create_task_rows(
+    verified_task_ids: list[str], benchmark_row: Benchmark, session: Session
+) -> Sequence[tuple[str, Task]]:
+    """
+    Create task_rows that do not already exist in the database for the benchmark row.
+
+    NOTE: Only return starting tasks to support resuming the benchmark.
+    """
+
+    # Find task ids that already exist so that we can filter them out
+    existing_task_ids: Sequence[str] = session.exec(
+        select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(verified_task_ids))
+    ).all()
+
+    task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
+
+    created_task_rows: dict[str, Task] = {}
+    for task_id in task_ids_to_create:
+        task_row = Task(task_id=task_id, benchmark=benchmark_row.id)
+        created_task_rows[task_id] = task_row
+
+    # Create the task rows if we need to add any new ones
+    if created_task_rows:
+        session.add_all(list(created_task_rows.values()))
+        session.commit()
+
+    # Fetch all task rows with the status of starting
+
+    starting_task_rows: Sequence[tuple[str, Task]] = session.exec(
+        select(Task.task_id, Task).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.STARTING)
+    ).all()
+
+    return starting_task_rows
+
+
 @broker.task
 async def process_benchmark(
     start_run_request_json: dict[str, Any],
@@ -260,26 +295,20 @@ async def process_benchmark(
     # NOTE: Will get ugly if we error on session create
     with Session(bind=engine, expire_on_commit=False) as session:
         # TODO: Delegate url since in the future this aspect can change
-        benchmark_service = BenchmarkService(name=start_run_request.benchmark_name, url=BENCHMARK_SERVICE_URL)
+        benchmark_service = start_run_request.benchmark_service
 
         benchmark_row = fetch_benchmark_row(benchmark_id, session)
 
         try:
             # Create tasks inside of the database for each task id
-            task_rows: dict[str, Task] = {}
-            for task_id in verified_task_ids:
-                task_row = Task(task_id=task_id, benchmark=benchmark_row.id)
-                task_rows[task_id] = task_row
-
-            session.add_all(list(task_rows.values()))
-            session.commit()
+            task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session)
 
             # Load the tasks we are going to be tracking
             tracked_tasks: dict[str, TrackedTask] = {
                 task_id: TrackedTask(
                     process_task(task_row, start_run_request, benchmark_service, benchmark_id, task_id)
                 )
-                for task_id, task_row in task_rows.items()
+                for task_id, task_row in task_rows
             }
 
             # Start the monitor to track the state the tasks are in and cancel them when no longer valid
@@ -477,3 +506,46 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
         .values(status=TaskStatus.STOPPED)
     )
     session.commit()
+
+
+async def resume_benchmark(
+    benchmark_row: Benchmark, session: Session, benchmark_service: BenchmarkService
+) -> list[str]:
+    """
+    Resets benchmark and task status to flag resuming the benchmark.
+
+    Benchmark - In progress status
+    Tasks - Starting status
+
+    NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
+    """
+    # Check if there are any tasks that have been stopped
+    task_ids = session.exec(
+        select(Task.task_id)
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STOPPED)
+    ).all()
+
+    if not task_ids:
+        raise ValueError(f"No tasks for benchmark {benchmark_row.id} have been stopped. Cannot resume benchmark.")
+
+    # Verify the task ids are still valid before priming to resume
+    # Raises if any task ids are invalid
+    verify_response = await benchmark_service.request_verify_task_ids(task_ids=list(task_ids), slice_str=None)
+
+    # Set the benchmark status to in progress to flag resuming the benchmark
+    benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+    session.add(benchmark_row)
+    session.commit()
+
+    # Set the task status to starting to flag resuming the tasks
+    session.exec(
+        update(Task)
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STOPPED)
+        .values(status=TaskStatus.STARTING)
+    )
+
+    session.commit()
+
+    return verify_response.task_ids

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -454,8 +454,10 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
     """
     # Check if there are any tasks yet that have not been started yet
     tasks = session.exec(
-        select(Task).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.STARTING)
-    ).all()
+        select(func.count(col(Task.id)))
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STARTING)
+    ).one()
 
     if not tasks:
         raise ValueError(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -79,7 +79,7 @@ class TaskMonitor:
 
         return task_row
 
-    def validate_task(self, task_id: str) -> bool:
+    def _validate_task(self, task_id: str) -> bool:
         """
         Runs while waiting to be aquired by the semaphore.
 
@@ -99,7 +99,7 @@ class TaskMonitor:
 
         return True
 
-    def check_is_waiting(self, task: TrackedTask) -> bool:
+    def _check_is_waiting(self, task: TrackedTask) -> bool:
         """
         Checks if the task is waiting to be aquired by the semaphore.
 
@@ -125,10 +125,10 @@ class TaskMonitor:
             for task_id in tasks_to_check:
                 task = self._task_tracking[task_id]
 
-                if not self.check_is_waiting(task):
+                if not self._check_is_waiting(task):
                     del self._task_tracking[task_id]
 
-                if not self.validate_task(task_id) and task.task:
+                if not self._validate_task(task_id) and task.task:
                     task.task.cancel(f"Task {task_id} has been invalidated. Benchmark has been requested to stop")
                     del self._task_tracking[task_id]
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from typing import Any, NamedTuple
 from uuid import UUID
 
-from sqlmodel import Session, case, col, func, select
+from sqlmodel import Session, case, col, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.config import BENCHMARK_SERVICE_URL, broker
@@ -226,6 +226,27 @@ async def process_task(
             return {task_id: None}
 
 
+async def set_benchmark_final_status(benchmark_row: Benchmark, session: Session) -> None:
+    """
+    Delegates status depending on if any tasks have been stopped.
+    """
+    tasks_stopped: int = session.exec(
+        select(func.count(col(Task.id)))
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STOPPED)
+    ).one()
+
+    # Default status is finished, if we stopped any tasks the benchmark status is stopped
+    # Later we can use the stopped status to determine if we can resume the benchmark
+    benchmark_status = BenchmarkStatus.FINISHED
+    if tasks_stopped:
+        benchmark_status = BenchmarkStatus.STOPPED
+
+    benchmark_row.status = benchmark_status
+    session.add(benchmark_row)
+    session.commit()
+
+
 @broker.task
 async def process_benchmark(
     start_run_request_json: dict[str, Any],
@@ -293,11 +314,7 @@ async def process_benchmark(
             session.add(final_evaluation_row)
             session.commit()
 
-            # Mark benchmark as completed
-            # NOTE: Finished at will be automatically set by an event when the status becomes finished
-            benchmark_row.status = BenchmarkStatus.FINISHED
-            session.add(benchmark_row)
-            session.commit()
+            await set_benchmark_final_status(benchmark_row, session)
         except Exception as e:
             error_message = str(e)
             commit_benchmark_error(benchmark_row, session, error_message)
@@ -424,3 +441,37 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
     except asyncio.CancelledError:
         logger.info(f"Client disconnected from benchmark {benchmark_id} stream")
         yield DISCONNECT
+
+
+async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
+    """
+    Sets the flags to initiate the stopping process for a benchmark.
+
+    Benchmark - Stopping status
+    Tasks - Stopped status
+
+    NOTE: Tasks that have already started will continue to run and finish.
+    """
+    # Check if there are any tasks yet that have not been started yet
+    tasks = session.exec(
+        select(Task).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.STARTING)
+    ).all()
+
+    if not tasks:
+        raise ValueError(
+            f"All tasks for benchmark {benchmark_row.id} have been started. Must wait for the tasks to finish running."
+        )
+
+    # Set the benchmark status to stopping to initiate the stopping process
+    benchmark_row.status = BenchmarkStatus.STOPPING
+    session.add(benchmark_row)
+    session.commit()
+
+    # Stop all tasks that have not been started yet from starting by setting the stop flag
+    session.exec(
+        update(Task)
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STARTING)
+        .values(status=TaskStatus.STOPPED)
+    )
+    session.commit()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -227,10 +227,23 @@ async def process_task(
             return {task_id: None}
 
 
-async def set_benchmark_final_status(benchmark_row: Benchmark, session: Session) -> None:
+def set_benchmark_final_status(benchmark_row: Benchmark, session: Session) -> None:
     """
     Delegates status depending on if any tasks have been stopped.
     """
+
+    # Check if any tasks are still in the starting or in progress state
+    tasks_not_finished: int = session.exec(
+        select(func.count(col(Task.id)))
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status).in_([TaskStatus.STARTING, TaskStatus.IN_PROGRESS]))
+    ).one()
+
+    if tasks_not_finished:
+        raise TrackerServiceError(
+            f"Cannot set final status for benchmark {benchmark_row.id} because tasks are still in the starting or in progress state."
+        )
+
     tasks_stopped: int = session.exec(
         select(func.count(col(Task.id)))
         .where(col(Task.benchmark) == benchmark_row.id)
@@ -262,6 +275,7 @@ def create_task_rows(
         select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(verified_task_ids))
     ).all()
 
+    # NOTE: Must maintain same order that was passed in
     task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
 
     created_task_rows: dict[str, Task] = {}
@@ -275,7 +289,6 @@ def create_task_rows(
         session.commit()
 
     # Fetch all task rows with the status of starting
-
     starting_task_rows: Sequence[tuple[str, Task]] = session.exec(
         select(Task.task_id, Task).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.STARTING)
     ).all()
@@ -344,7 +357,7 @@ async def process_benchmark(
             session.add(final_evaluation_row)
             session.commit()
 
-            await set_benchmark_final_status(benchmark_row, session)
+            set_benchmark_final_status(benchmark_row, session)
         except Exception as e:
             error_message = str(e)
             commit_benchmark_error(benchmark_row, session, error_message)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -13,6 +13,7 @@ from tracker.benchmark_service import BenchmarkService
 from tracker.config import broker
 from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
+from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.sandbox import create_sandbox, install_dependencies, run_agent, upload_contract_to_sandbox
 from tracker.types import (
@@ -481,31 +482,36 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
 
     NOTE: Tasks that have already started will continue to run and finish.
     """
-    # Check if there are any tasks yet that have not been started yet
-    tasks = session.exec(
-        select(func.count(col(Task.id)))
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.status) == TaskStatus.STARTING)
-    ).one()
+    try:
+        # Check if there are any tasks yet that have not been started yet
+        tasks = session.exec(
+            select(func.count(col(Task.id)))
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.status) == TaskStatus.STARTING)
+        ).one()
 
-    if not tasks:
-        raise ValueError(
-            f"All tasks for benchmark {benchmark_row.id} have been started. Must wait for the tasks to finish running."
+        if not tasks:
+            raise TrackerServiceError(
+                f"All tasks for benchmark {benchmark_row.id} have been started. Must wait for the tasks to finish running."
+            )
+
+        # Set the benchmark status to stopping to initiate the stopping process
+        benchmark_row.status = BenchmarkStatus.STOPPING
+        session.add(benchmark_row)
+        session.commit()
+
+        # Stop all tasks that have not been started yet from starting by setting the stop flag
+        session.exec(
+            update(Task)
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.status) == TaskStatus.STARTING)
+            .values(status=TaskStatus.STOPPED)
         )
-
-    # Set the benchmark status to stopping to initiate the stopping process
-    benchmark_row.status = BenchmarkStatus.STOPPING
-    session.add(benchmark_row)
-    session.commit()
-
-    # Stop all tasks that have not been started yet from starting by setting the stop flag
-    session.exec(
-        update(Task)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.status) == TaskStatus.STARTING)
-        .values(status=TaskStatus.STOPPED)
-    )
-    session.commit()
+        session.commit()
+    except TrackerServiceError:
+        raise
+    except Exception as e:
+        raise TrackerServiceError(f"Unexpected error stopping benchmark {benchmark_row.id}: {str(e)}") from e
 
 
 async def resume_benchmark(
@@ -519,33 +525,40 @@ async def resume_benchmark(
 
     NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
     """
-    # Check if there are any tasks that have been stopped
-    task_ids = session.exec(
-        select(Task.task_id)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.status) == TaskStatus.STOPPED)
-    ).all()
+    try:
+        # Check if there are any tasks that have been stopped
+        task_ids = session.exec(
+            select(Task.task_id)
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.status) == TaskStatus.STOPPED)
+        ).all()
 
-    if not task_ids:
-        raise ValueError(f"No tasks for benchmark {benchmark_row.id} have been stopped. Cannot resume benchmark.")
+        if not task_ids:
+            raise TrackerServiceError(
+                f"No tasks for benchmark {benchmark_row.id} have been stopped. Cannot resume benchmark."
+            )
 
-    # Verify the task ids are still valid before priming to resume
-    # Raises if any task ids are invalid
-    verify_response = await benchmark_service.request_verify_task_ids(task_ids=list(task_ids), slice_str=None)
+        # Verify the task ids are still valid before priming to resume
+        # Raises if any task ids are invalid
+        verify_response = await benchmark_service.request_verify_task_ids(task_ids=list(task_ids), slice_str=None)
 
-    # Set the benchmark status to in progress to flag resuming the benchmark
-    benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-    session.add(benchmark_row)
-    session.commit()
+        # Set the benchmark status to in progress to flag resuming the benchmark
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        session.add(benchmark_row)
+        session.commit()
 
-    # Set the task status to starting to flag resuming the tasks
-    session.exec(
-        update(Task)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.status) == TaskStatus.STOPPED)
-        .values(status=TaskStatus.STARTING)
-    )
+        # Set the task status to starting to flag resuming the tasks
+        session.exec(
+            update(Task)
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.status) == TaskStatus.STOPPED)
+            .values(status=TaskStatus.STARTING)
+        )
 
-    session.commit()
+        session.commit()
 
-    return verify_response.task_ids
+        return verify_response.task_ids
+    except TrackerServiceError:
+        raise
+    except Exception as e:
+        raise TrackerServiceError(f"Unexpected error resuming benchmark {benchmark_row.id}: {str(e)}") from e

--- a/services/tracker/supervisord.conf
+++ b/services/tracker/supervisord.conf
@@ -1,0 +1,23 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:api]
+command=uv run uvicorn main:app --host 0.0.0.0 --port 8000
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:worker]
+command=uv run taskiq worker tracker.config:broker tracker.utils
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/services/tracker/tests/integration/test_process_benchmark.py
+++ b/services/tracker/tests/integration/test_process_benchmark.py
@@ -1,4 +1,3 @@
-from asyncio import Semaphore
 from functools import partial
 from sqlite3 import OperationalError
 from typing import Any
@@ -80,9 +79,6 @@ class TestProcessBenchmark:
             benchmark_name="swebench", contract_name="claude_code", concurrency=5, task_ids=[task_id]
         )
 
-        # Concurrency control for each task being processed inside of the benchmark
-        semaphore = Semaphore(start_run_request.concurrency)
-
         benchmark_row = BenchmarkService.start_run_request_to_benchmark_object(start_run_request)
 
         database_session.add(benchmark_row)
@@ -120,7 +116,7 @@ class TestProcessBenchmark:
         )
 
         # Starts and evaluates a single task inside using the benchmark service
-        _ = await process_task(task_row_mapping, start_run_request, semaphore, benchmark_service, task_id)
+        _ = await process_task(task_row, start_run_request, benchmark_service, benchmark_row.id, task_id)
 
         # Ensure that the evaluation result is viewable from the database after the task has been processed
         evaluation_result = database_session.exec(
@@ -133,9 +129,7 @@ class TestProcessBenchmark:
         database_session.refresh(task_row_mapping[task_id])
         assert task_row_mapping[task_id].status == TaskStatus.FINISHED
 
-    async def test_process_benchmark(
-        self, database_session: Session, benchmark_service: BenchmarkService, monkeypatch: MonkeyPatch
-    ):
+    async def test_process_benchmark(self, database_session: Session, monkeypatch: MonkeyPatch):
         # Task ids sent by user to be processed
         task_ids: list[str] = ["astropy__astropy-12907", "astropy__astropy-13033"]
 
@@ -169,7 +163,7 @@ class TestProcessBenchmark:
         )
 
         # Run the benchmark
-        await process_benchmark(start_run_request, benchmark_row.id, task_ids, benchmark_service, database_session)
+        await process_benchmark(start_run_request.model_dump(), str(benchmark_row.id), task_ids)
 
         # Benchmark status is updated to finished once the benchmark is done running
         database_session.refresh(benchmark_row)
@@ -242,7 +236,7 @@ class TestProcessBenchmark:
         )
 
         # Run the benchmark (error is not raised and instead handled)
-        await process_benchmark(start_run_request, benchmark_row.id, task_ids, benchmark_service, database_session)
+        await process_benchmark(start_run_request.model_dump(), str(benchmark_row.id), task_ids)
 
         # Benchmark status is updated to error once the benchmark is done running
         database_session.refresh(benchmark_row)
@@ -306,7 +300,7 @@ class TestProcessBenchmark:
             TestProcessBenchmark._mock_run_agent,
         )
 
-        await process_benchmark(start_run_request, benchmark_row.id, task_ids, benchmark_service, database_session)
+        await process_benchmark(start_run_request.model_dump(), str(benchmark_row.id), task_ids)
 
         # Benchmark status is still finished even though one task has errored out
         database_session.refresh(benchmark_row, attribute_names=["final_evaluation"])

--- a/services/tracker/tests/integration/test_process_benchmark.py
+++ b/services/tracker/tests/integration/test_process_benchmark.py
@@ -265,19 +265,19 @@ class TestProcessBenchmark:
         database_session.add(benchmark_row)
         database_session.commit()
 
-        async def mock_request_setup_task(original_method: Any, task_id: str, instance_id: str) -> SetupTaskResponse:
+        original_request_setup_task = BenchmarkService.request_setup_task
+
+        async def mock_request_setup_task(self: Any, task_id: str, instance_id: str) -> SetupTaskResponse:
             if task_id == "astropy__astropy-13033":
                 raise Exception("Exception raised while setting up the task")
 
-            return await original_method(task_id, instance_id)
-
-        original_request_setup_task = benchmark_service.request_setup_task
+            return await original_request_setup_task(self, task_id, instance_id)
 
         # Setup fails for the second task
         monkeypatch.setattr(
-            benchmark_service,
+            BenchmarkService,
             "request_setup_task",
-            partial(mock_request_setup_task, original_request_setup_task),
+            mock_request_setup_task,
         )
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
@@ -303,7 +303,7 @@ class TestProcessBenchmark:
         await process_benchmark(start_run_request.model_dump(), str(benchmark_row.id), task_ids)
 
         # Benchmark status is still finished even though one task has errored out
-        database_session.refresh(benchmark_row, attribute_names=["final_evaluation"])
+        database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.FINISHED, benchmark_row.error_message
 
         tasks = database_session.exec(

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -1,17 +1,21 @@
+from datetime import datetime
 from functools import partial
 from typing import Any
+from zoneinfo import ZoneInfo
 
+import pytest
 from httpx._models import Response
 from pytest import MonkeyPatch
-from sqlmodel import Session, col, func, select
+from sqlmodel import Session, col, func, select, update
 
 from main import app
 from tests.unit.test_fastapi_server import client
 from tracker.benchmark_service import BenchmarkService
 from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.database.session import get_session
-from tracker.types import StartRunRequest, VerifyTaskIdsResponse
-from tracker.utils import fetch_benchmark_row
+from tracker.exceptions import TrackerServiceError
+from tracker.types import FinalScoreResponse, StartRunRequest, VerifyTaskIdsResponse
+from tracker.utils import create_task_rows, fetch_benchmark_row, set_benchmark_final_status
 
 
 class TestBenchmarkUtils:
@@ -22,6 +26,11 @@ class TestBenchmarkUtils:
 
     async def _mock_process_benchmark(self, *args: Any, **kwargs: Any) -> None:
         pass
+
+    async def _mock_request_final_score(
+        self, *args: Any, final_score: float, metadata: dict[str, Any], tasks_evaluated: list[str], **kwargs: Any
+    ) -> FinalScoreResponse:
+        return FinalScoreResponse(final_score=final_score, metadata=metadata, tasks_evaluated=tasks_evaluated)
 
     def test_stop_benchmark(self, example_benchmark_object: Benchmark, database_session: Session):
         """
@@ -253,3 +262,94 @@ class TestBenchmarkUtils:
 
         recreated_start_run_request = benchmark_row.start_run_request
         assert recreated_start_run_request == original_start_run_request
+
+    def test_create_task_rows(self, example_benchmark_object: Benchmark, database_session: Session):
+        """
+        Tests different scenarios for creating task rows
+
+        Test Cases:
+            - No tasks exist in the database already
+            - Some tasks exist in the database already
+            - No duplicate tasks are created
+            - All returned tasks are in the starting state
+        """
+
+        # Create benchmark in progress state
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Verified tasks to create
+        verified_task_ids = [f"task_{i}" for i in range(5)]
+
+        # Creates all tasks in starting state
+        task_rows = create_task_rows(verified_task_ids, benchmark_row, database_session)
+        assert len(task_rows) == len(verified_task_ids)
+        assert all(task_row[1].status == TaskStatus.STARTING for task_row in task_rows)
+
+        # Same order is returned as the verified task ids are passed in (must be deterministic)
+        for i, task_row in enumerate(task_rows):
+            assert task_row[0] == verified_task_ids[i]
+
+        # Try calling the same method again when the tasks already exist
+        task_rows = create_task_rows(verified_task_ids, benchmark_row, database_session)
+        assert len(task_rows) == len(verified_task_ids)
+        assert all(task_row[1].status == TaskStatus.STARTING for task_row in task_rows)
+
+        # No duplicate tasks are created and they are all in the starting state
+        all_tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        assert len(all_tasks) == len(verified_task_ids)
+        assert all(task.status == TaskStatus.STARTING for task in all_tasks)
+
+    async def test_set_benchmark_final_status(self, example_benchmark_object: Benchmark, database_session: Session):
+        """
+        Tests the end to end flow when stopping and resuming a benchmark
+        """
+
+        # Create benchmark
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Create some starting tasks
+        task_ids = [f"task_{i}" for i in range(5)]
+        task_rows = create_task_rows(task_ids, benchmark_row, database_session)
+        assert len(task_rows) == len(task_ids)
+        assert all(task_row[1].status == TaskStatus.STARTING for task_row in task_rows)
+
+        # Error is raised because tasks are still in the starting state
+        with pytest.raises(TrackerServiceError):
+            set_benchmark_final_status(benchmark_row, database_session)
+
+        # Make all tasks in finished state
+        # NOTE: Need to manually set the finished_at timestamp because the event listener is not triggered with bulk updates
+        database_session.exec(
+            update(Task)
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .values(status=TaskStatus.FINISHED, finished_at=datetime.now(ZoneInfo("UTC")))
+        )
+        database_session.commit()
+
+        # Benchmark status is set to finished
+        set_benchmark_final_status(benchmark_row, database_session)
+        database_session.refresh(benchmark_row, attribute_names=["status"])
+        assert benchmark_row.status == BenchmarkStatus.FINISHED
+
+        # Reset benchmark status to in progress
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Change some tasks to the stopped state
+        stopped_tasks = task_ids[:2]
+        database_session.exec(
+            update(Task)
+            .where(col(Task.task_id).in_(stopped_tasks))
+            .values(status=TaskStatus.STOPPED, finished_at=datetime.now(ZoneInfo("UTC")))
+        )
+        database_session.commit()
+
+        # Benchmark status is set to stopped when stopped tasks exist
+        set_benchmark_final_status(benchmark_row, database_session)
+        database_session.refresh(benchmark_row, attribute_names=["status"])
+        assert benchmark_row.status == BenchmarkStatus.STOPPED

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -10,7 +10,7 @@ from tests.unit.test_fastapi_server import client
 from tracker.benchmark_service import BenchmarkService
 from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.database.session import get_session
-from tracker.types import VerifyTaskIdsResponse
+from tracker.types import StartRunRequest, VerifyTaskIdsResponse
 from tracker.utils import fetch_benchmark_row
 
 
@@ -24,6 +24,15 @@ class TestBenchmarkUtils:
         pass
 
     def test_stop_benchmark(self, example_benchmark_object: Benchmark, database_session: Session):
+        """
+        Tests the flow of updating the benchmark related objects to the proper states when stopping a benchmark
+
+        Test Cases:
+            - Benchmark can be stopped if it is in progress and tasks that have not started yet exist
+            - After stopping, the benchmark status is "stopping" and tasks have been set to "stopped"
+            - Tasks not in starting state are left alone
+        """
+
         def get_test_session():
             yield database_session
 
@@ -82,6 +91,15 @@ class TestBenchmarkUtils:
         assert task_rows == 5
 
     def test_stop_benchmark_edge_cases(self, example_benchmark_object: Benchmark, database_session: Session):
+        """
+        Tests edge cases for stopping a benchmark
+
+        Test Cases:
+            - Cannot stop a benchmark that is not in progress
+            - Cannot stop a benchmark where all tasks have already started
+            - Errors are raised and returned to the client
+        """
+
         def get_test_session():
             yield database_session
 
@@ -117,6 +135,15 @@ class TestBenchmarkUtils:
     def test_resume_benchmark(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
     ):
+        """
+        Tests the flow of updating the benchmark related objects to the proper states when resuming a benchmark
+
+        Test Cases:
+            - Benchmark can be resumed if it is in a stopped state and a single task with the stopped status exists
+            - After resuming, the benchmark status is "in progress" and tasks have been set to "starting" that were in the stopped state
+            - Only the status of stopped tasks are updated
+        """
+
         def get_test_session():
             yield database_session
 
@@ -173,6 +200,16 @@ class TestBenchmarkUtils:
         assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
 
     def test_resume_benchmark_edge_cases(self, example_benchmark_object: Benchmark, database_session: Session):
+        """
+        Tests edge cases for resuming a benchmark
+
+        Test Cases:
+            - Cannot resume a benchmark that is not in a stopped state
+            - Cannot resume a benchmark where all tasks have already finished
+            - Errors are raised and returned to the client
+            - Can recreate the same environment the benchmark was started in
+        """
+
         def get_test_session():
             yield database_session
 
@@ -202,3 +239,17 @@ class TestBenchmarkUtils:
         # error is returned because we have no stopped tasks to resume
         response = client.post(f"/resume-run/{benchmark_row.id}")
         assert response.status_code == 500
+
+        # Ensure that we can recreate the environment the benchmark was started in
+        original_start_run_request = StartRunRequest(
+            contract_name="claude_code",
+            benchmark_name="swebench",
+            concurrency=5,
+            task_ids=["task_0", "task_1", "task_2", "task_3", "task_4"],
+            slice_str=":10",
+        )
+
+        benchmark_row = BenchmarkService.start_run_request_to_benchmark_object(original_start_run_request)
+
+        recreated_start_run_request = benchmark_row.start_run_request
+        assert recreated_start_run_request == original_start_run_request

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -1,0 +1,204 @@
+from functools import partial
+from typing import Any
+
+from httpx._models import Response
+from pytest import MonkeyPatch
+from sqlmodel import Session, col, func, select
+
+from main import app
+from tests.unit.test_fastapi_server import client
+from tracker.benchmark_service import BenchmarkService
+from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
+from tracker.database.session import get_session
+from tracker.types import VerifyTaskIdsResponse
+from tracker.utils import fetch_benchmark_row
+
+
+class TestBenchmarkUtils:
+    async def _mock_request_verify_task_ids(
+        self, *args: Any, task_ids: list[str], **kwargs: Any
+    ) -> VerifyTaskIdsResponse:
+        return VerifyTaskIdsResponse(task_ids=task_ids)
+
+    async def _mock_process_benchmark(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def test_stop_benchmark(self, example_benchmark_object: Benchmark, database_session: Session):
+        def get_test_session():
+            yield database_session
+
+        app.dependency_overrides[get_session] = get_test_session
+
+        # Create benchmark that has already been started
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # create tasks, some which are starting and some which are in progress
+        initial_task_rows: list[Task] = []
+        for i in range(5):
+            initial_task_rows.append(Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STARTING))
+        for i in range(5, 10):
+            initial_task_rows.append(
+                Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+            )
+        database_session.add_all(initial_task_rows)
+        database_session.commit()
+
+        # Test request to stop the benchmark
+        response: Response = client.post(f"/stop-run/{benchmark_row.id}")
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+
+        # Check that the benchmark status is now "stopping"
+        benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session)
+        assert benchmark_row.status == BenchmarkStatus.STOPPING
+
+        # Task status in starting state should be set to "stopped" / otherwise known as no starting tasks left
+        task_rows = database_session.exec(
+            select(func.count(col(Task.id)))
+            .where(Task.benchmark == benchmark_row.id)
+            .where(Task.status == TaskStatus.STARTING)
+        ).one()
+
+        assert task_rows == 0
+
+        # Check the right amount of tasks are in stopped state
+        task_rows = database_session.exec(
+            select(func.count(col(Task.id)))
+            .where(Task.benchmark == benchmark_row.id)
+            .where(Task.status == TaskStatus.STOPPED)
+        ).one()
+        assert task_rows == 5
+
+        # The remaining tasks have been left alone in in progress state
+        task_rows = database_session.exec(
+            select(func.count(col(Task.id)))
+            .where(Task.benchmark == benchmark_row.id)
+            .where(Task.status == TaskStatus.IN_PROGRESS)
+        ).one()
+
+        assert task_rows == 5
+
+    def test_stop_benchmark_edge_cases(self, example_benchmark_object: Benchmark, database_session: Session):
+        def get_test_session():
+            yield database_session
+
+        app.dependency_overrides[get_session] = get_test_session
+
+        # Cannot stop a benchmark that is not in progress
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.FINISHED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Fail to stop the run
+        response: Response = client.post(f"/stop-run/{benchmark_row.id}")
+        assert response.status_code == 400
+
+        # Cannot stop a run with no tasks yet to start
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Add some tasks, all have already started
+
+        task_rows = [
+            Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS) for i in range(5)
+        ]
+        database_session.add_all(task_rows)
+        database_session.commit()
+
+        # Error is returned because we have no starting tasks left to stop
+        response = client.post(f"/stop-run/{benchmark_row.id}")
+        assert response.status_code == 500
+
+    def test_resume_benchmark(
+        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
+    ):
+        def get_test_session():
+            yield database_session
+
+        app.dependency_overrides[get_session] = get_test_session
+
+        # Create benchmark that has already been stopped
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Add some tasks, non-starting (stopped and finished tasks only)
+        task_rows: list[Task] = []
+        for i in range(5):
+            task_rows.append(Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STOPPED))
+        for i in range(5, 10):
+            task_rows.append(Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.FINISHED))
+        database_session.add_all(task_rows)
+        database_session.commit()
+
+        # Fetch all the task ids that are stopped
+        task_ids = database_session.exec(
+            select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.STOPPED)
+        ).all()
+
+        assert len(task_ids) == 5
+
+        # Patch the verify endpoint to return the same task ids
+        monkeypatch.setattr(
+            BenchmarkService,
+            "request_verify_task_ids",
+            partial(self._mock_request_verify_task_ids, task_ids=list(task_ids)),
+        )
+
+        # Ignore the process benchmark task (not testing that here)
+        monkeypatch.setattr(
+            "main.process_benchmark.kiq",
+            self._mock_process_benchmark,
+        )
+
+        # Test request to resume the benchmark
+        response: Response = client.post(f"/resume-run/{benchmark_row.id}")
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+
+        # Validate stopped tasks are now in starting state
+        task_ids = database_session.exec(
+            select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.STARTING)
+        ).all()
+        assert len(task_ids) == 5
+
+        # Validate the benchmark is now in progress state
+        benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session)
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+
+    def test_resume_benchmark_edge_cases(self, example_benchmark_object: Benchmark, database_session: Session):
+        def get_test_session():
+            yield database_session
+
+        app.dependency_overrides[get_session] = get_test_session
+
+        # Benchmark is not in a stopped state
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # failure code to resume the benchmark
+        response: Response = client.post(f"/resume-run/{benchmark_row.id}")
+        assert response.status_code == 400
+
+        # Set benchmark to stopped state but add only finished tasks
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # All of them finished
+        task_rows = [
+            Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.FINISHED) for i in range(5)
+        ]
+        database_session.add_all(task_rows)
+        database_session.commit()
+
+        # error is returned because we have no stopped tasks to resume
+        response = client.post(f"/resume-run/{benchmark_row.id}")
+        assert response.status_code == 500

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -304,6 +304,11 @@ class TestBenchmarkUtils:
     async def test_set_benchmark_final_status(self, example_benchmark_object: Benchmark, database_session: Session):
         """
         Tests the end to end flow when stopping and resuming a benchmark
+
+        Test Cases:
+            - Error is raised if tasks are still in the starting or in progress state
+            - Benchmark status is set to finished if all tasks are finished
+            - Benchmark status is set to stopped if any tasks are stopped
         """
 
         # Create benchmark

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -29,7 +29,7 @@ class TestFastapiServer:
     async def _mock_request_verify_task_ids(self, *args: Any, **kwargs: Any) -> VerifyTaskIdsResponse:
         return VerifyTaskIdsResponse(task_ids=["task_id"] * 500)
 
-    def _mock_process_benchmark(self, *args: Any, **kwargs: Any) -> None:
+    async def _mock_process_benchmark_kiq(self, *args: Any, **kwargs: Any) -> None:
         pass
 
     async def _mock_request_health_check(self, *args: Any, **kwargs: Any) -> HealthCheckResponse:
@@ -93,8 +93,8 @@ class TestFastapiServer:
 
         # Ignore background task to run benchmark
         monkeypatch.setattr(
-            "main.process_benchmark",
-            self._mock_process_benchmark,
+            "main.process_benchmark.kiq",
+            self._mock_process_benchmark_kiq,
         )
 
         # Send request to start the run and ensure that the start response is returned
@@ -275,11 +275,15 @@ class TestFastapiServer:
         assert len(response_json.get("evaluation_results")) == 10
 
         # Change benchmark status to finished and add final evaluation row
+        # Refresh to get the latest state
+        database_session.refresh(benchmark_row)
         benchmark_row.status = BenchmarkStatus.FINISHED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
         final_evaluation_row = FinalEvaluation(
             benchmark=benchmark_row.id, final_score=100, properties={"resolved_tasks": [], "unresolved_tasks": []}
         )
-        database_session.add(benchmark_row)
         database_session.add(final_evaluation_row)
         database_session.commit()
 

--- a/services/tracker/tests/unit/test_tracker.py
+++ b/services/tracker/tests/unit/test_tracker.py
@@ -1,0 +1,115 @@
+import asyncio
+from asyncio import Semaphore, gather
+from typing import Any
+
+import pytest
+
+from tracker.utils import TrackedTask, TrackedTaskStatus
+
+
+class TestTracker:
+    async def _mock_coro(self, task_id: str) -> dict[str, dict[str, Any] | None]:
+        """Blank coro that returns the same format as process_task method"""
+        await asyncio.sleep(5)
+
+        return {task_id: {"result": task_id}}
+
+    async def _validate_task_state_before_run(
+        self, tracked_task: TrackedTask, task_id: str
+    ) -> dict[str, dict[str, Any] | None]:
+        """
+        Validates the state of the tracked task while its running.
+
+        the task running needs to start before the timer ends.
+        """
+        await asyncio.sleep(1)
+
+        assert tracked_task.status == TrackedTaskStatus.RUNNING
+        assert tracked_task.task
+
+        return {task_id: None}
+
+    def test_task_monitor(self) -> None: ...
+
+    async def test_tracked_task(self) -> None:
+        """
+        Test functionality of the TrackedTask class
+
+        Test Cases:
+            - When first created, it is in the waiting state
+            - When waiting to be aquired by the semaphore, it is still waiting
+            - When picked up by the semaphore, it is in the running state
+            - When cancelled or finished, it is in the done state
+        """
+
+        # Pass in a blank method to replace process_task
+        mock_coro = self._mock_coro(task_id="task_id_1")
+        tracked_task = TrackedTask(coro=mock_coro)
+
+        # Test case 1. When first created, it is in the waiting state
+        assert tracked_task.status == TrackedTaskStatus.WAITING
+        assert tracked_task.task is None
+
+        # Create another task that tracks the status of the first task
+        # Allows us to test that the task status changes to running once the semaphore is aquired.
+        tracked_task_2 = TrackedTask(coro=self._validate_task_state_before_run(tracked_task, "task_id_2"))
+
+        semaphore = Semaphore(value=2)
+        tasks = [tracked_task.run(semaphore, "task_id_1"), tracked_task_2.run(semaphore, "task_id_2")]
+        results = await gather(*tasks)
+        assert results == [{"task_id_1": {"result": "task_id_1"}}, {"task_id_2": None}]
+
+        # Test case 2. After the tasks have finished running, we can validate that the task status changes to done
+        assert tracked_task.status == TrackedTaskStatus.DONE
+        assert tracked_task.task is not None
+        assert tracked_task.task.result() == {"task_id_1": {"result": "task_id_1"}}
+
+        assert tracked_task_2.status == TrackedTaskStatus.DONE
+        assert tracked_task_2.task is not None
+        assert tracked_task_2.task.result() == {"task_id_2": None}
+
+        # Test case 3. When the task is cancelled, it is in the done state and default response is returned
+        tracked_task = TrackedTask(coro=self._mock_coro(task_id="task_id_3"))
+
+        # Create semaphore to run task instantly
+        semaphore = Semaphore(value=1)
+        run_task = asyncio.create_task(tracked_task.run(semaphore, "task_id_3"))
+
+        # Wait for the task to start running and ensure that the status is running
+        await asyncio.sleep(1)
+        assert tracked_task.status == TrackedTaskStatus.RUNNING
+
+        # Once the task is cancelled, the tracker should go to the done state
+        run_task.cancel()
+
+        result = await run_task
+
+        assert tracked_task.status == TrackedTaskStatus.DONE
+
+        # The response of the tracked result should be None since the task was cancelled
+        assert tracked_task.task is not None
+
+        # Ensurance of cancellation
+        with pytest.raises(asyncio.CancelledError):
+            tracked_task.task.result()
+
+        assert result == {"task_id_3": None}
+
+        # Test case 4. When a task is waiting to be aquired it is kept inside of the waiting state
+        running_task = TrackedTask(coro=self._mock_coro(task_id="task_id_4"))
+        waiting_task = TrackedTask(coro=self._mock_coro(task_id="task_id_5"))
+
+        semaphore = Semaphore(value=1)
+        running_task_coro = running_task.run(semaphore, "task_id_4")
+        waiting_task_coro = waiting_task.run(semaphore, "task_id_5")
+
+        results = asyncio.gather(running_task_coro, waiting_task_coro)
+
+        # Give the first task time to acquire semaphore
+        await asyncio.sleep(1)
+
+        # First task aquired is running and the second task is still waiting
+        assert running_task.status == TrackedTaskStatus.RUNNING
+        assert waiting_task.status == TrackedTaskStatus.WAITING
+
+        await results

--- a/services/tracker/tests/unit/test_tracker.py
+++ b/services/tracker/tests/unit/test_tracker.py
@@ -3,8 +3,10 @@ from asyncio import Semaphore, gather
 from typing import Any
 
 import pytest
+from sqlmodel import Session
 
-from tracker.utils import TrackedTask, TrackedTaskStatus
+from tracker.database.models import Benchmark, Task, TaskStatus
+from tracker.utils import TaskMonitor, TrackedTask, TrackedTaskStatus
 
 
 class TestTracker:
@@ -29,7 +31,72 @@ class TestTracker:
 
         return {task_id: None}
 
-    def test_task_monitor(self) -> None: ...
+    async def test_task_monitor(self, database_session: Session, example_benchmark_object: Benchmark) -> None:
+        """
+        Test functionality of the TaskMonitor class
+
+        NOTE: Most of the functionality is closed off so we used the private variables and methods.
+        had to use type: ignore to satisfy the type checker.
+
+        Test Cases:
+            - _check_is_waiting returns true if the task is not running
+            - _validate_task fetches from updates database
+            - _validate_task returns false if the task status has been set to stopped
+            - track_tasks cancels the task if the task status has been set to stopped
+        """
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Populate the database with tasks we will be tracking
+        tasks_to_track: list[str] = ["task_id_1"]
+        for task_id in tasks_to_track:
+            task_row = Task(task_id=task_id, benchmark=benchmark_row.id)
+            database_session.add(task_row)
+            database_session.commit()
+
+        task_tracking: dict[str, TrackedTask] = {
+            task_id: TrackedTask(coro=self._mock_coro(task_id=task_id)) for task_id in tasks_to_track
+        }
+
+        # Create the task monitor and start tracking the tasks
+        # NOTE: We copy the mapping so we can still fetch the tasks and check references even if they are removed from the mapping inside of the monitor
+        monitor = TaskMonitor(benchmark_row, database_session, task_tracking.copy())
+
+        # Test case 1. returns true if task is not running
+        assert monitor._check_is_waiting(task_tracking["task_id_1"])  # type: ignore
+
+        # Change task status to running and add a task to the object
+        task_tracking["task_id_1"]._status = TrackedTaskStatus.RUNNING  # type: ignore
+        task_tracking["task_id_1"]._task = asyncio.create_task(task_tracking["task_id_1"]._coro)  # type: ignore
+
+        # Returns false if the task is not in a waiting state
+        assert not monitor._check_is_waiting(task_tracking["task_id_1"])  # type: ignore
+
+        # Test case 2. Validate task returns true if the task is not stopped
+        assert monitor._validate_task("task_id_1")  # type: ignore
+
+        # Change the task status to stopped to make sure that it gets invalidated inside of the validate task method
+        task_row = monitor._fetch_task_row("task_id_1")  # type: ignore
+
+        # Commit the changes to the database, will be available from any session
+        task_row.status = TaskStatus.STOPPED
+        database_session.add(task_row)
+        database_session.commit()
+
+        # Test case 3. Validate task returns false if the task status has been set to stopped
+        # NOTE: ensures that the database change gets picked up by the session
+        assert not monitor._validate_task("task_id_1")  # type: ignore
+
+        # Test case 4. track_tasks cancels the task if the task status has been set to stopped
+        # Run the track_tasks method and ensure that the task is cancelled
+        await monitor.track_tasks()
+        assert task_tracking["task_id_1"].task
+        assert task_tracking["task_id_1"].task.cancelled()
+
+        # Need to await the result to avoid getting a warning at the end of the test
+        with pytest.raises(asyncio.CancelledError):
+            await task_tracking["task_id_1"].task
 
     async def test_tracked_task(self) -> None:
         """

--- a/services/tracker/tests/unit/test_tracker.py
+++ b/services/tracker/tests/unit/test_tracker.py
@@ -179,4 +179,18 @@ class TestTracker:
         assert running_task.status == TrackedTaskStatus.RUNNING
         assert waiting_task.status == TrackedTaskStatus.WAITING
 
-        await results
+        # Cancel the waiting task
+        assert waiting_task.task is not None
+        waiting_task.task.cancel()
+
+        task_results = await results
+
+        # All results are now done
+        assert running_task.status == TrackedTaskStatus.DONE
+        assert waiting_task.status == TrackedTaskStatus.DONE
+
+        # Waiting task returns an empty response since we cancelled it
+        assert task_results[1] == {"task_id_5": None}
+
+        # Running task was completed so the result is full
+        assert task_results[0] == {"task_id_4": {"result": "task_id_4"}}

--- a/services/tracker/tests/utils.py
+++ b/services/tracker/tests/utils.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from daytona import AsyncDaytona, AsyncSandbox, CreateSandboxFromImageParams, DaytonaNotFoundError, Image, Resources
+from daytona import AsyncDaytona, AsyncSandbox, CreateSandboxFromImageParams, DaytonaNotFoundError, Resources
 
 
 async def validate_docker_image(image_name: str) -> bool:
@@ -53,11 +53,9 @@ async def build_task_environment(
         A context manager that yields the sandbox
     """
 
-    task_image = Image.base(docker_image)
     sandbox = await daytona.create(
         CreateSandboxFromImageParams(
-            env_vars={"TEST_DIR": "/tests"},
-            image=task_image,
+            image=docker_image,
             name=task_id,
             network_block_all=False,
             resources=Resources(cpu=4, memory=8, disk=10),

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1017,6 +1017,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-env"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/12/9c87d0ca45d5992473208bcef2828169fa7d39b8d7fc6e3401f5c08b8bf7/pytest_env-1.2.0.tar.gz", hash = "sha256:475e2ebe8626cee01f491f304a74b12137742397d6c784ea4bc258f069232b80", size = 8973, upload-time = "2025-10-09T19:15:47.42Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/98/822b924a4a3eb58aacba84444c7439fce32680592f394de26af9c76e2569/pytest_env-1.2.0-py3-none-any.whl", hash = "sha256:d7e5b7198f9b83c795377c09feefa45d56083834e60d04767efd64819fc9da00", size = 6251, upload-time = "2025-10-09T19:15:46.077Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1336,6 +1348,7 @@ dev = [
     { name = "basedpyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-env" },
     { name = "ruff" },
 ]
 
@@ -1357,6 +1370,7 @@ dev = [
     { name = "basedpyright" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "ruff" },
 ]
 

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -80,6 +80,18 @@ wheels = [
 ]
 
 [[package]]
+name = "amqp"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -129,6 +141,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/d7/9476af6f45a70e8d23045ec59d99c2698513b7395283cadc75caeeea2b83/basedpyright-1.37.0.tar.gz", hash = "sha256:affbffced97a04a08bfc44aef2da43951a5ab5e2e55921a144ed786c4fd2c6ad", size = 22837441, upload-time = "2026-01-04T09:59:32.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/63/753918f0bad07a1b24755a540b64bca1388322615025d4c954e3740fcdbe/basedpyright-1.37.0-py3-none-any.whl", hash = "sha256:261a02a8732a19f3f585e2940582147560058626a062a2320724de84fb2dc41b", size = 11884509, upload-time = "2026-01-04T09:59:35.997Z" },
+]
+
+[[package]]
+name = "billiard"
+version = "4.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
 ]
 
 [[package]]
@@ -187,6 +208,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/61/5715ec25b3dcb2a08133811f6a18a9ca9be54567452ab3e92cadcaec746e/botocore_stubs-1.42.24.tar.gz", hash = "sha256:f5fbe240267b27036b1217a304de34bf2bf993087e049a300d17d6f52d77988b", size = 42415, upload-time = "2026-01-07T21:27:03.862Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/6b/cffb62a7872ba32e08c22c9c918a4d5d1d39ed6d74195bf50a3ae75a22f3/botocore_stubs-1.42.24-py3-none-any.whl", hash = "sha256:025999e68f419472cc8dfb7bcc2964fa0a06b447f43e7fc309012ff4c665b3db", size = 66762, upload-time = "2026-01-07T21:27:02.249Z" },
+]
+
+[[package]]
+name = "celery"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "billiard" },
+    { name = "click" },
+    { name = "click-didyoumean" },
+    { name = "click-plugins" },
+    { name = "click-repl" },
+    { name = "kombu" },
+    { name = "python-dateutil" },
+    { name = "tzlocal" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/9d/3d13596519cfa7207a6f9834f4b082554845eb3cd2684b5f8535d50c7c44/celery-5.6.2.tar.gz", hash = "sha256:4a8921c3fcf2ad76317d3b29020772103581ed2454c4c042cc55dcc43585009b", size = 1718802, upload-time = "2026-01-04T12:35:58.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/bd/9ecd619e456ae4ba73b6583cc313f26152afae13e9a82ac4fe7f8856bfd1/celery-5.6.2-py3-none-any.whl", hash = "sha256:3ffafacbe056951b629c7abcf9064c4a2366de0bdfc9fdba421b97ebb68619a5", size = 445502, upload-time = "2026-01-04T12:35:55.894Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "kombu", extra = ["redis"] },
+]
+
+[[package]]
+name = "celery-types"
+version = "0.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/25/2276a1f00f8ab9fc88128c939333933a24db7df1d75aa57ecc27b7dd3a22/celery_types-0.24.0.tar.gz", hash = "sha256:c93fbcd0b04a9e9c2f55d5540aca4aa1ea4cc06a870c0c8dee5062fdd59663fe", size = 33148, upload-time = "2025-12-23T17:16:30.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/7e/3252cba5f5c9a65a3f52a69734d8e51e023db8981022b503e8183cf0225e/celery_types-0.24.0-py3-none-any.whl", hash = "sha256:a21e04681e68719a208335e556a79909da4be9c5e0d6d2fd0dd4c5615954b3fd", size = 60473, upload-time = "2025-12-23T17:16:29.89Z" },
 ]
 
 [[package]]
@@ -256,6 +314,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
+
+[[package]]
+name = "click-didyoumean"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
+]
+
+[[package]]
+name = "click-plugins"
+version = "1.1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
+]
+
+[[package]]
+name = "click-repl"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
 ]
 
 [[package]]
@@ -665,6 +760,26 @@ wheels = [
 ]
 
 [[package]]
+name = "kombu"
+version = "5.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "amqp" },
+    { name = "packaging" },
+    { name = "tzdata" },
+    { name = "vine" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -840,6 +955,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -1044,6 +1171,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
     { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
     { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "redis"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
 ]
 
 [[package]]
@@ -1255,6 +1391,8 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
+    { name = "celery", extra = ["redis"] },
+    { name = "celery-types" },
     { name = "daytona" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
@@ -1274,6 +1412,8 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
+    { name = "celery", extras = ["redis"], specifier = ">=5.6.2" },
+    { name = "celery-types", specifier = ">=0.24.0" },
     { name = "daytona", specifier = ">=0.128.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.127.1" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -1344,6 +1484,27 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1391,6 +1552,15 @@ wheels = [
 ]
 
 [[package]]
+name = "vine"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1412,6 +1582,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
     { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
     { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.2.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
 ]
 
 [[package]]

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -80,18 +80,6 @@ wheels = [
 ]
 
 [[package]]
-name = "amqp"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "vine" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/79/fc/ec94a357dfc6683d8c86f8b4cfa5416a4c36b28052ec8260c77aca96a443/amqp-5.3.1.tar.gz", hash = "sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432", size = 129013, upload-time = "2024-11-12T19:55:44.051Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/99/fc813cd978842c26c82534010ea849eee9ab3a13ea2b74e95cb9c99e747b/amqp-5.3.1-py3-none-any.whl", hash = "sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2", size = 50944, upload-time = "2024-11-12T19:55:41.782Z" },
-]
-
-[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -141,15 +129,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/d7/9476af6f45a70e8d23045ec59d99c2698513b7395283cadc75caeeea2b83/basedpyright-1.37.0.tar.gz", hash = "sha256:affbffced97a04a08bfc44aef2da43951a5ab5e2e55921a144ed786c4fd2c6ad", size = 22837441, upload-time = "2026-01-04T09:59:32.652Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/63/753918f0bad07a1b24755a540b64bca1388322615025d4c954e3740fcdbe/basedpyright-1.37.0-py3-none-any.whl", hash = "sha256:261a02a8732a19f3f585e2940582147560058626a062a2320724de84fb2dc41b", size = 11884509, upload-time = "2026-01-04T09:59:35.997Z" },
-]
-
-[[package]]
-name = "billiard"
-version = "4.2.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
 ]
 
 [[package]]
@@ -208,43 +187,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/86/61/5715ec25b3dcb2a08133811f6a18a9ca9be54567452ab3e92cadcaec746e/botocore_stubs-1.42.24.tar.gz", hash = "sha256:f5fbe240267b27036b1217a304de34bf2bf993087e049a300d17d6f52d77988b", size = 42415, upload-time = "2026-01-07T21:27:03.862Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/6b/cffb62a7872ba32e08c22c9c918a4d5d1d39ed6d74195bf50a3ae75a22f3/botocore_stubs-1.42.24-py3-none-any.whl", hash = "sha256:025999e68f419472cc8dfb7bcc2964fa0a06b447f43e7fc309012ff4c665b3db", size = 66762, upload-time = "2026-01-07T21:27:02.249Z" },
-]
-
-[[package]]
-name = "celery"
-version = "5.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "billiard" },
-    { name = "click" },
-    { name = "click-didyoumean" },
-    { name = "click-plugins" },
-    { name = "click-repl" },
-    { name = "kombu" },
-    { name = "python-dateutil" },
-    { name = "tzlocal" },
-    { name = "vine" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/9d/3d13596519cfa7207a6f9834f4b082554845eb3cd2684b5f8535d50c7c44/celery-5.6.2.tar.gz", hash = "sha256:4a8921c3fcf2ad76317d3b29020772103581ed2454c4c042cc55dcc43585009b", size = 1718802, upload-time = "2026-01-04T12:35:58.012Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/bd/9ecd619e456ae4ba73b6583cc313f26152afae13e9a82ac4fe7f8856bfd1/celery-5.6.2-py3-none-any.whl", hash = "sha256:3ffafacbe056951b629c7abcf9064c4a2366de0bdfc9fdba421b97ebb68619a5", size = 445502, upload-time = "2026-01-04T12:35:55.894Z" },
-]
-
-[package.optional-dependencies]
-redis = [
-    { name = "kombu", extra = ["redis"] },
-]
-
-[[package]]
-name = "celery-types"
-version = "0.24.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/25/2276a1f00f8ab9fc88128c939333933a24db7df1d75aa57ecc27b7dd3a22/celery_types-0.24.0.tar.gz", hash = "sha256:c93fbcd0b04a9e9c2f55d5540aca4aa1ea4cc06a870c0c8dee5062fdd59663fe", size = 33148, upload-time = "2025-12-23T17:16:30.847Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/7e/3252cba5f5c9a65a3f52a69734d8e51e023db8981022b503e8183cf0225e/celery_types-0.24.0-py3-none-any.whl", hash = "sha256:a21e04681e68719a208335e556a79909da4be9c5e0d6d2fd0dd4c5615954b3fd", size = 60473, upload-time = "2025-12-23T17:16:29.89Z" },
 ]
 
 [[package]]
@@ -314,43 +256,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
-]
-
-[[package]]
-name = "click-didyoumean"
-version = "0.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/30/ce/217289b77c590ea1e7c24242d9ddd6e249e52c795ff10fac2c50062c48cb/click_didyoumean-0.3.1.tar.gz", hash = "sha256:4f82fdff0dbe64ef8ab2279bd6aa3f6a99c3b28c05aa09cbfc07c9d7fbb5a463", size = 3089, upload-time = "2024-03-24T08:22:07.499Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/5b/974430b5ffdb7a4f1941d13d83c64a0395114503cc357c6b9ae4ce5047ed/click_didyoumean-0.3.1-py3-none-any.whl", hash = "sha256:5c4bb6007cfea5f2fd6583a2fb6701a22a41eb98957e63d0fac41c10e7c3117c", size = 3631, upload-time = "2024-03-24T08:22:06.356Z" },
-]
-
-[[package]]
-name = "click-plugins"
-version = "1.1.1.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/a4/34847b59150da33690a36da3681d6bbc2ec14ee9a846bc30a6746e5984e4/click_plugins-1.1.1.2.tar.gz", hash = "sha256:d7af3984a99d243c131aa1a828331e7630f4a88a9741fd05c927b204bcf92261", size = 8343, upload-time = "2025-06-25T00:47:37.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/9a/2abecb28ae875e39c8cad711eb1186d8d14eab564705325e77e4e6ab9ae5/click_plugins-1.1.1.2-py2.py3-none-any.whl", hash = "sha256:008d65743833ffc1f5417bf0e78e8d2c23aab04d9745ba817bd3e71b0feb6aa6", size = 11051, upload-time = "2025-06-25T00:47:36.731Z" },
-]
-
-[[package]]
-name = "click-repl"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "prompt-toolkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/a2/57f4ac79838cfae6912f997b4d1a64a858fb0c86d7fcaae6f7b58d267fca/click-repl-0.3.0.tar.gz", hash = "sha256:17849c23dba3d667247dc4defe1757fff98694e90fe37474f3feebb69ced26a9", size = 10449, upload-time = "2023-06-15T12:43:51.141Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/40/9d857001228658f0d59e97ebd4c346fe73e138c6de1bce61dc568a57c7f8/click_repl-0.3.0-py3-none-any.whl", hash = "sha256:fb7e06deb8da8de86180a33a9da97ac316751c094c6899382da7feeeeb51b812", size = 10289, upload-time = "2023-06-15T12:43:48.626Z" },
 ]
 
 [[package]]
@@ -739,6 +644,15 @@ wheels = [
 ]
 
 [[package]]
+name = "izulu"
+version = "0.50.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/58/6d6335c78b7ade54d8a6c6dbaa589e5c21b3fd916341d5a16f774c72652a/izulu-0.50.0.tar.gz", hash = "sha256:cc8e252d5e8560c70b95380295008eeb0786f7b745a405a40d3556ab3252d5f5", size = 48558, upload-time = "2025-03-24T15:52:21.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/9f/bf9d33546bbb6e5e80ebafe46f90b7d8b4a77410b7b05160b0ca8978c15a/izulu-0.50.0-py3-none-any.whl", hash = "sha256:4e9ae2508844e7c5f62c468a8b9e2deba2f60325ef63f01e65b39fd9a6b3fab4", size = 18095, upload-time = "2025-03-24T15:52:19.667Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -757,26 +671,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
-]
-
-[[package]]
-name = "kombu"
-version = "5.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "amqp" },
-    { name = "packaging" },
-    { name = "tzdata" },
-    { name = "vine" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b6/a5/607e533ed6c83ae1a696969b8e1c137dfebd5759a2e9682e26ff1b97740b/kombu-5.6.2.tar.gz", hash = "sha256:8060497058066c6f5aed7c26d7cd0d3b574990b09de842a8c5aaed0b92cc5a55", size = 472594, upload-time = "2025-12-29T20:30:07.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/0f/834427d8c03ff1d7e867d3db3d176470c64871753252b21b4f4897d1fa45/kombu-5.6.2-py3-none-any.whl", hash = "sha256:efcfc559da324d41d61ca311b0c64965ea35b4c55cc04ee36e55386145dace93", size = 214219, upload-time = "2025-12-29T20:30:05.74Z" },
-]
-
-[package.optional-dependencies]
-redis = [
-    { name = "redis" },
 ]
 
 [[package]]
@@ -958,18 +852,6 @@ wheels = [
 ]
 
 [[package]]
-name = "prompt-toolkit"
-version = "3.0.52"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wcwidth" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
-]
-
-[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,6 +891,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/cf/d2d3b9f5699fb1e4615c8e32ff220203e43b248e1dfcc6736ad9057731ca/pycparser-2.23.tar.gz", hash = "sha256:78816d4f24add8f10a06d6f05b4d424ad9e96cfebf68a4ddc99c65c0720d00c2", size = 173734, upload-time = "2025-09-09T13:23:47.91Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/e3/59cd50310fc9b59512193629e1984c1f95e5c8ae6e5d8c69532ccc65a7fe/pycparser-2.23-py3-none-any.whl", hash = "sha256:e5c6e8d3fbad53479cab09ac03729e0a9faf2bee3db8208a550daf5af81a5934", size = 118140, upload-time = "2025-09-09T13:23:46.651Z" },
+]
+
+[[package]]
+name = "pycron"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5d/340be12ae4a69c33102dfb6ddc1dc6e53e69b2d504fa26b5d34a472c3057/pycron-3.2.0.tar.gz", hash = "sha256:e125a28aca0295769541a40633f70b602579df48c9cb357c36c28d2628ba2b13", size = 4248, upload-time = "2025-06-05T13:24:12.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/76/caf316909f4545e7158e0e1defd8956a1da49f4af04f5d16b18c358dfeac/pycron-3.2.0-py3-none-any.whl", hash = "sha256:6d2349746270bd642b71b9f7187cf13f4d9ee2412b4710396a507b5fe4f60dac", size = 4904, upload-time = "2025-06-05T13:24:11.477Z" },
 ]
 
 [[package]]
@@ -1376,6 +1267,46 @@ wheels = [
 ]
 
 [[package]]
+name = "taskiq"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "izulu" },
+    { name = "packaging" },
+    { name = "pycron" },
+    { name = "pydantic" },
+    { name = "taskiq-dependencies" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/cf/c4a47be05d85754f3e0ecc7b72131249adc067ea37517054459e94268fb1/taskiq-0.12.1.tar.gz", hash = "sha256:338dcf58eaca327e511a9380b2185bfa6a415dd79a5cf144546a2dbb95459298", size = 60536, upload-time = "2025-12-07T16:07:43.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/e4/a2fda3bcbb8b61108dc8e9db1a2d19a23578953db73e981f66b9d44f1207/taskiq-0.12.1-py3-none-any.whl", hash = "sha256:a8ade45e2e23edbadb972a88dec44e68c7daef83383d01fa3af48594a24a712a", size = 90668, upload-time = "2025-12-07T16:07:42.296Z" },
+]
+
+[[package]]
+name = "taskiq-dependencies"
+version = "1.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/90/47a627696e53bfdcacabc3e8c05b73bf1424685bcb5f17209cb8b12da1bf/taskiq_dependencies-1.5.7.tar.gz", hash = "sha256:0d3b240872ef152b719153b9526d866d2be978aeeaea6600e878414babc2dcb4", size = 14875, upload-time = "2025-02-26T22:07:39.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/6d/4a012f2de002c2e93273f5e7d3e3feea02f7fdbb7b75ca2ca1dd10703091/taskiq_dependencies-1.5.7-py3-none-any.whl", hash = "sha256:6fcee5d159bdb035ef915d4d848826169b6f06fe57cc2297a39b62ea3e76036f", size = 13801, upload-time = "2025-02-26T22:07:38.622Z" },
+]
+
+[[package]]
+name = "taskiq-redis"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "taskiq" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/0b/5006792cbdf6e78abaab45407968d96e2a1ffd0238cd41b13a62b33880cf/taskiq_redis-1.1.2.tar.gz", hash = "sha256:f878a047abc1a0fa0ddda6e4b063d742f030858d5a4409de96261a00a992c9c9", size = 16225, upload-time = "2025-10-07T10:46:13.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/20/9bf19b05eb7cb275a04871f3c38bf088c108579c4c19ea2a1358d2a81334/taskiq_redis-1.1.2-py3-none-any.whl", hash = "sha256:3b69468ff99da33243314c84acfa137a4a014abad10dd44e62195bc5e4ae9947", size = 20424, upload-time = "2025-10-07T10:46:12.779Z" },
+]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1391,13 +1322,13 @@ source = { editable = "." }
 dependencies = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
-    { name = "celery", extra = ["redis"] },
-    { name = "celery-types" },
     { name = "daytona" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "moto", extra = ["s3"] },
     { name = "sqlmodel" },
+    { name = "taskiq" },
+    { name = "taskiq-redis" },
 ]
 
 [package.dev-dependencies]
@@ -1412,13 +1343,13 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "celery", extras = ["redis"], specifier = ">=5.6.2" },
-    { name = "celery-types", specifier = ">=0.24.0" },
     { name = "daytona", specifier = ">=0.128.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.127.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "moto", extras = ["s3"] },
     { name = "sqlmodel", specifier = ">=0.0.31" },
+    { name = "taskiq", specifier = ">=0.12.1" },
+    { name = "taskiq-redis", specifier = ">=1.1.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1484,27 +1415,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tzdata"
-version = "2025.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
-]
-
-[[package]]
 name = "urllib3"
 version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1552,15 +1462,6 @@ wheels = [
 ]
 
 [[package]]
-name = "vine"
-version = "5.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
-]
-
-[[package]]
 name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1582,15 +1483,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
     { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
     { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
-]
-
-[[package]]
-name = "wcwidth"
-version = "0.2.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/30/6b0809f4510673dc723187aeaf24c7f5459922d01e2f794277a3dfb90345/wcwidth-0.2.14.tar.gz", hash = "sha256:4d478375d31bc5395a3c55c40ccdf3354688364cd61c4f6adacaa9215d0b3605", size = 102293, upload-time = "2025-09-22T16:29:53.023Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl", hash = "sha256:a7bb560c8aee30f9957e5f9895805edd20602f2d7f720186dfd906e82b4982e1", size = 37286, upload-time = "2025-09-22T16:29:51.641Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3001,6 +3001,7 @@ dev = [
     { name = "basedpyright" },
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "ruff" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1296,6 +1296,15 @@ requires-dist = [
 ]
 
 [[package]]
+name = "izulu"
+version = "0.50.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/58/6d6335c78b7ade54d8a6c6dbaa589e5c21b3fd916341d5a16f774c72652a/izulu-0.50.0.tar.gz", hash = "sha256:cc8e252d5e8560c70b95380295008eeb0786f7b745a405a40d3556ab3252d5f5", size = 48558, upload-time = "2025-03-24T15:52:21.51Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/9f/bf9d33546bbb6e5e80ebafe46f90b7d8b4a77410b7b05160b0ca8978c15a/izulu-0.50.0-py3-none-any.whl", hash = "sha256:4e9ae2508844e7c5f62c468a8b9e2deba2f60325ef63f01e65b39fd9a6b3fab4", size = 18095, upload-time = "2025-03-24T15:52:19.667Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2194,6 +2203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycron"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/5d/340be12ae4a69c33102dfb6ddc1dc6e53e69b2d504fa26b5d34a472c3057/pycron-3.2.0.tar.gz", hash = "sha256:e125a28aca0295769541a40633f70b602579df48c9cb357c36c28d2628ba2b13", size = 4248, upload-time = "2025-06-05T13:24:12.636Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/76/caf316909f4545e7158e0e1defd8956a1da49f4af04f5d16b18c358dfeac/pycron-3.2.0-py3-none-any.whl", hash = "sha256:6d2349746270bd642b71b9f7187cf13f4d9ee2412b4710396a507b5fe4f60dac", size = 4904, upload-time = "2025-06-05T13:24:11.477Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -2847,6 +2865,46 @@ wheels = [
 ]
 
 [[package]]
+name = "taskiq"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anyio" },
+    { name = "izulu" },
+    { name = "packaging" },
+    { name = "pycron" },
+    { name = "pydantic" },
+    { name = "taskiq-dependencies" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/cf/c4a47be05d85754f3e0ecc7b72131249adc067ea37517054459e94268fb1/taskiq-0.12.1.tar.gz", hash = "sha256:338dcf58eaca327e511a9380b2185bfa6a415dd79a5cf144546a2dbb95459298", size = 60536, upload-time = "2025-12-07T16:07:43.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/e4/a2fda3bcbb8b61108dc8e9db1a2d19a23578953db73e981f66b9d44f1207/taskiq-0.12.1-py3-none-any.whl", hash = "sha256:a8ade45e2e23edbadb972a88dec44e68c7daef83383d01fa3af48594a24a712a", size = 90668, upload-time = "2025-12-07T16:07:42.296Z" },
+]
+
+[[package]]
+name = "taskiq-dependencies"
+version = "1.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/90/47a627696e53bfdcacabc3e8c05b73bf1424685bcb5f17209cb8b12da1bf/taskiq_dependencies-1.5.7.tar.gz", hash = "sha256:0d3b240872ef152b719153b9526d866d2be978aeeaea6600e878414babc2dcb4", size = 14875, upload-time = "2025-02-26T22:07:39.876Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/6d/4a012f2de002c2e93273f5e7d3e3feea02f7fdbb7b75ca2ca1dd10703091/taskiq_dependencies-1.5.7-py3-none-any.whl", hash = "sha256:6fcee5d159bdb035ef915d4d848826169b6f06fe57cc2297a39b62ea3e76036f", size = 13801, upload-time = "2025-02-26T22:07:38.622Z" },
+]
+
+[[package]]
+name = "taskiq-redis"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "taskiq" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/0b/5006792cbdf6e78abaab45407968d96e2a1ffd0238cd41b13a62b33880cf/taskiq_redis-1.1.2.tar.gz", hash = "sha256:f878a047abc1a0fa0ddda6e4b063d742f030858d5a4409de96261a00a992c9c9", size = 16225, upload-time = "2025-10-07T10:46:13.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/20/9bf19b05eb7cb275a04871f3c38bf088c108579c4c19ea2a1358d2a81334/taskiq_redis-1.1.2-py3-none-any.whl", hash = "sha256:3b69468ff99da33243314c84acfa137a4a014abad10dd44e62195bc5e4ae9947", size = 20424, upload-time = "2025-10-07T10:46:12.779Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2921,6 +2979,8 @@ dependencies = [
     { name = "httpx" },
     { name = "moto", extra = ["s3"] },
     { name = "sqlmodel" },
+    { name = "taskiq" },
+    { name = "taskiq-redis" },
 ]
 
 [package.metadata]
@@ -2932,6 +2992,8 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "moto", extras = ["s3"] },
     { name = "sqlmodel", specifier = ">=0.0.31" },
+    { name = "taskiq", specifier = ">=0.12.1" },
+    { name = "taskiq-redis", specifier = ">=1.1.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
### Main changes
- Added broker and taskiq for async queue system
- Made `process_benchmark` a task
- Implemented `TaskTracker` and `TaskManager` to manage and track the position tasks are in (Allows us to cancel tasks while waiting in semaphore)
- Added stop and resume feature to `tracker-service`
- Updated documentation with latest commands
- Updated docker container

### Tests
- Tracker and manager systems
- Updated older tests
- Added tests for stop and resume run + edge cases


### Run steps

pre-req, `make tracker-service` and updated `BENCHMARK_SERVICE_URL` value in .env

```
# Start the run
uv run harness start-benchmark \
  --contract contracts/claude_code \
  --benchmark swebench \
  --concurrency 1 \
  --slice :5


# wait a moment for tasks to start up
uv run harness fetch-benchmark --benchmark-id <benchmark_id> --connect

# Stop the run (will remove all tasks yet to start from queue and finish processing in progress tasks)
uv run harness harness stop-run --benchmark-id <benchmark_id>

# Watch it go from stopping to stopped
uv run harness fetch-benchmark --benchmark-id <benchmark_id> --connect

# Once benchmark is in stopped status you can resume it once again
uv run harness harness resume-run --benchmark-id <benchmark_id>

# Watch it spin up again from where it left off
uv run harness fetch-benchmark --benchmark-id <benchmark_id> --connect
```

### Unit tests

Run all the unit tests I added

inside of `tracker/`
`uv run pytest tests/unit -vv`


### README

Tasks which have been stopped or have an error will not show up under evaluation results because there is no evaluation result. They are still counted during final eval so the score is accurate