### PR TITLE
Add post process lambda option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ harness benchmark start \
   -k temperature 7 -k max_tokens 1000 \
   --benchmark <benchmark_name> \
   --concurrency 1 \
+  --lambda <aws_lambda_function_name> \
   --task-ids "task_1_id,task_2_id" \
   --slice "start:stop:step"
 ```
@@ -120,6 +121,7 @@ Flags
 --model: Model key
 --benchmark: Name of the benchmark
 --concurrency: The amount of concurrent tasks that are processed concurrently
+--lambda: The name of the lambda function you would like to be ran after the benchmark is done running
 --slice: Takes a slice from the dataset between the given values "start:stop:step"
 --kwarg (-k): Single kwarg that is passed into the agent run command
 --task-ids: comma separated list of task ids to run

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -3,15 +3,15 @@ import tarfile
 import traceback
 from uuid import UUID
 
+from benchmark_service.client import BenchmarkServiceError
 from fastapi import Body, Depends, FastAPI, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import joinedload
-from sqlmodel import Session, col, func, select
+from sqlmodel import Session, select
 
-from benchmark_service.client import BenchmarkServiceError
 from tracker.cloudwatch import get_cloudwatch_url
 from tracker.config import AWS_S3_BUCKET
-from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
+from tracker.database.models import Benchmark, BenchmarkStatus
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
@@ -31,7 +31,6 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
-    FinalViewResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
@@ -44,6 +43,7 @@ from tracker.utils import (
     BenchmarkContext,
     YieldingWriter,
     commit_benchmark_error,
+    create_final_view,
     fetch_filtered_benchmark_rows,
     force_stop_sandboxes,
     initiate_stop_benchmark,
@@ -51,6 +51,7 @@ from tracker.utils import (
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
     stream_benchmark_results,
+    upload_final_view,
 )
 
 logger = get_logger(__name__)
@@ -264,32 +265,10 @@ async def retrieve_results(
     if not benchmark_row:
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
-    tasks_stopped: int = session.exec(
-        select(func.count(col(Task.id)))
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.status) == TaskStatus.STOPPED)
-    ).one()
-
-    final_view: FinalViewResponse = FinalViewResponse(
-        benchmark_name=benchmark_row.name,
-        status=benchmark_row.status,
-        error_message=benchmark_row.error_message,
-        benchmark_id=benchmark_row.id,
-        benchmark_arguments=benchmark_row.arguments,
-        tasks_stopped=tasks_stopped or None,  # NOTE: Only include if we stopped the benchmark
-        final_evaluation=benchmark_row.final_evaluation,
-        evaluation_results=benchmark_row.fetch_evaluation_results(session),
-        task_errors=benchmark_row.fetch_tasks_with_errors(session),
-    )
+    final_view = create_final_view(benchmark_row, session)
 
     if s3:
-        s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{benchmark_row.name}.json"
-        upload_to_s3(
-            final_view.model_dump_json(
-                indent=4, exclude_none=True, exclude={"benchmark_arguments": {"contract": {"env"}}}
-            ).encode(),
-            s3_key,
-        )
+        s3_key = upload_final_view(benchmark_row, final_view)
 
         https_url = f"https://{AWS_S3_BUCKET}.s3.amazonaws.com/{s3_key}"
         presigned_url = create_presigned_url(s3_key)

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -17,6 +17,7 @@ from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.s3 import (
     S3_BENCHMARKS_PREFIX,
+    create_benchmark_url,
     create_console_url,
     create_presigned_url,
     download_from_s3_stream,
@@ -201,6 +202,7 @@ async def start_benchmark(
         started_at=benchmark_row.started_at,
         task_count=len(verify_response.task_ids),
         cloudwatch_url=get_cloudwatch_url(str(benchmark_row.id)),
+        s3_bucket_url=create_benchmark_url(str(benchmark_row.id)),
     )
 
 
@@ -244,6 +246,7 @@ async def fetch_benchmark(
         benchmark_name=benchmark_row.name,
         benchmark_id=benchmark_row.id,
         details=benchmark_context.benchmark_details,
+        s3_bucket_url=create_benchmark_url(str(benchmark_row.id)),
     )
 
 
@@ -270,7 +273,7 @@ async def retrieve_results(
     if s3:
         s3_key = upload_final_view(benchmark_row, final_view)
 
-        https_url = f"https://{AWS_S3_BUCKET}.s3.amazonaws.com/{s3_key}"
+        https_url = f"s3://{AWS_S3_BUCKET}/{s3_key}"
         presigned_url = create_presigned_url(s3_key)
         console_url = create_console_url(s3_key)
 

--- a/services/tracker/src/tracker/_lambda.py
+++ b/services/tracker/src/tracker/_lambda.py
@@ -2,24 +2,40 @@ import json
 from typing import Any
 
 import boto3
-from botocore.utils import ClientError
+from botocore.exceptions import ClientError
 
 from tracker.exceptions import LambdaError
 
 
 def invoke_lambda(function_name: str, payload: dict[str, Any]):
     """
-    Invokes lambda method provided the function name and the payload
+    Invokes lambda method provided the function name and the payload.
 
-    # NOTE Will not return anything, merely background
+    Raises LambdaError if the invocation fails or the Lambda returns an error.
     """
 
     try:
         lambda_client = boto3.client("lambda")
 
-        _ = lambda_client.invoke(
+        response = lambda_client.invoke(
             FunctionName=function_name,
             Payload=json.dumps(payload),
         )
+
+        function_error = response.get("FunctionError")
+        response_payload = json.loads(response["Payload"].read())
+
+        # Check if the Lambda function errored
+        if function_error:
+            raise LambdaError(
+                f"Lambda function '{function_name}' returned error: {json.dumps(response_payload, indent=4)}"
+            )
+
+        # Check for errors returned from the lambda itself
+        payload_status = response_payload.get("statusCode") if isinstance(response_payload, dict) else None
+        if payload_status and payload_status >= 400:
+            raise LambdaError(
+                f"Lambda function '{function_name}' returned status {payload_status}: {json.dumps(response_payload, indent=4)}"
+            )
     except ClientError as e:
         raise LambdaError(f"Failed to invoke lambda function '{function_name}': {e}") from e

--- a/services/tracker/src/tracker/_lambda.py
+++ b/services/tracker/src/tracker/_lambda.py
@@ -1,0 +1,25 @@
+import json
+from typing import Any
+
+import boto3
+from botocore.utils import ClientError
+
+from tracker.exceptions import LambdaError
+
+
+def invoke_lambda(function_name: str, payload: dict[str, Any]):
+    """
+    Invokes lambda method provided the function name and the payload
+
+    # NOTE Will not return anything, merely background
+    """
+
+    try:
+        lambda_client = boto3.client("lambda")
+
+        _ = lambda_client.invoke(
+            FunctionName=function_name,
+            Payload=json.dumps(payload),
+        )
+    except ClientError as e:
+        raise LambdaError(f"Failed to invoke lambda function '{function_name}': {e}") from e

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -64,6 +64,7 @@ class BenchmarkArguments(BaseModel):
     concurrency: int
     task_ids: list[str] | None = None
     slice_str: str | None = None
+    lambda_function: str | None = None
 
 
 class FinalEvaluation(SQLModel, table=True):

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -162,6 +162,7 @@ class Benchmark(SQLModel, table=True):
             concurrency=self.arguments.concurrency,
             task_ids=self.arguments.task_ids,
             slice_str=self.arguments.slice_str,
+            lambda_function=self.arguments.lambda_function,
         )
 
     @property

--- a/services/tracker/src/tracker/exceptions.py
+++ b/services/tracker/src/tracker/exceptions.py
@@ -26,3 +26,10 @@ class CloudWatchError(TrackerServiceError):
 
     def __str__(self) -> str:
         return "CloudWatch error: " + super().__str__()
+
+
+class LambdaError(TrackerServiceError):
+    """Exception raised for Lambda operation errors."""
+
+    def __str__(self) -> str:
+        return "Lambda error: " + super().__str__()

--- a/services/tracker/src/tracker/s3.py
+++ b/services/tracker/src/tracker/s3.py
@@ -203,3 +203,22 @@ def create_console_url(s3_key: str) -> str:
     region = s3_client.meta.region_name  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
 
     return f"https://{region}.console.aws.amazon.com/s3/object/{AWS_S3_BUCKET}?region={region}&prefix={s3_key}"
+
+
+@handle_s3_error(message=f"Failed to create benchmark URL for S3 bucket '{AWS_S3_BUCKET}'")
+def create_benchmark_url(benchmark_id: str) -> str:
+    """
+    Create the AWS Console URL for a benchmark's S3 folder.
+
+    Args:
+        benchmark_id: Benchmark UUID as a string
+
+    Returns:
+        AWS Console URL pointing to the benchmark folder prefix
+    """
+
+    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
+    region = s3_client.meta.region_name  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+    prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
+
+    return f"https://{region}.console.aws.amazon.com/s3/buckets/{AWS_S3_BUCKET}?region={region}&prefix={prefix}"

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -56,12 +56,14 @@ class StartBenchmarkResponse(BaseModel):
     started_at: datetime
     task_count: int
     cloudwatch_url: str
+    s3_bucket_url: str
 
 
 class FetchBenchmarkResponse(BaseModel):
     benchmark_name: str
     benchmark_id: UUID
     details: BenchmarkDetails
+    s3_bucket_url: str
 
 
 class FinalViewResponse(BaseModel):

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -34,6 +34,7 @@ class StartBenchmarkRequest(BaseModel):
     concurrency: int = 5
     task_ids: list[str] | None = None
     slice_str: str | None = None
+    lambda_function: str | None = None
 
     @property
     def benchmark_service(self) -> BenchmarkServiceClient:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -568,6 +568,11 @@ async def process_benchmark(
 
             set_benchmark_final_status(benchmark_row, session)
 
+            # Push the final benchmark view to the bucket
+            final_view: FinalViewResponse = create_final_view(benchmark_row, session)
+
+            upload_final_view(benchmark_row, final_view)
+
             # If the user has chosen to evoke a lambda function at the end of the benchmark
             # We are indeed obligated to run it even if it does not succeed
             arguments = benchmark_row.arguments

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -203,7 +203,7 @@ class TaskMonitor:
 
         exit_condition_met: bool = False
 
-        while not exit_condition_met:
+        while not exit_condition_met and self._task_tracking:
             tasks_to_check: list[str] = list(self._task_tracking.keys())
             for task_id in tasks_to_check:
                 task = self._task_tracking[task_id]
@@ -534,15 +534,14 @@ async def process_benchmark(
 
         await monitor_task
 
-        if not any(result_dict for result_dict in evaluation_result_rows):
-            raise TrackerServiceError("No tasks were completed successfully")
-
-        # NOTE: Tasks with errors will still need to be included inside of the final score calculation to ensure that they are accounted for
-        evaluation_results: dict[str, dict[str, Any] | None] = {
-            task_id: evaluation_result
-            for result_dict in evaluation_result_rows
-            for task_id, evaluation_result in result_dict.items()
-        }
+        evaluation_results: dict[str, dict[str, Any] | None] = {}
+        if any(result_dict for result_dict in evaluation_result_rows):
+            # NOTE: Tasks with errors will still need to be included inside of the final score calculation to ensure that they are accounted for
+            evaluation_results: dict[str, dict[str, Any] | None] = {
+                task_id: evaluation_result
+                for result_dict in evaluation_result_rows
+                for task_id, evaluation_result in result_dict.items()
+            }
 
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session)
@@ -550,6 +549,9 @@ async def process_benchmark(
             remaining_task_results = await fetch_missing_tasks(session, benchmark_row, evaluation_results)
 
         evaluation_results.update(remaining_task_results)
+
+        if not evaluation_results:
+            raise TrackerServiceError("No tasks were completed successfully")
 
         # Calculate the final score based off the tasks that were ran
         final_score_response = await benchmark_service.final_score(evaluation_results=evaluation_results)
@@ -563,6 +565,11 @@ async def process_benchmark(
 
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session)
+            # Delete existing final evaluation if re-running
+            if benchmark_row.final_evaluation:
+                session.delete(benchmark_row.final_evaluation)
+                session.flush()
+
             session.add(final_evaluation_row)
             session.commit()
 
@@ -573,15 +580,16 @@ async def process_benchmark(
 
             upload_final_view(benchmark_row, final_view)
 
-            # If the user has chosen to evoke a lambda function at the end of the benchmark
-            # We are indeed obligated to run it even if it does not succeed
+            # If the user has chosen to invoke a lambda function at the end of the benchmark
+            # We run it but do not let a failure affect the benchmark status
             arguments = benchmark_row.arguments
             if arguments.lambda_function:
                 # Expose the benchmark arguments and the benchmark id inside of the lambda
                 lambda_payload: dict[str, Any] = arguments.model_dump()
-                lambda_payload["benchmark_id"] = benchmark_id
+                lambda_payload["benchmark_id"] = str(benchmark_id)
 
                 invoke_lambda(arguments.lambda_function, lambda_payload)
+
     except Exception as e:
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session)
@@ -931,10 +939,9 @@ async def reset_to_in_progress_status(
                 f"{', '.join(missing_task_ids)} was requested to be force resumed but does not exist in the dataset"
             )
 
+        # Allow re-running the end of the benchmark without running any tasks
         if not task_ids:
-            raise TrackerServiceError(
-                f"No tasks for benchmark {benchmark_row.id} can be resumed because all tasks are finished"
-            )
+            return []
 
         # Verify the task ids are still valid before priming to resume
         # Raises if any task ids are invalid

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -566,7 +566,11 @@ async def process_benchmark(
             # We are indeed obligated to run it even if it does not succeed
             arguments = benchmark_row.arguments
             if arguments.lambda_function:
-                invoke_lambda(arguments.lambda_function, arguments.model_dump())
+                # Expose the benchmark arguments and the benchmark id inside of the lambda
+                lambda_payload: dict[str, Any] = arguments.model_dump()
+                lambda_payload["benchmark_id"] = benchmark_id
+
+                invoke_lambda(arguments.lambda_function, lambda_payload)
     except Exception as e:
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -33,6 +33,7 @@ from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
 from tracker.s3 import (
     S3_BENCHMARKS_PREFIX,
+    create_benchmark_url,
     get_agent_result_s3_key,
     upload_to_s3,
 )
@@ -772,6 +773,7 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
                     benchmark_name=fresh_benchmark.name,
                     benchmark_id=fresh_benchmark.id,
                     details=benchmark_context.benchmark_details,
+                    s3_bucket_url=create_benchmark_url(str(fresh_benchmark.id)),
                 )
 
                 yield f"{DATA_PREFIX} {response_data.model_dump_json()}\n\n"

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -538,7 +538,7 @@ async def process_benchmark(
         evaluation_results: dict[str, dict[str, Any] | None] = {}
         if any(result_dict for result_dict in evaluation_result_rows):
             # NOTE: Tasks with errors will still need to be included inside of the final score calculation to ensure that they are accounted for
-            evaluation_results: dict[str, dict[str, Any] | None] = {
+            evaluation_results = {
                 task_id: evaluation_result
                 for result_dict in evaluation_result_rows
                 for task_id, evaluation_result in result_dict.items()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -16,6 +16,7 @@ from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceErr
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
 
+from tracker._lambda import invoke_lambda
 from tracker.cloudwatch import cloudwatch_stream, create_benchmark_group, reset_cloudwatch_stream
 from tracker.config import broker
 from tracker.database.models import (
@@ -560,6 +561,12 @@ async def process_benchmark(
             session.commit()
 
             set_benchmark_final_status(benchmark_row, session)
+
+            # If the user has chosen to evoke a lambda function at the end of the benchmark
+            # We are indeed obligated to run it even if it does not succeed
+            arguments = benchmark_row.arguments
+            if arguments.lambda_function:
+                invoke_lambda(arguments.lambda_function, arguments.model_dump())
     except Exception as e:
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session)
@@ -567,6 +574,7 @@ async def process_benchmark(
             commit_benchmark_error(benchmark_row, session, error_message)
     finally:
         with Session(bind=engine) as session:
+            # Handle any misalignments between the benchmark status and tasks
             catch_errors_during_cleanup(benchmark_id, session)
 
         await benchmark_service.close()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -432,6 +432,7 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session) -> No
         benchmark_status = BenchmarkStatus.STOPPED
 
     benchmark_row.status = benchmark_status
+    benchmark_row.error_message = None
     session.add(benchmark_row)
     session.commit()
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -79,6 +79,7 @@ def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest) -> Benc
             concurrency=request.concurrency,
             task_ids=request.task_ids,
             slice_str=request.slice_str,
+            lambda_function=request.lambda_function,
         ),
     )
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -31,12 +31,17 @@ from tracker.database.models import (
 from tracker.database.session import engine
 from tracker.exceptions import TrackerServiceError
 from tracker.logger import get_logger
-from tracker.s3 import get_agent_result_s3_key
+from tracker.s3 import (
+    S3_BENCHMARKS_PREFIX,
+    get_agent_result_s3_key,
+    upload_to_s3,
+)
 from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     BenchmarkDetails,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
+    FinalViewResponse,
     Order,
     StartBenchmarkRequest,
 )
@@ -1025,3 +1030,39 @@ class YieldingWriter(io.RawIOBase):
         self._buffer.clear()
 
         return chunk
+
+
+def create_final_view(benchmark_row: Benchmark, session: Session) -> FinalViewResponse:
+    """Creates final view of a benchmark that includes metadata about evaluations and score"""
+    tasks_stopped: int = session.exec(
+        select(func.count(col(Task.id)))
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status) == TaskStatus.STOPPED)
+    ).one()
+
+    final_view: FinalViewResponse = FinalViewResponse(
+        benchmark_name=benchmark_row.name,
+        status=benchmark_row.status,
+        error_message=benchmark_row.error_message,
+        benchmark_id=benchmark_row.id,
+        benchmark_arguments=benchmark_row.arguments,
+        tasks_stopped=tasks_stopped or None,  # NOTE: Only include if we stopped the benchmark
+        final_evaluation=benchmark_row.final_evaluation,
+        evaluation_results=benchmark_row.fetch_evaluation_results(session),
+        task_errors=benchmark_row.fetch_tasks_with_errors(session),
+    )
+
+    return final_view
+
+
+def upload_final_view(benchmark_row: Benchmark, final_view: FinalViewResponse) -> str:
+    """Uploads the final view to the root of the benchmark folder and returns the s3 key"""
+    s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_row.id}/{benchmark_row.name}.json"
+    upload_to_s3(
+        final_view.model_dump_json(
+            indent=4, exclude_none=True, exclude={"benchmark_arguments": {"contract": {"env"}}}
+        ).encode(),
+        s3_key,
+    )
+
+    return s3_key

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -36,8 +36,12 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     def _mock_get_contract_s3_key(contract_name: str) -> str:
         return f"contracts/{contract_name}.zip"
 
+    def _mock_upload_to_s3(_file_content: bytes, _s3_key: str) -> None:
+        pass
+
     monkeypatch.setattr("tracker.s3.download_from_s3", _mock_download_from_s3)
     monkeypatch.setattr("tracker.s3.get_contract_s3_key", _mock_get_contract_s3_key)
+    monkeypatch.setattr("tracker.utils.upload_to_s3", _mock_upload_to_s3)
 
 
 @pytest.fixture(autouse=True)

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -223,9 +223,9 @@ class TestBenchmarkUtils:
         database_session.add_all(task_rows)
         database_session.commit()
 
-        # error is returned because we have no stopped tasks to resume
+        # No stopped tasks to resume, but this is allowed (re-runs post-task steps like lambda)
         response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=false")
-        assert response.status_code == 500
+        assert response.status_code == 200
 
         # Ensure that we can recreate the environment the benchmark was started in
         original_start_benchmark_request = StartBenchmarkRequest(

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -70,6 +70,14 @@ def agent():
     help="Number of concurrent tasks to run (e.g., 5)",
 )
 @click.option(
+    "--lambda",
+    "lambda_function",
+    type=str,
+    default=None,
+    required=False,
+    help="Lambda function to invoke at the end of the benchmark run",
+)
+@click.option(
     "--task-ids",
     type=str,
     required=False,
@@ -105,6 +113,7 @@ def start(
     model: str | None,
     benchmark: str,
     concurrency: int,
+    lambda_function: str | None,
     task_ids: str | None,
     task_ids_file: Path | None,
     slice_str: str | None,
@@ -171,6 +180,7 @@ def start(
                 concurrency,
                 formatted_task_ids,
                 slice_str,
+                lambda_function,
             )
 
             click.echo("\r\033[K", nl=False)

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -102,6 +102,7 @@ class TrackerService:
         concurrency: int,
         task_ids: list[str] | None,
         slice_str: str | None,
+        lambda_function: str | None = None,
     ) -> Response:
         """
         Start a benchmark run on the tracker service.
@@ -123,6 +124,7 @@ class TrackerService:
                 concurrency=concurrency,
                 task_ids=task_ids,
                 slice_str=slice_str,
+                lambda_function=lambda_function,
             )
 
             response = self._client.post(f"{self._base_url}/start-benchmark", json=payload.model_dump())

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -128,6 +128,8 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     click.echo(f"{click.style('Benchmark:', bold=True)} {benchmark_name}")
     click.echo(f"{click.style('Started at:', bold=True)} {local_time(started_at)}")
     click.echo(f"{click.style('Benchmark ID:', bold=True)} {benchmark_id}")
+    click.echo(click.style("Agent outputs and the final view will be saved to:", fg="yellow"))
+    click.echo(f"{benchmark_response.s3_bucket_url}")
     click.echo()
 
     status_text = click.style(status.value.replace("_", " ").title(), fg=status_color, bold=True)
@@ -154,7 +156,11 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ Max concurrency:   {start_benchmark_response.concurrency}")
     click.echo(f"│ Total tasks:   {start_benchmark_response.task_count}")
     click.echo(f"│ CloudWatch:    {start_benchmark_response.cloudwatch_url}")
+    click.echo(f"│ S3 Bucket:     {start_benchmark_response.s3_bucket_url}")
     click.echo("└" + "─" * 79)
+    click.echo()
+    click.echo(click.style("Agent outputs and the final view will be saved to:", fg="yellow"))
+    click.echo(f"{start_benchmark_response.s3_bucket_url}")
     click.echo()
     click.echo(
         click.style(
@@ -203,6 +209,10 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None
         tracker: TrackerService instance
         benchmark_id: Benchmark UUID to stream
     """
+    initial = tracker.fetch_benchmark(benchmark_id)
+    click.echo(click.style("Agent outputs and the final view will be saved to:", fg="yellow"))
+    click.echo(f"{initial.s3_bucket_url}")
+    click.echo()
     click.echo(click.style("Streaming benchmark updates (Ctrl+C to stop)...", fg="cyan"))
     click.echo()
 


### PR DESCRIPTION
### Main changes
Added a lambda option that allows you to automate an action when a benchmark finishes running

- Lambda argument to the cli
- Lambda is stored with the benchmark arguments as a string
- Allow retrying a benchmark if its only the lambda that errors
- Reset benchmark error message if benchmark was retried to finished
- Automatically upload final view to s3 when benchmark is finished running
- Updated docs