### PR TITLE
Force stop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ uv run harness retrieve-results --benchmark-id <benchmark_id> --path ./results.j
 uv run harness stop-run --benchmark-id <benchmark_id>
 ```
 
+Flags
+```
+--force: Force stops all tasks in progress or evaluating (default: false)
+```
+
+
 #### Resume a benchmark
 
 ```bash

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -270,7 +270,7 @@ async def stop_run(
             detail=f"Benchmark {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress benchmark.",
         )
 
-    await stop_benchmark(benchmark_row, session)
+    await stop_benchmark(benchmark_row, session, force)
 
     if force:
         await force_stop_sandboxes(benchmark_row, session)

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -28,6 +28,7 @@ from tracker.utils import (
     BenchmarkContext,
     commit_benchmark_error,
     fetch_filtered_benchmark_rows,
+    force_stop_sandboxes,
     process_benchmark,
     resume_benchmark,
     stop_benchmark,
@@ -245,12 +246,15 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
 
 
 @app.post("/stop-run/{benchmark_id}")
-async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) -> StopRunResponse:
+async def stop_run(
+    benchmark_id: UUID, force: bool = Query(default=False), session: Session = Depends(get_session)
+) -> StopRunResponse:
     """
     Stop a benchmark run by its id.
+    If force is True, the sandboxes will be stopped and deleted, even if the tasks are in progress.
 
     Usage:
-    curl -X POST http://<endpoint>/stop-run/<benchmark_id>
+    curl -X POST http://<endpoint>/stop-run/<benchmark_id>?force=true
 
     Returns:
         StopRunResponse
@@ -267,6 +271,9 @@ async def stop_run(benchmark_id: UUID, session: Session = Depends(get_session)) 
         )
 
     await stop_benchmark(benchmark_row, session)
+
+    if force:
+        await force_stop_sandboxes(benchmark_row, session)
 
     return StopRunResponse(
         status="success",

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "boto3-stubs[s3]",
     "moto[s3]",
     "fastapi[standard]>=0.127.1",
-    "daytona>=0.128.1",
+    "daytona>=0.135.0",
     "sqlmodel>=0.0.31",
     "httpx>=0.28.1",
     "taskiq>=0.12.1",

--- a/services/tracker/src/tracker/benchmark_service.py
+++ b/services/tracker/src/tracker/benchmark_service.py
@@ -23,6 +23,7 @@ class BenchmarkService:
     _name: str
     _url: str
     _environment_keys: dict[str, str]
+    _daytona_client: AsyncDaytona | None = None
 
     def __init__(self, name: str, url: str):
         self._name = name
@@ -39,12 +40,18 @@ class BenchmarkService:
 
     @property
     def daytona_client(self) -> AsyncDaytona:
+        if self._daytona_client:
+            return self._daytona_client
+
         config = DaytonaConfig(
             api_key=self.environment_keys["DAYTONA_API_KEY"],
             api_url=self.environment_keys["DAYTONA_API_URL"],
             target=self.environment_keys["DAYTONA_TARGET"],
         )
-        return AsyncDaytona(config=config)
+
+        self._daytona_client = AsyncDaytona(config=config)
+
+        return self._daytona_client
 
     @staticmethod
     def daytona_keys() -> dict[str, str]:

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -22,10 +22,10 @@ from sqlmodel import (
     select,
 )
 
-from tracker.benchmark_service import BenchmarkService
 from tracker.database.utils import has_field_changed
 
 if TYPE_CHECKING:
+    from tracker.benchmark_service import BenchmarkService
     from tracker.types import BenchmarkTableRow, StartRunRequest
 
 
@@ -161,7 +161,7 @@ class Benchmark(SQLModel, table=True):
         )
 
     @property
-    def benchmark_service(self) -> BenchmarkService:
+    def benchmark_service(self) -> "BenchmarkService":
         return self.start_run_request.benchmark_service
 
     def create_benchmark_table_row(self, session: Session) -> "BenchmarkTableRow":

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel, computed_field, field_serializer
 from sqlalchemy import Connection, Dialect, event
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -22,6 +22,7 @@ from sqlmodel import (
     select,
 )
 
+from tracker.benchmark_service import BenchmarkService
 from tracker.database.utils import has_field_changed
 
 if TYPE_CHECKING:
@@ -159,6 +160,10 @@ class Benchmark(SQLModel, table=True):
             slice_str=self.arguments.slice_str,
         )
 
+    @property
+    def benchmark_service(self) -> BenchmarkService:
+        return self.start_run_request.benchmark_service
+
     def create_benchmark_table_row(self, session: Session) -> "BenchmarkTableRow":
         """
         Creates a benchmark table row object used to display the current data from this benchmark row.
@@ -233,6 +238,12 @@ class Task(SQLModel, table=True):
     error_message: str | None = Field(default=None)
     finished_at: datetime | None = None
     benchmark: UUID = Field(foreign_key="benchmark.id")
+
+    @computed_field
+    @property
+    def alias(self) -> str:
+        """Unique alias for the task that is used to uniquely identify the same task when creating sandboxes"""
+        return f"{self.task_id}_{self.id.hex[:5]}"
 
 
 @event.listens_for(Task, "before_insert")

--- a/services/tracker/src/tracker/exceptions.py
+++ b/services/tracker/src/tracker/exceptions.py
@@ -14,12 +14,6 @@ class SandboxError(TrackerServiceError):
         return "Sandbox error: " + super().__str__()
 
 
-class SandboxDestroyedError(SandboxError):
-    """Exception raised for when a sandbox has been destroyed"""
-
-    pass
-
-
 class BenchmarkServiceError(TrackerServiceError):
     """Exception raised for benchmark service communication errors."""
 

--- a/services/tracker/src/tracker/exceptions.py
+++ b/services/tracker/src/tracker/exceptions.py
@@ -14,6 +14,12 @@ class SandboxError(TrackerServiceError):
         return "Sandbox error: " + super().__str__()
 
 
