### PR TITLE
Runtime bug fixes

### DIFF
--- a/agents/sweagent/contract.py
+++ b/agents/sweagent/contract.py
@@ -26,7 +26,8 @@ class SWEAgentContract(BaseAgentContract):
 
     @property
     def final_output(self) -> Path | None:
-        return Path("/logs/sweagent/stats.json")
+        # return Path("/logs/sweagent/stats.json")
+        return None
 
     @property
     def run_cmd(self) -> str:

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -263,8 +263,9 @@ async def stop_benchmark(
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
-    # Can only pause a in progress benchmark
-    if benchmark_row.status not in [BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.ERROR]:
+    valid_stop_states = [BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPING]
+
+    if benchmark_row.status not in valid_stop_states:
         raise HTTPException(
             status_code=400,
             detail=f"Benchmark {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress or error benchmark.",
@@ -300,7 +301,9 @@ async def resume_benchmark(
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
-    if benchmark_row.status not in [BenchmarkStatus.STOPPED, BenchmarkStatus.ERROR]:
+    valid_resume_states = [BenchmarkStatus.STOPPED, BenchmarkStatus.ERROR]
+
+    if benchmark_row.status not in valid_resume_states:
         raise HTTPException(
             status_code=400,
             detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the stopped or error state to resume.",

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -300,10 +300,10 @@ async def resume_benchmark(
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
-    if benchmark_row.status != BenchmarkStatus.STOPPED:
+    if benchmark_row.status not in [BenchmarkStatus.STOPPED, BenchmarkStatus.ERROR]:
         raise HTTPException(
             status_code=400,
-            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the stopped state to resume.",
+            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the stopped or error state to resume.",
         )
 
     start_benchmark_request = benchmark_row.start_benchmark_request

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -264,10 +264,10 @@ async def stop_benchmark(
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
     # Can only pause a in progress benchmark
-    if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+    if benchmark_row.status not in [BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.ERROR]:
         raise HTTPException(
             status_code=400,
-            detail=f"Benchmark {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress benchmark.",
+            detail=f"Benchmark {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress or error benchmark.",
         )
 
     await initiate_stop_benchmark(benchmark_row, session, force)

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -22,5 +22,8 @@ result_backend: RedisAsyncResultBackend[Any] = RedisAsyncResultBackend(
 broker = (
     InMemoryBroker()
     if BROKER_ENVIRONMENT == "testing"
-    else RedisStreamBroker(url=REDIS_URL).with_result_backend(result_backend)
+    else RedisStreamBroker(
+        url=REDIS_URL,
+        idle_timeout=86400000,  # 24 hours
+    ).with_result_backend(result_backend)
 )

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -131,7 +131,6 @@ async def install_agent_dependencies(sandbox: AsyncSandbox, contract: AgentContr
         logger.error(error_msg)
         raise SandboxError(error_msg)
 
-    logger.info(response.result)
     logger.info(f"Finished running installing dependencies for contract: {contract.name}")
 
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -124,14 +124,45 @@ async def install_agent_dependencies(sandbox: AsyncSandbox, contract: AgentContr
 
     contract_path = get_contract_path(contract.name)
 
-    response = await sandbox.process.exec(contract.install_cmd, cwd=str(contract_path))
+    def on_data(data: str) -> None:
+        stream_logger.info(data.strip("\n"))
 
-    if response.exit_code != 0:
-        error_msg = f"Failed to install dependencies for contract {contract.name}: {response.result}"
-        logger.error(error_msg)
-        raise SandboxError(error_msg)
+    try:
+        session_id = f"{contract.name}-install"
 
-    logger.info(f"Finished running installing dependencies for contract: {contract.name}")
+        await sandbox.process.create_session(session_id)
+
+        session_exec_resp = await sandbox.process.execute_session_command(
+            session_id, SessionExecuteRequest(command=f"cd {contract_path} && {contract.install_cmd}", run_async=True)
+        )
+
+        cmd_id = session_exec_resp.cmd_id
+
+        if not cmd_id:
+            raise SandboxError(f"Failed to execute install command for {contract.name}")
+
+        await sandbox.process.get_session_command_logs_async(
+            session_id=session_id,
+            command_id=cmd_id,
+            # on_stdout=on_data,
+            # on_stderr=on_data,
+        )
+
+        cmd = await sandbox.process.get_session_command(session_id, cmd_id)
+
+        if cmd.exit_code != 0:
+            error_msg = f"Failed to install dependencies for contract {contract.name}"
+            logger.error(error_msg)
+            raise SandboxError(error_msg)
+
+        logger.info(f"Finished running installing dependencies for contract: {contract.name}")
+
+    finally:
+        try:
+            await sandbox.process.delete_session(session_id)
+        except Exception:
+            logger.error(f"Caught failure to delete session `{session_id}`")
+            pass
 
 
 async def run_agent(

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -124,45 +124,15 @@ async def install_agent_dependencies(sandbox: AsyncSandbox, contract: AgentContr
 
     contract_path = get_contract_path(contract.name)
 
-    def on_data(data: str) -> None:
-        stream_logger.info(data.strip("\n"))
+    response = await sandbox.process.exec(contract.install_cmd, cwd=str(contract_path))
 
-    try:
-        session_id = f"{contract.name}-install"
+    if response.exit_code != 0:
+        error_msg = f"Failed to install dependencies for contract {contract.name}: {response.result}"
+        logger.error(error_msg)
+        raise SandboxError(error_msg)
 
-        await sandbox.process.create_session(session_id)
-
-        session_exec_resp = await sandbox.process.execute_session_command(
-            session_id, SessionExecuteRequest(command=f"cd {contract_path} && {contract.install_cmd}", run_async=True)
-        )
-
-        cmd_id = session_exec_resp.cmd_id
-
-        if not cmd_id:
-            raise SandboxError(f"Failed to execute install command for {contract.name}")
-
-        await sandbox.process.get_session_command_logs_async(
-            session_id=session_id,
-            command_id=cmd_id,
-            # on_stdout=on_data,
-            # on_stderr=on_data,
-        )
-
-        cmd = await sandbox.process.get_session_command(session_id, cmd_id)
-
-        if cmd.exit_code != 0:
-            error_msg = f"Failed to install dependencies for contract {contract.name}"
-            logger.error(error_msg)
-            raise SandboxError(error_msg)
-
-        logger.info(f"Finished running installing dependencies for contract: {contract.name}")
-
-    finally:
-        try:
-            await sandbox.process.delete_session(session_id)
-        except Exception:
-            logger.error(f"Caught failure to delete session `{session_id}`")
-            pass
+    logger.info(response.result)
+    logger.info(f"Finished running installing dependencies for contract: {contract.name}")
 
 
 async def run_agent(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -617,20 +617,13 @@ async def initiate_stop_benchmark(benchmark_row: Benchmark, session: Session, fo
         raise TrackerServiceError(f"Unexpected error stopping benchmark {benchmark_row.id}: {str(e)}") from e
 
 
-async def stop_sandbox(
-    sandbox: AsyncSandbox, daytona_client: AsyncDaytona, session: Session, task_id: UUID | None
-) -> str | None:
+async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> str | None:
     try:
         # Wait for the sandbox to be in a valid deletion state
         await sandbox.wait_for_sandbox_start(timeout=0)
 
         # Delete the sandbox
         await daytona_client.delete(sandbox)
-
-        # Only update the task row if it is still in progress
-        if task_id:
-            session.exec(update(Task).where(col(Task.id) == task_id).values(status=TaskStatus.STOPPED))
-            session.commit()
 
         return None
     except Exception as e:
@@ -680,26 +673,20 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
     """
     daytona_client: AsyncDaytona = benchmark_row.benchmark_service.daytona_client
 
-    # Create a mapping between all task primary key id and their task_id (that are pending or evaluating)
-    task_rows: Sequence[Task] = session.exec(
-        select(Task)
+    # Update all tasks being processed to stopped
+    session.exec(
+        update(Task)
         .where(col(Task.benchmark) == benchmark_row.id)
         .where(col(Task.status).in_([TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
-    ).all()
+        .values(status=TaskStatus.STOPPED)
+    )
 
-    # Create a mapping upfront that we can use to update the task rows after stopping the sandboxes
-    task_metadata: dict[str, UUID] = {task.alias: task.id for task in task_rows}
+    session.commit()
 
     # Iterate through each running sandbox and stop it, collecting error messages
     results: dict[str, str | None] = {}
     async for sandbox in sandbox_generator(benchmark_row, daytona_client):
-        # If task id does not exist, the task is finished and we can just close the sandbox
-        # Edge case where the sandbox is hanging
-        task_id: UUID | None = task_metadata.get(sandbox.name)
-        if not task_id:
-            logger.info(f"Discovered sandbox not being tracked with the name {sandbox.name}. Closing sandbox.")
-
-        result = await stop_sandbox(sandbox, daytona_client, session, task_id if task_id else None)
+        result = await stop_sandbox(sandbox, daytona_client)
 
         results[sandbox.name] = result
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -6,7 +6,7 @@ from collections.abc import AsyncGenerator, Coroutine
 from datetime import datetime
 from enum import Enum
 from functools import cached_property
-from typing import Any, NamedTuple, Sequence
+from typing import Any, NamedTuple, Sequence, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -396,6 +396,23 @@ async def process_benchmark(
                 for result_dict in evaluation_result_rows
                 for task_id, evaluation_result in result_dict.items()
             }
+
+            # Fetch remaining tasks (in case this benchmark was resumed)
+            remaining_task_results_query = cast(
+                Sequence[tuple[str, dict[str, Any]]],
+                session.exec(
+                    select(Task.task_id, EvaluationResult.result)  # pyright: ignore[reportUnknownArgumentType]
+                    .join(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
+                    .where(col(Task.benchmark) == benchmark_row.id)
+                    .where(col(Task.task_id).notin_(list(evaluation_results.keys())))
+                ).all(),
+            )
+
+            remaining_task_results: dict[str, dict[str, Any] | None] = {
+                task_id: evaluation_result for task_id, evaluation_result in remaining_task_results_query
+            }
+
+            evaluation_results.update(remaining_task_results)
 
             # Calculate the final score based off the tasks that were ran
             final_score_response = await benchmark_service.request_final_score(evaluation_results=evaluation_results)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -114,9 +114,12 @@ class TaskMonitor:
 
         """
         self._session.expire_all()
+        self._session.refresh(self._benchmark_row)
+
         task_row = self._fetch_task_row(task_id)
 
-        if task_row.status == TaskStatus.STOPPED:
+        # If task has been stopped or benchmark has occured an error we need to exit
+        if task_row.status == TaskStatus.STOPPED or self._benchmark_row.status == BenchmarkStatus.ERROR:
             return False
 
         return True
@@ -330,6 +333,7 @@ def create_task_rows(
         session.add(task_row)
 
     session.commit()
+    session.expire_all()
 
     # Fetch all task rows with the status of pending
     pending_task_rows: Sequence[tuple[str, Task]] = session.exec(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -325,15 +325,11 @@ def create_task_rows(
     # NOTE: Must maintain same order that was passed in
     task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
 
-    created_task_rows: dict[str, Task] = {}
     for task_id in task_ids_to_create:
         task_row = Task(task_id=task_id, benchmark=benchmark_row.id)
-        created_task_rows[task_id] = task_row
+        session.add(task_row)
 
-    # Create the task rows if we need to add any new ones
-    if created_task_rows:
-        session.add_all(list(created_task_rows.values()))
-        session.commit()
+    session.commit()
 
     # Fetch all task rows with the status of pending
     pending_task_rows: Sequence[tuple[str, Task]] = session.exec(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -343,6 +343,25 @@ def create_task_rows(
     return pending_task_rows
 
 
+async def fetch_missing_tasks(
+    session: Session, benchmark_row: Benchmark, evaluation_results: dict[str, dict[str, Any]]
+):
+    remaining_task_results_query = cast(
+        Sequence[tuple[str, dict[str, Any]]],
+        session.exec(
+            select(Task.task_id, EvaluationResult.result)  # pyright: ignore[reportUnknownArgumentType]
+            .join(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.task_id).notin_(list(evaluation_results.keys())))
+        ).all(),
+    )
+
+    remaining_task_results: dict[str, dict[str, Any] | None] = {
+        task_id: evaluation_result for task_id, evaluation_result in remaining_task_results_query
+    }
+    return remaining_task_results
+
+
 @broker.task
 async def process_benchmark(
     start_benchmark_request_json: dict[str, Any],
@@ -398,19 +417,7 @@ async def process_benchmark(
             }
 
             # Fetch remaining tasks (in case this benchmark was resumed)
-            remaining_task_results_query = cast(
-                Sequence[tuple[str, dict[str, Any]]],
-                session.exec(
-                    select(Task.task_id, EvaluationResult.result)  # pyright: ignore[reportUnknownArgumentType]
-                    .join(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
-                    .where(col(Task.benchmark) == benchmark_row.id)
-                    .where(col(Task.task_id).notin_(list(evaluation_results.keys())))
-                ).all(),
-            )
-
-            remaining_task_results: dict[str, dict[str, Any] | None] = {
-                task_id: evaluation_result for task_id, evaluation_result in remaining_task_results_query
-            }
+            remaining_task_results = await fetch_missing_tasks(session, benchmark_row, evaluation_results)
 
             evaluation_results.update(remaining_task_results)
 

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -151,7 +151,7 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ Agent:      {start_benchmark_response.agent_name}")
     click.echo(f"│ Benchmark ID:  {start_benchmark_response.benchmark_id}")
     click.echo(f"│ Started at:    {start_benchmark_response.started_at}")
-    click.echo(f"│ Concurrency:   {start_benchmark_response.concurrency}")
+    click.echo(f"│ Max concurrency:   {start_benchmark_response.concurrency}")
     click.echo(f"│ Total tasks:   {start_benchmark_response.task_count}")
     click.echo("└" + "─" * 79)
     click.echo()


### PR DESCRIPTION
### Main changes
- Broker does not timeout after 10 minutes
- Can resume a run with the status error
- Fixed bug where we were not fetching remaining tasks when evaluating after resuming
- Simplified how we stop a benchmark
- As a fall back i made it so that you can still stop a benchmark if it has an error state


### Description
This pr addresses a lot of the runtime errors I was running into and general usability issues a spotted