### PR TITLE
Resume --force flag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Flags
 
 ```
 --retry: Retry tasks with the status `error`
+--force task_1 task_2: force retry tasks with the specified space separated ids
 ```
 
 #### List and filter benchmarks

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Flags
 
 ```
 --retry: Retry tasks with the status `error`
---force task_1 task_2: force retry tasks with the specified space separated ids
+--force task_1 task_2: force retry tasks with the specified space separated ids (the retry flag is separate and not required to use this flag)
 ```
 
 #### List and filter benchmarks

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1,7 +1,7 @@
 import traceback
 from uuid import UUID
 
-from fastapi import Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
+from fastapi import Body, Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import joinedload
 from sqlmodel import Session, col, func, select
@@ -282,14 +282,17 @@ async def stop_run(
 
 @app.post("/resume-run/{benchmark_id}")
 async def resume_run(
-    benchmark_id: UUID, retry: bool = Query(default=False), session: Session = Depends(get_session)
+    benchmark_id: UUID,
+    retry: bool = Query(default=False),
+    force: list[str] = Body(default=[]),
+    session: Session = Depends(get_session),
 ) -> ResumeRunResponse:
     """
     Resume a benchmark run by its id.
 
     Usage:
     curl -X POST http://<endpoint>/resume-run/<benchmark_id>?retry=true
-
+      -d '{"force": ["task_id_1", "task_id_2"]}'
     Returns:
         ResumeRunResponse
     """
@@ -308,7 +311,7 @@ async def resume_run(
     benchmark_service = start_run_request.benchmark_service
 
     # prepare benchmark and tasks to be resumed
-    verified_task_ids = await resume_benchmark(benchmark_row, session, benchmark_service, retry)
+    verified_task_ids = await resume_benchmark(benchmark_row, session, benchmark_service, retry, force)
 
     # start the benchmark with the same args used to create it
     # we will delegate inside what tasks we are running

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -684,11 +684,13 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
 
 
 async def resume_benchmark(
-    benchmark_row: Benchmark, session: Session, benchmark_service: BenchmarkService, retry: bool
+    benchmark_row: Benchmark, session: Session, benchmark_service: BenchmarkService, retry: bool, force: list[str]
 ) -> list[str]:
     """
     Resets benchmark and task status to flag resuming the benchmark.
-    if user requests to retry tasks, we reset objects with an error status ontop of the stopped status
+
+    Retry: we reset objects with an error status ontop of the stopped status
+    Force: even if task has been finished we restart it
 
     Benchmark - In progress status
     Tasks - Starting status
@@ -700,7 +702,11 @@ async def resume_benchmark(
         if retry:
             retry_statuses.append(TaskStatus.ERROR)
 
-        filter_query = (col(Task.benchmark) == benchmark_row.id, col(Task.status).in_(retry_statuses))
+        filter_query = [col(Task.benchmark) == benchmark_row.id, col(Task.status).in_(retry_statuses)]
+
+        # If force is provided, we add the task ids to the filter query
+        if force:
+            filter_query.append(col(Task.task_id).in_(force))
 
         # Check if there are any tasks that have been stopped
         task_ids = session.exec(select(Task.id, Task.task_id).where(*filter_query)).all()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -719,6 +719,13 @@ async def resume_benchmark(
         # id is task row primary key, task_id is the task id
         task_mapping: dict[UUID, str] = {id: task_id for id, task_id in task_ids}
 
+        # Ensure we are not missing any tasks that were requested (skips if force is empty)
+        missing_task_ids = [task_id for task_id in force if task_id not in task_mapping.values()]
+        if missing_task_ids:
+            raise TrackerServiceError(
+                f"Task ids {', '.join(missing_task_ids)} were requested to be force resumed but do not exist"
+            )
+
         # Verify the task ids are still valid before priming to resume
         # Raises if any task ids are invalid
         verify_response = await benchmark_service.request_verify_task_ids(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -11,7 +11,7 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from sqlmodel import Session, asc, case, col, delete, desc, func, select, update
+from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.config import broker
@@ -702,19 +702,16 @@ async def resume_benchmark(
         if retry:
             retry_statuses.append(TaskStatus.ERROR)
 
-        filter_query = [col(Task.benchmark) == benchmark_row.id, col(Task.status).in_(retry_statuses)]
-
-        # If force is provided, we add the task ids to the filter query
-        if force:
-            filter_query.append(col(Task.task_id).in_(force))
+        filter_query = [
+            col(Task.benchmark) == benchmark_row.id,
+            or_(
+                col(Task.status).in_(retry_statuses),
+                col(Task.task_id).in_(force),
+            ),
+        ]
 
         # Check if there are any tasks that have been stopped
         task_ids = session.exec(select(Task.id, Task.task_id).where(*filter_query)).all()
-
-        if not task_ids:
-            raise TrackerServiceError(
-                f"No tasks for benchmark {benchmark_row.id} can be resumed because all tasks are finished"
-            )
 
         # id is task row primary key, task_id is the task id
         task_mapping: dict[UUID, str] = {id: task_id for id, task_id in task_ids}
@@ -723,7 +720,12 @@ async def resume_benchmark(
         missing_task_ids = [task_id for task_id in force if task_id not in task_mapping.values()]
         if missing_task_ids:
             raise TrackerServiceError(
-                f"Task ids {', '.join(missing_task_ids)} were requested to be force resumed but do not exist"
+                f"{', '.join(missing_task_ids)} was requested to be force resumed but does not exist in the dataset"
+            )
+
+        if not task_ids:
+            raise TrackerServiceError(
+                f"No tasks for benchmark {benchmark_row.id} can be resumed because all tasks are finished"
             )
 
         # Verify the task ids are still valid before priming to resume

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -223,7 +223,11 @@ class TestBenchmarkUtils:
         assert all(task_row.status == TaskStatus.STARTING for task_row in fetched_task_rows)
 
     def test_resume_benchmark_edge_cases(
-        self, contract: AgentContractRequest, example_benchmark_object: Benchmark, database_session: Session
+        self,
+        contract: AgentContractRequest,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
     ):
         """
         Tests edge cases for resuming a benchmark
@@ -233,6 +237,7 @@ class TestBenchmarkUtils:
             - Cannot resume a benchmark where all tasks have already finished
             - Errors are raised and returned to the client
             - Can recreate the same environment the benchmark was started in
+            - Can force resume a task and validate the task ids passed in
         """
 
         def get_test_session():
@@ -278,6 +283,48 @@ class TestBenchmarkUtils:
 
         recreated_start_run_request = benchmark_row.start_run_request
         assert recreated_start_run_request == original_start_run_request
+
+        # Assert we have 5 tasks in the database
+        task_rows = database_session.exec(select(Task).where(col(Task.benchmark) == example_benchmark_object.id)).all()
+        assert len(task_rows) == 5
+
+        # Change one task to stopped state
+        database_session.exec(
+            update(Task).where(col(Task.task_id) == task_rows[0].task_id).values(status=TaskStatus.STOPPED)
+        )
+        database_session.commit()
+
+        # Task id is provided as a force parameter but does not exist in dataset
+        response = client.post(f"/resume-run/{example_benchmark_object.id}?retry=false", json=["task_5"])
+        assert response.status_code == 500
+        assert "task_5" in response.json()["detail"]
+
+        # Assert all tasks but 0 are in finished state
+        task_rows = database_session.exec(
+            select(Task).where(
+                (col(Task.benchmark) == example_benchmark_object.id) & (col(Task.task_id) != task_rows[0].task_id)
+            )
+        ).all()
+        task_ids = [task_row.task_id for task_row in task_rows]
+
+        monkeypatch.setattr(
+            BenchmarkService,
+            "request_verify_task_ids",
+            partial(self._mock_request_verify_task_ids, task_ids=task_ids),
+        )
+
+        assert all(task_row.status == TaskStatus.FINISHED for task_row in task_rows)
+
+        # Try again with the correct task ids
+
+        response = client.post(f"/resume-run/{example_benchmark_object.id}?retry=false", json=task_ids)
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+
+        # Validate the tasks are now in starting state
+        task_rows = database_session.exec(select(Task).where(col(Task.benchmark) == example_benchmark_object.id)).all()
+        assert len(task_rows) == 5
+        assert all(task_row.status == TaskStatus.STARTING for task_row in task_rows)
 
     def test_create_task_rows(self, example_benchmark_object: Benchmark, database_session: Session):
         """

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -142,7 +142,7 @@ class TestStopAndResume:
         )
 
         verified_task_ids = await resume_benchmark(
-            benchmark_row, database_session, start_run_request.benchmark_service, retry=False
+            benchmark_row, database_session, start_run_request.benchmark_service, retry=False, force=[]
         )
 
         # Only 3 tasks should be verified for resume (the 3 tasks that are stopped)

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -288,7 +288,14 @@ def stop_run(benchmark_id: UUID, force: bool):
     default=False,
     help="Retry tasks with the status error",
 )
