### PR TITLE
Fix bug with client warnings

### DIFF
--- a/services/tracker/src/tracker/benchmark_service.py
+++ b/services/tracker/src/tracker/benchmark_service.py
@@ -24,13 +24,11 @@ class BenchmarkService:
     _name: str
     _url: str
     _environment_keys: dict[str, str]
-    _daytona_client: AsyncDaytona
 
     def __init__(self, name: str, url: str):
         self._name = name
         self._url = url
         self._environment_keys = self.daytona_keys()
-        self._daytona_client = self.create_daytona_client()
 
     @property
     def name(self) -> str:
@@ -42,7 +40,12 @@ class BenchmarkService:
 
     @property
     def daytona_client(self) -> AsyncDaytona:
-        return self._daytona_client
+        config = DaytonaConfig(
+            api_key=self.environment_keys["DAYTONA_API_KEY"],
+            api_url=self.environment_keys["DAYTONA_API_URL"],
+            target=self.environment_keys["DAYTONA_TARGET"],
+        )
+        return AsyncDaytona(config=config)
 
     @staticmethod
     def daytona_keys() -> dict[str, str]:
@@ -63,15 +66,6 @@ class BenchmarkService:
             )
 
         return environment_keys
-
-    def create_daytona_client(self) -> AsyncDaytona:
-        return AsyncDaytona(
-            config=DaytonaConfig(
-                api_key=self.environment_keys["DAYTONA_API_KEY"],
-                api_url=self.environment_keys["DAYTONA_API_URL"],
-                target=self.environment_keys["DAYTONA_TARGET"],
-            )
-        )
 
     @staticmethod
     def start_run_request_to_benchmark_object(request: StartRunRequest) -> Benchmark:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -7,7 +7,6 @@ from contextlib import asynccontextmanager
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
 
-from tracker.logger import get_logger
 from daytona import (
     AsyncDaytona,
     AsyncSandbox,
@@ -18,8 +17,9 @@ from daytona import (
 )
 
 from tracker.exceptions import SandboxError
-from tracker.types import AgentContractRequest
+from tracker.logger import get_logger
 from tracker.s3 import download_from_s3, get_contract_s3_key
+from tracker.types import AgentContractRequest
 
 logger = get_logger(__name__)
 
@@ -67,6 +67,7 @@ async def create_sandbox(
     finally:
         logger.info(f"Deleting sandbox {sandbox.name}")
         await daytona.delete(sandbox)
+        await daytona.close()
 
 
 async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest) -> None:

--- a/services/tracker/tests/integration/conftest.py
+++ b/services/tracker/tests/integration/conftest.py
@@ -21,8 +21,6 @@ async def benchmark_service() -> AsyncGenerator[BenchmarkService, None]:
 
     yield service
 
-    await service.daytona_client.close()
-
 
 @pytest.fixture
 async def daytona_client(benchmark_service: BenchmarkService) -> AsyncGenerator[AsyncDaytona, None]:


### PR DESCRIPTION
### Bug

We were creating the client on creation which was causing warnings since we were never closing it, i just simplified the code and removed the on creation issue so the warnings went away

```
[2026-01-20 21:07:52,685][httpx][INFO   ][worker-0] HTTP Request: POST http://100.53.2.33:8000/final-score/ "HTTP/1.1 200 OK"
[2026-01-20 21:07:52,695][asyncio][ERROR  ][worker-0] Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0xffff7c52ff20>
[2026-01-20 21:07:52,696][asyncio][ERROR  ][worker-0] Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0xffff7c5574d0>, 6766.466617914)])']
connector: <aiohttp.connector.TCPConnector object at 0xffff7fc52d20>
[2026-01-20 21:07:52,696][asyncio][ERROR  ][worker-0] Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0xffff7ffd27b0>
[2026-01-20 21:07:52,696][asyncio][ERROR  ][worker-0] Unclosed connector
connections: ['deque([(<aiohttp.client_proto.ResponseHandler object at 0xffff7c2fe210>, 6766.652542539)])']
connector: <aiohttp.connector.TCPConnector object at 0xffff7ffd2180>
```


### Pass case

Ran `uv run pytest tests` and they all passed


plugins: anyio-4.12.1, alembic-0.12.1, asyncio-1.3.0, env-1.2.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 34 items                                                                                                                                                                                                                                                        

```
tests/integration/test_database_integration.py ....                                                                                                                                                                                                                 [ 11%]
tests/integration/test_process_benchmark.py .....                                                                                                                                                                                                                   [ 26%]
tests/integration/test_sandbox.py ....                                                                                                                                                                                                                              [ 38%]
tests/integration/test_swebench_service.py .......                                                                                                                                                                                                                  [ 58%]
tests/unit/test_benchmark_utils.py ......                                                                                                                                                                                                                           [ 76%]
tests/unit/test_fastapi_server.py ......                                                                                                                                                                                                                            [ 94%]
tests/unit/test_tracker.py ..                                                                                                                                                                                                                                       [100%]
```
