### PR TITLE
Resume retry enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,15 +79,21 @@ uv run harness stop-run --benchmark-id <benchmark_id>
 ```
 
 Flags
+
 ```
 --force: Force stops all tasks in progress or evaluating (default: false)
 ```
-
 
 #### Resume a benchmark
 
 ```bash
 uv run harness resume-run --benchmark-id <benchmark_id>
+```
+
+Flags
+
+```
+--retry: Retry tasks with the status `error`
 ```
 
 #### List and filter benchmarks

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -281,12 +281,14 @@ async def stop_run(
 
 
 @app.post("/resume-run/{benchmark_id}")
-async def resume_run(benchmark_id: UUID, session: Session = Depends(get_session)) -> ResumeRunResponse:
+async def resume_run(
+    benchmark_id: UUID, retry: bool = Query(default=False), session: Session = Depends(get_session)
+) -> ResumeRunResponse:
     """
     Resume a benchmark run by its id.
 
     Usage:
-    curl -X POST http://<endpoint>/resume-run/<benchmark_id>
+    curl -X POST http://<endpoint>/resume-run/<benchmark_id>?retry=true
 
     Returns:
         ResumeRunResponse
@@ -306,7 +308,7 @@ async def resume_run(benchmark_id: UUID, session: Session = Depends(get_session)
     benchmark_service = start_run_request.benchmark_service
 
     # prepare benchmark and tasks to be resumed
-    verified_task_ids = await resume_benchmark(benchmark_row, session, benchmark_service)
+    verified_task_ids = await resume_benchmark(benchmark_row, session, benchmark_service, retry)
 
     # start the benchmark with the same args used to create it
     # we will delegate inside what tasks we are running

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -710,10 +710,13 @@ async def resume_benchmark(
                 f"No tasks for benchmark {benchmark_row.id} can be resumed because all tasks are finished"
             )
 
+        # id is task row primary key, task_id is the task id
+        task_mapping: dict[str, str] = {id: task_id for id, task_id in task_ids}
+
         # Verify the task ids are still valid before priming to resume
         # Raises if any task ids are invalid
         verify_response = await benchmark_service.request_verify_task_ids(
-            task_ids=[task_id for _, task_id in task_ids], slice_str=None
+            task_ids=list(task_mapping.values()), slice_str=None
         )
 
         # Set the benchmark status to in progress to flag resuming the benchmark
@@ -734,7 +737,7 @@ async def resume_benchmark(
         )
 
         # Delete all evaluation results for the tasks (unlikely they exist)
-        session.exec(delete(EvaluationResult).where(col(EvaluationResult.task).in_([id for id, _ in task_ids])))
+        session.exec(delete(EvaluationResult).where(col(EvaluationResult.task).in_(list(task_mapping.keys()))))
 
         session.commit()
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -703,7 +703,7 @@ async def resume_benchmark(
         filter_query = (col(Task.benchmark) == benchmark_row.id, col(Task.status).in_(retry_statuses))
 
         # Check if there are any tasks that have been stopped
-        task_ids = session.exec(select(Task.task_id).where(*filter_query)).all()
+        task_ids = session.exec(select(Task.id, Task.task_id).where(*filter_query)).all()
 
         if not task_ids:
             raise TrackerServiceError(
@@ -712,7 +712,9 @@ async def resume_benchmark(
 
         # Verify the task ids are still valid before priming to resume
         # Raises if any task ids are invalid
-        verify_response = await benchmark_service.request_verify_task_ids(task_ids=list(task_ids), slice_str=None)
+        verify_response = await benchmark_service.request_verify_task_ids(
+            task_ids=[task_id for _, task_id in task_ids], slice_str=None
+        )
 
         # Set the benchmark status to in progress to flag resuming the benchmark
         benchmark_row.status = BenchmarkStatus.IN_PROGRESS
@@ -732,7 +734,7 @@ async def resume_benchmark(
         )
 
         # Delete all evaluation results for the tasks (unlikely they exist)
-        session.exec(delete(EvaluationResult).where(col(EvaluationResult.task).in_(task_ids)))
+        session.exec(delete(EvaluationResult).where(col(EvaluationResult.task).in_([id for id, _ in task_ids])))
 
         session.commit()
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -700,12 +700,10 @@ async def resume_benchmark(
         if retry:
             retry_statuses.append(TaskStatus.ERROR)
 
+        filter_query = (col(Task.benchmark) == benchmark_row.id, col(Task.status).in_(retry_statuses))
+
         # Check if there are any tasks that have been stopped
-        task_ids = session.exec(
-            select(Task.task_id)
-            .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.status).in_(retry_statuses))
-        ).all()
+        task_ids = session.exec(select(Task.task_id).where(*filter_query)).all()
 
         if not task_ids:
             raise TrackerServiceError(
@@ -724,8 +722,7 @@ async def resume_benchmark(
         # Set the task status to starting to flag resuming the tasks
         session.exec(
             update(Task)
-            .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.status).in_(retry_statuses))
+            .where(*filter_query)
             .values(  # Reset to defaults
                 status=TaskStatus.STARTING,
                 started_at=datetime.now(ZoneInfo("UTC")),

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -711,7 +711,7 @@ async def resume_benchmark(
             )
 
         # id is task row primary key, task_id is the task id
-        task_mapping: dict[str, str] = {id: task_id for id, task_id in task_ids}
+        task_mapping: dict[UUID, str] = {id: task_id for id, task_id in task_ids}
 
         # Verify the task ids are still valid before priming to resume
         # Raises if any task ids are invalid

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from sqlmodel import Session, asc, case, col, desc, func, select, update
+from sqlmodel import Session, asc, case, col, delete, desc, func, select, update
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.config import broker
@@ -684,10 +684,11 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
 
 
 async def resume_benchmark(
-    benchmark_row: Benchmark, session: Session, benchmark_service: BenchmarkService
+    benchmark_row: Benchmark, session: Session, benchmark_service: BenchmarkService, retry: bool
 ) -> list[str]:
     """
     Resets benchmark and task status to flag resuming the benchmark.
+    if user requests to retry tasks, we reset objects with an error status ontop of the stopped status
 
     Benchmark - In progress status
     Tasks - Starting status
@@ -695,16 +696,20 @@ async def resume_benchmark(
     NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
     """
     try:
+        retry_statuses = [TaskStatus.STOPPED]
+        if retry:
+            retry_statuses.append(TaskStatus.ERROR)
+
         # Check if there are any tasks that have been stopped
         task_ids = session.exec(
             select(Task.task_id)
             .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.status) == TaskStatus.STOPPED)
+            .where(col(Task.status).in_(retry_statuses))
         ).all()
 
         if not task_ids:
             raise TrackerServiceError(
-                f"No tasks for benchmark {benchmark_row.id} have been stopped. Cannot resume benchmark."
+                f"No tasks for benchmark {benchmark_row.id} can be resumed because all tasks are finished"
             )
 
         # Verify the task ids are still valid before priming to resume
@@ -720,9 +725,17 @@ async def resume_benchmark(
         session.exec(
             update(Task)
             .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.status) == TaskStatus.STOPPED)
-            .values(status=TaskStatus.STARTING, started_at=datetime.now(ZoneInfo("UTC")))
+            .where(col(Task.status).in_(retry_statuses))
+            .values(  # Reset to defaults
+                status=TaskStatus.STARTING,
+                started_at=datetime.now(ZoneInfo("UTC")),
+                error_message=None,
+                finished_at=None,
+            )
         )
+
+        # Delete all evaluation results for the tasks (unlikely they exist)
+        session.exec(delete(EvaluationResult).where(col(EvaluationResult.task).in_(task_ids)))
 
         session.commit()
 

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from functools import partial
-from typing import Any
+from typing import Any, Sequence
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -134,6 +134,7 @@ class TestBenchmarkUtils:
             - Benchmark can be resumed if it is in a stopped state and a single task with the stopped status exists
             - After resuming, the benchmark status is "in progress" and tasks have been set to "starting" that were in the stopped state
             - Only the status of stopped tasks are updated
+            - Can resume a benchmark with tasks that have the status error
         """
 
         def get_test_session():
@@ -177,8 +178,8 @@ class TestBenchmarkUtils:
         )
 
         # Test request to resume the benchmark
-        response: Response = client.post(f"/resume-run/{benchmark_row.id}")
-        assert response.status_code == 200
+        response: Response = client.post(f"/resume-run/{benchmark_row.id}?retry=false")
+        assert response.status_code == 200, response.text
         assert response.json() == {"status": "success"}
 
         # Validate stopped tasks are now in starting state
@@ -190,6 +191,36 @@ class TestBenchmarkUtils:
         # Validate the benchmark is now in progress state
         benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session)
         assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+
+        # Reset benchmark row to stopped state
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # Fetch all tasks
+        fetched_task_rows: Sequence[Task] = database_session.exec(
+            select(Task).where(col(Task.benchmark) == benchmark_row.id)
+        ).all()
+        assert len(fetched_task_rows) == 10
+
+        # Change half of them to error and the other half reset to stopped
+        for i, task_row in enumerate(fetched_task_rows):
+            if i < 5:
+                task_row.status = TaskStatus.ERROR
+            else:
+                task_row.status = TaskStatus.STOPPED
+
+        database_session.commit()
+
+        # Call resume benchmark with retry enabled
+        response = client.post(f"/resume-run/{benchmark_row.id}?retry=true")
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+
+        # Validate all tasks are now in starting state
+        fetched_task_rows = database_session.exec(select(Task).where(col(Task.benchmark) == benchmark_row.id)).all()
+        assert len(fetched_task_rows) == 10
+        assert all(task_row.status == TaskStatus.STARTING for task_row in fetched_task_rows)
 
     def test_resume_benchmark_edge_cases(
         self, contract: AgentContractRequest, example_benchmark_object: Benchmark, database_session: Session
@@ -215,7 +246,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # failure code to resume the benchmark
-        response: Response = client.post(f"/resume-run/{benchmark_row.id}")
+        response: Response = client.post(f"/resume-run/{benchmark_row.id}?retry=false")
         assert response.status_code == 400
 
         # Set benchmark to stopped state but add only finished tasks
@@ -231,7 +262,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # error is returned because we have no stopped tasks to resume
-        response = client.post(f"/resume-run/{benchmark_row.id}")
+        response = client.post(f"/resume-run/{benchmark_row.id}?retry=false")
         assert response.status_code == 500
 
         # Ensure that we can recreate the environment the benchmark was started in

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -141,7 +141,9 @@ class TestStopAndResume:
             partial(self._mock_request_verify_task_ids, task_ids=starting_task_ids),
         )
 
-        verified_task_ids = await resume_benchmark(benchmark_row, database_session, start_run_request.benchmark_service)
+        verified_task_ids = await resume_benchmark(
+            benchmark_row, database_session, start_run_request.benchmark_service, retry=False
+        )
 
         # Only 3 tasks should be verified for resume (the 3 tasks that are stopped)
         assert len(verified_task_ids) == 3

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -281,12 +281,19 @@ def stop_run(benchmark_id: UUID, force: bool):
     required=True,
     help="Benchmark id (e.g., 123e4567-e89b-12d3-a456-426614174000)",
 )
-def resume_run(benchmark_id: UUID):
+@click.option(
+    "--retry",
+    is_flag=True,
+    required=False,
+    default=False,
+    help="Retry tasks with the status error",
+)
+def resume_run(benchmark_id: UUID, retry: bool):
     """
     Resume a benchmark run by its benchmark id.
 
     Example:
-        harness resume-run --benchmark-id 123e4567-e89b-12d3-a456-426614174000
+        harness resume-run --benchmark-id 123e4567-e89b-12d3-a456-426614174000 --retry
     """
     click.echo(f"Resuming run for benchmark: {benchmark_id}")
     try:
@@ -294,7 +301,7 @@ def resume_run(benchmark_id: UUID):
             if not check_tracker_service_health(tracker):
                 return
 
-            _ = tracker.resume_run(benchmark_id)
+            _ = tracker.resume_run(benchmark_id, retry)
             click.echo(click.style("Run resumed successfully!", fg="green", bold=True))
             click.echo(
                 click.style(

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -225,18 +225,18 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stop run: {e}") from e
 
-    def resume_run(self, benchmark_id: UUID) -> ResumeRunResponse:
+    def resume_run(self, benchmark_id: UUID, retry: bool) -> ResumeRunResponse:
         """
         Resume a benchmark run by its benchmark id.
 
         Args:
             benchmark_id: Benchmark id
-
+            retry: Whether to retry tasks with the status error
         Returns:
             ResumeRunResponse with status and message
         """
         try:
-            response = self._client.post(f"{self._base_url}/resume-run/{benchmark_id}")
+            response = self._client.post(f"{self._base_url}/resume-run/{benchmark_id}", params={"retry": retry})
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)
                 raise TrackerServiceError(f"Failed to resume run: {details}")


### PR DESCRIPTION
### Main changes
- Added a --retry flag to the resume command that retries all tasks with the status error (ontop of resuming the stopped tasks)
- Added unit test to ensure the status change took affect
- Updated tests and references with new flag (plus docs)


### Additional Notes
This change was pretty easy to make since the `process_benchmark` method is flexible in the way that it runs all `task_ids` that are passed in. So as long as we are resetting the tasks we can retry any tasks we want.

### Next steps
- Adding a --force flag that restarts a task in a finished state, this will be for if we ever want to re-run a set of tasks and not have to redo the whole benchmark