### PR TITLE
s3 retrieve-results feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,14 @@ harness fetch-benchmark --benchmark-id <benchmark_id>
 #### Download results
 
 ```bash
-harness retrieve-results --benchmark-id <benchmark_id> --path ./results.json
+harness retrieve-results --benchmark-id <benchmark_id>
+```
+
+Flags
+
+```
+--path: Downloads the final view to disk (default: ./results.json)
+--s3: Download the final view to s3, found in bucket://benchmarks/benchmark_id/results.json
 ```
 
 #### Stop a benchmark

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -17,6 +17,8 @@ from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.s3 import (
     S3_BENCHMARKS_PREFIX,
+    create_console_url,
+    create_presigned_url,
     download_from_s3_stream,
     get_contract_s3_key,
     list_s3_objects,
@@ -278,7 +280,10 @@ async def retrieve_results(
         upload_to_s3(final_view.model_dump_json(indent=2).encode(), s3_key)
 
         https_url = f"https://{AWS_S3_BUCKET}.s3.amazonaws.com/{s3_key}"
-        return S3UploadResultsResponse(s3_url=https_url)
+        presigned_url = create_presigned_url(s3_key)
+        console_url = create_console_url(s3_key)
+
+        return S3UploadResultsResponse(s3_url=https_url, presigned_url=presigned_url, console_url=console_url)
 
     return final_view
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -10,19 +10,29 @@ from sqlmodel import Session, col, func, select
 
 from tracker.benchmark_service import BenchmarkService
 from tracker.cloudwatch import get_cloudwatch_url
+from tracker.config import AWS_S3_BUCKET
 from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
-from tracker.s3 import S3_BENCHMARKS_PREFIX, download_from_s3_stream, get_contract_s3_key, list_s3_objects, upload_to_s3
+from tracker.s3 import (
+    S3_BENCHMARKS_PREFIX,
+    download_from_s3_stream,
+    get_contract_s3_key,
+    list_s3_objects,
+    s3_object_exists,
+    upload_to_s3,
+)
 from tracker.types import (
     BenchmarkTableRow,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
+    FinalViewResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
+    S3UploadResultsResponse,
     StartBenchmarkErrorResponse,
     StartBenchmarkRequest,
     StartBenchmarkResponse,
@@ -228,12 +238,14 @@ async def fetch_benchmark(
 
 
 @app.get("/retrieve-results")
-async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_session)) -> RetrieveResultsResponse:
+async def retrieve_results(
+    benchmark_id: UUID, s3: bool = Query(default=False), session: Session = Depends(get_session)
+) -> RetrieveResultsResponse:
     """
     Retrieve the results of a benchmark by its id.
 
     Usage:
-    curl -X GET http://<endpoint>/retrieve-results/<benchmark_id>
+    curl -X GET http://<endpoint>/retrieve-results/<benchmark_id>?s3=false
 
     Returns:
         RetrieveResultsResponse
@@ -249,7 +261,7 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
         .where(col(Task.status) == TaskStatus.STOPPED)
     ).one()
 
-    return RetrieveResultsResponse(
+    final_view: FinalViewResponse = FinalViewResponse(
         benchmark_name=benchmark_row.name,
         status=benchmark_row.status,
         error_message=benchmark_row.error_message,
@@ -260,6 +272,31 @@ async def retrieve_results(benchmark_id: UUID, session: Session = Depends(get_se
         evaluation_results=benchmark_row.fetch_evaluation_results(session),
         task_errors=benchmark_row.fetch_tasks_with_errors(session),
     )
+
+    if s3:
+        s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/results.json"
+        upload_to_s3(final_view.model_dump_json(indent=2).encode(), s3_key)
+
+        https_url = f"https://{AWS_S3_BUCKET}.s3.amazonaws.com/{s3_key}"
+        return S3UploadResultsResponse(s3_url=https_url)
+
+    return final_view
+
+
+@app.get("/check-results-exist")
+async def check_results_exist(benchmark_id: UUID) -> dict[str, bool]:
+    """
+    Check if results.json already exists in S3 for the given benchmark.
+
+    Usage:
+    curl -X GET http://<endpoint>/check-results-exist?benchmark_id=<uuid>
+
+    Returns:
+        {"exists": true/false}
+    """
+    s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/results.json"
+    exists = s3_object_exists(s3_key)
+    return {"exists": exists}
 
 
 @app.post("/stop-benchmark/{benchmark_id}")

--- a/services/tracker/src/tracker/s3.py
+++ b/services/tracker/src/tracker/s3.py
@@ -104,6 +104,28 @@ def download_from_s3_stream(s3_key: str) -> tuple[StreamingBody, int]:
         ) from e
 
 
+def s3_object_exists(s3_key: str) -> bool:
+    """
+    Check if an S3 object exists.
+
+    Args:
+        s3_key: S3 object key (path in bucket)
+
+    Returns:
+        True if the object exists, False otherwise
+    """
+    try:
+        s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
+        s3_client.head_object(Bucket=AWS_S3_BUCKET, Key=s3_key)
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            return False
+        raise S3Error(f"Failed to check S3 object existence for '{s3_key}': {str(e)}") from e
+    except BotoCoreError as e:
+        raise S3Error(f"Failed to check S3 object existence for '{s3_key}': {str(e)}") from e
+
+
 def list_s3_objects(prefix: str) -> list[str]:
     """
     List all S3 object keys with the given prefix.

--- a/services/tracker/src/tracker/s3.py
+++ b/services/tracker/src/tracker/s3.py
@@ -155,3 +155,49 @@ def list_s3_objects(prefix: str) -> list[str]:
         raise S3Error(
             f"Failed to list objects from S3 bucket '{AWS_S3_BUCKET}' with prefix '{prefix}': {str(e)}"
         ) from e
+
+
+def create_presigned_url(s3_key: str, expiration: int = 86400) -> str:
+    """
+    Create a presigned URL for an S3 object.
+
+    Args:
+        s3_key: S3 object key (path in bucket)
+        expiration: URL expiration time in seconds (default: 1 day)
+
+    Returns:
+        Presigned URL as a string
+
+    Raises:
+        S3Error: If presigned URL creation fails
+    """
+    try:
+        s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
+        presigned_url: str = s3_client.generate_presigned_url(
+            "get_object", Params={"Bucket": AWS_S3_BUCKET, "Key": s3_key}, ExpiresIn=expiration
+        )
+        return presigned_url
+    except (ClientError, BotoCoreError) as e:
+        raise S3Error(
+            f"Failed to create presigned URL for S3 bucket '{AWS_S3_BUCKET}' with key '{s3_key}': {str(e)}"
+        ) from e
+
+
+def create_console_url(s3_key: str) -> str:
+    """
+    Create an AWS console URL for an S3 object.
+
+    Args:
+        s3_key: S3 object key (path in bucket)
+
+    Returns:
+        AWS console URL as a string
+    """
+    try:
+        s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
+        region = s3_client.meta.region_name  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        return f"https://{region}.console.aws.amazon.com/s3/object/{AWS_S3_BUCKET}?region={region}&prefix={s3_key}"
+    except (ClientError, BotoCoreError) as e:
+        raise S3Error(
+            f"Failed to create console URL for S3 bucket '{AWS_S3_BUCKET}' with key '{s3_key}': {str(e)}"
+        ) from e

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -79,6 +79,8 @@ class FinalViewResponse(BaseModel):
 
 class S3UploadResultsResponse(BaseModel):
     s3_url: str
+    presigned_url: str
+    console_url: str
 
 
 RetrieveResultsResponse = FinalViewResponse | S3UploadResultsResponse

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -65,7 +65,7 @@ class FetchBenchmarkResponse(BaseModel):
     details: BenchmarkDetails
 
 
-class RetrieveResultsResponse(BaseModel):
+class FinalViewResponse(BaseModel):
     benchmark_name: str
     status: BenchmarkStatus
     error_message: str | None
@@ -75,6 +75,13 @@ class RetrieveResultsResponse(BaseModel):
     final_evaluation: FinalEvaluation | None
     evaluation_results: dict[str, dict[str, Any]] | None
     task_errors: dict[str, str] | None
+
+
+class S3UploadResultsResponse(BaseModel):
+    s3_url: str
+
+
+RetrieveResultsResponse = FinalViewResponse | S3UploadResultsResponse
 
 
 class FinalScoreResponse(BaseModel):

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -22,7 +22,7 @@ from tracker.database.models import (
 )
 from tracker.types import (
     FetchBenchmarksRequest,
-    RetrieveResultsResponse,
+    FinalViewResponse,
     StartBenchmarkRequest,
     VerifyTaskIdsResponse,
 )
@@ -245,7 +245,7 @@ class TestFastapiServer:
         assert response.status_code == 200
 
         # NOTE: We have defaults so we need to exclude none to get the same response as the user
-        response_json = RetrieveResultsResponse(**response.json()).model_dump(exclude_none=True)
+        response_json = FinalViewResponse(**response.json()).model_dump(exclude_none=True)
 
         # Test case 5. Evaluation results are returned if they exist even if benchmark has not finished yet
         assert response_json.get("evaluation_results")

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -225,12 +225,15 @@ def retrieve_results(benchmark_id: UUID, path: Path, s3: bool):
                         raise click.Abort()
 
             results_response = tracker.retrieve_results(benchmark_id, s3)
-            click.echo(click.style("Results retrieved successfully!", fg="green", bold=True))
 
             if isinstance(results_response, FinalViewResponse):
                 download_final_view(path, results_response)
             else:
-                click.echo(f"Results saved in s3 at '{results_response.s3_url}'")
+                click.echo(click.style("Download (expires in 1 day):", fg="cyan", bold=True))
+                click.echo(f"  {results_response.presigned_url}")
+                click.echo()
+                click.echo(click.style("AWS Console:", fg="cyan", bold=True))
+                click.echo(f"  {results_response.console_url}")
 
     except TrackerServiceError as e:
         raise click.ClickException(str(e))

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import click
 from tracker.database.models import BenchmarkStatus
-from tracker.types import Order, StartBenchmarkResponse
+from tracker.types import FinalViewResponse, Order, StartBenchmarkResponse
 
 from agentic_harness.cli.bundler import get_agent_zip_stream, get_contract
 from agentic_harness.cli.exceptions import BundlerError, TrackerServiceError
@@ -13,6 +13,7 @@ from agentic_harness.cli.tracker_service import TrackerService
 from agentic_harness.cli.utils import (
     check_tracker_service_health,
     download_agent_outputs,
+    download_final_view,
     format_benchmark_status,
     format_start_benchmark_response,
     paginate_benchmarks,
@@ -193,10 +194,18 @@ def fetch_benchmark(benchmark_id: UUID, connect: bool):
 @click.option(
     "--path",
     type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
-    required=True,
+    default="./results.json",
+    required=False,
     help="Path to save the results (e.g., ./results.json)",
 )
-def retrieve_results(benchmark_id: UUID, path: Path):
+@click.option(
+    "--s3",
+    is_flag=True,
+    default=False,
+    required=False,
+    help="Saves results to s3 instead of downloading them locally. Can be found at bucket://benchmarks/benchmark_id/results.json",
+)
+def retrieve_results(benchmark_id: UUID, path: Path, s3: bool):
     """
     Retrieve the results of a benchmark by its benchmark id.
 
@@ -210,26 +219,19 @@ def retrieve_results(benchmark_id: UUID, path: Path):
             if not check_tracker_service_health(tracker):
                 return
 
-            results_response = tracker.retrieve_results(benchmark_id)
+            if s3:
+                if tracker.check_results_exist_in_s3(benchmark_id):
+                    if not click.confirm("Results already exist in S3. Overwrite?"):
+                        raise click.Abort()
+
+            results_response = tracker.retrieve_results(benchmark_id, s3)
             click.echo(click.style("Results retrieved successfully!", fg="green", bold=True))
 
-            if not path.parent.exists():
-                raise click.ClickException(f"'{path.parent}' directory does not exist! Please create it first.")
+            if isinstance(results_response, FinalViewResponse):
+                download_final_view(path, results_response)
+            else:
+                click.echo(f"Results saved in s3 at '{results_response.s3_url}'")
 
-            if path.exists():
-                if not click.confirm(f"File '{path}' already exists. Overwrite?"):
-                    raise click.Abort()
-
-            with open(path, "w") as f:
-                f.write(
-                    results_response.model_dump_json(
-                        indent=4,
-                        exclude_none=True,
-                        exclude={"benchmark_arguments": {"contract": {"env"}}},
-                    )
-                )
-
-            click.echo(f"Results saved to '{path}'")
     except TrackerServiceError as e:
         raise click.ClickException(str(e))
 

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -14,8 +14,10 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
+    FinalViewResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
+    S3UploadResultsResponse,
     StartBenchmarkRequest,
     StopBenchmarkResponse,
 )
@@ -184,7 +186,7 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stream benchmark: {e}") from e
 
-    def retrieve_results(self, benchmark_id: UUID) -> RetrieveResultsResponse:
+    def retrieve_results(self, benchmark_id: UUID, s3: bool) -> RetrieveResultsResponse:
         """
         Retrieve the results of a benchmark by its benchmark id.
 
@@ -196,16 +198,47 @@ class TrackerService:
         """
         try:
             response = self._client.get(
-                f"{self._base_url}/retrieve-results", params={"benchmark_id": str(benchmark_id)}
+                f"{self._base_url}/retrieve-results", params={"benchmark_id": str(benchmark_id), "s3": s3}
             )
 
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)
                 raise TrackerServiceError(f"Failed to retrieve results: {details}")
 
-            return RetrieveResultsResponse.model_validate(response.json())
+            response_data = response.json()
+            if not s3:
+                return FinalViewResponse.model_validate(response_data)
+
+            return S3UploadResultsResponse.model_validate(response_data)
+
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to retrieve results: {e}") from e
+
+    def check_results_exist_in_s3(self, benchmark_id: UUID) -> bool:
+        """
+        Check if results already exist in S3 for the given benchmark.
+
+        Args:
+            benchmark_id: Benchmark id
+
+        Returns:
+            True if results exist in S3, False otherwise
+
+        Raises:
+            TrackerServiceError if request fails
+        """
+        try:
+            response = self._client.get(
+                f"{self._base_url}/check-results-exist", params={"benchmark_id": str(benchmark_id)}
+            )
+
+            if response.status_code != 200:
+                details = response.json().get("detail", response.text)
+                raise TrackerServiceError(f"Failed to check S3 results: {details}")
+
+            return response.json()["exists"]
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to check S3 results: {e}") from e
 
     def stop_benchmark(self, benchmark_id: UUID, force: bool) -> StopBenchmarkResponse:
         """

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -13,6 +13,7 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
+    FinalViewResponse,
     Order,
     StartBenchmarkResponse,
 )
@@ -421,3 +422,23 @@ def download_agent_outputs(agent_outputs_response: Response, output_dir: Path) -
             nested_tar.unlink()
 
     tmp_path.unlink()
+
+
+def download_final_view(path: Path, final_view: FinalViewResponse) -> None:
+    if not path.parent.exists():
+        raise click.ClickException(f"'{path.parent}' directory does not exist! Please create it first.")
+
+    if path.exists():
+        if not click.confirm(f"File '{path}' already exists. Overwrite?"):
+            raise click.Abort()
+
+    with open(path, "w") as f:
+        f.write(
+            final_view.model_dump_json(
+                indent=4,
+                exclude_none=True,
+                exclude={"benchmark_arguments": {"contract": {"env"}}},
+            )
+        )
+
+    click.echo(f"Results saved to '{path}'")

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -441,4 +441,4 @@ def download_final_view(path: Path, final_view: FinalViewResponse) -> None:
             )
         )
 
-    click.echo(f"Results saved to '{path}'")
+    click.echo(click.style(f"View the  '{path}'", fg="green", bold=True))


### PR DESCRIPTION
### Main changes
- Allow uploading results to s3 instead of downloading to disk
- create presigned url
- create url to s3 bucket dashboard
- union for two different return types now (s3 or just the final view)
- endpoint for checking if file exists in s3 already
- updated documentation