### PR TITLE
Updated retrieve response endpoint

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -3,10 +3,10 @@ from uuid import UUID
 from fastapi import Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import joinedload
-from sqlmodel import Session, select
+from sqlmodel import Session, col, func, select
 
 from tracker.benchmark_service import BenchmarkService
-from tracker.database.models import Benchmark, BenchmarkStatus
+from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.database.session import get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
@@ -220,13 +220,21 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
+    tasks_stopped: int = session.exec(
+        select(func.count(col(Task.id)))
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STOPPED)
+    ).one()
+
     return RetrieveResultsResponse(
         benchmark_name=benchmark_row.name,
         status=benchmark_row.status,
         benchmark_id=benchmark_row.id,
         benchmark_arguments=benchmark_row.arguments,
+        tasks_stopped=tasks_stopped or None,  # NOTE: Only include if we stopped the benchmark
         final_evaluation=benchmark_row.final_evaluation,
         evaluation_results=benchmark_row.fetch_evaluation_results(session),
+        task_errors=benchmark_row.fetch_tasks_with_errors(session),
     )
 
 

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -17,6 +17,7 @@ from sqlmodel import (
     SQLModel,
     TypeDecorator,
     UniqueConstraint,
+    select,
 )
 
 from tracker.database.utils import has_field_changed
@@ -117,6 +118,19 @@ class Benchmark(SQLModel, table=True):
         from tracker.utils import fetch_evaluation_results
 
         return fetch_evaluation_results(self.id, session)
+
+    def fetch_tasks_with_errors(self, session: Session) -> dict[str, str] | None:
+        statement = (
+            select(Task.task_id, Task.error_message)
+            .where(Task.benchmark == self.id)
+            .where(Task.status == TaskStatus.ERROR)
+        )
+        tasks = session.exec(statement).all()
+
+        if not tasks:
+            return None
+
+        return {task_id: (error_message or "No error message was provided") for task_id, error_message in tasks}
 
     @property
     def start_run_request(self) -> "StartRunRequest":

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -57,8 +57,10 @@ class RetrieveResultsResponse(BaseModel):
     status: BenchmarkStatus
     benchmark_id: UUID
     benchmark_arguments: BenchmarkArguments
+    tasks_stopped: int | None
     final_evaluation: FinalEvaluation | None
     evaluation_results: dict[str, dict[str, Any]] | None
+    task_errors: dict[str, str] | None
 
 
 class FinalScoreResponse(BaseModel):

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -222,6 +222,8 @@ class TestFastapiServer:
             - Evaluation results are returned as the tasks are being completed
             - Works when no tasks are completed
             - Base fields are included within response
+            - Tasks stopped field is populated when we stop the benchmark
+            - Task errors field is populated when we encounter an error
         """
 
         def get_test_session():
@@ -274,6 +276,10 @@ class TestFastapiServer:
         assert response_json.get("evaluation_results")
         assert len(response_json.get("evaluation_results")) == 10
 
+        # No stopped tasks or task_errors fields in response
+        assert "tasks_stopped" not in response_json
+        assert "task_errors" not in response_json
+
         # Change benchmark status to finished and add final evaluation row
         # Refresh to get the latest state
         database_session.refresh(benchmark_row)
@@ -294,6 +300,61 @@ class TestFastapiServer:
         # Test case 6. Final evaluation now exists
         assert response_json.get("final_evaluation")
         assert response_json.get("final_evaluation").get("final_score") == 100
+
+        # Test case 7. Tasks stopped field is populated when we stop the benchmark
+        # Stop the benchmark
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Add some new tasks with the status stopped
+        task_rows = [
+            Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STOPPED) for i in range(11, 21)
+        ]
+        database_session.add_all(task_rows)
+        database_session.commit()
+
+        response = client.get("/retrieve-results", params=query_params)
+        assert response.status_code == 200
+        response_json = response.json()
+
+        # NOTE: We chose to use a number instead of a list or string since some benchmarks have a lot of tasks
+        assert response_json.get("tasks_stopped") == 10
+        assert len(response_json.get("evaluation_results")) == 10
+
+        # Test case 8. Task errors field is populated when we encounter an error
+        # Add some new tasks with the status error (One with erro message and one without)
+        error_message = "Error occured during task execution or evaluation"
+        task_rows = [
+            Task(
+                task_id=f"task_{i}",
+                benchmark=benchmark_row.id,
+                status=TaskStatus.ERROR,
+                error_message=error_message if i == 22 else None,
+            )
+            for i in range(22, 24)
+        ]
+        database_session.add_all(task_rows)
+        database_session.commit()
+
+        response = client.get("/retrieve-results", params=query_params)
+        assert response.status_code == 200
+        response_json = response.json()
+
+        # Ensure we did not lose any previous data
+        assert response_json.get("tasks_stopped") == 10
+        assert len(response_json.get("evaluation_results")) == 10
+        assert response_json.get("final_evaluation")
+
+        # Check for tasks with erorrs
+        assert response_json.get("task_errors")
+        assert len(response_json.get("task_errors")) == 2
+
+        # Error message we saved was returned in the response
+        assert response_json.get("task_errors").get("task_22") == error_message
+
+        # If we did not get an error message, we return a default message
+        assert response_json.get("task_errors").get("task_23") == "No error message was provided"
 
     async def test_benchmark_error_handling(self, database_session: Session, monkeypatch: MonkeyPatch):
         """


### PR DESCRIPTION
Now we return
- tasks stopped: int (number of tasks stopped, omitted if none exist)
- task errors: dict[str, str]  | None (tasks with error's, if none exist its omitted from the response)

Updated the tests, this feature is pretty simple