### PR TITLE
Agent output

### DIFF
--- a/agents/CONTRACTS.md
+++ b/agents/CONTRACTS.md
@@ -13,6 +13,7 @@ Create a `contract.py` file in your agent directory that defines a contract clas
 ```python
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 
 from agentic_harness.contract import BaseAgentContract
 from agentic_harness.schemas import AgentConfig
@@ -36,6 +37,10 @@ class MyAgentContract(BaseAgentContract):
         return "bash setup.sh"
 
     @property
+    def final_output(self) -> Path | str:
+        return Path("path/to/agent_output.json")
+
+    @property
     def env(self) -> dict[str, str]:
         return {"API_KEY": os.getenv("API_KEY")}
 
@@ -53,6 +58,7 @@ contract = MyAgentContract
 Your contract class must implement these abstract properties:
 
 ### `name: str`
+
 The name of your agent contract.
 
 ```python
@@ -62,6 +68,7 @@ def name(self) -> str:
 ```
 
 ### `install_cmd: str`
+
 Command to install the agent and its dependencies. Runs once during sandbox setup with the working directory set to `/bundle/<agent_name>/`.
 
 ```python
@@ -70,7 +77,18 @@ def install_cmd(self) -> str:
     return "bash setup.sh"
 ```
 
+### `final_output: Path | None`
+
+Path to the file with the final output you want to parse. This will be returned within a `agent_output` field inside of the evaluation result json. Use this to include metadata about the agent run you would like to see after. If `None` the field will be ommited from the evaluation result. Parses jsons automatically, will put text from a `.txt` file inside of a result field.
+
+```python
+@property
+def final_output(self) -> Path | None:
+    return Path("/absolute/path/file.txt")
+```
+
 ### `run_cmd: str`
+
 Command to run the agent on a task. Use `{problem_statement}` as a placeholder (single braces!) - it will be replaced with the actual task prompt at runtime.
 
 ```python
@@ -83,6 +101,7 @@ def run_cmd(self) -> str:
 ## Optional Properties
 
 ### `artifacts: list[str]`
+
 Files and directories to bundle with the agent (default: empty list). Paths are relative to your agent directory.
 
 ```python
@@ -92,6 +111,7 @@ def artifacts(self) -> list[str]:
 ```
 
 ### `env: dict[str, str]`
+
 Environment variables required by the agent (default: empty dict). Load secrets from your local environment.
 
 ```python
@@ -121,6 +141,7 @@ class MyAgentContract(BaseAgentContract):
 ```
 
 Then run from the CLI with:
+
 ```bash
 harness start-benchmark --agent agents/my_agent --model openai/gpt-4o --benchmark swebench
 ```
@@ -143,6 +164,7 @@ agents/
 The `install_cmd` runs inside the sandbox with the working directory set to `/bundle/<agent_name>/`. Use it to install dependencies and set up your agent.
 
 Example `setup.sh`:
