### PR TITLE
Added retry feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Flags
 uv run harness resume-benchmark --benchmark-id <benchmark_id>
 ```
 
+#### Retry a benchmark
+
+```bash
+uv run harness retry-benchmark --benchmark-id <benchmark_id>
+```
+
 Flags
 
 ```

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -17,9 +17,8 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
-    ResumeBenchmarkResponse,
     RetrieveResultsResponse,
-    RetryBenchmarkResponse,
+    RetryOrResumeBenchmarkResponse,
     StartBenchmarkErrorResponse,
     StartBenchmarkRequest,
     StartBenchmarkResponse,
@@ -32,7 +31,7 @@ from tracker.utils import (
     force_stop_sandboxes,
     initiate_stop_benchmark,
     process_benchmark,
-    restart_benchmark,
+    reset_to_in_progress_status,
     stream_benchmark_results,
 )
 
@@ -284,34 +283,36 @@ async def stop_benchmark(
     )
 
 
-@app.post("/resume-benchmark/{benchmark_id}")
-async def resume_benchmark(
+@app.post("/retry-or-resume-benchmark/{benchmark_id}")
+async def retry_or_resume_benchmark(
     benchmark_id: UUID,
     retry: bool = Query(default=False),
     task_ids: list[str] = Body(default=[]),
     session: Session = Depends(get_session),
-) -> ResumeBenchmarkResponse:
+) -> RetryOrResumeBenchmarkResponse:
     """
-    Resume a benchmark run by its id, we only can resume a benchmark that is in a stopped state.
+    Retry or resume a benchmark run by its id, we only can retry or resume a benchmark if its not currently running.
 
     Usage:
-    curl -X POST http://<endpoint>/resume-benchmark/<benchmark_id>?retry=true
+    curl -X POST http://<endpoint>/retry-or-resume-benchmark/<benchmark_id>?retry=true
       -d '{"task_ids": ["task_id_1", "task_id_2"]}'
     Returns:
-        ResumeBenchmarkResponse
+        RetryOrResumeBenchmarkResponse
     """
     benchmark_row = session.get(Benchmark, benchmark_id)
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
-    if benchmark_row.status != BenchmarkStatus.STOPPED:
+    invalid_states = [BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.STOPPING]
+
+    if benchmark_row.status in invalid_states:
         raise HTTPException(
             status_code=400,
-            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the stopped or error state to resume.",
+            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Cannot continue a benchmark that is currently running.",
         )
 