-def resume_run(benchmark_id: UUID, retry: bool):
+@click.option(
+    "--force",
+    nargs=-1,
+    required=False,
+    default=[],
+    help="Force retry tasks with the given task ids (e.g., task_1_id task_2_id)",
+)
+def resume_run(benchmark_id: UUID, retry: bool, force: list[str]):
     """
     Resume a benchmark run by its benchmark id.
 
@@ -301,7 +308,7 @@ def resume_run(benchmark_id: UUID, retry: bool):
             if not check_tracker_service_health(tracker):
                 return
 
-            _ = tracker.resume_run(benchmark_id, retry)
+            _ = tracker.resume_run(benchmark_id, retry, force)
             click.echo(click.style("Run resumed successfully!", fg="green", bold=True))
             click.echo(
                 click.style(

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -290,12 +290,12 @@ def stop_run(benchmark_id: UUID, force: bool):
 )
 @click.option(
     "--force",
-    nargs=-1,
+    type=str,
     required=False,
-    default=[],
+    default=None,
     help="Force retry tasks with the given task ids (e.g., task_1_id task_2_id)",
 )
-def resume_run(benchmark_id: UUID, retry: bool, force: list[str]):
+def resume_run(benchmark_id: UUID, retry: bool, force: str | None):
     """
     Resume a benchmark run by its benchmark id.
 
