### PR TITLE
Task breakdown inside of CLI

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1,3 +1,4 @@
+import traceback
 from uuid import UUID
 
 from fastapi import Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
@@ -140,7 +141,7 @@ async def start_run(
             task_ids=request.task_ids, slice_str=request.slice_str
         )
     except Exception as e:
-        error_message = str(e)
+        error_message = f"{str(e)}\n{traceback.format_exc()}"
         commit_benchmark_error(benchmark_row, session, error_message)
         error_response = StartRunErrorResponse(
             benchmark_id=benchmark_row.id,

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -233,6 +233,7 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
     return RetrieveResultsResponse(
         benchmark_name=benchmark_row.name,
         status=benchmark_row.status,
+        error_message=benchmark_row.error_message,
         benchmark_id=benchmark_row.id,
         benchmark_arguments=benchmark_row.arguments,
         tasks_stopped=tasks_stopped or None,  # NOTE: Only include if we stopped the benchmark

--- a/services/tracker/src/tracker/benchmark_service.py
+++ b/services/tracker/src/tracker/benchmark_service.py
@@ -4,11 +4,10 @@ from typing import Any
 import httpx
 from daytona import AsyncDaytona, DaytonaConfig
 
-from tracker.database.models import Benchmark
+from tracker.database.models import Benchmark, BenchmarkArguments
 from tracker.exceptions import BenchmarkServiceError
 from tracker.logger import get_logger
 from tracker.types import (
-    BenchmarkArguments,
     FinalScoreResponse,
     HealthCheckResponse,
     RetrieveTaskResponse,

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -15,6 +15,7 @@ from tracker.database.models import (
     BenchmarkArguments,
     BenchmarkStatus,
     FinalEvaluation,
+    TaskStatus,
 )
 
 if TYPE_CHECKING:
@@ -26,6 +27,7 @@ class BenchmarkDetails(BaseModel):
     started_at: datetime
     total_tasks: int
     finished_tasks: int
+    task_breakdown: dict[TaskStatus, int]
 
 
 class StartRunRequest(BaseModel):

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -67,12 +67,13 @@ class FetchBenchmarkResponse(BaseModel):
 class RetrieveResultsResponse(BaseModel):
     benchmark_name: str
     status: BenchmarkStatus
+    error_message: str | None
     benchmark_id: UUID
     benchmark_arguments: BenchmarkArguments
-    tasks_stopped: int | None = None
-    final_evaluation: FinalEvaluation | None = None
-    evaluation_results: dict[str, dict[str, Any]] | None = None
-    task_errors: dict[str, str] | None = None
+    tasks_stopped: int | None
+    final_evaluation: FinalEvaluation | None
+    evaluation_results: dict[str, dict[str, Any]] | None
+    task_errors: dict[str, str] | None
 
 
 class FinalScoreResponse(BaseModel):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import json
+import traceback
 from asyncio import Semaphore, gather
 from collections.abc import AsyncGenerator, Coroutine
 from datetime import datetime
@@ -377,7 +378,7 @@ async def process_benchmark(
 
             set_benchmark_final_status(benchmark_row, session)
         except Exception as e:
-            error_message = str(e)
+            error_message = f"{str(e)}\n{traceback.format_exc()}"
             commit_benchmark_error(benchmark_row, session, error_message)
 
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -401,7 +401,7 @@ class BenchmarkContext:
 
     @cached_property
     def _task_counts(self) -> TaskCounts:
-        finished_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR]
+        finished_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
 
         statement = (
             select(
@@ -419,6 +419,30 @@ class BenchmarkContext:
 
         return task_counts
 
+    @property
+    def _task_breakdown(self) -> dict[TaskStatus, int]:
+        """
+        Returns a mapping between the task status and the number of tasks in that status
+
+        Provides a breakdown of the benchmark.
+        """
+        statement = (
+            select(Task.status, func.count(col(Task.id)))
+            .select_from(Task)
+            .where(Task.benchmark == self._benchmark_row.id)
+            .group_by(Task.status)
+            .having(func.count(col(Task.id)) > 0)  # Exclude all with count of 0
+        )
+
+        result = self._session.exec(statement).all()
+
+        if not result:
+            raise TrackerServiceError(
+                f"No tasks have been discovered for benchmark {self._benchmark_row.id}, cannot provide task breakdown"
+            )
+
+        return {TaskStatus(status): count for status, count in result}
+
     @cached_property
     def benchmark_details(self) -> BenchmarkDetails:
         return BenchmarkDetails(
@@ -426,6 +450,7 @@ class BenchmarkContext:
             started_at=self._benchmark_row.started_at,
             total_tasks=self._task_counts.total_tasks,
             finished_tasks=self._task_counts.finished_tasks,
+            task_breakdown=self._task_breakdown,
         )
 
 

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -406,7 +406,7 @@ class TestFastapiServer:
         # benchmark id and error message are included in the response
         assert detail
         assert detail.get("benchmark_id")
-        assert detail.get("error_message") == "Error verifying task ids"
+        assert "Error verifying task ids" in detail.get("error_message")
 
         # Test case 2. Benchmark row is marked as error and error message is set
         benchmark_row = database_session.get(Benchmark, UUID(detail.get("benchmark_id")))

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -54,17 +54,15 @@ class BenchmarkFormatter:
         return bar, progress_pct
 
     @staticmethod
-    def format_task_breakdown(task_breakdown: dict[TaskStatus, int]) -> str | None:
+    def format_task_breakdown(task_breakdown: dict[TaskStatus, int]) -> str:
         """
         Format task breakdown with colored status counts.
 
         Returns:
             Formatted string with colored task counts
         """
-        if not task_breakdown:
-            return None
 
-        # Define status order: starting, in progress, evaluation, error, stopped, finished
+        # Order we display statuses in
         status_order = [
             TaskStatus.STARTING,
             TaskStatus.IN_PROGRESS,
@@ -77,11 +75,10 @@ class BenchmarkFormatter:
         parts: list[str] = []
         for status in status_order:
             count = task_breakdown.get(status, 0)
-            if count > 0:
-                color = BenchmarkFormatter.fetch_status_color(status.value)
-                label = status.value.replace("_", " ").title()
-                colored_part = click.style(f"{label}: {count}", fg=color)
-                parts.append(colored_part)
+            color = BenchmarkFormatter.fetch_status_color(status.value)
+            label = status.value.replace("_", " ").title()
+            colored_part = click.style(f"{label}: {count}", fg=color)
+            parts.append(colored_part)
 
         return f"│ {' │ '.join(parts)} │" if parts else ""
 
@@ -133,8 +130,7 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     click.echo(f"[{bar}] {finished_tasks}/{total_tasks} ({progress_pct:.1f}%) • {status_text}")
 
     breakdown_text = BenchmarkFormatter.format_task_breakdown(details.task_breakdown)
-    if breakdown_text:
-        click.echo(f"  {breakdown_text}")
+    click.echo(f"  {breakdown_text}")
 
 
 def format_start_run_response(start_run_response: StartRunResponse) -> None:
@@ -211,10 +207,7 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None
                 )
                 breakdown_text = BenchmarkFormatter.format_task_breakdown(details.task_breakdown)
 
-                if breakdown_text:
-                    click.echo(f"\r\033[K{progress_line}\n  {breakdown_text}\033[F", nl=False)
-                else:
-                    click.echo(f"\r\033[K{progress_line}", nl=False)
+                click.echo(f"\r\033[K{progress_line}\n  {breakdown_text}\033[F", nl=False)
 
             elif event.startswith("event: complete"):
                 click.echo("\n")

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -134,7 +134,7 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     click.echo(f"[{bar}] {finished_tasks}/{total_tasks} ({progress_pct:.1f}%) • {status_text}")
 
     breakdown_text = BenchmarkFormatter.format_task_breakdown(details.task_breakdown)
-    click.echo(f"  {breakdown_text}")
+    click.echo(breakdown_text)
 
 
 def format_start_run_response(start_run_response: StartRunResponse) -> None:
@@ -211,7 +211,7 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None
                 )
                 breakdown_text = BenchmarkFormatter.format_task_breakdown(details.task_breakdown)
 
-                click.echo(f"\r\033[K{progress_line}\n  {breakdown_text}\033[F", nl=False)
+                click.echo(f"\r\033[K{progress_line}\n{breakdown_text}\033[F", nl=False)
 
             elif event.startswith("event: complete"):
                 click.echo("\n")

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -75,6 +75,10 @@ class BenchmarkFormatter:
         parts: list[str] = []
         for status in status_order:
             count = task_breakdown.get(status, 0)
+
+            if count == 0:
+                continue
+
             color = BenchmarkFormatter.fetch_status_color(status.value)
             label = status.value.replace("_", " ").title()
             colored_part = click.style(f"{label}: {count}", fg=color)

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -4,7 +4,7 @@ import json
 from uuid import UUID
 
 import click
-from tracker.database.models import BenchmarkStatus
+from tracker.database.models import BenchmarkStatus, TaskStatus
 from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
@@ -18,12 +18,24 @@ from agentic_harness.cli.tracker_service import TrackerService
 
 class BenchmarkFormatter:
     @staticmethod
-    def get_status_color(status_value: str) -> str:
+    def fetch_status_color(status_value: str) -> str:
+        """
+        Get color for a status value string.
+        NOTE: Used for both benchmark and task statuses, thats why we pass in a string value instead of using an enum.
+
+        Args:
+            status_value: Status value as string (e.g., "in_progress", "finished")
+
+        Returns:
+            Color name for the status
+        """
         status_colors = {
+            "starting": "yellow",
             "in_progress": "blue",
+            "evaluating": "magenta",
             "stopping": "magenta",
             "stopped": "cyan",
-            "finished": "cyan",
+            "finished": "green",
             "error": "red",
         }
         return status_colors.get(status_value, "white")
@@ -40,6 +52,38 @@ class BenchmarkFormatter:
         filled_width = int(bar_width * progress_pct / 100)
         bar = "█" * filled_width + "░" * (bar_width - filled_width)
         return bar, progress_pct
+
+    @staticmethod
+    def format_task_breakdown(task_breakdown: dict[TaskStatus, int]) -> str | None:
+        """
+        Format task breakdown with colored status counts.
+
+        Returns:
+            Formatted string with colored task counts
+        """
+        if not task_breakdown:
+            return None
+
+        # Define status order: starting, in progress, evaluation, error, stopped, finished
+        status_order = [
+            TaskStatus.STARTING,
+            TaskStatus.IN_PROGRESS,
+            TaskStatus.EVALUATING,
+            TaskStatus.ERROR,
+            TaskStatus.STOPPED,
+            TaskStatus.FINISHED,
+        ]
+
+        parts: list[str] = []
+        for status in status_order:
+            count = task_breakdown.get(status, 0)
+            if count > 0:
+                color = BenchmarkFormatter.fetch_status_color(status.value)
+                label = status.value.replace("_", " ").title()
+                colored_part = click.style(f"{label}: {count}", fg=color)
+                parts.append(colored_part)
+
+        return f"│ {' │ '.join(parts)} │" if parts else ""
 
 
 def check_tracker_service_health(tracker: TrackerService) -> bool:
@@ -78,7 +122,7 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     finished_tasks = details.finished_tasks
 
     bar, progress_pct = BenchmarkFormatter.create_progress_bar(finished_tasks, total_tasks)
-    status_color = BenchmarkFormatter.get_status_color(status.value)
+    status_color = BenchmarkFormatter.fetch_status_color(status.value)
 
     click.echo(f"{click.style('Benchmark:', bold=True)} {benchmark_name}")
     click.echo(f"{click.style('Started at:', bold=True)} {started_at}")
@@ -87,6 +131,10 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
 
     status_text = click.style(status.value.replace("_", " ").title(), fg=status_color, bold=True)
     click.echo(f"[{bar}] {finished_tasks}/{total_tasks} ({progress_pct:.1f}%) • {status_text}")
+
+    breakdown_text = BenchmarkFormatter.format_task_breakdown(details.task_breakdown)
+    if breakdown_text:
+        click.echo(f"  {breakdown_text}")
 
 
 def format_start_run_response(start_run_response: StartRunResponse) -> None:
@@ -155,13 +203,18 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None
                 details = response.details
 
                 bar, progress_pct = BenchmarkFormatter.create_progress_bar(details.finished_tasks, details.total_tasks)
-                status_color = BenchmarkFormatter.get_status_color(details.status.value)
+                status_color = BenchmarkFormatter.fetch_status_color(details.status.value)
                 status_text = click.style(details.status.value.replace("_", " ").title(), fg=status_color, bold=True)
 
-                click.echo(
-                    f"\r\033[K[{bar}] {details.finished_tasks}/{details.total_tasks} ({progress_pct:.1f}%) • {status_text}",
-                    nl=False,
+                progress_line = (
+                    f"[{bar}] {details.finished_tasks}/{details.total_tasks} ({progress_pct:.1f}%) • {status_text}"
                 )
+                breakdown_text = BenchmarkFormatter.format_task_breakdown(details.task_breakdown)
+
+                if breakdown_text:
+                    click.echo(f"\r\033[K{progress_line}\n  {breakdown_text}\033[F", nl=False)
+                else:
+                    click.echo(f"\r\033[K{progress_line}", nl=False)
 
             elif event.startswith("event: complete"):
                 click.echo("\n")
@@ -226,7 +279,7 @@ def format_fetch_benchmarks_response(
 
     for benchmark in benchmarks:
         _, progress_percentage = BenchmarkFormatter.create_progress_bar(benchmark.finished_tasks, benchmark.total_tasks)
-        status_color = BenchmarkFormatter.get_status_color(benchmark.status.value)
+        status_color = BenchmarkFormatter.fetch_status_color(benchmark.status.value)
         status_display = benchmark.status.value.replace("_", " ").title()
 
         click.echo(

--- a/uv.lock
+++ b/uv.lock
@@ -191,6 +191,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/cc/aca263693b2ece99fa99a09b6d092acb89973eb2bb575faef1777e04f8b4/alembic-1.18.1.tar.gz", hash = "sha256:83ac6b81359596816fb3b893099841a0862f2117b2963258e965d70dc62fb866", size = 2044319, upload-time = "2026-01-14T18:53:14.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/36/cd9cb6101e81e39076b2fbe303bfa3c85ca34e55142b0324fcbf22c5c6e2/alembic-1.18.1-py3-none-any.whl", hash = "sha256:f1c3b0920b87134e851c25f1f7f236d8a332c34b75416802d06971df5d1b7810", size = 260973, upload-time = "2026-01-14T18:53:17.533Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1383,6 +1397,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/f0/962ba77fae91ad0cca2ead4fb0ff5aa00f9793c1a78cd807672f9e5a9aa3/liccheck-0.9.2.tar.gz", hash = "sha256:bdc2190f8e95af3c8f9c19edb784ba7d41ecb2bf9189422eae6112bf84c08cd5", size = 16020, upload-time = "2023-09-22T14:23:59.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/bb/fbc7dd6ea215b97b90c35efc8c8f3dbfcbacb91af8c806dff1f49deddd8e/liccheck-0.9.2-py2.py3-none-any.whl", hash = "sha256:15cbedd042515945fe9d58b62e0a5af2f2a7795def216f163bb35b3016a16637", size = 13652, upload-time = "2023-09-22T14:23:57.849Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
 ]
 
 [[package]]
@@ -2966,6 +2992,7 @@ name = "tracker"
 version = "0.1.0"
 source = { editable = "services/tracker" }
 dependencies = [
+    { name = "alembic" },
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["s3"] },
     { name = "daytona" },
@@ -2979,6 +3006,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.18.1" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "daytona", specifier = ">=0.128.1" },
@@ -2994,6 +3022,7 @@ requires-dist = [
 dev = [
     { name = "basedpyright" },
     { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest-alembic", specifier = ">=0.12.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "ruff" },


### PR DESCRIPTION
### Main changes
- Added error message from benchmark row to results json in case it errors out
- Added task breakdown field and displayed it for streaming and non-streaming endpoint
- Simplified the RetrieveResultsResponse (No need to set defaults anymore)
- Fixed import bug, for some reason benchmark args were not imported correctly
- Added stopped task as a finished state to task count property
- Added traceback to benchmark error
- Consolidated colors for benchmark and task statuses
- Updated unit test since it now has traceback inside


### Images
<img width="463" height="165" alt="image" src="https://github.com/user-attachments/assets/06f2b67b-d204-41b4-869b-ee284b008906" />


### Feature Importance
We need to have a way to see the counts to visually confirm progression and see if any error out while the benchmark is running. We can include more details inside of a task specific table that we can add in the future. For now the counts are enough