+
 ```bash
 #!/bin/bash
 set -euo pipefail
@@ -200,5 +222,6 @@ def run_cmd(self) -> str:
 ## Complete Examples
 
 See these agent implementations for reference:
+
 - `agents/claude_code/` - CLI tool installation
 - `agents/sweagent/` - Python agent with dynamic model configuration

--- a/agents/claude_code/contract.py
+++ b/agents/claude_code/contract.py
@@ -1,8 +1,10 @@
 import os
+from pathlib import Path
+
 from dotenv import load_dotenv
+from model_library.registry_utils import get_model_names_by_provider
 
 from agentic_harness.contract import BaseAgentContract
-from model_library.registry_utils import get_model_names_by_provider
 
 load_dotenv()
 
@@ -47,6 +49,10 @@ class ClaudeCodeContract(BaseAgentContract):
     @property
     def env(self) -> dict[str, str]:
         return {"ANTHROPIC_API_KEY": os.environ["ANTHROPIC_API_KEY"]}
+
+    @property
+    def final_output(self) -> Path | None:
+        return None
 
     @property
     def run_cmd(self) -> str:

--- a/agents/sweagent/contract.py
+++ b/agents/sweagent/contract.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from dotenv import dotenv_values
 
 from agentic_harness.contract import BaseAgentContract
@@ -21,6 +23,10 @@ class SWEAgentContract(BaseAgentContract):
     @property
     def env(self) -> dict[str, str]:
         return {k: v for k, v in dotenv_values().items() if v is not None}
+
+    @property
+    def final_output(self) -> Path | None:
+        return Path("/logs/sweagent/stats.json")
 
     @property
     def run_cmd(self) -> str:

--- a/services/tracker/src/tracker/database/migrations/versions/26b342c24bd4_updated_contract_and_agent_output.py
+++ b/services/tracker/src/tracker/database/migrations/versions/26b342c24bd4_updated_contract_and_agent_output.py
@@ -1,0 +1,41 @@
+"""Updated contract and agent output
+
+Revision ID: 26b342c24bd4
+Revises: 2a83996162a5
+Create Date: 2026-01-29 12:22:43.282031
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401 # type: ignore
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "26b342c24bd4"
+down_revision: Union[str, Sequence[str], None] = "2a83996162a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    # Convert empty strings to empty JSON objects BEFORE changing the column type
+    connection.execute(
+        text("""
+        UPDATE evaluationresult
+        SET agent_output = '{}'
+        WHERE agent_output = '' OR agent_output IS NULL
+    """)
+    )
+
+    # Now change the column type using batch mode
+    with op.batch_alter_table("evaluationresult") as batch_op:
+        batch_op.alter_column("agent_output", existing_type=sa.VARCHAR(), type_=sa.JSON(), existing_nullable=False)
+
+
+def downgrade() -> None:
+    pass

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
@@ -51,6 +52,7 @@ class AgentContractRequest(BaseModel):
     artifacts: list[str] = []
     install_cmd: str
     run_cmd: str
+    final_output: Path | None = None
     env: dict[str, str] = {}
 
 

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -269,4 +269,4 @@ class EvaluationResult(SQLModel, table=True):
     task: UUID = Field(foreign_key="task.id")
     instance_id: str = Field(unique=True)
     result: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))
-    agent_output: str = Field(default="")
+    agent_output: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
@@ -52,7 +51,7 @@ class AgentContractRequest(BaseModel):
     artifacts: list[str] = []
     install_cmd: str
     run_cmd: str
-    final_output: Path | None = None
+    final_output: str | None = None
     env: dict[str, str] = {}
 
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -147,7 +147,7 @@ async def run_agent(
         problem_statement: Problem statement to pass to the agent
 
     Returns:
-        Agent output
+        Agent output if the final output is a valid json, otherwise an empty dict
 
     Raises:
         SandboxError: If the agent fails to run or times out
@@ -156,8 +156,18 @@ async def run_agent(
 
     run_cmd = contract.run_cmd.replace("{problem_statement}", shlex.quote(problem_statement))
 
+    # Tracks last line from the agent
+    # NOTE: Basedpyright gives us an unreachable error if we use str | None here
+    output: list[str] = []
+
     def on_data(data: str) -> None:
-        stream_logger.info(data.strip("\n"))
+        data = data.strip("\n")
+        stream_logger.info(data)
+
+        if output:
+            output[-1] = data
+        else:
+            output.append(data)
 
     session_id = f"{contract.name}-{task_id.replace(' ', '_')}"
 
@@ -189,24 +199,15 @@ async def run_agent(
         if cmd.exit_code != 0:
             raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
 
-        agent_output_path = "/tmp/agent_output.json"
-
-        # Check if a agent_output.json file exists
-        agent_output_exists = await sandbox.process.exec(f"[ -f {agent_output_path} ]")
-
-        # If agent output does not exist, return an empty result
-        if agent_output_exists.exit_code != 0:
+        if not output:
             return {}
 
-        # If agent output exists, try to load it as a json, if not, return the result as a string
-        agent_output = await sandbox.process.exec(f"cat {agent_output_path}")
-
         try:
-            return json.loads(agent_output.result)
+            return json.loads(output[-1])
         except Exception:
             pass
 
-        return {"result": agent_output.result}
+        return {}
 
     finally:
         try:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -205,6 +205,7 @@ async def run_agent(
         try:
             return json.loads(agent_output.result)
         except Exception:
+            logger.warning("Failed to load agent output as a json, creating a fallback result")
             pass
 
         return {

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import io
+import json
 import shlex
 import zipfile
 from contextlib import asynccontextmanager
@@ -136,7 +137,7 @@ async def install_agent_dependencies(sandbox: AsyncSandbox, contract: AgentContr
 
 async def run_agent(
     sandbox: AsyncSandbox, contract: AgentContractRequest, problem_statement: str, task_id: str, cwd: str
-) -> str:
+) -> dict[str, Any]:
     """
     Run the agent inside the sandbox for a given task.
 
@@ -145,8 +146,8 @@ async def run_agent(
         contract_name: Name of the contract
         problem_statement: Problem statement to pass to the agent
 
-    Retruns:
-        Agent stdout and stderr
+    Returns:
+        Agent output
 
     Raises:
         SandboxError: If the agent fails to run or times out
@@ -188,7 +189,25 @@ async def run_agent(
         if cmd.exit_code != 0:
             raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
 
-        return ""
+        agent_output_path = "/tmp/agent_output.json"
+
+        # Check if a agent_output.json file exists
+        agent_output_exists = await sandbox.process.exec(f"[ -f {agent_output_path} ]")
+
+        # If agent output does not exist, return an empty result
+        if agent_output_exists.exit_code != 0:
+            return {}
+
+        # If agent output exists, try to load it as a json, if not, return the result as a string
+        agent_output = await sandbox.process.exec(f"cat {agent_output_path}")
+
+        try:
+            return json.loads(agent_output.result)
+        except Exception:
+            pass
+
+        return {"result": agent_output.result}
+
     finally:
         try:
             await sandbox.process.delete_session(session_id)

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -147,7 +147,7 @@ async def run_agent(
         problem_statement: Problem statement to pass to the agent
 
     Returns:
-        Agent output if the final output is a valid json, otherwise an empty dict
+        Agent output as a dictionary
 
     Raises:
         SandboxError: If the agent fails to run or times out
@@ -156,18 +156,8 @@ async def run_agent(
 
     run_cmd = contract.run_cmd.replace("{problem_statement}", shlex.quote(problem_statement))
 
-    # Tracks last line from the agent
-    # NOTE: Basedpyright gives us an unreachable error if we use str | None here
-    output: list[str] = []
-
     def on_data(data: str) -> None:
-        data = data.strip("\n")
-        stream_logger.info(data)
-
-        if output:
-            output[-1] = data
-        else:
-            output.append(data)
+        stream_logger.info(data.strip("\n"))
 
     session_id = f"{contract.name}-{task_id.replace(' ', '_')}"
 
@@ -199,15 +189,24 @@ async def run_agent(
         if cmd.exit_code != 0:
             raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
 
-        if not output:
+        # Check if a agent_output.json file exists
+        agent_output_exists = await sandbox.process.exec(f"[ -f {contract.final_output} ]")
+
+        # If agent output does not exist, return an empty result
+        if agent_output_exists.exit_code != 0:
             return {}
 
+        # If agent output exists, try to load it as a json, if not, return the result as a string
+        agent_output = await sandbox.process.exec(f"cat {contract.final_output}")
+
         try:
-            return json.loads(output[-1])
+            return json.loads(agent_output.result)
         except Exception:
             pass
 
-        return {}
+        return {
+            "result": agent_output.result,
+        }
 
     finally:
         try:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -189,6 +189,9 @@ async def run_agent(
         if cmd.exit_code != 0:
             raise SandboxError(f"Failed to run agent {contract.name}, exit code: {cmd.exit_code}")
 
+        if not contract.final_output:
+            return {}
+
         # Check if a agent_output.json file exists
         agent_output_exists = await sandbox.process.exec(f"[ -f {contract.final_output} ]")
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -494,6 +494,9 @@ def fetch_evaluation_results(benchmark_id: UUID, session: Session) -> dict[str, 
     evaluation_results: dict[str, dict[str, Any]] = {}
     for evaluation_result, task_id in results:
         result_data = evaluation_result.result
+        if evaluation_result.agent_output:
+            result_data["agent_output"] = evaluation_result.agent_output
+
         evaluation_results[task_id] = result_data
 
     return evaluation_results

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -223,7 +223,6 @@ async def process_task(
                         _ = await benchmark_service.request_setup_task(task_row.task_id, sandbox.id)
 
                     # Run the agent inside of the sandbox
-                    # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
                     agent_output = await run_agent(
                         sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd
                     )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -224,7 +224,7 @@ async def process_task(
 
                     # Run the agent inside of the sandbox
                     # NOTE: Currently only testing when agent does not need a response, in the future run agent will return a json to evaluate it needed
-                    await run_agent(
+                    agent_output = await run_agent(
                         sandbox, start_run_request.contract, task_data.problem_statement, task_id, task_data.cwd
                     )
 
@@ -240,7 +240,7 @@ async def process_task(
 
                     # Save the evaluation result to the database with the task row
                     evaluation_result_row = EvaluationResult(
-                        task=task_row.id, instance_id=sandbox.id, result=evaluation_result
+                        task=task_row.id, instance_id=sandbox.id, result=evaluation_result, agent_output=agent_output
                     )
                     task_session.add(evaluation_result_row)
 

--- a/services/tracker/tests/integration/conftest.py
+++ b/services/tracker/tests/integration/conftest.py
@@ -21,6 +21,9 @@ async def benchmark_service() -> AsyncGenerator[BenchmarkService, None]:
 
     yield service
 
+    if service.daytona_client:
+        await service.daytona_client.close()
+
 
 @pytest.fixture
 async def daytona_client(benchmark_service: BenchmarkService) -> AsyncGenerator[AsyncDaytona, None]:

--- a/services/tracker/tests/integration/test_process_benchmark.py
+++ b/services/tracker/tests/integration/test_process_benchmark.py
@@ -259,7 +259,7 @@ class TestProcessBenchmark:
         # Benchmark status is updated to error once the benchmark is done running
         database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.ERROR
-        assert benchmark_row.error_message == "Handled database error"
+        assert "Handled database error" in (benchmark_row.error_message or "")
 
     async def test_process_task_error(
         self,
@@ -335,7 +335,7 @@ class TestProcessBenchmark:
         assert len(tasks) == 1
 
         # Error message is set on the task row
-        assert tasks[0].error_message == "Exception raised while setting up the task"
+        assert "Exception raised while setting up the task" in (tasks[0].error_message or "")
         assert tasks[0].status == TaskStatus.ERROR
 
         final_evaluation = benchmark_row.final_evaluation

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -2,6 +2,7 @@
 
 import io
 import zipfile
+from pathlib import Path
 from typing import AsyncGenerator, Generator
 from unittest.mock import MagicMock, patch
 
@@ -126,16 +127,19 @@ class TestSandboxOperations:
 
         mock_stream_logger.info.side_effect = mock_info
 
-        run_cmd = "echo line1 && sleep 1 && echo line2 && sleep 1 && echo line3"
+        run_cmd = 'echo line1 && sleep 1 && echo line2 && sleep 1 && echo line3 && echo \'{"result": "hello world"}\' > /tmp/agent_output.json'
 
         contract = AgentContractRequest(
             name="test_agent",
             artifacts=[],
             install_cmd="echo 'no-op'",
             run_cmd=run_cmd,
+            final_output=Path("/tmp/agent_output.json"),
         )
 
-        await run_agent(test_sandbox, contract, "some problem statement", "some task id", cwd="/")
+        final_output = await run_agent(test_sandbox, contract, "some problem statement", "some task id", cwd="/")
+
+        assert final_output == {"result": "hello world"}
 
         output = "\n".join(logged_messages)
         assert "line1" in output

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -2,7 +2,6 @@
 
 import io
 import zipfile
-from pathlib import Path
 from typing import AsyncGenerator, Generator
 from unittest.mock import MagicMock, patch
 
@@ -134,7 +133,7 @@ class TestSandboxOperations:
             artifacts=[],
             install_cmd="echo 'no-op'",
             run_cmd=run_cmd,
-            final_output=Path("/tmp/agent_output.json"),
+            final_output="/tmp/agent_output.json",
         )
 
         final_output = await run_agent(test_sandbox, contract, "some problem statement", "some task id", cwd="/")

--- a/src/agentic_harness/contract.py
+++ b/src/agentic_harness/contract.py
@@ -96,9 +96,9 @@ class BaseAgentContract(ABC):
         Path to the final output of the agent. Needs to be an absolute path.
 
         Returns:
-            Path to the final output of the agent or None if no final output is required
+            Path | None: The path to the final output that the agent writes to.
         """
-        return None
+        pass
 
     def to_request(self) -> AgentContractRequest:
         """

--- a/src/agentic_harness/contract.py
+++ b/src/agentic_harness/contract.py
@@ -113,4 +113,5 @@ class BaseAgentContract(ABC):
             install_cmd=self.install_cmd,
             env=self.env,
             artifacts=self.artifacts,
+            final_output=self.final_output,
         )

--- a/src/agentic_harness/contract.py
+++ b/src/agentic_harness/contract.py
@@ -113,5 +113,5 @@ class BaseAgentContract(ABC):
             install_cmd=self.install_cmd,
             env=self.env,
             artifacts=self.artifacts,
-            final_output=self.final_output,
+            final_output=str(self.final_output) if self.final_output else None,
         )

--- a/src/agentic_harness/contract.py
+++ b/src/agentic_harness/contract.py
@@ -93,7 +93,7 @@ class BaseAgentContract(ABC):
     @abstractmethod
     def final_output(self) -> Path | None:
         """
-        Path to the final output of the agent.
+        Path to the final output of the agent. Needs to be an absolute path.
 
         Returns:
             Path to the final output of the agent or None if no final output is required

--- a/src/agentic_harness/contract.py
+++ b/src/agentic_harness/contract.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from tracker.database.models import AgentContractRequest
+
 from agentic_harness.schemas import AgentConfig
 
 
@@ -86,6 +88,17 @@ class BaseAgentContract(ABC):
             List of artifact paths (default: empty list)
         """
         return []
+
+    @property
+    @abstractmethod
+    def final_output(self) -> Path | None:
+        """
+        Path to the final output of the agent.
+
+        Returns:
+            Path to the final output of the agent or None if no final output is required
+        """
+        return None
 
     def to_request(self) -> AgentContractRequest:
         """


### PR DESCRIPTION
### Main changes
- Added `final_output : Path | None` property to the agent contract, this is where the user will state the absolute path to the file they want to parse
- Updated both agent contracts to have this property
- Updated sweagent commit to a new branch i made. In this branch i changed where the trajectory info is saved so its more deterministic
- Updated the contracts documentation
- Updated the database column type for the `agent_output`
- Updated the `run_agent` method to handle parsing the final agent output if its specified, if we fail to parse it into a json it just becomes text inside of a base `result` dict we create
- Removed some old docs and updated references + added a test case for the run agent method

### Where to find after task completion?

The agent output field will be present inside of the evaluation results.
```
"evaluation_results": {
  "astropy__astropy-12907": {
  "agent_output": {
      "instance_cost": 0.3102047499999999,
      "tokens_sent": 1876364,
      "tokens_received": 20493,
      "api_calls": 51,
```