@@ -308,7 +308,8 @@ def resume_run(benchmark_id: UUID, retry: bool, force: list[str]):
             if not check_tracker_service_health(tracker):
                 return
 
-            _ = tracker.resume_run(benchmark_id, retry, force)
+            force_task_ids = force.split() if force else []
+            _ = tracker.resume_run(benchmark_id, retry, force_task_ids)
             click.echo(click.style("Run resumed successfully!", fg="green", bold=True))
             click.echo(
                 click.style(

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -225,18 +225,22 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stop run: {e}") from e
 
-    def resume_run(self, benchmark_id: UUID, retry: bool) -> ResumeRunResponse:
+    def resume_run(self, benchmark_id: UUID, retry: bool, force: list[str]) -> ResumeRunResponse:
         """
         Resume a benchmark run by its benchmark id.
 
         Args:
             benchmark_id: Benchmark id
             retry: Whether to retry tasks with the status error
+            force: List of task ids to force retry
+
         Returns:
             ResumeRunResponse with status and message
         """
         try:
-            response = self._client.post(f"{self._base_url}/resume-run/{benchmark_id}", params={"retry": retry})
+            response = self._client.post(
+                f"{self._base_url}/resume-run/{benchmark_id}", params={"retry": retry}, json={"force": force}
+            )
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)
                 raise TrackerServiceError(f"Failed to resume run: {details}")

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -239,7 +239,7 @@ class TrackerService:
         """
         try:
             response = self._client.post(
-                f"{self._base_url}/resume-run/{benchmark_id}", params={"retry": retry}, json={"force": force}
+                f"{self._base_url}/resume-run/{benchmark_id}", params={"retry": retry}, json=force
             )
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)


### PR DESCRIPTION
### Main changes
- Added a `--force` flag to the resume feature which allows you to specify a list of tasks that you want to retry while resuming a run
- Added unit test with the other resume unit tests
- Updated docs

### Testing
- You can just finish a single task in a run, stop the run then resume again using the --force flag to retry that task

### Additional Notes
- I am also going to make a separate cli to just retry a finished benchmark. Right now these flags are only good for if you want to resume a benchmark. The functionality is the same so its really just going to be an alias with a slight tweak to the utils
- Another thing I was thinking about is that maybe instead of `--force` we can do `--task_ids`?