+class SandboxDestroyedError(SandboxError):
+    """Exception raised for when a sandbox has been destroyed"""
+
+    pass
+
+
 class BenchmarkServiceError(TrackerServiceError):
     """Exception raised for benchmark service communication errors."""
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -159,34 +159,31 @@ async def run_agent(
 
     session_id = f"{contract.name}-{task_id.replace(' ', '_')}"
 
-    try:
-        await sandbox.process.create_session(session_id)
+    await sandbox.process.create_session(session_id)
 
-        session_exec_resp = await sandbox.process.execute_session_command(
-            session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", run_async=True)
+    session_exec_resp = await sandbox.process.execute_session_command(
+        session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", run_async=True)
+    )
+
+    cmd_id = session_exec_resp.cmd_id
+
+    if not cmd_id:
+        raise SandboxError(f"Failed to execute command {run_cmd} in session {session_id}")
+
+    log_task = asyncio.create_task(
+        sandbox.process.get_session_command_logs_async(
+            session_id=session_id,
+            command_id=cmd_id,
+            on_stdout=on_data,
+            on_stderr=on_data,
         )
+    )
 
-        cmd_id = session_exec_resp.cmd_id
+    await log_task
 
-        if not cmd_id:
-            raise SandboxError(f"Failed to execute command {run_cmd} in session {session_id}")
+    cmd = await sandbox.process.get_session_command(session_id, cmd_id)
 
-        log_task = asyncio.create_task(
-            sandbox.process.get_session_command_logs_async(
-                session_id=session_id,
-                command_id=cmd_id,
-                on_stdout=on_data,
-                on_stderr=on_data,
-            )
-        )
+    if cmd.exit_code != 0:
+        raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
 
-        await log_task
-
-        cmd = await sandbox.process.get_session_command(session_id, cmd_id)
-
-        if cmd.exit_code != 0:
-            raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
-
-        return ""
-    finally:
-        await sandbox.process.delete_session(session_id)
+    return ""

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -13,7 +13,6 @@ from daytona import (
     AsyncSandbox,
     CreateSandboxFromImageParams,
     FileUpload,
-    Image,
     Resources,
     SessionExecuteRequest,
 )
@@ -41,22 +40,20 @@ async def create_sandbox(
     daytona: AsyncDaytona,
     sandbox_name: str,
     image: str,
-    hash_suffix: str | None = None,
+    labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
 ) -> AsyncGenerator[AsyncSandbox, Any]:
     """
-    Create a sandbox with the given name and image.
+    Create a sandbox with the given name, image, and labels.
     Automatically cleans up the sandbox when the context manager exits.
     """
     logger.info(f"Creating sandbox {sandbox_name} with image {image}")
 
-    if hash_suffix:
-        sandbox_name = f"{sandbox_name}-{hash_suffix}"
-
     sandbox = await daytona.create(
         CreateSandboxFromImageParams(
             name=sandbox_name,
-            image=Image.base(image),
+            labels=labels,
+            image=image,
             network_block_all=False,
             resources=Resources(
                 cpu=4,

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -14,6 +14,7 @@ from daytona import (
     CreateSandboxFromImageParams,
     FileUpload,
     Resources,
+    SandboxState,
     SessionExecuteRequest,
 )
 
@@ -68,9 +69,9 @@ async def create_sandbox(
     try:
         yield sandbox
     finally:
-        logger.info(f"Deleting sandbox {sandbox.name}")
-        await daytona.delete(sandbox)
-        await daytona.close()
+        await sandbox.refresh_data()
+        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+            await daytona.delete(sandbox)
 
 
 async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest) -> None:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -159,31 +159,38 @@ async def run_agent(
 
     session_id = f"{contract.name}-{task_id.replace(' ', '_')}"
 
-    await sandbox.process.create_session(session_id)
+    try:
+        await sandbox.process.create_session(session_id)
 
-    session_exec_resp = await sandbox.process.execute_session_command(
-        session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", run_async=True)
-    )
-
-    cmd_id = session_exec_resp.cmd_id
-
-    if not cmd_id:
-        raise SandboxError(f"Failed to execute command {run_cmd} in session {session_id}")
-
-    log_task = asyncio.create_task(
-        sandbox.process.get_session_command_logs_async(
-            session_id=session_id,
-            command_id=cmd_id,
-            on_stdout=on_data,
-            on_stderr=on_data,
+        session_exec_resp = await sandbox.process.execute_session_command(
+            session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", run_async=True)
         )
-    )
 
-    await log_task
+        cmd_id = session_exec_resp.cmd_id
 
-    cmd = await sandbox.process.get_session_command(session_id, cmd_id)
+        if not cmd_id:
+            raise SandboxError(f"Failed to execute command {run_cmd} in session {session_id}")
 
-    if cmd.exit_code != 0:
-        raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
+        log_task = asyncio.create_task(
+            sandbox.process.get_session_command_logs_async(
+                session_id=session_id,
+                command_id=cmd_id,
+                on_stdout=on_data,
+                on_stderr=on_data,
+            )
+        )
 
-    return ""
+        await log_task
+
+        cmd = await sandbox.process.get_session_command(session_id, cmd_id)
+
+        if cmd.exit_code != 0:
+            raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
+
+        return ""
+    finally:
+        try:
+            await sandbox.process.delete_session(session_id)
+        except Exception:
+            # NOTE: If we kill the sandbox this sometimes errors
+            pass

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -12,6 +12,7 @@ from daytona import (
     AsyncDaytona,
     AsyncSandbox,
     CreateSandboxFromImageParams,
+    DaytonaNotFoundError,
     FileUpload,
     Resources,
     SandboxState,
@@ -69,9 +70,15 @@ async def create_sandbox(
     try:
         yield sandbox
     finally:
-        await sandbox.refresh_data()
-        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-            await daytona.delete(sandbox)
+        try:
+            await sandbox.refresh_data()
+            if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+                await daytona.delete(sandbox)
+        except DaytonaNotFoundError:
+            # If we error here that means the sandbox has just been deleted before we could refresh the state
+            pass
+        except Exception as e:
+            logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
 
 
 async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest) -> None:
@@ -151,7 +158,7 @@ async def run_agent(
         await sandbox.process.create_session(session_id)
 
         session_exec_resp = await sandbox.process.execute_session_command(
-            session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", runAsync=True)
+            session_id, SessionExecuteRequest(command=f"cd {cwd} && {run_cmd}", run_async=True)
         )
 
         cmd_id = session_exec_resp.cmd_id

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -37,6 +37,19 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
     return bundle_path / contract_name
 
 
+async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
+    """Delete sandbox if it is not already destroyed or being destroyed"""
+    try:
+        await sandbox.refresh_data()
+        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+            await daytona.delete(sandbox)
+    except DaytonaNotFoundError:
+        # If we error here that means the sandbox has just been deleted before we could refresh the state
+        pass
+    except Exception as e:
+        logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
+
+
 @asynccontextmanager
 async def create_sandbox(
     daytona: AsyncDaytona,
@@ -70,15 +83,7 @@ async def create_sandbox(
     try:
         yield sandbox
     finally:
-        try:
-            await sandbox.refresh_data()
-            if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-                await daytona.delete(sandbox)
-        except DaytonaNotFoundError:
-            # If we error here that means the sandbox has just been deleted before we could refresh the state
-            pass
-        except Exception as e:
-            logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
+        await delete_sandbox(sandbox, daytona)
 
 
 async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest) -> None:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -19,10 +19,10 @@ from daytona import (
     SessionExecuteRequest,
 )
 
+from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SandboxError
 from tracker.logger import get_logger
 from tracker.s3 import download_from_s3, get_contract_s3_key
-from tracker.types import AgentContractRequest
 
 logger = get_logger(__name__)
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -45,6 +45,7 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
             await daytona.delete(sandbox)
     except DaytonaNotFoundError:
         # If we error here that means the sandbox has just been deleted before we could refresh the state
+        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
         pass
     except Exception as e:
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
@@ -193,4 +194,5 @@ async def run_agent(
             await sandbox.process.delete_session(session_id)
         except Exception:
             # NOTE: If we kill the sandbox this sometimes errors
+            logger.error(f"Caught failure to delete session `{session_id}`")
             pass

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import hashlib
 import json
 import traceback
 from asyncio import Semaphore, gather
@@ -11,6 +10,9 @@ from typing import Any, NamedTuple, Sequence
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
+from daytona import AsyncSandbox
+from daytona._async.daytona import AsyncDaytona
+from daytona._async.sandbox import AsyncPaginatedSandboxes
 from sqlmodel import Session, asc, case, col, desc, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
@@ -192,17 +194,18 @@ async def process_task(
             task_session.add(task_row)
             task_session.commit()
 
-            # Generate a hash suffix shared across all tasks in a single benchmark to ensure that you can run more than one benchmark at a time
-            hash_suffix = hashlib.md5(
-                f"{benchmark_row.id}-{benchmark_row.started_at.isoformat()}".encode()
-            ).hexdigest()[:5]
+            labels = {
+                "Benchmark": benchmark_row.name,
+                "Id": str(benchmark_row.id),
+                "Task": task_row.task_id,
+            }
 
             async with create_sandbox(
-                benchmark_service.daytona_client,
-                task_row.task_id,
-                task_data.docker_image,
-                hash_suffix,
-                start_run_request.contract.env,
+                daytona=benchmark_service.daytona_client,
+                sandbox_name=task_row.alias,
+                image=task_data.docker_image,
+                labels=labels,
+                env_vars=start_run_request.contract.env,
             ) as sandbox:
                 # Upload the contract to the sandbox after creating and install the dependencies
                 await upload_agent_artifacts(sandbox, start_run_request.contract)
@@ -576,6 +579,93 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
         raise
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error stopping benchmark {benchmark_row.id}: {str(e)}") from e
+
+
+async def stop_sandbox(
+    sandbox: AsyncSandbox, daytona_client: AsyncDaytona, session: Session, task_id: str | None
+) -> str | None:
+    try:
+        # Wait for the sandbox to be in a valid deletion state
+        await sandbox.wait_for_sandbox_start(timeout=0)
+
+        # Delete the sandbox
+        await daytona_client.delete(sandbox)
+
+        # Only update the task row if it is still in progress
+        if task_id:
+            session.exec(update(Task).where(col(Task.id) == task_id).values(status=TaskStatus.STOPPED))
+            session.commit()
+
+        return None
+    except Exception as e:
+        return f"{str(e)}: {traceback.format_exc()}"
+
+
+async def sandbox_generator(benchmark_row: Benchmark) -> AsyncGenerator[AsyncSandbox, None]:
+    """
+    Generator that yields all sandboxes for a given benchmark in paginated chunks of 10.
+    """
+    daytona_client: AsyncDaytona = benchmark_row.benchmark_service.daytona_client
+
+    async def fetch_sandboxes(page: int) -> AsyncPaginatedSandboxes:
+        return await daytona_client.list(
+            labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page
+        )
+
+    paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(1)
+
+    total_pages = paginated_sandboxes.total_pages
+    while paginated_sandboxes.page < total_pages:
+        sandboxes = paginated_sandboxes.items
+        for sandbox in sandboxes:
+            yield sandbox
+
+        paginated_sandboxes = await fetch_sandboxes(int(paginated_sandboxes.page) + 1)
+
+
+async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> None:
+    """
+    Stops and deletes all sandboxes which are in progress or evaluating.
+    NOTE: If task is not in progress but sandbox exists, we kill it and leave the task status as is.
+
+    Raises:
+        TrackerServiceError: If there are any errors stopping the sandboxes
+    """
+    daytona_client: AsyncDaytona = benchmark_row.benchmark_service.daytona_client
+    try:
+        # Create a mapping between all task primary key id and their task_id (that are pending or evaluating)
+        task_rows: Sequence[Task] = session.exec(
+            select(Task)
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.status).in_([TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
+        ).all()
+
+        # Create a mapping upfront that we can use to update the task rows after stopping the sandboxes
+        task_metadata: dict[str, str] = {task.alias: str(task.id) for task in task_rows}
+
+        # Iterate through each running sandbox and stop it, collecting erorr messages
+        results: dict[str, str | None] = {}
+        async for sandbox in sandbox_generator(benchmark_row):
+            # If task id does not exist, the task is finished and we can just close the sandbox
+            # Edge case where the sandbox is hanging
+            task_id = task_metadata.get(sandbox.name)
+            result = await stop_sandbox(sandbox, daytona_client, session, task_id)
+
+            results[sandbox.name] = result
+
+        error_mapping: dict[str, str] = {}
+        for sandbox_name, error_message in results.items():
+            if error_message:
+                error_mapping[sandbox_name] = error_message
+
+        if error_mapping:
+            error_message = "\n".join(
+                [f"{task_alias}: {error_message}" for task_alias, error_message in error_mapping.items()]
+            )
+
+            raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
+    finally:
+        await daytona_client.close()
 
 
 async def resume_benchmark(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -565,7 +565,7 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
                     yield EVENT_COMPLETE
                     break
 
-            await asyncio.sleep(60)
+            await asyncio.sleep(5)
 
     except asyncio.CancelledError:
         logger.info(f"Client disconnected from benchmark {benchmark_id} stream")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -10,16 +10,14 @@ from typing import Any, NamedTuple, Sequence
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from daytona import AsyncSandbox
-from daytona._async.daytona import AsyncDaytona
-from daytona._async.sandbox import AsyncPaginatedSandboxes
+from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from sqlmodel import Session, asc, case, col, desc, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.config import broker
 from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
-from tracker.exceptions import TrackerServiceError
+from tracker.exceptions import SandboxDestroyedError, TrackerServiceError
 from tracker.logger import get_logger
 from tracker.sandbox import create_sandbox, install_agent_dependencies, run_agent, upload_agent_artifacts
 from tracker.types import (
@@ -27,6 +25,7 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     Order,
+    RetrieveTaskResponse,
     StartRunRequest,
 )
 
@@ -170,6 +169,76 @@ def handle_early_exit(task_row: Task, task_session: Session) -> None:
     task_session.commit()
 
 
+async def monitor_sandbox(sandbox: AsyncSandbox) -> None:
+    """
+    Monitors a sandbox until its been destroyed
+
+    Raises:
+        SandboxDestroyedError: If the sandbox has been destroyed
+    """
+    while True:
+        await sandbox.refresh_data()
+
+        if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+            raise SandboxDestroyedError("Sandbox has been destroyed")
+
+        await asyncio.sleep(1)
+
+
+async def run_task(
+    task_row: Task,
+    start_run_request: StartRunRequest,
+    benchmark_service: BenchmarkService,
+    task_session: Session,
+    task_id: str,
+    sandbox: AsyncSandbox,
+    task_data: RetrieveTaskResponse,
+) -> dict[str, dict[str, Any] | None]:
+    """
+    Runs a task and returns the evaluation result
+
+    Exceptions should be propagated up one level where they are handled
+    """
+
+    task_row = task_session.merge(task_row)
+    task_row.status = TaskStatus.IN_PROGRESS
+    task_session.add(task_row)
+    task_session.commit()
+
+    # Upload the contract to the sandbox after creating and install the dependencies
+    await upload_agent_artifacts(sandbox, start_run_request.contract)
+    await install_agent_dependencies(sandbox, start_run_request.contract)
+
+    # Setup task if requested
+    if task_data.request_setup:
+        _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
+
+    # Run the agent inside of the sandbox
+    # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
+    await run_agent(sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd)
+
+    # Update the status to evaluating once we finish running the agent
+    task_row.status = TaskStatus.EVALUATING
+    task_session.add(task_row)
+    task_session.commit()
+
+    # Evaluate the instance
+    # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
+    logger.info(f"Evaluating agent {start_run_request.contract.name} in sandbox {sandbox.name}")
+    evaluation_result = await benchmark_service.request_evaluate_instance(task_row.task_id, sandbox.id)
+
+    # Save the evaluation result to the database with the task row
+    evaluation_result_row = EvaluationResult(task=task_row.id, instance_id=sandbox.id, result=evaluation_result)
+    task_session.add(evaluation_result_row)
+
+    # Mark the task status as finished since we have finished processing the task
+    task_row.status = TaskStatus.FINISHED
+    task_session.add(task_row)
+    task_session.commit()
+
+    return {task_id: evaluation_result_row.result}
+
+
 async def process_task(
     task_row: Task,
     start_run_request: StartRunRequest,
@@ -177,6 +246,21 @@ async def process_task(
     benchmark_id: UUID,
     task_id: str,
 ) -> dict[str, dict[str, Any] | None]:
+    """
+    Processes a task and returns the evaluation result
+
+    NOTE: We run the task and sandbox monitor at the same time,
+    if the sandbox is destroyed before the task is completed we propagate the error up and end the task early.
+
+
+    Returns:
+        A dictionary with the task id as the key and the evaluation result as the value, or None if the task was stopped early (not forced)
+
+    Raises:
+        SandboxDestroyedError: If the sandbox has been destroyed intentionally
+        TrackerServiceError: If the result is not the expected type
+        Exception: Unexpected error occured that was not handled
+    """
     with Session(bind=engine, expire_on_commit=False) as task_session:
         benchmark_row = fetch_benchmark_row(benchmark_id, task_session)
 
@@ -187,11 +271,6 @@ async def process_task(
 
         try:
             task_data = await benchmark_service.request_retrieve_task(task_id=task_id)
-
-            task_row = task_session.merge(task_row)
-            task_row.status = TaskStatus.IN_PROGRESS
-            task_session.add(task_row)
-            task_session.commit()
 
             # Labels that show up in the UI we can use to filter sandboxes
             labels = {
@@ -207,50 +286,50 @@ async def process_task(
                 labels=labels,
                 env_vars=start_run_request.contract.env,
             ) as sandbox:
-                # Upload the contract to the sandbox after creating and install the dependencies
-                await upload_agent_artifacts(sandbox, start_run_request.contract)
-                await install_agent_dependencies(sandbox, start_run_request.contract)
-
-                # Setup task if requested
-                if task_data.request_setup:
-                    _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
-
-                # Run the agent inside of the sandbox
-                # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
-                await run_agent(
-                    sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd
+                run_task_task = asyncio.create_task(
+                    run_task(
+                        sandbox=sandbox,
+                        task_row=task_row,
+                        start_run_request=start_run_request,
+                        benchmark_service=benchmark_service,
+                        task_session=task_session,
+                        task_id=task_id,
+                        task_data=task_data,
+                    )
                 )
+                monitor_task = asyncio.create_task(monitor_sandbox(sandbox))
 
-                # Update the status to evaluating once we finish running the agent
-                task_row.status = TaskStatus.EVALUATING
-                task_session.add(task_row)
-                task_session.commit()
+                # Run the task and sandbox monitor at the same time and wait for the first to complete
+                done, pending = await asyncio.wait([monitor_task, run_task_task], return_when=asyncio.FIRST_COMPLETED)
 
-                # Evaluate the instance
-                # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
-                logger.info(f"Evaluating agent {start_run_request.contract.name} in sandbox {sandbox.name}")
-                evaluation_result = await benchmark_service.request_evaluate_instance(task_row.task_id, sandbox.id)
+                # We are only interested in what has been completed first
+                for task in pending:
+                    task.cancel()
 
-                # Save the evaluation result to the database with the task row
-                evaluation_result_row = EvaluationResult(
-                    task=task_row.id, instance_id=sandbox.id, result=evaluation_result
-                )
-                task_session.add(evaluation_result_row)
+                result = done.pop()
 
-                # Mark the task status as finished since we have finished processing the task
-                task_row.status = TaskStatus.FINISHED
-                task_session.add(task_row)
-                task_session.commit()
+                # Raise any exception that occured
+                # Main use case is for the SandboxDestroyedError, since we want to propagate this so that it can be handled
+                if result.exception():
+                    raise result.exception()  # type: ignore
 
-                return {task_id: evaluation_result_row.result}
+                # Otherwise its going to be the evaluation result (check the type to be sure)
+                result = result.result()
+                if not isinstance(result, dict):
+                    raise TrackerServiceError(f"Unexpected result type: {type(result)}")
+
+                return result
+
+        except SandboxDestroyedError:
+            # If the sandbox has been destroyed intentionally we don't need to do anything
+            # NOTE: State changes are already handled at this point
+
+            return {task_id: None}
         except Exception as e:
-            # If the task status is stopped its because we killed the sandbox early
-            # In that case we can skip to just returning the final result, else its an error we need to report
-            task_session.refresh(task_row)
-            if task_row.status != TaskStatus.STOPPED:
-                error_message = str(e)
-                logger.error(error_message)
-                commit_task_error(task_row, task_session, error_message)
+            error_message = str(e)
+            logger.error(error_message)
+
+            commit_task_error(task_row, task_session, error_message)
 
             return {task_id: None}
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -17,14 +17,13 @@ from sqlmodel import Session, asc, case, col, desc, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.config import broker
-from tracker.database.models import Benchmark, EvaluationResult, FinalEvaluation, Task, TaskStatus
+from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
 from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.sandbox import create_sandbox, install_agent_dependencies, run_agent, upload_agent_artifacts
 from tracker.types import (
     BenchmarkDetails,
-    BenchmarkStatus,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     Order,
@@ -396,6 +395,8 @@ async def process_benchmark(
         except Exception as e:
             error_message = f"{str(e)}\n{traceback.format_exc()}"
             commit_benchmark_error(benchmark_row, session, error_message)
+        finally:
+            await benchmark_service.daytona_client.close()
 
 
 class TaskCounts(NamedTuple):
@@ -588,7 +589,7 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
 
 
 async def stop_sandbox(
-    sandbox: AsyncSandbox, daytona_client: AsyncDaytona, session: Session, task_id: str | None
+    sandbox: AsyncSandbox, daytona_client: AsyncDaytona, session: Session, task_id: UUID | None
 ) -> str | None:
     try:
         # Wait for the sandbox to be in a valid deletion state
@@ -621,7 +622,7 @@ async def sandbox_generator(benchmark_row: Benchmark) -> AsyncGenerator[AsyncSan
     paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(1)
 
     total_pages = paginated_sandboxes.total_pages
-    while paginated_sandboxes.page < total_pages:
+    while paginated_sandboxes.page <= total_pages:
         sandboxes = paginated_sandboxes.items
         for sandbox in sandboxes:
             yield sandbox
@@ -655,7 +656,7 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
             # If task id does not exist, the task is finished and we can just close the sandbox
             # Edge case where the sandbox is hanging
             task_id = task_metadata.get(sandbox.name)
-            result = await stop_sandbox(sandbox, daytona_client, session, task_id)
+            result = await stop_sandbox(sandbox, daytona_client, session, UUID(task_id))
 
             results[sandbox.name] = result
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -10,7 +10,7 @@ from typing import Any, NamedTuple, Sequence
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, DaytonaNotFoundError, SandboxState
+from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from sqlmodel import Session, asc, case, col, desc, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
@@ -168,20 +168,6 @@ def handle_early_exit(task_row: Task, task_session: Session) -> None:
     task_session.commit()
 
 
-async def check_force_stop(sandbox: AsyncSandbox) -> bool:
-    """
-    Checks if the sandbox has been destroyed and returns True if it has
-    """
-    try:
-        await sandbox.refresh_data()
-        if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-            return True
-
-        return False
-    except DaytonaNotFoundError:
-        return True
-
-
 async def process_task(
     task_row: Task,
     start_run_request: StartRunRequest,
@@ -267,7 +253,7 @@ async def process_task(
                 except Exception as e:
                     # Error can come from the sandbox being destroyed
                     task_session.refresh(task_row)
-                    if task_row.status == TaskStatus.STOPPED or (await check_force_stop(sandbox)):
+                    if task_row.status == TaskStatus.STOPPED:
                         return {task_id: None}
 
                     raise e from e

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -194,6 +194,7 @@ async def process_task(
             task_session.add(task_row)
             task_session.commit()
 
+            # Labels that show up in the UI we can use to filter sandboxes
             labels = {
                 "Benchmark": benchmark_row.name,
                 "Id": str(benchmark_row.id),
@@ -244,9 +245,14 @@ async def process_task(
 
                 return {task_id: evaluation_result_row.result}
         except Exception as e:
-            error_message = str(e)
-            logger.error(error_message)
-            commit_task_error(task_row, task_session, error_message)
+            # If the task status is stopped its because we killed the sandbox early
+            # In that case we can skip to just returning the final result, else its an error we need to report
+            task_session.refresh(task_row)
+            if task_row.status != TaskStatus.STOPPED:
+                error_message = str(e)
+                logger.error(error_message)
+                commit_task_error(task_row, task_session, error_message)
+
             return {task_id: None}
 
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -524,10 +524,13 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
     Returns:
         AsyncGenerator[str]
     """
+    PULL_INTERVAL = 5
+
     EVENT_COMPLETE = "event: complete\n\n"
     EVENT_ERROR = "event: error\ndata:"
     DATA_PREFIX = "data:"
     DISCONNECT = "event: disconnect\n\n"
+
     try:
         while True:
             with Session(bind=session.bind) as fresh_session:
@@ -551,7 +554,7 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
                     yield EVENT_COMPLETE
                     break
 
-            await asyncio.sleep(5)
+            await asyncio.sleep(PULL_INTERVAL)
 
     except asyncio.CancelledError:
         logger.info(f"Client disconnected from benchmark {benchmark_id} stream")
@@ -568,34 +571,20 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session, force: bool
     NOTE: Tasks that have already started will continue to run and finish.
     """
     try:
-        # Check if there are any tasks yet that have not been started yet
-        tasks = session.exec(
-            select(func.count(col(Task.id)))
-            .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.status) == TaskStatus.STARTING)
-        ).one()
-
-        # If we are forcing we want to update the benchmark status to stopping anyway
-        if not tasks and not force:
-            return None
-
-        # Set the benchmark status to stopping to initiate the stopping process
-        benchmark_row.status = BenchmarkStatus.STOPPING
-        session.add(benchmark_row)
-        session.commit()
-
-        # Can return early if no starting tasks exist
-        if not tasks:
-            return None
-
-        # Stop all tasks that have not been started yet from starting by setting the stop flag
-        session.exec(
+        # Update all rows where tasks are starting to stopped
+        result = session.exec(
             update(Task)
             .where(col(Task.benchmark) == benchmark_row.id)
             .where(col(Task.status) == TaskStatus.STARTING)
             .values(status=TaskStatus.STOPPED)
         )
         session.commit()
+
+        # If we have stopped any tasks or are forcing the benchmark to stop, set the benchmark status to stopping
+        if result.rowcount > 0 or force:
+            benchmark_row.status = BenchmarkStatus.STOPPING
+            session.add(benchmark_row)
+            session.commit()
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error stopping benchmark {benchmark_row.id}: {str(e)}") from e
 
@@ -671,31 +660,26 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
     ).all()
 
     # Create a mapping upfront that we can use to update the task rows after stopping the sandboxes
-    task_metadata: dict[str, str] = {task.alias: str(task.id) for task in task_rows}
+    task_metadata: dict[str, UUID] = {task.alias: task.id for task in task_rows}
 
-    # Iterate through each running sandbox and stop it, collecting erorr messages
+    # Iterate through each running sandbox and stop it, collecting error messages
     results: dict[str, str | None] = {}
     async for sandbox in sandbox_generator(benchmark_row, daytona_client):
         # If task id does not exist, the task is finished and we can just close the sandbox
         # Edge case where the sandbox is hanging
-        task_id = task_metadata.get(sandbox.name)
+        task_id: UUID | None = task_metadata.get(sandbox.name)
         if not task_id:
             logger.info(f"Discovered sandbox not being tracked with the name {sandbox.name}. Closing sandbox.")
 
-        result = await stop_sandbox(sandbox, daytona_client, session, UUID(task_id) if task_id else None)
+        result = await stop_sandbox(sandbox, daytona_client, session, task_id if task_id else None)
 
         results[sandbox.name] = result
 
-    error_mapping: dict[str, str] = {}
-    for sandbox_name, error_message in results.items():
-        if error_message:
-            error_mapping[sandbox_name] = error_message
+    error_message: str = "\n".join(
+        f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
+    )
 
-    if error_mapping:
-        error_message = "\n".join(
-            [f"{task_alias}: {error_message}" for task_alias, error_message in error_mapping.items()]
-        )
-
+    if error_message:
         raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
 
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -265,14 +265,14 @@ async def process_task(
 
                     return {task_id: evaluation_result_row.result}
                 except Exception as e:
-                    # Validate that the sandbox has not been destroyed
+                    # Error can come from the sandbox being destroyed
                     task_session.refresh(task_row)
-                    if task_row.status == TaskStatus.STOPPED and await check_force_stop(sandbox):
+                    if task_row.status == TaskStatus.STOPPED or (await check_force_stop(sandbox)):
                         return {task_id: None}
 
                     raise e from e
         except Exception as e:
-            error_message = str(e)
+            error_message = f"{str(e)}\n{traceback.format_exc()}"
             logger.error(error_message)
 
             commit_task_error(task_row, task_session, error_message)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -10,14 +10,14 @@ from typing import Any, NamedTuple, Sequence
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
+from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, DaytonaNotFoundError, SandboxState
 from sqlmodel import Session, asc, case, col, desc, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.config import broker
 from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, FinalEvaluation, Task, TaskStatus
 from tracker.database.session import engine
-from tracker.exceptions import SandboxDestroyedError, TrackerServiceError
+from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.sandbox import create_sandbox, install_agent_dependencies, run_agent, upload_agent_artifacts
 from tracker.types import (
@@ -25,11 +25,10 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     Order,
-    RetrieveTaskResponse,
     StartRunRequest,
 )
 
-logger = get_logger(__name__, stream=True)
+logger = get_logger(__name__)
 
 
 class TrackedTaskStatus(str, Enum):
@@ -169,74 +168,18 @@ def handle_early_exit(task_row: Task, task_session: Session) -> None:
     task_session.commit()
 
 
-async def monitor_sandbox(sandbox: AsyncSandbox) -> None:
+async def check_force_stop(sandbox: AsyncSandbox) -> bool:
     """
-    Monitors a sandbox until its been destroyed
-
-    Raises:
-        SandboxDestroyedError: If the sandbox has been destroyed
+    Checks if the sandbox has been destroyed and returns True if it has
     """
-    while True:
+    try:
         await sandbox.refresh_data()
-
         if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-            raise SandboxDestroyedError("Sandbox has been destroyed")
+            return True
 
-        await asyncio.sleep(1)
-
-
-async def run_task(
-    task_row: Task,
-    start_run_request: StartRunRequest,
-    benchmark_service: BenchmarkService,
-    task_session: Session,
-    task_id: str,
-    sandbox: AsyncSandbox,
-    task_data: RetrieveTaskResponse,
-) -> dict[str, dict[str, Any] | None]:
-    """
-    Runs a task and returns the evaluation result
-
-    Exceptions should be propagated up one level where they are handled
-    """
-
-    task_row = task_session.merge(task_row)
-    task_row.status = TaskStatus.IN_PROGRESS
-    task_session.add(task_row)
-    task_session.commit()
-
-    # Upload the contract to the sandbox after creating and install the dependencies
-    await upload_agent_artifacts(sandbox, start_run_request.contract)
-    await install_agent_dependencies(sandbox, start_run_request.contract)
-
-    # Setup task if requested
-    if task_data.request_setup:
-        _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
-
-    # Run the agent inside of the sandbox
-    # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
-    await run_agent(sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd)
-
-    # Update the status to evaluating once we finish running the agent
-    task_row.status = TaskStatus.EVALUATING
-    task_session.add(task_row)
-    task_session.commit()
-
-    # Evaluate the instance
-    # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
-    logger.info(f"Evaluating agent {start_run_request.contract.name} in sandbox {sandbox.name}")
-    evaluation_result = await benchmark_service.request_evaluate_instance(task_row.task_id, sandbox.id)
-
-    # Save the evaluation result to the database with the task row
-    evaluation_result_row = EvaluationResult(task=task_row.id, instance_id=sandbox.id, result=evaluation_result)
-    task_session.add(evaluation_result_row)
-
-    # Mark the task status as finished since we have finished processing the task
-    task_row.status = TaskStatus.FINISHED
-    task_session.add(task_row)
-    task_session.commit()
-
-    return {task_id: evaluation_result_row.result}
+        return False
+    except DaytonaNotFoundError:
+        return True
 
 
 async def process_task(
@@ -257,12 +200,14 @@ async def process_task(
         A dictionary with the task id as the key and the evaluation result as the value, or None if the task was stopped early (not forced)
 
     Raises:
-        SandboxDestroyedError: If the sandbox has been destroyed intentionally
         TrackerServiceError: If the result is not the expected type
         Exception: Unexpected error occured that was not handled
     """
     with Session(bind=engine, expire_on_commit=False) as task_session:
         benchmark_row = fetch_benchmark_row(benchmark_id, task_session)
+
+        # Merge the task row to get the latest state from the database
+        task_row = task_session.merge(task_row)
 
         # If user has requested to stop the benchmark we exit before we process the task
         if benchmark_row.status == BenchmarkStatus.STOPPING:
@@ -286,45 +231,54 @@ async def process_task(
                 labels=labels,
                 env_vars=start_run_request.contract.env,
             ) as sandbox:
-                run_task_task = asyncio.create_task(
-                    run_task(
-                        sandbox=sandbox,
-                        task_row=task_row,
-                        start_run_request=start_run_request,
-                        benchmark_service=benchmark_service,
-                        task_session=task_session,
-                        task_id=task_id,
-                        task_data=task_data,
+                try:
+                    task_row.status = TaskStatus.IN_PROGRESS
+                    task_session.add(task_row)
+                    task_session.commit()
+
+                    # Upload the contract to the sandbox after creating and install the dependencies
+                    await upload_agent_artifacts(sandbox, start_run_request.contract)
+                    await install_agent_dependencies(sandbox, start_run_request.contract)
+
+                    # Setup task if requested
+                    if task_data.request_setup:
+                        _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
+
+                    # Run the agent inside of the sandbox
+                    # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
+                    await run_agent(
+                        sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd
                     )
-                )
-                monitor_task = asyncio.create_task(monitor_sandbox(sandbox))
 
-                # Run the task and sandbox monitor at the same time and wait for the first to complete
-                done, pending = await asyncio.wait([monitor_task, run_task_task], return_when=asyncio.FIRST_COMPLETED)
+                    # Update the status to evaluating once we finish running the agent
+                    task_row.status = TaskStatus.EVALUATING
+                    task_session.add(task_row)
+                    task_session.commit()
 
-                # We are only interested in what has been completed first
-                for task in pending:
-                    task.cancel()
+                    # Evaluate the instance
+                    # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
+                    logger.info(f"Evaluating agent {start_run_request.contract.name} in sandbox {sandbox.name}")
+                    evaluation_result = await benchmark_service.request_evaluate_instance(task_row.task_id, sandbox.id)
 
-                result = done.pop()
+                    # Save the evaluation result to the database with the task row
+                    evaluation_result_row = EvaluationResult(
+                        task=task_row.id, instance_id=sandbox.id, result=evaluation_result
+                    )
+                    task_session.add(evaluation_result_row)
 
-                # Raise any exception that occured
-                # Main use case is for the SandboxDestroyedError, since we want to propagate this so that it can be handled
-                if result.exception():
-                    raise result.exception()  # type: ignore
+                    # Mark the task status as finished since we have finished processing the task
+                    task_row.status = TaskStatus.FINISHED
+                    task_session.add(task_row)
+                    task_session.commit()
 
-                # Otherwise its going to be the evaluation result (check the type to be sure)
-                result = result.result()
-                if not isinstance(result, dict):
-                    raise TrackerServiceError(f"Unexpected result type: {type(result)}")
+                    return {task_id: evaluation_result_row.result}
+                except Exception as e:
+                    # Validate that the sandbox has not been destroyed
+                    task_session.refresh(task_row)
+                    if task_row.status == TaskStatus.STOPPED and await check_force_stop(sandbox):
+                        return {task_id: None}
 
-                return result
-
-        except SandboxDestroyedError:
-            # If the sandbox has been destroyed intentionally we don't need to do anything
-            # NOTE: State changes are already handled at this point
-
-            return {task_id: None}
+                    raise e from e
         except Exception as e:
             error_message = str(e)
             logger.error(error_message)
@@ -626,7 +580,7 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
         yield DISCONNECT
 
 
-async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
+async def stop_benchmark(benchmark_row: Benchmark, session: Session, force: bool) -> None:
     """
     Sets the flags to initiate the stopping process for a benchmark.
 
@@ -643,15 +597,18 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
             .where(col(Task.status) == TaskStatus.STARTING)
         ).one()
 
-        if not tasks:
-            raise TrackerServiceError(
-                f"All tasks for benchmark {benchmark_row.id} have been started. Must wait for the tasks to finish running."
-            )
+        # If we are forcing we want to update the benchmark status to stopping anyway
+        if not tasks and not force:
+            return None
 
         # Set the benchmark status to stopping to initiate the stopping process
         benchmark_row.status = BenchmarkStatus.STOPPING
         session.add(benchmark_row)
         session.commit()
+
+        # Can return early if no starting tasks exist
+        if not tasks:
+            return None
 
         # Stop all tasks that have not been started yet from starting by setting the stop flag
         session.exec(
@@ -661,8 +618,6 @@ async def stop_benchmark(benchmark_row: Benchmark, session: Session) -> None:
             .values(status=TaskStatus.STOPPED)
         )
         session.commit()
-    except TrackerServiceError:
-        raise
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error stopping benchmark {benchmark_row.id}: {str(e)}") from e
 
@@ -687,26 +642,37 @@ async def stop_sandbox(
         return f"{str(e)}: {traceback.format_exc()}"
 
 
-async def sandbox_generator(benchmark_row: Benchmark) -> AsyncGenerator[AsyncSandbox, None]:
+async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona, page: int) -> AsyncPaginatedSandboxes:
+    return await daytona_client.list(
+        labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page
+    )
+
+
+async def sandbox_generator(
+    benchmark_row: Benchmark, daytona_client: AsyncDaytona
+) -> AsyncGenerator[AsyncSandbox, None]:
     """
     Generator that yields all sandboxes for a given benchmark in paginated chunks of 10.
+
+    NOTE: At the time of this implementation there are several things weird with the dayyona api
+        1. If you delete the sandboxes in the list, the next page should be the first page (repopulated)
+        2. Final state is not DESTROYED, but rather DESTROYING
+        3. The total_pages count is not updated as you delete sandboxes
     """
-    daytona_client: AsyncDaytona = benchmark_row.benchmark_service.daytona_client
 
-    async def fetch_sandboxes(page: int) -> AsyncPaginatedSandboxes:
-        return await daytona_client.list(
-            labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page
-        )
-
-    paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(1)
+    paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(benchmark_row, daytona_client, 1)
 
     total_pages = paginated_sandboxes.total_pages
-    while paginated_sandboxes.page <= total_pages:
+    while (paginated_sandboxes.page <= total_pages) and paginated_sandboxes.items:
         sandboxes = paginated_sandboxes.items
         for sandbox in sandboxes:
+            if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+                continue
+
             yield sandbox
 
-        paginated_sandboxes = await fetch_sandboxes(int(paginated_sandboxes.page) + 1)
+        # NOTE: Since we deleted the first 10 the first page will be populated with the next 10 sandboxes
+        paginated_sandboxes = await fetch_sandboxes(benchmark_row, daytona_client, int(paginated_sandboxes.page))
 
 
 async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> None:
@@ -718,40 +684,41 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
         TrackerServiceError: If there are any errors stopping the sandboxes
     """
     daytona_client: AsyncDaytona = benchmark_row.benchmark_service.daytona_client
-    try:
-        # Create a mapping between all task primary key id and their task_id (that are pending or evaluating)
-        task_rows: Sequence[Task] = session.exec(
-            select(Task)
-            .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.status).in_([TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
-        ).all()
 
-        # Create a mapping upfront that we can use to update the task rows after stopping the sandboxes
-        task_metadata: dict[str, str] = {task.alias: str(task.id) for task in task_rows}
+    # Create a mapping between all task primary key id and their task_id (that are pending or evaluating)
+    task_rows: Sequence[Task] = session.exec(
+        select(Task)
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status).in_([TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
+    ).all()
 
-        # Iterate through each running sandbox and stop it, collecting erorr messages
-        results: dict[str, str | None] = {}
-        async for sandbox in sandbox_generator(benchmark_row):
-            # If task id does not exist, the task is finished and we can just close the sandbox
-            # Edge case where the sandbox is hanging
-            task_id = task_metadata.get(sandbox.name)
-            result = await stop_sandbox(sandbox, daytona_client, session, UUID(task_id))
+    # Create a mapping upfront that we can use to update the task rows after stopping the sandboxes
+    task_metadata: dict[str, str] = {task.alias: str(task.id) for task in task_rows}
 
-            results[sandbox.name] = result
+    # Iterate through each running sandbox and stop it, collecting erorr messages
+    results: dict[str, str | None] = {}
+    async for sandbox in sandbox_generator(benchmark_row, daytona_client):
+        # If task id does not exist, the task is finished and we can just close the sandbox
+        # Edge case where the sandbox is hanging
+        task_id = task_metadata.get(sandbox.name)
+        if not task_id:
+            logger.info(f"Discovered sandbox not being tracked with the name {sandbox.name}. Closing sandbox.")
 
-        error_mapping: dict[str, str] = {}
-        for sandbox_name, error_message in results.items():
-            if error_message:
-                error_mapping[sandbox_name] = error_message
+        result = await stop_sandbox(sandbox, daytona_client, session, UUID(task_id) if task_id else None)
 
-        if error_mapping:
-            error_message = "\n".join(
-                [f"{task_alias}: {error_message}" for task_alias, error_message in error_mapping.items()]
-            )
+        results[sandbox.name] = result
 
-            raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
-    finally:
-        await daytona_client.close()
+    error_mapping: dict[str, str] = {}
+    for sandbox_name, error_message in results.items():
+        if error_message:
+            error_mapping[sandbox_name] = error_message
+
+    if error_mapping:
+        error_message = "\n".join(
+            [f"{task_alias}: {error_message}" for task_alias, error_message in error_mapping.items()]
+        )
+
+        raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
 
 
 async def resume_benchmark(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -192,16 +192,8 @@ async def process_task(
     """
     Processes a task and returns the evaluation result
 
-    NOTE: We run the task and sandbox monitor at the same time,
-    if the sandbox is destroyed before the task is completed we propagate the error up and end the task early.
-
-
-    Returns:
-        A dictionary with the task id as the key and the evaluation result as the value, or None if the task was stopped early (not forced)
-
-    Raises:
-        TrackerServiceError: If the result is not the expected type
-        Exception: Unexpected error occured that was not handled
+    NOTE: When we close the sandbox the agent process will be killed and we will instantly go to evaluating,
+    the evaluation will fail since the instance no longer exists. We handle this inside of the exception caught.
     """
     with Session(bind=engine, expire_on_commit=False) as task_session:
         benchmark_row = fetch_benchmark_row(benchmark_id, task_session)

--- a/services/tracker/tests/conftest.py
+++ b/services/tracker/tests/conftest.py
@@ -9,8 +9,7 @@ from sqlalchemy.pool import ConnectionPoolEntry
 from sqlmodel import Session, SQLModel, StaticPool, create_engine
 
 from tracker.database.models import *  # noqa: F403
-from tracker.database.models import Benchmark, BenchmarkArguments
-from tracker.types import AgentContractRequest
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkArguments
 
 _ = load_dotenv()
 

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -1,0 +1,201 @@
+import asyncio
+
+from daytona import AsyncDaytona, AsyncSandbox, CreateSandboxFromImageParams, Resources
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+from sqlmodel import Session, select
+
+from main import app, get_session
+from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
+from tracker.logger import get_logger
+from tracker.utils import fetch_sandboxes, force_stop_sandboxes, process_benchmark, stop_sandbox
+
+logger = get_logger(__name__)
+
+
+class TestForceStop:
+    async def _create_sandbox_without_manager(
+        self,
+        daytona: AsyncDaytona,
+        sandbox_name: str,
+        image: str,
+        labels: dict[str, str] = {},
+        resources: Resources = Resources(cpu=2, memory=4, disk=5),
+    ) -> AsyncSandbox:
+        sandbox = await daytona.create(
+            CreateSandboxFromImageParams(
+                name=sandbox_name,
+                labels=labels,
+                image=image,
+                network_block_all=False,
+                resources=resources,
+            ),
+            timeout=360,
+        )
+
+        return sandbox
+
+    async def test_force_stop_sandbox(self, example_benchmark_object: Benchmark, database_session: Session) -> None:
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        # Create a single task
+        task = Task(benchmark=example_benchmark_object.id, task_id="test-task", status=TaskStatus.IN_PROGRESS)
+        database_session.add(task)
+        database_session.commit()
+
+        daytona_client = example_benchmark_object.benchmark_service.daytona_client
+
+        async def force_stop_sandbox(sandbox_name: str) -> None:
+            await asyncio.sleep(0.5)
+            sandbox = await daytona_client.get(sandbox_name)
+
+            await stop_sandbox(sandbox, daytona_client, database_session, task.id)
+
+        # Start sandbox and immediately try to stop it, expected to wait until its started to delete
+        await asyncio.gather(
+            self._create_sandbox_without_manager(
+                daytona_client,
+                "test-sandbox",
+                "ghcr.io/epoch-research/swe-bench.eval.x86_64.scikit-learn__scikit-learn-13142:latest",
+                resources=Resources(
+                    cpu=4,
+                    memory=8,
+                    disk=10,
+                ),  # Large sandbox to take more time to load (if it loads instantly its hard to know if the test is working)
+            ),
+            force_stop_sandbox("test-sandbox"),
+        )
+
+        await daytona_client.close()
+
+        # Ensure that the task is in the stopped state
+        task = database_session.exec(select(Task).where(Task.id == task.id)).one()
+        assert task.status == TaskStatus.STOPPED
+
+    async def test_force_stop_sandboxes(self, example_benchmark_object: Benchmark, database_session: Session) -> None:
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        daytona_client = example_benchmark_object.benchmark_service.daytona_client
+
+        labels = {"Benchmark": example_benchmark_object.name, "Id": str(example_benchmark_object.id)}
+
+        async def create_sandbox_with_delay(sandbox_name: str) -> None:
+            """Create sandbox that will not be closed automatically"""
+            _ = await self._create_sandbox_without_manager(
+                daytona=daytona_client, sandbox_name=sandbox_name, image="python:3.11-slim", labels=labels
+            )
+
+            # NOTE: Will not exit when we delete the sandbox so keep the sleep short
+            await asyncio.sleep(20)
+
+        # Create 12 tasks that are in progress and evaluating
+        tasks: list[Task] = []
+        for i in range(12):
+            status = TaskStatus.IN_PROGRESS if i < 6 else TaskStatus.EVALUATING
+            task = Task(benchmark=example_benchmark_object.id, task_id=f"test-task-{i}", status=status)
+            tasks.append(task)
+            database_session.add(task)
+
+        database_session.commit()
+
+        # Test force_stop_sandboxes util by running all 12 sandboxes in parallel and
+        # seeing if we can close them all
+        created_sandboxes = asyncio.gather(
+            *[asyncio.create_task(create_sandbox_with_delay(task.alias)) for task in tasks]
+        )
+
+        # Pause for 10 seconds to ensure that the sandboxes are created
+        await asyncio.sleep(10)
+
+        # Force stop the benchmark run with all sandboxes
+        await force_stop_sandboxes(example_benchmark_object, database_session)
+
+        await created_sandboxes
+
+        # Ensure that there are no more sandboxes left running
+        sandboxes = await fetch_sandboxes(example_benchmark_object, daytona_client, 1)
+        assert len(sandboxes.items) == 0
+
+        await daytona_client.close()
+
+    async def test_force_stop_end_to_end(
+        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
+    ) -> None:
+        example_benchmark_object.arguments.slice_str = ":5"
+        example_benchmark_object.arguments.concurrency = 2
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        def get_test_session():
+            yield database_session
+
+        app.dependency_overrides[get_session] = get_test_session
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+
+        client = TestClient(app)
+
+        benchmark_service = example_benchmark_object.benchmark_service
+
+        verify_response = await benchmark_service.request_verify_task_ids(
+            task_ids=example_benchmark_object.arguments.task_ids, slice_str=example_benchmark_object.arguments.slice_str
+        )
+
+        # Start the benchmark run with just 5 tasks
+        benchmark_task = asyncio.create_task(
+            process_benchmark(
+                start_run_request_json=example_benchmark_object.start_run_request.model_dump(),
+                benchmark_id_str=str(example_benchmark_object.id),
+                verified_task_ids=verify_response.task_ids,
+            )
+        )
+
+        # Wait a few seconds for all the tasks to start
+        await asyncio.sleep(15)
+
+        # Force stop the benchmark run with all sandboxes
+        response = client.post(f"/stop-run/{example_benchmark_object.id}?force=true")
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+
+        await benchmark_task
+
+        # Ensure no tasks are in starting state
+        pending_tasks = database_session.exec(
+            select(Task)
+            .where(Task.benchmark == example_benchmark_object.id)
+            .where(Task.status in [TaskStatus.STARTING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING])
+        ).all()
+        assert len(pending_tasks) == 0
+
+        # No tasks have error status
+        error_tasks = database_session.exec(
+            select(Task).where(Task.benchmark == example_benchmark_object.id).where(Task.status == TaskStatus.ERROR)
+        ).all()
+        assert len(error_tasks) == 0, (
+            f"Tasks have error status: {', '.join([task.error_message or 'No error message' for task in error_tasks])}"
+        )
+
+        # Fetch all the tasks and ensure that they are in the stopped state
+        stopped_tasks = database_session.exec(
+            select(Task).where(Task.benchmark == example_benchmark_object.id).where(Task.status == TaskStatus.STOPPED)
+        ).all()
+
+        assert len(stopped_tasks) == 5
+        assert all(task.status == TaskStatus.STOPPED for task in stopped_tasks)
+
+        # Wait for the benchmark to enter the stopped state
+        await asyncio.sleep(10)
+
+        # Fetch the benchmark and ensure that it is in the stopped state
+        database_session.refresh(example_benchmark_object)
+        assert example_benchmark_object.status == BenchmarkStatus.STOPPED
+
+        daytona_client = example_benchmark_object.benchmark_service.daytona_client
+
+        # Try to fetch the sandboxes and see if any of them are still running
+        sandboxes = await fetch_sandboxes(example_benchmark_object, daytona_client, 1)
+        assert len(sandboxes.items) == 0
+
+        await daytona_client.close()

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -65,7 +65,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # Test request to stop the benchmark
-        response: Response = client.post(f"/stop-run/{benchmark_row.id}")
+        response: Response = client.post(f"/stop-run/{benchmark_row.id}?force=false")
         assert response.status_code == 200
         assert response.json() == {"status": "success"}
 
@@ -121,25 +121,8 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # Fail to stop the run
-        response: Response = client.post(f"/stop-run/{benchmark_row.id}")
+        response: Response = client.post(f"/stop-run/{benchmark_row.id}?force=false")
         assert response.status_code == 400
-
-        # Cannot stop a run with no tasks yet to start
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        # Add some tasks, all have already started
-
-        task_rows = [
-            Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS) for i in range(5)
-        ]
-        database_session.add_all(task_rows)
-        database_session.commit()
-
-        # Error is returned because we have no starting tasks left to stop
-        response = client.post(f"/stop-run/{benchmark_row.id}")
-        assert response.status_code == 500
 
     def test_resume_benchmark(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -355,7 +355,7 @@ class TestFastapiServer:
         assert len(response_json.get("evaluation_results")) == 10
         assert response_json.get("final_evaluation")
 
-        # Check for tasks with erorrs
+        # Check for tasks with error
         assert response_json.get("task_errors")
         assert len(response_json.get("task_errors")) == 2
 

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -113,7 +113,7 @@ class TestStopAndResume:
         database_session.commit()
 
         # Stop benchmark - only tasks that are starting become stopped
-        await stop_benchmark(benchmark_row, database_session)
+        await stop_benchmark(benchmark_row, database_session, force=False)
 
         # Verify: 2 tasks are finished, 3 tasks are stopped
         finished_count = len(

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -324,7 +324,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -341,14 +341,14 @@ dependencies = [
     { name = "toml" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/32/30541cb7ca76bee6b445efa39794bd502b67d30d5848713b198ead5a283c/daytona-0.132.0.tar.gz", hash = "sha256:9084640488f09ac14f54637dbd17ad9af0d2de1ba9cd721a6d455c5a8b1f66e2", size = 117551, upload-time = "2026-01-18T08:34:31.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e4/7e4fe284abcd098990582214ec686f618d6f956e1770eba02c4a411ce4b5/daytona-0.135.0.tar.gz", hash = "sha256:443a84de25b446afebd2b8bdac7d9f7ceffa849e25d7040956fe72e2e5cdb744", size = 114556, upload-time = "2026-01-26T14:17:11.147Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/63/1c9159c902eb16e4bbf5002e8f05d2824f5628222eafc67f12ca0e446a4f/daytona-0.132.0-py3-none-any.whl", hash = "sha256:c8415a472eac341389bbe6786b8d45061c1f5c90be6891136ec79eec72474ce5", size = 146075, upload-time = "2026-01-18T08:34:30.463Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7d/5e6a00e48b0fe7b2c9f35c4e19b54db8c8af0e95c99ca51e0454fa70049d/daytona-0.135.0-py3-none-any.whl", hash = "sha256:90a02c6742a55742fd441c0fc6ab7e2b014d2bb04b2b779733da802ea5a767a9", size = 142796, upload-time = "2026-01-26T14:17:10.126Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -356,14 +356,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/79/7dd891b03ae88c9f1a17981384fe4a853d24ebae877b7c65f5cc336eeb93/daytona_api_client-0.132.0.tar.gz", hash = "sha256:98f41bee2d52d8e5bb43ebb54174c5b9acbd4ae2efce786bcf26dd7b1719dfeb", size = 139381, upload-time = "2026-01-18T08:33:30.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/dd/97c8f379838503a5970d291475646db29ee0c40bd8df2b0417b2b0a9acab/daytona_api_client-0.135.0.tar.gz", hash = "sha256:7da12d5ca36d9def7e583893cff0d2d517ac52b71b608da681aa43af460e2cd5", size = 134318, upload-time = "2026-01-26T14:16:06.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/20/9ba3625d6da32a029aaa840ba12d4ebf9b6d0e82ec683929fa895f423157/daytona_api_client-0.132.0-py3-none-any.whl", hash = "sha256:802e6df77b50241c4533e5933fc78732848bb5879a4eddb31b74f70cbb88dca6", size = 410264, upload-time = "2026-01-18T08:33:29.28Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f9/465a1bd629080de69bfb5d310031722e22fa26c21cd89c2f12edbeb908a5/daytona_api_client-0.135.0-py3-none-any.whl", hash = "sha256:f91d0f6a111e49a6d7f0e0afcb9b13ccae272a3ef193af8e4989f0b10d4593b8", size = 373701, upload-time = "2026-01-26T14:16:05.195Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -373,14 +373,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a78a494908492695a1d43c3afba705276feedf31f6c64af6f43d194ed4aa/daytona_api_client_async-0.132.0.tar.gz", hash = "sha256:58bafe786a6597a0aa301fa78e83bfa7d1043ebc12d6268c5deda03477f3a1cc", size = 140366, upload-time = "2026-01-18T08:33:41.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/18/625796c1fc182e744de9bf41e3de7d43e932b09dd240c5c4b3d415c20d81/daytona_api_client_async-0.135.0.tar.gz", hash = "sha256:bcfb4d11f51903056d7a36857a471887c591b06ef9b83355843b191c487824a8", size = 134411, upload-time = "2026-01-26T14:16:18.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/15/19880e911d77fc6ea2781d9e84a870e6ed83494025b3496cacd98380d2ca/daytona_api_client_async-0.132.0-py3-none-any.whl", hash = "sha256:b24dda04fa7ce8a2972336b0089ec6ce365ed6cd8ba4477f36da842ab055579f", size = 415629, upload-time = "2026-01-18T08:33:40.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c1/20dd00596fb300d6fda6799fe2dd7a6e3117a9156577db12e2b6d0a51020/daytona_api_client_async-0.135.0-py3-none-any.whl", hash = "sha256:6e2d7ae798b4606820a432acbefccb2a724b9086a5c7914d4d22e1eaafa463c5", size = 376545, upload-time = "2026-01-26T14:16:16.575Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -388,14 +388,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/f9/65e90a83a28fce5d651072fa9a7a97a6f599285e799f0f90e0298394f5f8/daytona_toolbox_api_client-0.132.0.tar.gz", hash = "sha256:0f1c5ca08e8dbc1fea5ec64233475202d3de7f0a56eb3f13792f7d24ef2260ea", size = 61355, upload-time = "2026-01-18T08:33:21.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/1a/f5dd18864e6f4c45bde3d2b2f5224f79c24c9aeaf778deef126104d73e7b/daytona_toolbox_api_client-0.135.0.tar.gz", hash = "sha256:1b79857eef85f25eb8c0a7c806b95170149d74f1ff605fe9b44f2154527df6a5", size = 61718, upload-time = "2026-01-26T14:15:55.567Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/fb/b02398c14dcb0c39321f5ec2b5413eabcf44842b7e9af20b1e3c1ededa74/daytona_toolbox_api_client-0.132.0-py3-none-any.whl", hash = "sha256:510e4c0c83db1bc9937c50d189813039d008397a139b2c4306a5d9498e2ecec5", size = 164409, upload-time = "2026-01-18T08:33:19.933Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a1/1242e24e56ef4fee7c6ff0037047865cb5582e1e45b6164777a14e1ab871/daytona_toolbox_api_client-0.135.0-py3-none-any.whl", hash = "sha256:5c385a627a34f0938d8b09e1a0737988dcca87784ff7d207d5069ab05e89b25c", size = 162010, upload-time = "2026-01-26T14:15:53.639Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -405,9 +405,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/5f/ca8fefe026131514346439e824b6d51cd99d41cb10e41a82a5d8ba1fd2c7/daytona_toolbox_api_client_async-0.132.0.tar.gz", hash = "sha256:74a04c16c514cd9a186d3c53cf2924bb56bc5dd8154382a7eda5f7dd65fb86c8", size = 58363, upload-time = "2026-01-18T08:33:48.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/63/dff882c2e6cb92ebb1d047be47c85c722a8b63bff1ae210a4f46af5c2707/daytona_toolbox_api_client_async-0.135.0.tar.gz", hash = "sha256:636f402f5e49eaff18e4ab65bfd51c9d8b2b658c995fa6c198e3307f8bbb225d", size = 58646, upload-time = "2026-01-26T14:16:24.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/30/f9fec5c870a24a4946f81c81ac51269cc3c8efeab3448a781dc3876c0a14/daytona_toolbox_api_client_async-0.132.0-py3-none-any.whl", hash = "sha256:5d0e3ebcb984f8884280ff1aedeefc77069c385d37dea05be00f8f72461435b2", size = 165672, upload-time = "2026-01-18T08:33:47.523Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e0/ecea9decb8596d1f309523a801e4f8064ac24c4689d2bd36fb9f84e2a30a/daytona_toolbox_api_client_async-0.135.0-py3-none-any.whl", hash = "sha256:fc3ada8f0b50c3c3d7a9e806569bb51fade9c6ff7fafed587dc4965dac7656d2", size = 163256, upload-time = "2026-01-26T14:16:23.006Z" },
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.1" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "daytona", specifier = ">=0.128.1" },
+    { name = "daytona", specifier = ">=0.135.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.127.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "moto", extras = ["s3"] },

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -213,7 +213,13 @@ def retrieve_results(benchmark_id: UUID, path: Path):
                     raise click.Abort()
 
             with open(path, "w") as f:
-                f.write(results_response.model_dump_json(indent=4, exclude_none=True))
+                f.write(
+                    results_response.model_dump_json(
+                        indent=4,
+                        exclude_none=True,
+                        exclude={"benchmark_arguments": {"contract": {"env"}}},
+                    )
+                )
 
             click.echo(f"Results saved to '{path}'")
     except TrackerServiceError as e:

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -227,7 +227,14 @@ def retrieve_results(benchmark_id: UUID, path: Path):
     required=True,
     help="Benchmark id (e.g., 123e4567-e89b-12d3-a456-426614174000)",
 )
-def stop_run(benchmark_id: UUID):
+@click.option(
+    "--force",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Force stop the benchmark run",
+)
+def stop_run(benchmark_id: UUID, force: bool):
     """
     Stop a benchmark run by its benchmark id.
 
@@ -235,12 +242,15 @@ def stop_run(benchmark_id: UUID):
         harness stop-run --benchmark-id 123e4567-e89b-12d3-a456-426614174000
     """
     click.echo(f"Stopping run for benchmark: {benchmark_id}")
+
+    if force:
+        click.echo(click.style("Force stopping the benchmark", fg="yellow", bold=True))
     try:
         with TrackerService() as tracker:
             if not check_tracker_service_health(tracker):
                 return
 
-            _ = tracker.stop_run(benchmark_id)
+            _ = tracker.stop_run(benchmark_id, force)
             click.echo(
                 click.style(
                     "Run is currently being stopped. Will be stopped when all tasks in flight are finished.",

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -205,7 +205,7 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to retrieve results: {e}") from e
 
-    def stop_run(self, benchmark_id: UUID) -> StopRunResponse:
+    def stop_run(self, benchmark_id: UUID, force: bool) -> StopRunResponse:
         """
         Stop a benchmark run by its benchmark id.
 
@@ -216,7 +216,7 @@ class TrackerService:
             StopRunResponse with status and message
         """
         try:
-            response = self._client.post(f"{self._base_url}/stop-run/{benchmark_id}")
+            response = self._client.post(f"{self._base_url}/stop-run/{benchmark_id}", params={"force": force})
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)
                 raise TrackerServiceError(f"Failed to stop run: {details}")

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -51,7 +51,7 @@ class BenchmarkFormatter:
         progress_pct = (finished_tasks / total_tasks * 100) if total_tasks > 0 else 0
         filled_width = int(bar_width * progress_pct / 100)
         bar = "█" * filled_width + "░" * (bar_width - filled_width)
-        return str(bar), progress_pct
+        return bar, progress_pct
 
     @staticmethod
     def format_task_breakdown(task_breakdown: dict[TaskStatus, int]) -> str:

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -51,7 +51,7 @@ class BenchmarkFormatter:
         progress_pct = (finished_tasks / total_tasks * 100) if total_tasks > 0 else 0
         filled_width = int(bar_width * progress_pct / 100)
         bar = "█" * filled_width + "░" * (bar_width - filled_width)
-        return bar, progress_pct
+        return str(bar), progress_pct
 
     @staticmethod
     def format_task_breakdown(task_breakdown: dict[TaskStatus, int]) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -544,7 +544,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -561,14 +561,14 @@ dependencies = [
     { name = "toml" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/32/30541cb7ca76bee6b445efa39794bd502b67d30d5848713b198ead5a283c/daytona-0.132.0.tar.gz", hash = "sha256:9084640488f09ac14f54637dbd17ad9af0d2de1ba9cd721a6d455c5a8b1f66e2", size = 117551, upload-time = "2026-01-18T08:34:31.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/e4/7e4fe284abcd098990582214ec686f618d6f956e1770eba02c4a411ce4b5/daytona-0.135.0.tar.gz", hash = "sha256:443a84de25b446afebd2b8bdac7d9f7ceffa849e25d7040956fe72e2e5cdb744", size = 114556, upload-time = "2026-01-26T14:17:11.147Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/63/1c9159c902eb16e4bbf5002e8f05d2824f5628222eafc67f12ca0e446a4f/daytona-0.132.0-py3-none-any.whl", hash = "sha256:c8415a472eac341389bbe6786b8d45061c1f5c90be6891136ec79eec72474ce5", size = 146075, upload-time = "2026-01-18T08:34:30.463Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7d/5e6a00e48b0fe7b2c9f35c4e19b54db8c8af0e95c99ca51e0454fa70049d/daytona-0.135.0-py3-none-any.whl", hash = "sha256:90a02c6742a55742fd441c0fc6ab7e2b014d2bb04b2b779733da802ea5a767a9", size = 142796, upload-time = "2026-01-26T14:17:10.126Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -576,14 +576,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/79/7dd891b03ae88c9f1a17981384fe4a853d24ebae877b7c65f5cc336eeb93/daytona_api_client-0.132.0.tar.gz", hash = "sha256:98f41bee2d52d8e5bb43ebb54174c5b9acbd4ae2efce786bcf26dd7b1719dfeb", size = 139381, upload-time = "2026-01-18T08:33:30.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/dd/97c8f379838503a5970d291475646db29ee0c40bd8df2b0417b2b0a9acab/daytona_api_client-0.135.0.tar.gz", hash = "sha256:7da12d5ca36d9def7e583893cff0d2d517ac52b71b608da681aa43af460e2cd5", size = 134318, upload-time = "2026-01-26T14:16:06.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/20/9ba3625d6da32a029aaa840ba12d4ebf9b6d0e82ec683929fa895f423157/daytona_api_client-0.132.0-py3-none-any.whl", hash = "sha256:802e6df77b50241c4533e5933fc78732848bb5879a4eddb31b74f70cbb88dca6", size = 410264, upload-time = "2026-01-18T08:33:29.28Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f9/465a1bd629080de69bfb5d310031722e22fa26c21cd89c2f12edbeb908a5/daytona_api_client-0.135.0-py3-none-any.whl", hash = "sha256:f91d0f6a111e49a6d7f0e0afcb9b13ccae272a3ef193af8e4989f0b10d4593b8", size = 373701, upload-time = "2026-01-26T14:16:05.195Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -593,14 +593,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a78a494908492695a1d43c3afba705276feedf31f6c64af6f43d194ed4aa/daytona_api_client_async-0.132.0.tar.gz", hash = "sha256:58bafe786a6597a0aa301fa78e83bfa7d1043ebc12d6268c5deda03477f3a1cc", size = 140366, upload-time = "2026-01-18T08:33:41.85Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/18/625796c1fc182e744de9bf41e3de7d43e932b09dd240c5c4b3d415c20d81/daytona_api_client_async-0.135.0.tar.gz", hash = "sha256:bcfb4d11f51903056d7a36857a471887c591b06ef9b83355843b191c487824a8", size = 134411, upload-time = "2026-01-26T14:16:18.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/15/19880e911d77fc6ea2781d9e84a870e6ed83494025b3496cacd98380d2ca/daytona_api_client_async-0.132.0-py3-none-any.whl", hash = "sha256:b24dda04fa7ce8a2972336b0089ec6ce365ed6cd8ba4477f36da842ab055579f", size = 415629, upload-time = "2026-01-18T08:33:40.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c1/20dd00596fb300d6fda6799fe2dd7a6e3117a9156577db12e2b6d0a51020/daytona_api_client_async-0.135.0-py3-none-any.whl", hash = "sha256:6e2d7ae798b4606820a432acbefccb2a724b9086a5c7914d4d22e1eaafa463c5", size = 376545, upload-time = "2026-01-26T14:16:16.575Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -608,14 +608,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/f9/65e90a83a28fce5d651072fa9a7a97a6f599285e799f0f90e0298394f5f8/daytona_toolbox_api_client-0.132.0.tar.gz", hash = "sha256:0f1c5ca08e8dbc1fea5ec64233475202d3de7f0a56eb3f13792f7d24ef2260ea", size = 61355, upload-time = "2026-01-18T08:33:21.467Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/1a/f5dd18864e6f4c45bde3d2b2f5224f79c24c9aeaf778deef126104d73e7b/daytona_toolbox_api_client-0.135.0.tar.gz", hash = "sha256:1b79857eef85f25eb8c0a7c806b95170149d74f1ff605fe9b44f2154527df6a5", size = 61718, upload-time = "2026-01-26T14:15:55.567Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/fb/b02398c14dcb0c39321f5ec2b5413eabcf44842b7e9af20b1e3c1ededa74/daytona_toolbox_api_client-0.132.0-py3-none-any.whl", hash = "sha256:510e4c0c83db1bc9937c50d189813039d008397a139b2c4306a5d9498e2ecec5", size = 164409, upload-time = "2026-01-18T08:33:19.933Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a1/1242e24e56ef4fee7c6ff0037047865cb5582e1e45b6164777a14e1ab871/daytona_toolbox_api_client-0.135.0-py3-none-any.whl", hash = "sha256:5c385a627a34f0938d8b09e1a0737988dcca87784ff7d207d5069ab05e89b25c", size = 162010, upload-time = "2026-01-26T14:15:53.639Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.132.0"
+version = "0.135.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -625,9 +625,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/5f/ca8fefe026131514346439e824b6d51cd99d41cb10e41a82a5d8ba1fd2c7/daytona_toolbox_api_client_async-0.132.0.tar.gz", hash = "sha256:74a04c16c514cd9a186d3c53cf2924bb56bc5dd8154382a7eda5f7dd65fb86c8", size = 58363, upload-time = "2026-01-18T08:33:48.615Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/63/dff882c2e6cb92ebb1d047be47c85c722a8b63bff1ae210a4f46af5c2707/daytona_toolbox_api_client_async-0.135.0.tar.gz", hash = "sha256:636f402f5e49eaff18e4ab65bfd51c9d8b2b658c995fa6c198e3307f8bbb225d", size = 58646, upload-time = "2026-01-26T14:16:24.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/30/f9fec5c870a24a4946f81c81ac51269cc3c8efeab3448a781dc3876c0a14/daytona_toolbox_api_client_async-0.132.0-py3-none-any.whl", hash = "sha256:5d0e3ebcb984f8884280ff1aedeefc77069c385d37dea05be00f8f72461435b2", size = 165672, upload-time = "2026-01-18T08:33:47.523Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e0/ecea9decb8596d1f309523a801e4f8064ac24c4689d2bd36fb9f84e2a30a/daytona_toolbox_api_client_async-0.135.0-py3-none-any.whl", hash = "sha256:fc3ada8f0b50c3c3d7a9e806569bb51fade9c6ff7fafed587dc4965dac7656d2", size = 163256, upload-time = "2026-01-26T14:16:23.006Z" },
 ]
 
 [[package]]
@@ -3009,7 +3009,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.1" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "daytona", specifier = ">=0.128.1" },
+    { name = "daytona", specifier = ">=0.135.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.127.1" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "moto", extras = ["s3"] },


### PR DESCRIPTION
### Main changes
- Refactored the way we were handling task alias and contained it to just the task context (easier to make and use)
- Added a force flag to the `stop_run` method that initiates force closure of sandboxes on the users request
- Added an alias property to Task table that allows us to create an alias for a task that we can use to make sandbox names unique (replaces older way)
- Added labels to sandboxes, this holds information we can use to create a generator and fetch the sandboxes up front
- Refactored the `process_task` method to handle force sandbox exit
- Reverted regression with `Image.Base(image_name)` syntax, should always be just the image string

### Unit tests
- Updated syntax for new --force flag
- Removed raise test for when we stop a benchmark and all tasks are running (since now we can force stop past this point)
- Added a new test for testing force stop functionality `tests/integration/test_force_stop.py`


### Test run instructions
`uv run pytest tests/integration/test_force_stop.py -s`


### New --force flag example
`uv run harness stop-run --benchmark-id <benchmark_id> --force`


### Additional Comments
- I would still consider this beta but the functionality works
- Noticing some fluctuations with the live watch feature. Ill fix that in another pr