### PR TITLE
Added cwd to the tracker

### DIFF
--- a/services/tracker/src/tracker/benchmark_service.py
+++ b/services/tracker/src/tracker/benchmark_service.py
@@ -144,7 +144,7 @@ class BenchmarkService:
 
         async with httpx.AsyncClient(timeout=None, follow_redirects=True) as client:
             response = await client.post(
-                f"{self._url}/setup-task/",
+                f"{self._url}/setup-task",
                 json={"task_id": task_id, "instance_id": instance_id},
                 headers={
                     "Content-Type": "application/json",

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -123,7 +123,9 @@ async def install_agent_dependencies(sandbox: AsyncSandbox, contract: AgentContr
     logger.info(f"Finished running installing dependencies for contract: {contract.name}")
 
 
-async def run_agent(sandbox: AsyncSandbox, contract: AgentContractRequest, problem_statement: str, task_id: str) -> str:
+async def run_agent(
+    sandbox: AsyncSandbox, contract: AgentContractRequest, problem_statement: str, task_id: str, cwd: str
+) -> str:
     """
     Run the agent inside the sandbox for a given task.
 
@@ -151,7 +153,7 @@ async def run_agent(sandbox: AsyncSandbox, contract: AgentContractRequest, probl
         await sandbox.process.create_session(session_id)
 
         session_exec_resp = await sandbox.process.execute_session_command(
-            session_id, SessionExecuteRequest(command=run_cmd, runAsync=True)
+            session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", runAsync=True)
         )
 
         cmd_id = session_exec_resp.cmd_id

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -95,6 +95,7 @@ class RetrieveTaskResponse(BaseModel):
     docker_image: str
     problem_statement: str
     request_setup: bool
+    cwd: str
 
 
 class VerifyTaskIdsResponse(BaseModel):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -213,7 +213,9 @@ async def process_task(
 
                 # Run the agent inside of the sandbox
                 # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
-                await run_agent(sandbox, start_run_request.contract, task_data.problem_statement, task_id)
+                await run_agent(
+                    sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd
+                )
 
                 # Update the status to evaluating once we finish running the agent
                 task_row.status = TaskStatus.EVALUATING

--- a/services/tracker/tests/integration/test_database_integration.py
+++ b/services/tracker/tests/integration/test_database_integration.py
@@ -313,16 +313,19 @@ class TestDatabaseIntegration:
             evaluation_results: dict[str, dict[str, Any] | None] = {}
 
             async def process_task(task_id: str) -> None:
-                async with semaphore:
-                    task_data = await benchmark_service.request_retrieve_task(task_id=task_id)
-                    task_row = task_row_mapping[task_id]
-                    evaluation_result = await self._evaluate_instance(
-                        database_session, benchmark_service, daytona_client, task_row, task_data
-                    )
-                    evaluation_result_row = await self._create_evaluation_result(
-                        database_session, task_row, evaluation_result
-                    )
-                    evaluation_results[task_id] = evaluation_result_row.result
+                try:
+                    async with semaphore:
+                        task_data = await benchmark_service.request_retrieve_task(task_id=task_id)
+                        task_row = task_row_mapping[task_id]
+                        evaluation_result = await self._evaluate_instance(
+                            database_session, benchmark_service, daytona_client, task_row, task_data
+                        )
+                        evaluation_result_row = await self._create_evaluation_result(
+                            database_session, task_row, evaluation_result
+                        )
+                        evaluation_results[task_id] = evaluation_result_row.result
+                except Exception as e:
+                    logger.error(f"Process task failed: {e}")
 
             _ = await gather(*[process_task(task_id) for task_id in task_ids])
 

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -135,7 +135,7 @@ class TestSandboxOperations:
             run_cmd=run_cmd,
         )
 
-        await run_agent(test_sandbox, contract, "some problem statement", "some task id")
+        await run_agent(test_sandbox, contract, "some problem statement", "some task id", cwd="/")
 
         output = "\n".join(logged_messages)
         assert "line1" in output

--- a/services/tracker/tests/utils.py
+++ b/services/tracker/tests/utils.py
@@ -2,7 +2,7 @@ import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from daytona import AsyncDaytona, AsyncSandbox, CreateSandboxFromImageParams, DaytonaNotFoundError, Resources
+from daytona import AsyncDaytona, AsyncSandbox, CreateSandboxFromImageParams, Resources
 
 
 async def validate_docker_image(image_name: str) -> bool:
@@ -75,5 +75,5 @@ async def build_task_environment(
                 sandbox = await daytona.get(task_id)
 
                 await daytona.delete(sandbox)
-            except DaytonaNotFoundError:
+            except Exception:
                 pass


### PR DESCRIPTION
### Main changes
- Added cwd from the benchmark service to the tracker (serves as the command work directory we execute the agent in)
- Fixed the bug with the setup-task url (was failing with the slash)
- Handle errors better in unit tests

### Usage
Add this to the `.env` 

`BENCHMARK_SERVICE_URL=https://benchmark-service.vals.ai`


### Tests
All tests pass