-    # Reset tasks and resume benchmark
-    await restart_benchmark(
+    # Reset tasks and retry or resume benchmark
+    verified_task_ids = await reset_to_in_progress_status(
         benchmark_row=benchmark_row,
         session=session,
         benchmark_service=benchmark_row.start_benchmark_request.benchmark_service,
@@ -319,58 +320,15 @@ async def resume_benchmark(
         rerun_task_ids=task_ids,
     )
 
-    return ResumeBenchmarkResponse(
-        status="success",
+    # start the benchmark with the same args used to create it
+    # we will delegate inside what tasks we are running
+    await process_benchmark.kiq(
+        start_benchmark_request_json=benchmark_row.start_benchmark_request.model_dump(),
+        benchmark_id_str=str(benchmark_row.id),
+        verified_task_ids=verified_task_ids,
     )
 
-
-async def retry_benchmark(
-    benchmark_id: UUID,
-    retry: bool = Query(default=False),
-    task_ids: list[str] = Body(default=[]),
-    session: Session = Depends(get_session),
-) -> RetryBenchmarkResponse:
-    """
-    Retry a benchmark by its id, difference between this and resume is that we allow to retry a benchmark that has been finished or errored out.
-
-    Usage:
-    curl -X POST http://<endpoint>/retry-benchmark/<benchmark_id>?retry=true
-      -d '{"task_ids": ["task_id_1", "task_id_2"]}'
-    Returns:
-        RetryBenchmarkResponse
-
-    Returns:
-    - 200 OK if benchmark is retried successfully
-    - 400 Bad Request if benchmark is not in the correct state
-    - 404 Not Found if benchmark is not found
-    """
-    benchmark_row = session.get(Benchmark, benchmark_id)
-    if not benchmark_row:
-        raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
-
-    if benchmark_row.status == BenchmarkStatus.STOPPED:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Benchmark {benchmark_id} is in the stopped state. Use the resume benchmark endpoint to resume the benchmark.",
-        )
-
-    valid_retry_states = [BenchmarkStatus.ERROR, BenchmarkStatus.FINISHED]
-    if benchmark_row.status not in valid_retry_states:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the error or finished state to retry.",
-        )
-
-    # Reset tasks and resume benchmark
-    await restart_benchmark(
-        benchmark_row=benchmark_row,
-        session=session,
-        benchmark_service=benchmark_row.start_benchmark_request.benchmark_service,
-        retry=retry,
-        rerun_task_ids=task_ids,
-    )
-
-    return RetryBenchmarkResponse(
+    return RetryOrResumeBenchmarkResponse(
         status="success",
     )
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -19,6 +19,7 @@ from tracker.types import (
     FetchBenchmarksResponse,
     ResumeBenchmarkResponse,
     RetrieveResultsResponse,
+    RetryBenchmarkResponse,
     StartBenchmarkErrorResponse,
     StartBenchmarkRequest,
     StartBenchmarkResponse,
@@ -29,9 +30,9 @@ from tracker.utils import (
     commit_benchmark_error,
     fetch_filtered_benchmark_rows,
     force_stop_sandboxes,
-    initiate_resume_benchmark,
     initiate_stop_benchmark,
     process_benchmark,
+    restart_benchmark,
     stream_benchmark_results,
 )
 
@@ -287,15 +288,15 @@ async def stop_benchmark(
 async def resume_benchmark(
     benchmark_id: UUID,
     retry: bool = Query(default=False),
-    force: list[str] = Body(default=[]),
+    task_ids: list[str] = Body(default=[]),
     session: Session = Depends(get_session),
 ) -> ResumeBenchmarkResponse:
     """
-    Resume a benchmark run by its id.
+    Resume a benchmark run by its id, we only can resume a benchmark that is in a stopped state.
 
     Usage:
     curl -X POST http://<endpoint>/resume-benchmark/<benchmark_id>?retry=true
-      -d '{"force": ["task_id_1", "task_id_2"]}'
+      -d '{"task_ids": ["task_id_1", "task_id_2"]}'
     Returns:
         ResumeBenchmarkResponse
     """
@@ -303,30 +304,73 @@ async def resume_benchmark(
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
-    valid_resume_states = [BenchmarkStatus.STOPPED, BenchmarkStatus.ERROR]
-
-    if benchmark_row.status not in valid_resume_states:
+    if benchmark_row.status != BenchmarkStatus.STOPPED:
         raise HTTPException(
             status_code=400,
             detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the stopped or error state to resume.",
         )
 
-    start_benchmark_request = benchmark_row.start_benchmark_request
-
-    benchmark_service = start_benchmark_request.benchmark_service
-
-    # prepare benchmark and tasks to be resumed
-    verified_task_ids = await initiate_resume_benchmark(benchmark_row, session, benchmark_service, retry, force)
-
-    # start the benchmark with the same args used to create it
-    # we will delegate inside what tasks we are running
-    await process_benchmark.kiq(
-        start_benchmark_request_json=start_benchmark_request.model_dump(),
-        benchmark_id_str=str(benchmark_row.id),
-        verified_task_ids=verified_task_ids,
+    # Reset tasks and resume benchmark
+    await restart_benchmark(
+        benchmark_row=benchmark_row,
+        session=session,
+        benchmark_service=benchmark_row.start_benchmark_request.benchmark_service,
+        retry=retry,
+        rerun_task_ids=task_ids,
     )
 
     return ResumeBenchmarkResponse(
+        status="success",
+    )
+
+
+async def retry_benchmark(
+    benchmark_id: UUID,
+    retry: bool = Query(default=False),
+    task_ids: list[str] = Body(default=[]),
+    session: Session = Depends(get_session),
+) -> RetryBenchmarkResponse:
+    """
+    Retry a benchmark by its id, difference between this and resume is that we allow to retry a benchmark that has been finished or errored out.
+
+    Usage:
+    curl -X POST http://<endpoint>/retry-benchmark/<benchmark_id>?retry=true
+      -d '{"task_ids": ["task_id_1", "task_id_2"]}'
+    Returns:
+        RetryBenchmarkResponse
+
+    Returns:
+    - 200 OK if benchmark is retried successfully
+    - 400 Bad Request if benchmark is not in the correct state
+    - 404 Not Found if benchmark is not found
+    """
+    benchmark_row = session.get(Benchmark, benchmark_id)
+    if not benchmark_row:
+        raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
+
+    if benchmark_row.status == BenchmarkStatus.STOPPED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Benchmark {benchmark_id} is in the stopped state. Use the resume benchmark endpoint to resume the benchmark.",
+        )
+
+    valid_retry_states = [BenchmarkStatus.ERROR, BenchmarkStatus.FINISHED]
+    if benchmark_row.status not in valid_retry_states:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Benchmark {benchmark_id} is in the {benchmark_row.status} state. Must be in the error or finished state to retry.",
+        )
+
+    # Reset tasks and resume benchmark
+    await restart_benchmark(
+        benchmark_row=benchmark_row,
+        session=session,
+        benchmark_service=benchmark_row.start_benchmark_request.benchmark_service,
+        retry=retry,
+        rerun_task_ids=task_ids,
+    )
+
+    return RetryBenchmarkResponse(
         status="success",
     )
 

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -134,6 +134,10 @@ class RetryBenchmarkResponse(StatusResponse):
     pass
 
 
+class RetryOrResumeBenchmarkResponse(StatusResponse):
+    pass
+
+
 class Order(str, Enum):
     ASC = "asc"
     DESC = "desc"

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -130,6 +130,10 @@ class ResumeBenchmarkResponse(StatusResponse):
     pass
 
 
+class RetryBenchmarkResponse(StatusResponse):
+    pass
+
+
 class Order(str, Enum):
     ASC = "asc"
     DESC = "desc"

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -126,14 +126,6 @@ class StopBenchmarkResponse(StatusResponse):
     pass
 
 
-class ResumeBenchmarkResponse(StatusResponse):
-    pass
-
-
-class RetryBenchmarkResponse(StatusResponse):
-    pass
-
-
 class RetryOrResumeBenchmarkResponse(StatusResponse):
     pass
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -749,13 +749,17 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
 
 
 async def initiate_resume_benchmark(
-    benchmark_row: Benchmark, session: Session, benchmark_service: BenchmarkService, retry: bool, force: list[str]
+    benchmark_row: Benchmark,
+    session: Session,
+    benchmark_service: BenchmarkService,
+    retry: bool,
+    rerun_task_ids: list[str],
 ) -> list[str]:
     """
     Resets benchmark and task status to flag resuming the benchmark.
 
     Retry: we reset objects with an error status ontop of the stopped status
-    Force: even if task has been finished we restart it
+    Rerun Task IDs: even if task has been finished we restart it
 
     Benchmark - In progress status
     Tasks - Pending status
@@ -771,7 +775,7 @@ async def initiate_resume_benchmark(
             col(Task.benchmark) == benchmark_row.id,
             or_(
                 col(Task.status).in_(retry_statuses),
-                col(Task.task_id).in_(force),
+                col(Task.task_id).in_(rerun_task_ids),
             ),
         ]
 
@@ -782,7 +786,7 @@ async def initiate_resume_benchmark(
         task_mapping: dict[UUID, str] = {id: task_id for id, task_id in task_ids}
 
         # Ensure we are not missing any tasks that were requested (skips if force is empty)
-        missing_task_ids = [task_id for task_id in force if task_id not in task_mapping.values()]
+        missing_task_ids = [task_id for task_id in rerun_task_ids if task_id not in task_mapping.values()]
         if missing_task_ids:
             raise TrackerServiceError(
                 f"{', '.join(missing_task_ids)} was requested to be force resumed but does not exist in the dataset"
@@ -866,3 +870,30 @@ def fetch_filtered_benchmark_rows(request: FetchBenchmarksRequest, session: Sess
     benchmark_rows: Sequence[Benchmark] = session.exec(query).all()
 
     return benchmark_rows, total_count
+
+
+async def restart_benchmark(
+    benchmark_row: Benchmark,
+    session: Session,
+    benchmark_service: BenchmarkService,
+    retry: bool,
+    rerun_task_ids: list[str],
+) -> None:
+    """
+    Effectively restarts a benchmark by resetting the tasks specified
+    """
+    verified_task_ids = await initiate_resume_benchmark(
+        benchmark_row=benchmark_row,
+        session=session,
+        benchmark_service=benchmark_service,
+        retry=retry,
+        rerun_task_ids=rerun_task_ids,
+    )
+
+    # start the benchmark with the same args used to create it
+    # we will delegate inside what tasks we are running
+    await process_benchmark.kiq(
+        start_benchmark_request_json=benchmark_row.start_benchmark_request.model_dump(),
+        benchmark_id_str=str(benchmark_row.id),
+        verified_task_ids=verified_task_ids,
+    )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -748,7 +748,7 @@ async def force_stop_sandboxes(benchmark_row: Benchmark, session: Session) -> No
         raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
 
 
-async def initiate_resume_benchmark(
+async def reset_to_in_progress_status(
     benchmark_row: Benchmark,
     session: Session,
     benchmark_service: BenchmarkService,
@@ -756,7 +756,7 @@ async def initiate_resume_benchmark(
     rerun_task_ids: list[str],
 ) -> list[str]:
     """
-    Resets benchmark and task status to flag resuming the benchmark.
+    Resets valid tasks to in progress and to allow for retrying or resuming the benchmark.
 
     Retry: we reset objects with an error status ontop of the stopped status
     Rerun Task IDs: even if task has been finished we restart it
@@ -870,30 +870,3 @@ def fetch_filtered_benchmark_rows(request: FetchBenchmarksRequest, session: Sess
     benchmark_rows: Sequence[Benchmark] = session.exec(query).all()
 
     return benchmark_rows, total_count
-
-
-async def restart_benchmark(
-    benchmark_row: Benchmark,
-    session: Session,
-    benchmark_service: BenchmarkService,
-    retry: bool,
-    rerun_task_ids: list[str],
-) -> None:
-    """
-    Effectively restarts a benchmark by resetting the tasks specified
-    """
-    verified_task_ids = await initiate_resume_benchmark(
-        benchmark_row=benchmark_row,
-        session=session,
-        benchmark_service=benchmark_service,
-        retry=retry,
-        rerun_task_ids=rerun_task_ids,
-    )
-
-    # start the benchmark with the same args used to create it
-    # we will delegate inside what tasks we are running
-    await process_benchmark.kiq(
-        start_benchmark_request_json=benchmark_row.start_benchmark_request.model_dump(),
-        benchmark_id_str=str(benchmark_row.id),
-        verified_task_ids=verified_task_ids,
-    )

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -178,7 +178,7 @@ class TestBenchmarkUtils:
         )
 
         # Test request to resume the benchmark
-        response: Response = client.post(f"/resume-benchmark/{benchmark_row.id}?retry=false")
+        response: Response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=false")
         assert response.status_code == 200, response.text
         assert response.json() == {"status": "success"}
 
@@ -213,7 +213,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # Call resume benchmark with retry enabled
-        response = client.post(f"/resume-benchmark/{benchmark_row.id}?retry=true")
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true")
         assert response.status_code == 200
         assert response.json() == {"status": "success"}
 
@@ -251,7 +251,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # failure code to resume the benchmark
-        response: Response = client.post(f"/resume-benchmark/{benchmark_row.id}?retry=false")
+        response: Response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=false")
         assert response.status_code == 400
 
         # Set benchmark to stopped state but add only finished tasks
@@ -267,7 +267,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # error is returned because we have no stopped tasks to resume
-        response = client.post(f"/resume-benchmark/{benchmark_row.id}?retry=false")
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=false")
         assert response.status_code == 500
 
         # Ensure that we can recreate the environment the benchmark was started in
@@ -295,7 +295,7 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # Task id is provided as a force parameter but does not exist in dataset
-        response = client.post(f"/resume-benchmark/{example_benchmark_object.id}?retry=false", json=["task_5"])
+        response = client.post(f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false", json=["task_5"])
         assert response.status_code == 500
         assert "task_5" in response.json()["detail"]
 
@@ -317,7 +317,7 @@ class TestBenchmarkUtils:
 
         # Try again with the correct task ids
 
-        response = client.post(f"/resume-benchmark/{example_benchmark_object.id}?retry=false", json=task_ids)
+        response = client.post(f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false", json=task_ids)
         assert response.status_code == 200
         assert response.json() == {"status": "success"}
 

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -15,7 +15,7 @@ from tracker.types import (
     StartBenchmarkRequest,
     VerifyTaskIdsResponse,
 )
-from tracker.utils import initiate_resume_benchmark, initiate_stop_benchmark, process_benchmark
+from tracker.utils import initiate_stop_benchmark, process_benchmark, reset_to_in_progress_status
 
 
 class TestStopAndResume:
@@ -148,8 +148,12 @@ class TestStopAndResume:
             partial(self._mock_request_verify_task_ids, task_ids=pending_task_ids),
         )
 
-        verified_task_ids = await initiate_resume_benchmark(
-            benchmark_row, database_session, start_benchmark_request.benchmark_service, retry=False, force=[]
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            retry=False,
+            rerun_task_ids=[],
         )
 
         # Only 3 tasks should be verified for resume (the 3 tasks that are stopped)

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -289,28 +289,28 @@ def stop_benchmark(benchmark_id: UUID, force: bool):
     help="Retry tasks with the status error",
 )
 @click.option(
-    "--force",
+    "--task-ids",
     type=str,
     required=False,
     default=None,
-    help="Force retry tasks with the given task ids (e.g., task_1_id task_2_id)",
+    help="Comma-separated list of task IDs (e.g., astropy__astropy-12907,astropy__astropy-12908)",
 )
-def resume_benchmark(benchmark_id: UUID, retry: bool, force: str | None):
+def resume_benchmark(benchmark_id: UUID, retry: bool, task_ids: str | None):
     """
     Resume a benchmark run by its benchmark id.
 
     Example:
         harness resume-benchmark --benchmark-id 123e4567-e89b-12d3-a456-426614174000 --retry
     """
-    click.echo(f"Resuming run for benchmark: {benchmark_id}")
+    click.echo("Selected to run a benchmark that has already been created, will rerun valid tasks.")
     try:
         with TrackerService() as tracker:
             if not check_tracker_service_health(tracker):
                 return
 
-            force_task_ids = force.split() if force else []
-            _ = tracker.resume_benchmark(benchmark_id, retry, force_task_ids)
-            click.echo(click.style("Run resumed successfully!", fg="green", bold=True))
+            retry_task_ids = task_ids.split() if task_ids else []
+            _ = tracker.retry_or_resume_benchmark(benchmark_id, retry, retry_task_ids)
+            click.echo(click.style("Run continued successfully!", fg="green", bold=True))
             click.echo(
                 click.style(
                     f"Track progress: harness fetch-benchmark --benchmark-id {benchmark_id} --connect",
@@ -319,6 +319,10 @@ def resume_benchmark(benchmark_id: UUID, retry: bool, force: str | None):
             )
     except TrackerServiceError as e:
         raise click.ClickException(str(e))
+
+
+# Alias for resume-benchmark, the logic is the same under the hood
+cli.add_command(resume_benchmark, name="retry-benchmark")
 
 
 @cli.command()

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -13,8 +13,8 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
-    ResumeBenchmarkResponse,
     RetrieveResultsResponse,
+    RetryOrResumeBenchmarkResponse,
     StartBenchmarkRequest,
     StopBenchmarkResponse,
 )
@@ -225,29 +225,33 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stop benchmark: {e}") from e
 
-    def resume_benchmark(self, benchmark_id: UUID, retry: bool, force: list[str]) -> ResumeBenchmarkResponse:
+    def retry_or_resume_benchmark(
+        self, benchmark_id: UUID, retry: bool, task_ids: list[str]
+    ) -> RetryOrResumeBenchmarkResponse:
         """
-        Resume a benchmark run by its benchmark id.
+        Run a benchmark that has already been created by its benchmark id.
 
         Args:
             benchmark_id: Benchmark id
             retry: Whether to retry tasks with the status error
-            force: List of task ids to force retry
+            task_ids: List of task ids to force retry
 
         Returns:
-            ResumeBenchmarkResponse with status and message
+            RetryOrResumeBenchmarkResponse with status and message
         """
         try:
             response = self._client.post(
-                f"{self._base_url}/resume-benchmark/{benchmark_id}", params={"retry": retry}, json=force
+                f"{self._base_url}/retry-or-resume-benchmark/{benchmark_id}",
+                params={"retry": retry},
+                json=task_ids,
             )
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)
-                raise TrackerServiceError(f"Failed to resume benchmark: {details}")
+                raise TrackerServiceError(f"Failed to run benchmark: {details}")
 
-            return ResumeBenchmarkResponse.model_validate(response.json())
+            return RetryOrResumeBenchmarkResponse.model_validate(response.json())
         except httpx.HTTPError as e:
-            raise TrackerServiceError(f"Failed to resume benchmark: {e}") from e
+            raise TrackerServiceError(f"Failed to run benchmark: {e}") from e
 
     def fetch_benchmarks(self, request: FetchBenchmarksRequest) -> FetchBenchmarksResponse:
         """

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -179,6 +179,12 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
             fg="cyan",
         )
     )
+    click.echo(
+        click.style(
+            f"Retry benchmark: harness retry-benchmark --benchmark-id {start_benchmark_response.benchmark_id}",
+            fg="cyan",
+        )
+    )
     click.echo()
 
 


### PR DESCRIPTION
### Main changes
- Added an alias for resume-benchmark to retry-benchmark
- Adjusted endpoint to be runnable if the user has requested to retry a benchmark or resume it
- Updated tests


### Reasoning
The logic is the same so I was wondering what to do with the endpoint, I decided the best way to not confuse the user was to make it an alias. 