### PR TITLE
Config addition

### DIFF
--- a/agents/claude_code/contract.py
+++ b/agents/claude_code/contract.py
@@ -64,9 +64,7 @@ class ClaudeCodeContract(BaseAgentContract):
             f"--allowedTools {' '.join(self._ALLOWED_TOOLS)}",
         ]
 
-        run_cmd = (
-            f"cat {problem_statement_path} | claude " + " ".join(args) + " 2>&1 | tee /logs/claude_code.log"
-        )
+        run_cmd = f"cat {problem_statement_path} | claude " + " ".join(args) + " 2>&1 | tee /logs/claude_code.log"
 
         return run_cmd
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -73,9 +73,9 @@ def fetch_harness_config(request: Request) -> HarnessConfig:
             aws_secret_access_key=flat["aws_secret_access_key"],
             aws_default_region=flat["aws_default_region"],
         ),
-        s3_bucket=flat.get("aws_s3_bucket", flat.get("s3_bucket", "")),
-        log_group=flat.get("log_group", flat.get("root_log_group", "")),
-        log_retention_policy=int(flat.get("log_retention_policy", "0")),
+        s3_bucket=flat["s3_bucket"],
+        log_group=flat["log_group"],
+        log_retention_policy=int(flat["log_retention_policy"]),
     )
 
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -26,6 +26,7 @@ from tracker.s3 import (
     upload_to_s3,
 )
 from tracker.types import (
+    AWSCredentials,
     BenchmarkTableRow,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
@@ -63,10 +64,19 @@ app = FastAPI()
 def fetch_harness_config(request: Request) -> HarnessConfig:
     """FastAPI dependency that reconstructs HarnessConfig from X-Harness-* request headers."""
     prefix = "x-harness-"
-    config = {
+    flat = {
         key[len(prefix) :].replace("-", "_"): value for key, value in request.headers.items() if key.startswith(prefix)
     }
-    return HarnessConfig.model_validate(config)
+    return HarnessConfig(
+        aws=AWSCredentials(
+            aws_access_key_id=flat["aws_access_key_id"],
+            aws_secret_access_key=flat["aws_secret_access_key"],
+            aws_default_region=flat["aws_default_region"],
+        ),
+        s3_bucket=flat.get("aws_s3_bucket", flat.get("s3_bucket", "")),
+        log_group=flat.get("log_group", flat.get("root_log_group", "")),
+        log_retention_policy=int(flat.get("log_retention_policy", "0")),
+    )
 
 
 # Ignore verbose health check logs
@@ -142,7 +152,7 @@ async def upload_contract_to_s3(
     # Extract contract name from filename (remove .zip extension)
     contract_name = contract.filename.rsplit(".zip", 1)[0]
     contract_s3_key = get_contract_s3_key(contract_name)
-    upload_to_s3(contract_content, contract_s3_key, harness_config)
+    upload_to_s3(contract_content, contract_s3_key, harness_config.aws, harness_config.s3_bucket)
 
     return {
         "status": "success",
@@ -211,8 +221,12 @@ async def start_benchmark(
         concurrency=request.concurrency,
         started_at=benchmark_row.started_at,
         task_count=len(verify_response.task_ids),
-        cloudwatch_url=get_cloudwatch_url(str(benchmark_row.id), request.harness_config),
-        s3_bucket_url=create_benchmark_url(str(benchmark_row.id), request.harness_config),
+        cloudwatch_url=get_cloudwatch_url(
+            str(benchmark_row.id), request.harness_config.aws.aws_default_region, request.harness_config.log_group
+        ),
+        s3_bucket_url=create_benchmark_url(
+            str(benchmark_row.id), request.harness_config.aws.aws_default_region, request.harness_config.s3_bucket
+        ),
     )
 
 
@@ -259,7 +273,9 @@ async def fetch_benchmark(
         benchmark_name=benchmark_row.name,
         benchmark_id=benchmark_row.id,
         details=benchmark_context.benchmark_details,
-        s3_bucket_url=create_benchmark_url(str(benchmark_row.id), harness_config),
+        s3_bucket_url=create_benchmark_url(
+            str(benchmark_row.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
+        ),
     )
 
 
@@ -289,9 +305,9 @@ async def retrieve_results(
     if s3:
         s3_key = upload_final_view(benchmark_row, final_view, harness_config)
 
-        https_url = f"s3://{harness_config.aws_s3_bucket}/{s3_key}"
-        presigned_url = create_presigned_url(s3_key, harness_config)
-        console_url = create_console_url(s3_key, harness_config)
+        https_url = f"s3://{harness_config.s3_bucket}/{s3_key}"
+        presigned_url = create_presigned_url(s3_key, harness_config.aws, harness_config.s3_bucket)
+        console_url = create_console_url(s3_key, harness_config.aws.aws_default_region, harness_config.s3_bucket)
 
         return S3UploadResultsResponse(s3_url=https_url, presigned_url=presigned_url, console_url=console_url)
 
@@ -313,7 +329,7 @@ async def check_results_exist(
         {"exists": true/false}
     """
     s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/results.json"
-    exists = s3_object_exists(s3_key, harness_config)
+    exists = s3_object_exists(s3_key, harness_config.aws, harness_config.s3_bucket)
     return {"exists": exists}
 
 
@@ -483,7 +499,7 @@ async def fetch_agent_outputs(
         StreamingResponse
     """
     prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
-    s3_keys = list_s3_objects(prefix, harness_config)
+    s3_keys = list_s3_objects(prefix, harness_config.aws, harness_config.s3_bucket)
 
     if not s3_keys:
         raise HTTPException(
@@ -499,7 +515,7 @@ async def fetch_agent_outputs(
                 relative_path: str = s3_key.removeprefix(prefix)
 
                 try:
-                    body, size = download_from_s3_stream(s3_key, harness_config)
+                    body, size = download_from_s3_stream(s3_key, harness_config.aws, harness_config.s3_bucket)
 
                     tarinfo = tarfile.TarInfo(name=relative_path)
                     tarinfo.size = size

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -26,7 +26,6 @@ from tracker.s3 import (
     upload_to_s3,
 )
 from tracker.types import (
-    AWSCredentials,
     BenchmarkTableRow,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
@@ -47,6 +46,7 @@ from tracker.utils import (
     commit_benchmark_error,
     create_final_view,
     fetch_filtered_benchmark_rows,
+    fetch_harness_config,
     force_stop_sandboxes,
     initiate_stop_benchmark,
     process_benchmark,
@@ -59,24 +59,6 @@ from tracker.utils import (
 logger = get_logger(__name__)
 
 app = FastAPI()
-
-
-def fetch_harness_config(request: Request) -> HarnessConfig:
-    """FastAPI dependency that reconstructs HarnessConfig from X-Harness-* request headers."""
-    prefix = "x-harness-"
-    flat = {
-        key[len(prefix) :].replace("-", "_"): value for key, value in request.headers.items() if key.startswith(prefix)
-    }
-    return HarnessConfig(
-        aws=AWSCredentials(
-            aws_access_key_id=flat["aws_access_key_id"],
-            aws_secret_access_key=flat["aws_secret_access_key"],
-            aws_default_region=flat["aws_default_region"],
-        ),
-        s3_bucket=flat["s3_bucket"],
-        log_group=flat["log_group"],
-        log_retention_policy=int(flat["log_retention_policy"]),
-    )
 
 
 # Ignore verbose health check logs

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -10,7 +10,6 @@ from sqlalchemy.orm import joinedload
 from sqlmodel import Session, select
 
 from tracker.cloudwatch import get_cloudwatch_url
-from tracker.config import AWS_S3_BUCKET
 from tracker.database.models import Benchmark, BenchmarkStatus
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
@@ -32,6 +31,7 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
+    HarnessConfig,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
@@ -58,6 +58,15 @@ from tracker.utils import (
 logger = get_logger(__name__)
 
 app = FastAPI()
+
+
+def fetch_harness_config(request: Request) -> HarnessConfig:
+    """FastAPI dependency that reconstructs HarnessConfig from X-Harness-* request headers."""
+    prefix = "x-harness-"
+    config = {
+        key[len(prefix) :].replace("-", "_"): value for key, value in request.headers.items() if key.startswith(prefix)
+    }
+    return HarnessConfig.model_validate(config)
 
 
 # Ignore verbose health check logs
@@ -106,6 +115,7 @@ def health_check() -> dict[str, str]:
 @app.post("/upload")
 async def upload_contract_to_s3(
     contract: UploadFile = File(..., description="Contract directory zip file"),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
 ) -> dict[str, str]:
     """
     Upload contract to S3.
@@ -132,7 +142,7 @@ async def upload_contract_to_s3(
     # Extract contract name from filename (remove .zip extension)
     contract_name = contract.filename.rsplit(".zip", 1)[0]
     contract_s3_key = get_contract_s3_key(contract_name)
-    upload_to_s3(contract_content, contract_s3_key)
+    upload_to_s3(contract_content, contract_s3_key, harness_config)
 
     return {
         "status": "success",
@@ -201,14 +211,17 @@ async def start_benchmark(
         concurrency=request.concurrency,
         started_at=benchmark_row.started_at,
         task_count=len(verify_response.task_ids),
-        cloudwatch_url=get_cloudwatch_url(str(benchmark_row.id)),
-        s3_bucket_url=create_benchmark_url(str(benchmark_row.id)),
+        cloudwatch_url=get_cloudwatch_url(str(benchmark_row.id), request.harness_config),
+        s3_bucket_url=create_benchmark_url(str(benchmark_row.id), request.harness_config),
     )
 
 
 @app.get("/fetch-benchmark", response_model=None)
 async def fetch_benchmark(
-    benchmark_id: UUID, connect: bool = Query(default=False), session: Session = Depends(get_session)
+    benchmark_id: UUID,
+    connect: bool = Query(default=False),
+    session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
 ) -> FetchBenchmarkResponse | StreamingResponse:
     """
     Fetch a benchmark by its id.
@@ -246,13 +259,16 @@ async def fetch_benchmark(
         benchmark_name=benchmark_row.name,
         benchmark_id=benchmark_row.id,
         details=benchmark_context.benchmark_details,
-        s3_bucket_url=create_benchmark_url(str(benchmark_row.id)),
+        s3_bucket_url=create_benchmark_url(str(benchmark_row.id), harness_config),
     )
 
 
 @app.get("/retrieve-results")
 async def retrieve_results(
-    benchmark_id: UUID, s3: bool = Query(default=False), session: Session = Depends(get_session)
+    benchmark_id: UUID,
+    s3: bool = Query(default=False),
+    session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
 ) -> RetrieveResultsResponse:
     """
     Retrieve the results of a benchmark by its id.
@@ -271,11 +287,11 @@ async def retrieve_results(
     final_view = create_final_view(benchmark_row, session)
 
     if s3:
-        s3_key = upload_final_view(benchmark_row, final_view)
+        s3_key = upload_final_view(benchmark_row, final_view, harness_config)
 
-        https_url = f"s3://{AWS_S3_BUCKET}/{s3_key}"
-        presigned_url = create_presigned_url(s3_key)
-        console_url = create_console_url(s3_key)
+        https_url = f"s3://{harness_config.aws_s3_bucket}/{s3_key}"
+        presigned_url = create_presigned_url(s3_key, harness_config)
+        console_url = create_console_url(s3_key, harness_config)
 
         return S3UploadResultsResponse(s3_url=https_url, presigned_url=presigned_url, console_url=console_url)
 
@@ -283,7 +299,10 @@ async def retrieve_results(
 
 
 @app.get("/check-results-exist")
-async def check_results_exist(benchmark_id: UUID) -> dict[str, bool]:
+async def check_results_exist(
+    benchmark_id: UUID,
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+) -> dict[str, bool]:
     """
     Check if results.json already exists in S3 for the given benchmark.
 
@@ -294,7 +313,7 @@ async def check_results_exist(benchmark_id: UUID) -> dict[str, bool]:
         {"exists": true/false}
     """
     s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/results.json"
-    exists = s3_object_exists(s3_key)
+    exists = s3_object_exists(s3_key, harness_config)
     return {"exists": exists}
 
 
@@ -341,6 +360,7 @@ async def retry_or_resume_benchmark(
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
     session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
 ) -> RetryOrResumeBenchmarkResponse:
     """
     Retry or resume a benchmark run by its id, we only can retry or resume a benchmark if its not currently running.
@@ -380,15 +400,18 @@ async def retry_or_resume_benchmark(
     verified_task_ids = await reset_to_in_progress_status(
         benchmark_row=benchmark_row,
         session=session,
-        benchmark_service=benchmark_row.start_benchmark_request.benchmark_service,
+        benchmark_service=benchmark_row.benchmark_service,
         retry=retry,
         rerun_task_ids=task_ids,
     )
 
+    # Ensure that credentials are included with the model dump
+    resume_request_json = benchmark_row.start_benchmark_request(harness_config).model_dump()
+
     # start the benchmark with the same args used to create it
     # we will delegate inside what tasks we are running
     await process_benchmark.kiq(
-        start_benchmark_request_json=benchmark_row.start_benchmark_request.model_dump(),
+        start_benchmark_request_json=resume_request_json,
         benchmark_id_str=str(benchmark_row.id),
         verified_task_ids=verified_task_ids,
     )
@@ -446,7 +469,10 @@ async def fetch_benchmark_metadata(
 
 
 @app.get("/fetch-agent-outputs/{benchmark_id}")
-async def fetch_agent_outputs(benchmark_id: UUID) -> StreamingResponse:
+async def fetch_agent_outputs(
+    benchmark_id: UUID,
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+) -> StreamingResponse:
     """
     Stream a tar file with agent outputs to the client.
 
@@ -457,7 +483,7 @@ async def fetch_agent_outputs(benchmark_id: UUID) -> StreamingResponse:
         StreamingResponse
     """
     prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
-    s3_keys = list_s3_objects(prefix)
+    s3_keys = list_s3_objects(prefix, harness_config)
 
     if not s3_keys:
         raise HTTPException(
@@ -473,7 +499,7 @@ async def fetch_agent_outputs(benchmark_id: UUID) -> StreamingResponse:
                 relative_path: str = s3_key.removeprefix(prefix)
 
                 try:
-                    body, size = download_from_s3_stream(s3_key)
+                    body, size = download_from_s3_stream(s3_key, harness_config)
 
                     tarinfo = tarfile.TarInfo(name=relative_path)
                     tarinfo.size = size

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -244,7 +244,7 @@ async def fetch_benchmark(
     # and additional updates about the tasks completed
     if connect:
         return StreamingResponse(
-            stream_benchmark_results(benchmark_id, session),
+            stream_benchmark_results(benchmark_id, session, harness_config),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/services/tracker/src/tracker/cloudwatch.py
+++ b/services/tracker/src/tracker/cloudwatch.py
@@ -9,18 +9,18 @@ from botocore.exceptions import BotoCoreError, ClientError
 from tracker.exceptions import CloudWatchError
 
 if TYPE_CHECKING:
-    from tracker.types import HarnessConfig
+    from tracker.types import AWSCredentials
 
 _created_streams: set[str] = set()
 
 
-def _cloudwatch_client(harness_config: "HarnessConfig") -> Any:
+def _cloudwatch_client(aws: "AWSCredentials") -> Any:
     """Create a CloudWatch Logs client from harness config credentials."""
     return boto3.client(  # pyright: ignore[reportUnknownMemberType]
         "logs",
-        aws_access_key_id=harness_config.aws_access_key_id,
-        aws_secret_access_key=harness_config.aws_secret_access_key,
-        region_name=harness_config.aws_default_region,
+        aws_access_key_id=aws.aws_access_key_id,
+        aws_secret_access_key=aws.aws_secret_access_key,
+        region_name=aws.aws_default_region,
         config=Config(max_pool_connections=75),
     )
 
@@ -39,22 +39,21 @@ def handle_cloudwatch_error(message: str):
     return decorator
 
 
-def get_cloudwatch_url(benchmark_id: str, harness_config: "HarnessConfig", task_id: str | None = None) -> str:
+def get_cloudwatch_url(benchmark_id: str, region: str, log_group: str, task_id: str | None = None) -> str:
     """
     Get the CloudWatch console URL for a benchmark or specific task.
 
     Args:
         benchmark_id: The benchmark identifier
-        harness_config: Harness config providing the region and log group
+        region: The AWS region
+        log_group: The root log group name
         task_id: Optional task identifier for task-specific logs
 
     Returns:
         CloudWatch console URL
     """
-    region = harness_config.aws_default_region
-    root_log_group = harness_config.root_log_group
     base = f"https://{region}.console.aws.amazon.com/cloudwatch/home?region={region}"
-    encoded_log_group = f"{root_log_group}$252F{benchmark_id}"
+    encoded_log_group = f"{log_group}$252F{benchmark_id}"
     if task_id:
         return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{task_id}"
 
@@ -62,23 +61,25 @@ def get_cloudwatch_url(benchmark_id: str, harness_config: "HarnessConfig", task_
 
 
 @handle_cloudwatch_error(message="Failed to create log group")
-def create_benchmark_group(benchmark_id: str, harness_config: "HarnessConfig") -> str:
+def create_benchmark_group(benchmark_id: str, aws: "AWSCredentials", log_group: str, log_retention_policy: int) -> str:
     """
     Create a log group for a benchmark.
 
     Args:
         benchmark_id: The benchmark identifier
-        harness_config: Harness config providing credentials, log group, and retention policy
+        aws: AWS credentials for CloudWatch client
+        log_group: The root log group name
+        log_retention_policy: Number of days to retain logs
 
     Returns:
         The log group name
     """
-    client = _cloudwatch_client(harness_config)
-    log_group_name: str = f"{harness_config.root_log_group}/{benchmark_id}"
+    client = _cloudwatch_client(aws)
+    log_group_name: str = f"{log_group}/{benchmark_id}"
 
     try:
         client.create_log_group(logGroupName=log_group_name)  # pyright: ignore[reportUnknownMemberType]
-        client.put_retention_policy(logGroupName=log_group_name, retentionInDays=harness_config.log_retention_policy)  # pyright: ignore[reportUnknownMemberType]
+        client.put_retention_policy(logGroupName=log_group_name, retentionInDays=log_retention_policy)  # pyright: ignore[reportUnknownMemberType]
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
             raise
@@ -87,7 +88,7 @@ def create_benchmark_group(benchmark_id: str, harness_config: "HarnessConfig") -
 
 
 @handle_cloudwatch_error(message="Failed to delete log stream")
-def reset_cloudwatch_stream(stream_key: str, harness_config: "HarnessConfig") -> None:
+def reset_cloudwatch_stream(stream_key: str, aws: "AWSCredentials", log_group: str) -> None:
     """
     Delete and recreate a CloudWatch log stream to reset it.
 
@@ -95,15 +96,16 @@ def reset_cloudwatch_stream(stream_key: str, harness_config: "HarnessConfig") ->
 
     Args:
         stream_key: The stream key (benchmark_id:task_id)
-        harness_config: Harness config providing credentials and log group
+        aws: AWS credentials for CloudWatch client
+        log_group: The root log group name
     """
     benchmark_id, task_id = stream_key.split(":")
 
     if not benchmark_id or not task_id:
         raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
 
-    client = _cloudwatch_client(harness_config)
-    log_group_name = f"{harness_config.root_log_group}/{benchmark_id}"
+    client = _cloudwatch_client(aws)
+    log_group_name = f"{log_group}/{benchmark_id}"
 
     try:
         client.delete_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
@@ -115,7 +117,7 @@ def reset_cloudwatch_stream(stream_key: str, harness_config: "HarnessConfig") ->
 
 
 @handle_cloudwatch_error(message="Failed to create cloudwatch stream")
-def cloudwatch_stream(stream_key: str, message: str, harness_config: "HarnessConfig") -> None:
+def cloudwatch_stream(stream_key: str, message: str, aws: "AWSCredentials", log_group: str) -> None:
     """
     Stream a log message to CloudWatch.
 
@@ -124,7 +126,8 @@ def cloudwatch_stream(stream_key: str, message: str, harness_config: "HarnessCon
     Args:
         stream_key: The stream key (benchmark_id:task_id)
         message: The log message
-        harness_config: Harness config providing credentials and log group
+        aws: AWS credentials for CloudWatch client
+        log_group: The root log group name
     """
     if not message.strip():
         return
@@ -134,12 +137,12 @@ def cloudwatch_stream(stream_key: str, message: str, harness_config: "HarnessCon
     if not benchmark_id or not task_id:
         raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
 
-    client = _cloudwatch_client(harness_config)
-    log_group = f"{harness_config.root_log_group}/{benchmark_id}"
+    client = _cloudwatch_client(aws)
+    log_group_name = f"{log_group}/{benchmark_id}"
 
     if stream_key not in _created_streams:
         try:
-            client.create_log_stream(logGroupName=log_group, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
+            client.create_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
                 raise
@@ -149,7 +152,7 @@ def cloudwatch_stream(stream_key: str, message: str, harness_config: "HarnessCon
 
     try:
         client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group,
+            logGroupName=log_group_name,
             logStreamName=task_id,
             logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
         )

--- a/services/tracker/src/tracker/cloudwatch.py
+++ b/services/tracker/src/tracker/cloudwatch.py
@@ -1,5 +1,6 @@
 import time
 from functools import wraps
+from typing import TYPE_CHECKING, Any
 
 import boto3
 from botocore.config import Config
@@ -7,10 +8,21 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 from tracker.exceptions import CloudWatchError
 
-_client = boto3.client("logs", config=Config(max_pool_connections=75))  # pyright: ignore[reportUnknownMemberType] # type: ignore[reportUnknownReturnType]
+if TYPE_CHECKING:
+    from tracker.types import HarnessConfig
+
 _created_streams: set[str] = set()
 
-ROOT_LOG_GROUP = "benchmarks"
+
+def _cloudwatch_client(harness_config: "HarnessConfig") -> Any:
+    """Create a CloudWatch Logs client from harness config credentials."""
+    return boto3.client(  # pyright: ignore[reportUnknownMemberType]
+        "logs",
+        aws_access_key_id=harness_config.aws_access_key_id,
+        aws_secret_access_key=harness_config.aws_secret_access_key,
+        region_name=harness_config.aws_default_region,
+        config=Config(max_pool_connections=75),
+    )
 
 
 def handle_cloudwatch_error(message: str):
@@ -27,42 +39,46 @@ def handle_cloudwatch_error(message: str):
     return decorator
 
 
-def get_cloudwatch_url(benchmark_id: str, task_id: str | None = None) -> str:
+def get_cloudwatch_url(benchmark_id: str, harness_config: "HarnessConfig", task_id: str | None = None) -> str:
     """
     Get the CloudWatch console URL for a benchmark or specific task.
 
     Args:
         benchmark_id: The benchmark identifier
+        harness_config: Harness config providing the region and log group
         task_id: Optional task identifier for task-specific logs
 
     Returns:
         CloudWatch console URL
     """
-    region = _client.meta.region_name  # pyright: ignore
+    region = harness_config.aws_default_region
+    root_log_group = harness_config.root_log_group
     base = f"https://{region}.console.aws.amazon.com/cloudwatch/home?region={region}"
-    log_group = f"benchmarks$252F{benchmark_id}"
+    encoded_log_group = f"{root_log_group}$252F{benchmark_id}"
     if task_id:
-        return f"{base}#logsV2:log-groups/log-group/{log_group}/log-events/{task_id}"
+        return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{task_id}"
 
-    return f"{base}#logsV2:log-groups/log-group/{log_group}"
+    return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}"
 
 
 @handle_cloudwatch_error(message="Failed to create log group")
-def create_benchmark_group(benchmark_id: str) -> str:
+def create_benchmark_group(benchmark_id: str, harness_config: "HarnessConfig") -> str:
     """
-    Create a log group for a benchmark with 1-day retention.
+    Create a log group for a benchmark.
 
     Args:
         benchmark_id: The benchmark identifier
+        harness_config: Harness config providing credentials, log group, and retention policy
 
     Returns:
         The log group name
     """
-    log_group_name: str = f"{ROOT_LOG_GROUP}/{benchmark_id}"
+    client = _cloudwatch_client(harness_config)
+    log_group_name: str = f"{harness_config.root_log_group}/{benchmark_id}"
 
     try:
-        _client.create_log_group(logGroupName=log_group_name)  # pyright: ignore[reportUnknownMemberType]
-        _client.put_retention_policy(logGroupName=log_group_name, retentionInDays=365)  # pyright: ignore[reportUnknownMemberType]
+        client.create_log_group(logGroupName=log_group_name)  # pyright: ignore[reportUnknownMemberType]
+        client.put_retention_policy(logGroupName=log_group_name, retentionInDays=harness_config.log_retention_policy)  # pyright: ignore[reportUnknownMemberType]
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
             raise
@@ -71,7 +87,7 @@ def create_benchmark_group(benchmark_id: str) -> str:
 
 
 @handle_cloudwatch_error(message="Failed to delete log stream")
-def reset_cloudwatch_stream(stream_key: str) -> None:
+def reset_cloudwatch_stream(stream_key: str, harness_config: "HarnessConfig") -> None:
     """
     Delete and recreate a CloudWatch log stream to reset it.
 
@@ -79,16 +95,18 @@ def reset_cloudwatch_stream(stream_key: str) -> None:
 
     Args:
         stream_key: The stream key (benchmark_id:task_id)
+        harness_config: Harness config providing credentials and log group
     """
     benchmark_id, task_id = stream_key.split(":")
 
     if not benchmark_id or not task_id:
         raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
 
-    log_group_name = f"{ROOT_LOG_GROUP}/{benchmark_id}"
+    client = _cloudwatch_client(harness_config)
+    log_group_name = f"{harness_config.root_log_group}/{benchmark_id}"
 
     try:
-        _client.delete_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
+        client.delete_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
             raise
@@ -97,7 +115,7 @@ def reset_cloudwatch_stream(stream_key: str) -> None:
 
 
 @handle_cloudwatch_error(message="Failed to create cloudwatch stream")
-def cloudwatch_stream(stream_key: str, message: str) -> None:
+def cloudwatch_stream(stream_key: str, message: str, harness_config: "HarnessConfig") -> None:
     """
     Stream a log message to CloudWatch.
 
@@ -106,6 +124,7 @@ def cloudwatch_stream(stream_key: str, message: str) -> None:
     Args:
         stream_key: The stream key (benchmark_id:task_id)
         message: The log message
+        harness_config: Harness config providing credentials and log group
     """
     if not message.strip():
         return
@@ -115,9 +134,12 @@ def cloudwatch_stream(stream_key: str, message: str) -> None:
     if not benchmark_id or not task_id:
         raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
 
+    client = _cloudwatch_client(harness_config)
+    log_group = f"{harness_config.root_log_group}/{benchmark_id}"
+
     if stream_key not in _created_streams:
         try:
-            _client.create_log_stream(logGroupName=f"{ROOT_LOG_GROUP}/{benchmark_id}", logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
+            client.create_log_stream(logGroupName=log_group, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
                 raise
@@ -126,8 +148,8 @@ def cloudwatch_stream(stream_key: str, message: str) -> None:
         _created_streams.add(stream_key)
 
     try:
-        _client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=f"{ROOT_LOG_GROUP}/{benchmark_id}",
+        client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
+            logGroupName=log_group,
             logStreamName=task_id,
             logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
         )

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -27,7 +27,7 @@ from tracker.database.utils import has_field_changed
 if TYPE_CHECKING:
     from benchmark_service.client import BenchmarkServiceClient
 
-    from tracker.types import BenchmarkTableRow, FetchBenchmarkMetadataResponse, StartBenchmarkRequest
+    from tracker.types import BenchmarkTableRow, FetchBenchmarkMetadataResponse, HarnessConfig, StartBenchmarkRequest
 
 
 class TaskStatus(str, Enum):
@@ -152,8 +152,7 @@ class Benchmark(SQLModel, table=True):
 
         return {task_id: (error_message or "No error message was provided") for task_id, error_message in tasks}
 
-    @property
-    def start_benchmark_request(self) -> "StartBenchmarkRequest":
+    def start_benchmark_request(self, harness_config: "HarnessConfig") -> "StartBenchmarkRequest":
         from tracker.types import StartBenchmarkRequest
 
         return StartBenchmarkRequest(
@@ -163,11 +162,15 @@ class Benchmark(SQLModel, table=True):
             task_ids=self.arguments.task_ids,
             slice_str=self.arguments.slice_str,
             lambda_function=self.arguments.lambda_function,
+            harness_config=harness_config,
         )
 
     @property
     def benchmark_service(self) -> "BenchmarkServiceClient":
-        return self.start_benchmark_request.benchmark_service
+        from tracker.config import BENCHMARK_SERVICE_URL
+        from tracker.utils import create_benchmark_service_client
+
+        return create_benchmark_service_client(url=BENCHMARK_SERVICE_URL)
 
     @property
     def benchmark_metadata(self) -> "FetchBenchmarkMetadataResponse":

--- a/services/tracker/src/tracker/s3.py
+++ b/services/tracker/src/tracker/s3.py
@@ -10,19 +10,19 @@ from botocore.response import StreamingBody
 from tracker.exceptions import S3Error
 
 if TYPE_CHECKING:
-    from tracker.types import HarnessConfig
+    from tracker.types import AWSCredentials
 
 S3_CONTRACTS_PREFIX = "contracts"
 S3_BENCHMARKS_PREFIX = "benchmarks"
 
 
-def _s3_client(harness_config: "HarnessConfig") -> Any:
+def _s3_client(aws: "AWSCredentials") -> Any:
     """Create an S3 client from harness config credentials."""
     return boto3.client(  # pyright: ignore[reportUnknownMemberType]
         "s3",
-        aws_access_key_id=harness_config.aws_access_key_id,
-        aws_secret_access_key=harness_config.aws_secret_access_key,
-        region_name=harness_config.aws_default_region,
+        aws_access_key_id=aws.aws_access_key_id,
+        aws_secret_access_key=aws.aws_secret_access_key,
+        region_name=aws.aws_default_region,
     )
 
 
@@ -51,30 +51,32 @@ def handle_s3_error(message: str):
 
 
 @handle_s3_error(message="Failed to upload to S3")
-def upload_to_s3(file_content: bytes, s3_key: str, harness_config: "HarnessConfig") -> None:
+def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> None:
     """
     Upload file content to S3.
 
     Args:
         file_content: File content as bytes
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
 
     Raises:
         S3Error: If upload fails due to AWS errors or network issues
     """
-    client = _s3_client(harness_config)
-    client.put_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key, Body=file_content)
+    client = _s3_client(aws)
+    client.put_object(Bucket=s3_bucket, Key=s3_key, Body=file_content)
 
 
 @handle_s3_error(message="Failed to download from S3")
-def download_from_s3(s3_key: str, harness_config: "HarnessConfig") -> bytes:
+def download_from_s3(s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> bytes:
     """
     Download file content from S3.
 
     Args:
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
 
     Returns:
         File content as bytes
@@ -82,42 +84,44 @@ def download_from_s3(s3_key: str, harness_config: "HarnessConfig") -> bytes:
     Raises:
         S3Error: If download fails due to AWS errors, network issues, or file not found
     """
-    client = _s3_client(harness_config)
-    response = client.get_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
+    client = _s3_client(aws)
+    response = client.get_object(Bucket=s3_bucket, Key=s3_key)
 
     return response["Body"].read()
 
 
 @handle_s3_error(message="Failed to delete from S3")
-def delete_from_s3(s3_key: str, harness_config: "HarnessConfig") -> None:
+def delete_from_s3(s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> None:
     """
     Delete file from S3.
 
     Args:
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
 
     Raises:
         S3Error: If deletion fails due to AWS errors or network issues
     """
-    client = _s3_client(harness_config)
-    client.delete_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
+    client = _s3_client(aws)
+    client.delete_object(Bucket=s3_bucket, Key=s3_key)
 
 
 @handle_s3_error(message="Failed to stream download from S3")
-def download_from_s3_stream(s3_key: str, harness_config: "HarnessConfig") -> tuple[StreamingBody, int]:
+def download_from_s3_stream(s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> tuple[StreamingBody, int]:
     """
     Download file content from S3 and return a streaming body and the content length.
 
     Args:
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
 
     Returns:
         tuple[StreamingBody, int]: Streaming body and content length
     """
-    client = _s3_client(harness_config)
-    response = client.get_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
+    client = _s3_client(aws)
+    response = client.get_object(Bucket=s3_bucket, Key=s3_key)
 
     body: StreamingBody = response["Body"]
     size = response["ContentLength"]
@@ -126,20 +130,21 @@ def download_from_s3_stream(s3_key: str, harness_config: "HarnessConfig") -> tup
 
 
 @handle_s3_error(message="Failed to check S3 object existence")
-def s3_object_exists(s3_key: str, harness_config: "HarnessConfig") -> bool:
+def s3_object_exists(s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> bool:
     """
     Check if an S3 object exists.
 
     Args:
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
 
     Returns:
         True if the object exists, False otherwise
     """
     try:
-        client = _s3_client(harness_config)
-        client.head_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
+        client = _s3_client(aws)
+        client.head_object(Bucket=s3_bucket, Key=s3_key)
         return True
     except ClientError as e:
         if e.response["Error"]["Code"] == "404":
@@ -149,13 +154,14 @@ def s3_object_exists(s3_key: str, harness_config: "HarnessConfig") -> bool:
 
 
 @handle_s3_error(message="Failed to list objects from S3")
-def list_s3_objects(prefix: str, harness_config: "HarnessConfig") -> list[str]:
+def list_s3_objects(prefix: str, aws: "AWSCredentials", s3_bucket: str) -> list[str]:
     """
     List all S3 object keys with the given prefix.
 
     Args:
         prefix: S3 prefix to filter objects
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
 
     Returns:
         List of S3 object keys
@@ -163,11 +169,11 @@ def list_s3_objects(prefix: str, harness_config: "HarnessConfig") -> list[str]:
     Raises:
         S3Error: If listing fails due to AWS errors or network issues
     """
-    client = _s3_client(harness_config)
+    client = _s3_client(aws)
     paginator = client.get_paginator("list_objects_v2")
 
     object_keys: list[str] = []
-    for page in paginator.paginate(Bucket=harness_config.aws_s3_bucket, Prefix=prefix):
+    for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
         if "Contents" in page:
             for obj in page["Contents"]:
                 if "Key" in obj:
@@ -177,13 +183,14 @@ def list_s3_objects(prefix: str, harness_config: "HarnessConfig") -> list[str]:
 
 
 @handle_s3_error(message="Failed to create presigned URL")
-def create_presigned_url(s3_key: str, harness_config: "HarnessConfig", expiration: int = 86400) -> str:
+def create_presigned_url(s3_key: str, aws: "AWSCredentials", s3_bucket: str, expiration: int = 86400) -> str:
     """
     Create a presigned URL for an S3 object.
 
     Args:
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials and bucket name
+        aws: AWS credentials for authentication
+        s3_bucket: S3 bucket name
         expiration: URL expiration time in seconds (default: 1 day)
 
     Returns:
@@ -192,10 +199,10 @@ def create_presigned_url(s3_key: str, harness_config: "HarnessConfig", expiratio
     Raises:
         S3Error: If presigned URL creation fails
     """
-    client = _s3_client(harness_config)
+    client = _s3_client(aws)
     presigned_url: str = client.generate_presigned_url(
         "get_object",
-        Params={"Bucket": harness_config.aws_s3_bucket, "Key": s3_key},
+        Params={"Bucket": s3_bucket, "Key": s3_key},
         ExpiresIn=expiration,
     )
 
@@ -203,33 +210,33 @@ def create_presigned_url(s3_key: str, harness_config: "HarnessConfig", expiratio
 
 
 @handle_s3_error(message="Failed to create console URL")
-def create_console_url(s3_key: str, harness_config: "HarnessConfig") -> str:
+def create_console_url(s3_key: str, region: str, s3_bucket: str) -> str:
     """
     Create an AWS console URL for an S3 object.
 
     Args:
         s3_key: S3 object key (path in bucket)
-        harness_config: Harness config providing credentials, region, and bucket name
+        region: AWS region
+        s3_bucket: S3 bucket name
 
     Returns:
         AWS console URL as a string
     """
-    region = harness_config.aws_default_region
-    return f"https://{region}.console.aws.amazon.com/s3/object/{harness_config.aws_s3_bucket}?region={region}&prefix={s3_key}"
+    return f"https://{region}.console.aws.amazon.com/s3/object/{s3_bucket}?region={region}&prefix={s3_key}"
 
 
 @handle_s3_error(message="Failed to create benchmark URL")
-def create_benchmark_url(benchmark_id: str, harness_config: "HarnessConfig") -> str:
+def create_benchmark_url(benchmark_id: str, region: str, s3_bucket: str) -> str:
     """
     Create the AWS Console URL for a benchmark's S3 folder.
 
     Args:
         benchmark_id: Benchmark UUID as a string
-        harness_config: Harness config providing credentials, region, and bucket name
+        region: AWS region
+        s3_bucket: S3 bucket name
 
     Returns:
         AWS Console URL pointing to the benchmark folder prefix
     """
-    region = harness_config.aws_default_region
     prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
-    return f"https://{region}.console.aws.amazon.com/s3/buckets/{harness_config.aws_s3_bucket}?region={region}&prefix={prefix}"
+    return f"https://{region}.console.aws.amazon.com/s3/buckets/{s3_bucket}?region={region}&prefix={prefix}"

--- a/services/tracker/src/tracker/s3.py
+++ b/services/tracker/src/tracker/s3.py
@@ -1,16 +1,29 @@
 """S3 upload utilities for the tracker service."""
 
 from functools import wraps
+from typing import TYPE_CHECKING, Any
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 from botocore.response import StreamingBody
 
-from tracker.config import AWS_S3_BUCKET
 from tracker.exceptions import S3Error
+
+if TYPE_CHECKING:
+    from tracker.types import HarnessConfig
 
 S3_CONTRACTS_PREFIX = "contracts"
 S3_BENCHMARKS_PREFIX = "benchmarks"
+
+
+def _s3_client(harness_config: "HarnessConfig") -> Any:
+    """Create an S3 client from harness config credentials."""
+    return boto3.client(  # pyright: ignore[reportUnknownMemberType]
+        "s3",
+        aws_access_key_id=harness_config.aws_access_key_id,
+        aws_secret_access_key=harness_config.aws_secret_access_key,
+        region_name=harness_config.aws_default_region,
+    )
 
 
 def get_contract_s3_key(contract_name: str) -> str:
@@ -37,30 +50,31 @@ def handle_s3_error(message: str):
     return decorator
 
 
-@handle_s3_error(message=f"Failed to upload to S3 bucket '{AWS_S3_BUCKET}'")
-def upload_to_s3(file_content: bytes, s3_key: str) -> None:
+@handle_s3_error(message="Failed to upload to S3")
+def upload_to_s3(file_content: bytes, s3_key: str, harness_config: "HarnessConfig") -> None:
     """
     Upload file content to S3.
 
     Args:
         file_content: File content as bytes
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials and bucket name
 
     Raises:
         S3Error: If upload fails due to AWS errors or network issues
     """
+    client = _s3_client(harness_config)
+    client.put_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key, Body=file_content)
 
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    s3_client.put_object(Bucket=AWS_S3_BUCKET, Key=s3_key, Body=file_content)
 
-
-@handle_s3_error(message=f"Failed to download from S3 bucket '{AWS_S3_BUCKET}'")
-def download_from_s3(s3_key: str) -> bytes:
+@handle_s3_error(message="Failed to download from S3")
+def download_from_s3(s3_key: str, harness_config: "HarnessConfig") -> bytes:
     """
     Download file content from S3.
 
     Args:
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials and bucket name
 
     Returns:
         File content as bytes
@@ -68,43 +82,42 @@ def download_from_s3(s3_key: str) -> bytes:
     Raises:
         S3Error: If download fails due to AWS errors, network issues, or file not found
     """
-
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    response = s3_client.get_object(Bucket=AWS_S3_BUCKET, Key=s3_key)
+    client = _s3_client(harness_config)
+    response = client.get_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
 
     return response["Body"].read()
 
 
-@handle_s3_error(message=f"Failed to delete from S3 bucket '{AWS_S3_BUCKET}'")
-def delete_from_s3(s3_key: str) -> None:
+@handle_s3_error(message="Failed to delete from S3")
+def delete_from_s3(s3_key: str, harness_config: "HarnessConfig") -> None:
     """
     Delete file from S3.
 
     Args:
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials and bucket name
 
     Raises:
         S3Error: If deletion fails due to AWS errors or network issues
     """
+    client = _s3_client(harness_config)
+    client.delete_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
 
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    s3_client.delete_object(Bucket=AWS_S3_BUCKET, Key=s3_key)
 
-
-@handle_s3_error(message=f"Failed to stream download from S3 bucket '{AWS_S3_BUCKET}'")
-def download_from_s3_stream(s3_key: str) -> tuple[StreamingBody, int]:
+@handle_s3_error(message="Failed to stream download from S3")
+def download_from_s3_stream(s3_key: str, harness_config: "HarnessConfig") -> tuple[StreamingBody, int]:
     """
     Download file content from S3 and return a streaming body and the content length.
 
     Args:
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials and bucket name
 
     Returns:
         tuple[StreamingBody, int]: Streaming body and content length
     """
-
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    response = s3_client.get_object(Bucket=AWS_S3_BUCKET, Key=s3_key)
+    client = _s3_client(harness_config)
+    response = client.get_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
 
     body: StreamingBody = response["Body"]
     size = response["ContentLength"]
@@ -113,35 +126,36 @@ def download_from_s3_stream(s3_key: str) -> tuple[StreamingBody, int]:
 
 
 @handle_s3_error(message="Failed to check S3 object existence")
-def s3_object_exists(s3_key: str) -> bool:
+def s3_object_exists(s3_key: str, harness_config: "HarnessConfig") -> bool:
     """
     Check if an S3 object exists.
 
     Args:
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials and bucket name
 
     Returns:
         True if the object exists, False otherwise
     """
     try:
-        s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-        s3_client.head_object(Bucket=AWS_S3_BUCKET, Key=s3_key)
+        client = _s3_client(harness_config)
+        client.head_object(Bucket=harness_config.aws_s3_bucket, Key=s3_key)
         return True
     except ClientError as e:
-        # Acceptable error if object does not exist
         if e.response["Error"]["Code"] == "404":
             return False
 
         raise
 
 
-@handle_s3_error(message=f"Failed to list objects from S3 bucket '{AWS_S3_BUCKET}'")
-def list_s3_objects(prefix: str) -> list[str]:
+@handle_s3_error(message="Failed to list objects from S3")
+def list_s3_objects(prefix: str, harness_config: "HarnessConfig") -> list[str]:
     """
     List all S3 object keys with the given prefix.
 
     Args:
         prefix: S3 prefix to filter objects
+        harness_config: Harness config providing credentials and bucket name
 
     Returns:
         List of S3 object keys
@@ -149,12 +163,11 @@ def list_s3_objects(prefix: str) -> list[str]:
     Raises:
         S3Error: If listing fails due to AWS errors or network issues
     """
-
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    paginator = s3_client.get_paginator("list_objects_v2")
+    client = _s3_client(harness_config)
+    paginator = client.get_paginator("list_objects_v2")
 
     object_keys: list[str] = []
-    for page in paginator.paginate(Bucket=AWS_S3_BUCKET, Prefix=prefix):
+    for page in paginator.paginate(Bucket=harness_config.aws_s3_bucket, Prefix=prefix):
         if "Contents" in page:
             for obj in page["Contents"]:
                 if "Key" in obj:
@@ -163,13 +176,14 @@ def list_s3_objects(prefix: str) -> list[str]:
     return object_keys
 
 
-@handle_s3_error(message=f"Failed to create presigned URL for S3 bucket '{AWS_S3_BUCKET}'")
-def create_presigned_url(s3_key: str, expiration: int = 86400) -> str:
+@handle_s3_error(message="Failed to create presigned URL")
+def create_presigned_url(s3_key: str, harness_config: "HarnessConfig", expiration: int = 86400) -> str:
     """
     Create a presigned URL for an S3 object.
 
     Args:
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials and bucket name
         expiration: URL expiration time in seconds (default: 1 day)
 
     Returns:
@@ -178,47 +192,44 @@ def create_presigned_url(s3_key: str, expiration: int = 86400) -> str:
     Raises:
         S3Error: If presigned URL creation fails
     """
-
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    presigned_url: str = s3_client.generate_presigned_url(
-        "get_object", Params={"Bucket": AWS_S3_BUCKET, "Key": s3_key}, ExpiresIn=expiration
+    client = _s3_client(harness_config)
+    presigned_url: str = client.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": harness_config.aws_s3_bucket, "Key": s3_key},
+        ExpiresIn=expiration,
     )
 
     return presigned_url
 
 
-@handle_s3_error(message=f"Failed to create console URL for S3 bucket '{AWS_S3_BUCKET}'")
-def create_console_url(s3_key: str) -> str:
+@handle_s3_error(message="Failed to create console URL")
+def create_console_url(s3_key: str, harness_config: "HarnessConfig") -> str:
     """
     Create an AWS console URL for an S3 object.
 
     Args:
         s3_key: S3 object key (path in bucket)
+        harness_config: Harness config providing credentials, region, and bucket name
 
     Returns:
         AWS console URL as a string
     """
-
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    region = s3_client.meta.region_name  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-
-    return f"https://{region}.console.aws.amazon.com/s3/object/{AWS_S3_BUCKET}?region={region}&prefix={s3_key}"
+    region = harness_config.aws_default_region
+    return f"https://{region}.console.aws.amazon.com/s3/object/{harness_config.aws_s3_bucket}?region={region}&prefix={s3_key}"
 
 
-@handle_s3_error(message=f"Failed to create benchmark URL for S3 bucket '{AWS_S3_BUCKET}'")
-def create_benchmark_url(benchmark_id: str) -> str:
+@handle_s3_error(message="Failed to create benchmark URL")
+def create_benchmark_url(benchmark_id: str, harness_config: "HarnessConfig") -> str:
     """
     Create the AWS Console URL for a benchmark's S3 folder.
 
     Args:
         benchmark_id: Benchmark UUID as a string
+        harness_config: Harness config providing credentials, region, and bucket name
 
     Returns:
         AWS Console URL pointing to the benchmark folder prefix
     """
-
-    s3_client = boto3.client("s3")  # pyright: ignore[reportUnknownMemberType]
-    region = s3_client.meta.region_name  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+    region = harness_config.aws_default_region
     prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
-
-    return f"https://{region}.console.aws.amazon.com/s3/buckets/{AWS_S3_BUCKET}?region={region}&prefix={prefix}"
+    return f"https://{region}.console.aws.amazon.com/s3/buckets/{harness_config.aws_s3_bucket}?region={region}&prefix={prefix}"

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -28,6 +28,7 @@ from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SandboxError
 from tracker.logger import get_logger
 from tracker.s3 import download_from_s3, get_contract_s3_key, upload_to_s3
+from tracker.types import HarnessConfig
 
 logger = get_logger(__name__)
 
@@ -147,13 +148,14 @@ async def create_sandbox(
         await delete_sandbox(sandbox, daytona)
 
 
-async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest) -> None:
+async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest, harness_config: HarnessConfig) -> None:
     """
     Upload contract from S3 to the sandbox.
 
     Args:
         sandbox: The sandbox to upload files to
         contract_name: Name of the contract (without extension)
+        harness_config: Harness config for S3 access
 
     Raises:
         SandboxError: If directory creation or file upload fails
@@ -161,7 +163,7 @@ async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractR
     logger.info(f"Uploading contract {contract.name} to sandbox {sandbox.name}")
 
     contract_s3_key = get_contract_s3_key(contract.name)
-    contract_content = download_from_s3(contract_s3_key)
+    contract_content = download_from_s3(contract_s3_key, harness_config)
 
     # Unzip contract and collect files and directories
     with zipfile.ZipFile(io.BytesIO(contract_content), "r") as zip_ref:
@@ -246,7 +248,7 @@ async def stream_command_output(
             pass
 
 
-async def archive_and_upload_output(sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str) -> None:
+async def archive_and_upload_output(sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str, harness_config: HarnessConfig) -> None:
     """Compress a file in the sandbox into a tar.gz and upload it to S3"""
     archive_path = f"/tmp/{uuid.uuid4().hex}.tar.gz"
 
@@ -259,7 +261,7 @@ async def archive_and_upload_output(sandbox: AsyncSandbox, output_path: str, age
         if b64_result.exit_code != 0:
             raise SandboxError(f"Failed to read archive from {output_path}")
 
-        upload_to_s3(base64.b64decode(b64_result.result), agent_output_s3_key)
+        upload_to_s3(base64.b64decode(b64_result.result), agent_output_s3_key, harness_config)
     finally:
         # Check if file exists and remove it if it does
         result = await sandbox.process.exec(f"test -e {shlex.quote(archive_path)}")
@@ -276,6 +278,7 @@ async def run_agent(
     task_id: str,
     log_output: Callable[[str], None],
     cwd: str,
+    harness_config: HarnessConfig,
     agent_output_s3_key: str | None = None,
 ) -> None:
     """
@@ -315,4 +318,4 @@ async def run_agent(
         return
 
     if agent_output_s3_key:
-        await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key)
+        await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, harness_config)

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -28,7 +28,7 @@ from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SandboxError
 from tracker.logger import get_logger
 from tracker.s3 import download_from_s3, get_contract_s3_key, upload_to_s3
-from tracker.types import HarnessConfig
+from tracker.types import AWSCredentials
 
 logger = get_logger(__name__)
 
@@ -148,7 +148,9 @@ async def create_sandbox(
         await delete_sandbox(sandbox, daytona)
 
 
-async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractRequest, harness_config: HarnessConfig) -> None:
+async def upload_agent_artifacts(
+    sandbox: AsyncSandbox, contract: AgentContractRequest, aws: AWSCredentials, s3_bucket: str
+) -> None:
     """
     Upload contract from S3 to the sandbox.
 
@@ -163,7 +165,7 @@ async def upload_agent_artifacts(sandbox: AsyncSandbox, contract: AgentContractR
     logger.info(f"Uploading contract {contract.name} to sandbox {sandbox.name}")
 
     contract_s3_key = get_contract_s3_key(contract.name)
-    contract_content = download_from_s3(contract_s3_key, harness_config)
+    contract_content = download_from_s3(contract_s3_key, aws, s3_bucket)
 
     # Unzip contract and collect files and directories
     with zipfile.ZipFile(io.BytesIO(contract_content), "r") as zip_ref:
@@ -248,7 +250,9 @@ async def stream_command_output(
             pass
 
 
-async def archive_and_upload_output(sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str, harness_config: HarnessConfig) -> None:
+async def archive_and_upload_output(
+    sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str, aws: AWSCredentials, s3_bucket: str
+) -> None:
     """Compress a file in the sandbox into a tar.gz and upload it to S3"""
     archive_path = f"/tmp/{uuid.uuid4().hex}.tar.gz"
 
@@ -261,7 +265,7 @@ async def archive_and_upload_output(sandbox: AsyncSandbox, output_path: str, age
         if b64_result.exit_code != 0:
             raise SandboxError(f"Failed to read archive from {output_path}")
 
-        upload_to_s3(base64.b64decode(b64_result.result), agent_output_s3_key, harness_config)
+        upload_to_s3(base64.b64decode(b64_result.result), agent_output_s3_key, aws, s3_bucket)
     finally:
         # Check if file exists and remove it if it does
         result = await sandbox.process.exec(f"test -e {shlex.quote(archive_path)}")
@@ -278,7 +282,8 @@ async def run_agent(
     task_id: str,
     log_output: Callable[[str], None],
     cwd: str,
-    harness_config: HarnessConfig,
+    aws: AWSCredentials,
+    s3_bucket: str,
     agent_output_s3_key: str | None = None,
 ) -> None:
     """
@@ -318,4 +323,4 @@ async def run_agent(
         return
 
     if agent_output_s3_key:
-        await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, harness_config)
+        await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, aws, s3_bucket)

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -7,9 +7,9 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
+from benchmark_service.client import BenchmarkServiceClient
 from pydantic import BaseModel
 
-from benchmark_service.client import BenchmarkServiceClient
 from tracker.config import BENCHMARK_SERVICE_URL
 from tracker.database.models import (
     AgentContractRequest,
@@ -28,6 +28,15 @@ class BenchmarkDetails(BaseModel):
     task_breakdown: dict[TaskStatus, int]
 
 
+class HarnessConfig(BaseModel):
+    aws_s3_bucket: str
+    root_log_group: str
+    log_retention_policy: int
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_default_region: str
+
+
 class StartBenchmarkRequest(BaseModel):
     contract: AgentContractRequest
     benchmark_name: str
@@ -35,6 +44,7 @@ class StartBenchmarkRequest(BaseModel):
     task_ids: list[str] | None = None
     slice_str: str | None = None
     lambda_function: str | None = None
+    harness_config: HarnessConfig
 
     @property
     def benchmark_service(self) -> BenchmarkServiceClient:

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -28,13 +28,17 @@ class BenchmarkDetails(BaseModel):
     task_breakdown: dict[TaskStatus, int]
 
 
-class HarnessConfig(BaseModel):
-    aws_s3_bucket: str
-    root_log_group: str
-    log_retention_policy: int
+class AWSCredentials(BaseModel):
     aws_access_key_id: str
     aws_secret_access_key: str
     aws_default_region: str
+
+
+class HarnessConfig(BaseModel):
+    aws: AWSCredentials
+    s3_bucket: str
+    log_group: str
+    log_retention_policy: int
 
 
 class StartBenchmarkRequest(BaseModel):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
+from fastapi import Request
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
 
 from tracker._lambda import invoke_lambda
@@ -1117,3 +1118,21 @@ def upload_final_view(benchmark_row: Benchmark, final_view: FinalViewResponse, h
     )
 
     return s3_key
+
+
+def fetch_harness_config(request: Request) -> HarnessConfig:
+    """Constructs HarnessConfig from X-Harness-* request headers."""
+    prefix = "x-harness-"
+    flat = {
+        key[len(prefix) :].replace("-", "_"): value for key, value in request.headers.items() if key.startswith(prefix)
+    }
+    return HarnessConfig(
+        aws=AWSCredentials(
+            aws_access_key_id=flat["aws_access_key_id"],
+            aws_secret_access_key=flat["aws_secret_access_key"],
+            aws_default_region=flat["aws_default_region"],
+        ),
+        s3_bucket=flat["s3_bucket"],
+        log_group=flat["log_group"],
+        log_retention_policy=int(flat["log_retention_policy"]),
+    )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -44,6 +44,7 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FinalViewResponse,
+    HarnessConfig,
     Order,
     StartBenchmarkRequest,
 )
@@ -248,7 +249,9 @@ def fetch_task_row(task_id: UUID, session: Session) -> Task:
     return task_row
 
 
-def buffer_logs(log_queue: asyncio.Queue[str], stream_key: str, force_flush: bool = False) -> None:
+def buffer_logs(
+    log_queue: asyncio.Queue[str], stream_key: str, harness_config: HarnessConfig, force_flush: bool = False
+) -> None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
     """
@@ -261,7 +264,7 @@ def buffer_logs(log_queue: asyncio.Queue[str], stream_key: str, force_flush: boo
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, cloudwatch_stream, stream_key, message)
+    loop.run_in_executor(None, cloudwatch_stream, stream_key, message, harness_config)
 
 
 async def process_task(
@@ -270,6 +273,7 @@ async def process_task(
     benchmark_service: BenchmarkServiceClient,
     benchmark_id: UUID,
     task_id: str,
+    harness_config: HarnessConfig,
 ) -> dict[str, dict[str, Any] | None]:
     """
     Processes a task and returns the evaluation result
@@ -291,7 +295,7 @@ async def process_task(
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
 
     # If we are retrying the task we clear logs from previous run
-    reset_cloudwatch_stream(stream_key)
+    reset_cloudwatch_stream(stream_key, harness_config)
 
     last_log_time: float = time.monotonic()
 
@@ -300,7 +304,7 @@ async def process_task(
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        buffer_logs(log_queue, stream_key)
+        buffer_logs(log_queue, stream_key, harness_config)
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -308,7 +312,7 @@ async def process_task(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                buffer_logs(log_queue, stream_key, force_flush=True)
+                buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
@@ -349,7 +353,7 @@ async def process_task(
                     _ = await benchmark_service.setup_task(task_row.task_id, sandbox.id, on_message=log_output)
 
                     # Force flush the logs if anything has been buffered
-                    buffer_logs(log_queue, stream_key, force_flush=True)
+                    buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -415,7 +419,7 @@ async def process_task(
         return {task_id: None}
     finally:
         flush_task.cancel()
-        buffer_logs(log_queue, stream_key, force_flush=True)
+        buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
 
 
 def set_benchmark_final_status(benchmark_row: Benchmark, session: Session) -> None:
@@ -515,10 +519,11 @@ async def process_benchmark(
     start_benchmark_request: StartBenchmarkRequest = StartBenchmarkRequest(**start_benchmark_request_json)
     benchmark_id: UUID = UUID(benchmark_id_str)
     benchmark_service = start_benchmark_request.benchmark_service
+    harness_config: HarnessConfig = start_benchmark_request.harness_config
 
     try:
         # Create benchmark cloudwatch log group
-        create_benchmark_group(str(benchmark_id))
+        create_benchmark_group(str(benchmark_id), harness_config)
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
@@ -535,7 +540,7 @@ async def process_benchmark(
         # Load the tasks we are going to be tracking
         tracked_tasks: dict[str, TrackedTask] = {
             task_id: TrackedTask(
-                process_task(task_row, start_benchmark_request, benchmark_service, benchmark_id, task_id)
+                process_task(task_row, start_benchmark_request, benchmark_service, benchmark_id, task_id, harness_config)
             )
             for task_id, task_row in task_rows
         }
@@ -596,7 +601,7 @@ async def process_benchmark(
             # Push the final benchmark view to the bucket
             final_view: FinalViewResponse = create_final_view(benchmark_row, session)
 
-            upload_final_view(benchmark_row, final_view)
+            upload_final_view(benchmark_row, final_view, harness_config)
 
             # If the user has chosen to invoke a lambda function at the end of the benchmark
             # We run it but do not let a failure affect the benchmark status
@@ -1086,7 +1091,7 @@ def create_final_view(benchmark_row: Benchmark, session: Session) -> FinalViewRe
     return final_view
 
 
-def upload_final_view(benchmark_row: Benchmark, final_view: FinalViewResponse) -> str:
+def upload_final_view(benchmark_row: Benchmark, final_view: FinalViewResponse, harness_config: HarnessConfig) -> str:
     """Uploads the final view to the root of the benchmark folder and returns the s3 key"""
     s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_row.id}/{benchmark_row.name}.json"
     upload_to_s3(
@@ -1094,6 +1099,7 @@ def upload_final_view(benchmark_row: Benchmark, final_view: FinalViewResponse) -
             indent=4, exclude_none=True, exclude={"benchmark_arguments": {"contract": {"env"}}}
         ).encode(),
         s3_key,
+        harness_config,
     )
 
     return s3_key

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -346,7 +346,7 @@ async def process_task(
                     task_session.commit()
 
                 # Upload the contract to the sandbox after creating and install the dependencies
-                await upload_agent_artifacts(sandbox, start_benchmark_request.contract)
+                await upload_agent_artifacts(sandbox, start_benchmark_request.contract, harness_config)
 
                 # Setup task if requested
                 if task_data.request_setup:
@@ -368,6 +368,7 @@ async def process_task(
                     task_id,
                     log_output,
                     task_data.cwd,
+                    harness_config=harness_config,
                     agent_output_s3_key=agent_output_s3_key,
                 )
 
@@ -384,7 +385,7 @@ async def process_task(
                 )
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, force_flush=True)
+                buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
 
                 # Save the evaluation result to the database with the task row
                 evaluation_result_row = EvaluationResult(
@@ -762,7 +763,7 @@ def commit_task_error(task_row: Task, session: Session, error_message: str) -> N
     session.commit()
 
 
-async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> AsyncGenerator[str]:
+async def stream_benchmark_results(benchmark_id: UUID, session: Session, harness_config: HarnessConfig) -> AsyncGenerator[str]:
     """
     Generate Server-Sent Events with benchmark updates. User connects to this when they want to view live updates of a benchmark.
 
@@ -794,7 +795,7 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session) -> Asyn
                     benchmark_name=fresh_benchmark.name,
                     benchmark_id=fresh_benchmark.id,
                     details=benchmark_context.benchmark_details,
-                    s3_bucket_url=create_benchmark_url(str(fresh_benchmark.id)),
+                    s3_bucket_url=create_benchmark_url(str(fresh_benchmark.id), harness_config),
                 )
 
                 yield f"{DATA_PREFIX} {response_data.model_dump_json()}\n\n"

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -40,6 +40,7 @@ from tracker.s3 import (
 )
 from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
+    AWSCredentials,
     BenchmarkDetails,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
@@ -250,7 +251,7 @@ def fetch_task_row(task_id: UUID, session: Session) -> Task:
 
 
 def buffer_logs(
-    log_queue: asyncio.Queue[str], stream_key: str, harness_config: HarnessConfig, force_flush: bool = False
+    log_queue: asyncio.Queue[str], stream_key: str, aws: AWSCredentials, log_group: str, force_flush: bool = False
 ) -> None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
@@ -264,7 +265,7 @@ def buffer_logs(
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, cloudwatch_stream, stream_key, message, harness_config)
+    loop.run_in_executor(None, cloudwatch_stream, stream_key, message, aws, log_group)
 
 
 async def process_task(
@@ -295,7 +296,7 @@ async def process_task(
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
 
     # If we are retrying the task we clear logs from previous run
-    reset_cloudwatch_stream(stream_key, harness_config)
+    reset_cloudwatch_stream(stream_key, harness_config.aws, harness_config.log_group)
 
     last_log_time: float = time.monotonic()
 
@@ -304,7 +305,7 @@ async def process_task(
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        buffer_logs(log_queue, stream_key, harness_config)
+        buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group)
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -312,7 +313,7 @@ async def process_task(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
+                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
@@ -346,14 +347,16 @@ async def process_task(
                     task_session.commit()
 
                 # Upload the contract to the sandbox after creating and install the dependencies
-                await upload_agent_artifacts(sandbox, start_benchmark_request.contract, harness_config)
+                await upload_agent_artifacts(
+                    sandbox, start_benchmark_request.contract, harness_config.aws, harness_config.s3_bucket
+                )
 
                 # Setup task if requested
                 if task_data.request_setup:
                     _ = await benchmark_service.setup_task(task_row.task_id, sandbox.id, on_message=log_output)
 
                     # Force flush the logs if anything has been buffered
-                    buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
+                    buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -368,7 +371,8 @@ async def process_task(
                     task_id,
                     log_output,
                     task_data.cwd,
-                    harness_config=harness_config,
+                    aws=harness_config.aws,
+                    s3_bucket=harness_config.s3_bucket,
                     agent_output_s3_key=agent_output_s3_key,
                 )
 
@@ -385,7 +389,7 @@ async def process_task(
                 )
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
+                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
                 # Save the evaluation result to the database with the task row
                 evaluation_result_row = EvaluationResult(
@@ -420,7 +424,7 @@ async def process_task(
         return {task_id: None}
     finally:
         flush_task.cancel()
-        buffer_logs(log_queue, stream_key, harness_config, force_flush=True)
+        buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
 
 def set_benchmark_final_status(benchmark_row: Benchmark, session: Session) -> None:
@@ -524,7 +528,9 @@ async def process_benchmark(
 
     try:
         # Create benchmark cloudwatch log group
-        create_benchmark_group(str(benchmark_id), harness_config)
+        create_benchmark_group(
+            str(benchmark_id), harness_config.aws, harness_config.log_group, harness_config.log_retention_policy
+        )
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
@@ -541,7 +547,9 @@ async def process_benchmark(
         # Load the tasks we are going to be tracking
         tracked_tasks: dict[str, TrackedTask] = {
             task_id: TrackedTask(
-                process_task(task_row, start_benchmark_request, benchmark_service, benchmark_id, task_id, harness_config)
+                process_task(
+                    task_row, start_benchmark_request, benchmark_service, benchmark_id, task_id, harness_config
+                )
             )
             for task_id, task_row in task_rows
         }
@@ -763,7 +771,9 @@ def commit_task_error(task_row: Task, session: Session, error_message: str) -> N
     session.commit()
 
 
-async def stream_benchmark_results(benchmark_id: UUID, session: Session, harness_config: HarnessConfig) -> AsyncGenerator[str]:
+async def stream_benchmark_results(
+    benchmark_id: UUID, session: Session, harness_config: HarnessConfig
+) -> AsyncGenerator[str]:
     """
     Generate Server-Sent Events with benchmark updates. User connects to this when they want to view live updates of a benchmark.
 
@@ -795,7 +805,9 @@ async def stream_benchmark_results(benchmark_id: UUID, session: Session, harness
                     benchmark_name=fresh_benchmark.name,
                     benchmark_id=fresh_benchmark.id,
                     details=benchmark_context.benchmark_details,
-                    s3_bucket_url=create_benchmark_url(str(fresh_benchmark.id), harness_config),
+                    s3_bucket_url=create_benchmark_url(
+                        str(fresh_benchmark.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
+                    ),
                 )
 
                 yield f"{DATA_PREFIX} {response_data.model_dump_json()}\n\n"
@@ -1100,7 +1112,8 @@ def upload_final_view(benchmark_row: Benchmark, final_view: FinalViewResponse, h
             indent=4, exclude_none=True, exclude={"benchmark_arguments": {"contract": {"env"}}}
         ).encode(),
         s3_key,
-        harness_config,
+        harness_config.aws,
+        harness_config.s3_bucket,
     )
 
     return s3_key

--- a/services/tracker/tests/conftest.py
+++ b/services/tracker/tests/conftest.py
@@ -19,7 +19,7 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
     def _mock_create_benchmark_group(benchmark_id: str) -> str:
         return f"mock-group-{benchmark_id}"
 
-    def _mock_cloudwatch_stream(_stream_key: str, _message: str) -> None:
+    def _mock_cloudwatch_stream(*_args: Any, **_kwargs: Any) -> None:
         pass
 
     monkeypatch.setattr("tracker.cloudwatch.create_benchmark_group", _mock_create_benchmark_group)

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -6,6 +6,8 @@ from sqlmodel import Session
 
 from benchmark_service.client import BenchmarkServiceClient
 from tracker.database.session import get_session
+from tracker.types import AWSCredentials, HarnessConfig
+from tracker.utils import fetch_harness_config
 from benchmark_service.schemas import HealthCheckResponse, SetupTaskResponse, VerifyTaskIdsResponse
 
 # Sets default aws credentials in the environment for moto to work
@@ -15,6 +17,22 @@ os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "test")
 
 # Needs to be after the environment variable setup
 from main import app
+
+TEST_HARNESS_CONFIG = HarnessConfig(
+    aws=AWSCredentials(
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+        aws_default_region="us-east-1",
+    ),
+    s3_bucket="test-bucket",
+    log_group="test-log-group",
+    log_retention_policy=7,
+)
+
+
+@pytest.fixture
+def harness_config() -> HarnessConfig:
+    return TEST_HARNESS_CONFIG
 
 
 @pytest.fixture(autouse=True)
@@ -36,7 +54,7 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     def _mock_get_contract_s3_key(contract_name: str) -> str:
         return f"contracts/{contract_name}.zip"
 
-    def _mock_upload_to_s3(_file_content: bytes, _s3_key: str) -> None:
+    def _mock_upload_to_s3(*_args: Any, **_kwargs: Any) -> None:
         pass
 
     monkeypatch.setattr("tracker.s3.download_from_s3", _mock_download_from_s3)
@@ -52,6 +70,16 @@ def override_database_session(database_session: Session) -> None:
         yield database_session
 
     app.dependency_overrides[get_session] = get_test_session
+
+
+@pytest.fixture(autouse=True)
+def override_harness_config() -> None:
+    """Overrides the harness config dependency so endpoints don't require X-Harness-* headers"""
+
+    def get_test_harness_config():
+        return TEST_HARNESS_CONFIG
+
+    app.dependency_overrides[fetch_harness_config] = get_test_harness_config
 
 
 @pytest.fixture(autouse=True)

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -12,7 +12,8 @@ from tracker.utils import start_benchmark_request_to_benchmark
 from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.exceptions import TrackerServiceError
 from benchmark_service.schemas import FinalScoreResponse
-from tracker.types import StartBenchmarkRequest
+from tracker.types import HarnessConfig, StartBenchmarkRequest
+from tests.unit.conftest import TEST_HARNESS_CONFIG
 from tracker.utils import create_task_rows, fetch_benchmark_row, set_benchmark_final_status
 
 
@@ -234,11 +235,12 @@ class TestBenchmarkUtils:
             concurrency=5,
             task_ids=["task_0", "task_1", "task_2", "task_3", "task_4"],
             slice_str=":10",
+            harness_config=TEST_HARNESS_CONFIG,
         )
 
         benchmark_row = start_benchmark_request_to_benchmark(original_start_benchmark_request)
 
-        recreated_start_benchmark_request = benchmark_row.start_benchmark_request
+        recreated_start_benchmark_request = benchmark_row.start_benchmark_request(TEST_HARNESS_CONFIG)
         assert recreated_start_benchmark_request == original_start_benchmark_request
 
         # Assert we have 5 tasks in the database

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -24,8 +24,10 @@ from benchmark_service.schemas import VerifyTaskIdsResponse
 from tracker.types import (
     FetchBenchmarksRequest,
     FinalViewResponse,
+    HarnessConfig,
     StartBenchmarkRequest,
 )
+from tests.unit.conftest import TEST_HARNESS_CONFIG
 
 client = TestClient(app)
 
@@ -70,6 +72,7 @@ class TestFastapiServer:
             benchmark_name="swebench",
             concurrency=10,
             task_ids=None,
+            harness_config=TEST_HARNESS_CONFIG,
         )
 
         async def _mock_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
@@ -352,6 +355,7 @@ class TestFastapiServer:
             benchmark_name="swebench",
             concurrency=10,
             task_ids=None,
+            harness_config=TEST_HARNESS_CONFIG,
         )
 
         # Send request to start the benchmark and ensure that the start response is returned

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -11,8 +11,9 @@ from benchmark_service.client import BenchmarkServiceClient
 from tracker.utils import start_benchmark_request_to_benchmark
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, Task, TaskStatus
 from benchmark_service.schemas import FinalScoreResponse, Resources, RetrieveTaskResponse, VerifyTaskIdsResponse
-from tracker.types import StartBenchmarkRequest
+from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import initiate_stop_benchmark, process_benchmark, reset_to_in_progress_status
+from tests.unit.conftest import TEST_HARNESS_CONFIG
 
 client = TestClient(app)
 
@@ -79,6 +80,7 @@ class TestStopAndResume:
             contract=contract,
             concurrency=2,
             task_ids=task_ids,
+            harness_config=TEST_HARNESS_CONFIG,
         )
 
         benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request)
@@ -145,7 +147,7 @@ class TestStopAndResume:
 
         # Run process_benchmark to complete the remaining tasks (the 3 tasks that are pending)
         await process_benchmark(
-            start_benchmark_request_json=benchmark_row.start_benchmark_request.model_dump(),
+            start_benchmark_request_json=benchmark_row.start_benchmark_request(TEST_HARNESS_CONFIG).model_dump(),
             benchmark_id_str=str(benchmark_row.id),
             verified_task_ids=verified_task_ids,
         )

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -66,7 +66,7 @@ def init() -> None:
         "AWS_SECRET_ACCESS_KEY": None,  # AWS SECRETS KEY
         "AWS_DEFAULT_REGION": None,  # What region your secrets are in
         "AWS_S3_BUCKET": None,  # Center point where all agents and benchmark results are uploaded
-        "ROOT_LOG_GROUP": "benchmarks",  # the prefix to the cloudwatch logs (e.x. benchmarks/<benchmark_id>)
+        "LOG_GROUP": "benchmarks",  # the prefix to the cloudwatch logs (e.x. benchmarks/<benchmark_id>)
         "LOG_RETENTION_POLICY": 365,  # How long logs are kept until auto deleted
     }
 

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -101,6 +101,34 @@ def init() -> None:
     click.echo(click.style(f"\nConfig written to {config_location}", fg="green", bold=True))
 
 
+@config.command()
+@click.argument("key")
+@click.argument("value")
+def modify(key: str, value: str) -> None:
+    """
+    Modify a single key in the harness config.
+
+    Example: harness config modify AWS_DEFAULT_REGION us-west-2
+    """
+    config_location = Path("~/.config/harness/harness.yaml").expanduser()
+
+    if not config_location.exists():
+        raise click.ClickException("Config not found. Run `harness config init` first.")
+
+    with open(config_location) as f:
+        current: dict[str, str] = yaml.safe_load(f) or {}
+
+    if key not in current:
+        raise click.ClickException(f"Key '{key}' not found in config. Valid keys: {', '.join(current)}")
+
+    current[key] = value
+
+    with open(config_location, "w") as f:
+        yaml.dump(current, f, default_flow_style=False)
+
+    click.echo(click.style(f"  {key} updated.", fg="green"))
+
+
 @benchmark.command(
     help="Start a benchmark run. \n\nExample:\nharness benchmark start --agent agents/claude_code --benchmark swebench --concurrency 5"
 )

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -1,10 +1,12 @@
 """CLI views/commands for the agentic harness."""
 
+import os
 from pathlib import Path
 from typing import Any
 from uuid import UUID
 
 import click
+import yaml
 from tracker.database.models import BenchmarkStatus
 from tracker.types import FinalViewResponse, Order, RetrieveResultsResponse, StartBenchmarkResponse
 
@@ -39,6 +41,64 @@ def benchmark():
 def agent():
     """Agent command group"""
     pass
+
+
+@cli.group()
+def config():
+    """Config command group"""
+    pass
+
+
+@config.command()
+def init() -> None:
+    """
+    Initializes a config we can trust to have references to dependencies to run the harness,
+    this becomes our source of truth for secrets required to run the harness
+    """
+    config_location: Path = Path("~/.config/harness/harness.yaml")
+
+    # Mapping between the expected key and default value
+    # None means its user provided if not found
+    environment_variables: dict[str, str | None | int] = {
+        "AWS_ACCESS_KEY_ID": None,  # AWS ACCESS KEY
+        "AWS_SECRET_ACCESS_KEY": None,  # AWS SECRETS KEY
+        "AWS_DEFAULT_REGION": None,  # What region your secrets are in
+        "AWS_S3_BUCKET": None,  # Center point where all agents and benchmark results are uploaded
+        "ROOT_LOG_GROUP": "benchmarks",  # the prefix to the cloudwatch logs (e.x. benchmarks/<benchmark_id>)
+        "LOG_RETENTION_POLICY": 365,  # How long logs are kept until auto deleted
+    }
+
+    collected_keys: dict[str, str] = {}
+
+    for key, default in environment_variables.items():
+        sourced = os.environ.get(key)
+        if sourced:
+            click.echo(f"  {key}: sourced from environment")
+            collected_keys[key] = sourced
+            continue
+
+        if not default:
+            value = click.prompt(
+                f"  {key} (required, Enter to cancel)",
+                default="",
+                show_default=False,
+            )
+
+            if not value.strip():
+                click.echo(click.style(f"\n  {key} is required. Aborting.", fg="red"))
+                raise click.Abort()
+        else:
+            value = click.prompt(f"  {key}", default=str(default))
+
+        collected_keys[key] = value
+
+    config_location = config_location.expanduser()
+    config_location.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(config_location, "w") as f:
+        yaml.dump(collected_keys, f, default_flow_style=False)
+
+    click.echo(click.style(f"\nConfig written to {config_location}", fg="green", bold=True))
 
 
 @benchmark.command(

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -49,13 +49,15 @@ def config():
     pass
 
 
+CONFIG_LOCATION: Path = Path("~/.config/harness/harness.yaml")
+
+
 @config.command()
 def init() -> None:
     """
     Initializes a config we can trust to have references to dependencies to run the harness,
     this becomes our source of truth for secrets required to run the harness
     """
-    config_location: Path = Path("~/.config/harness/harness.yaml")
 
     # Mapping between the expected key and default value
     # None means its user provided if not found
@@ -92,7 +94,7 @@ def init() -> None:
 
         collected_keys[key] = value
 
-    config_location = config_location.expanduser()
+    config_location = CONFIG_LOCATION.expanduser()
     config_location.parent.mkdir(parents=True, exist_ok=True)
 
     with open(config_location, "w") as f:
@@ -110,7 +112,7 @@ def modify(key: str, value: str) -> None:
 
     Example: harness config modify AWS_DEFAULT_REGION us-west-2
     """
-    config_location = Path("~/.config/harness/harness.yaml").expanduser()
+    config_location = CONFIG_LOCATION.expanduser()
 
     if not config_location.exists():
         raise click.ClickException("Config not found. Run `harness config init` first.")

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -18,6 +18,7 @@ from tracker.types import (
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
     FinalViewResponse,
+    HarnessConfig,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
@@ -169,7 +170,7 @@ class TrackerService:
                 task_ids=task_ids,
                 slice_str=slice_str,
                 lambda_function=lambda_function,
-                harness_config=self._build_harness_config_payload(),
+                harness_config=HarnessConfig.model_validate(self._build_harness_config_payload()),
             )
 
             body = payload.model_dump()

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -97,9 +97,19 @@ class TrackerService:
         """Build the X-Harness-* headers from the loaded config values."""
         return {f"X-Harness-{re.sub(r'_', '-', key).title()}": value for key, value in self._config_values.items()}
 
-    def _build_harness_config_payload(self) -> dict[str, str]:
+    def _build_harness_config_payload(self) -> dict[str, Any]:
         """Build the harness_config dict for inclusion in request bodies."""
-        return {key.lower(): value for key, value in self._config_values.items()}
+        flat = {key.lower(): value for key, value in self._config_values.items()}
+        return {
+            "aws": {
+                "aws_access_key_id": flat["aws_access_key_id"],
+                "aws_secret_access_key": flat["aws_secret_access_key"],
+                "aws_default_region": flat["aws_default_region"],
+            },
+            "s3_bucket": flat["aws_s3_bucket"],
+            "log_group": flat.get("log_group", flat.get("root_log_group", "")),
+            "log_retention_policy": int(flat.get("log_retention_policy", "0")),
+        }
 
     def health_check(self) -> Response:
         """

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -94,11 +94,11 @@ class TrackerService:
         return config_keys
 
     def _build_harness_headers(self) -> dict[str, str]:
-        """Build the X-Harness-* headers from the loaded config values."""
+        """Automate building the headers from the config keys"""
         return {f"X-Harness-{re.sub(r'_', '-', key).title()}": value for key, value in self._config_values.items()}
 
     def _build_harness_config_payload(self) -> dict[str, Any]:
-        """Build the harness_config dict for inclusion in request bodies."""
+        """Build the harness config in a way that can be packed into a object"""
         flat = {key.lower(): value for key, value in self._config_values.items()}
         return {
             "aws": {
@@ -107,8 +107,8 @@ class TrackerService:
                 "aws_default_region": flat["aws_default_region"],
             },
             "s3_bucket": flat["aws_s3_bucket"],
-            "log_group": flat.get("log_group", flat.get("root_log_group", "")),
-            "log_retention_policy": int(flat.get("log_retention_policy", "0")),
+            "log_group": flat["log_group"],
+            "log_retention_policy": int(flat["log_retention_policy"]),
         }
 
     def health_check(self) -> Response:

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -1,11 +1,14 @@
 """Client for interacting with the tracker service."""
 
 import os
+import re
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any, BinaryIO
 from uuid import UUID
 
 import httpx
+import yaml
 from dotenv import load_dotenv
 from httpx._models import Response
 from tracker.database.models import AgentContractRequest
@@ -27,10 +30,19 @@ from agentic_harness.cli.exceptions import TrackerServiceError
 load_dotenv()
 
 TRACKER_URL = os.environ.get("TRACKER_SERVICE_URL", "https://benchmark-tracker.vals.ai")
+_CONFIG_LOCATION = Path("~/.config/harness/harness.yaml")
+_REQUIRED_CONFIG_KEYS = {
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_DEFAULT_REGION",
+    "AWS_S3_BUCKET",
+}
 
 
 class TrackerService:
     """Client for tracker service API."""
+
+    _config_values: dict[str, str] = {}
 
     def __init__(self, base_url: str = TRACKER_URL, timeout: int = 120):
         """
@@ -40,9 +52,10 @@ class TrackerService:
             base_url: Base URL of tracker service
             timeout: Request timeout in seconds
         """
+        self._config_values = self.parse_config_keys()
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
-        self._client = httpx.Client(timeout=timeout)
+        self._client = httpx.Client(timeout=timeout, headers=self._build_harness_headers())
 
     def __enter__(self) -> "TrackerService":
         """Context manager entry."""
@@ -55,6 +68,37 @@ class TrackerService:
     def close(self) -> None:
         """Close the HTTP client."""
         self._client.close()
+
+    @staticmethod
+    def parse_config_keys() -> dict[str, str]:
+        """Parses expected config keys and handles edge cases"""
+        config_path: Path = _CONFIG_LOCATION.expanduser()
+        config_keys: dict[str, str] = {}
+        if not config_path.exists():
+            raise TrackerServiceError(f"Could not find the config at {_CONFIG_LOCATION}, run `harness config init`")
+
+        with open(config_path) as f:
+            harness_config: dict[str, str] = yaml.safe_load(f) or {}
+
+        missing = _REQUIRED_CONFIG_KEYS - harness_config.keys()
+        if missing:
+            raise TrackerServiceError(
+                f"Missing required config keys: {', '.join(sorted(missing))}."
+                + "Run `harness config init` to initialize the harness config or run harness config modify to change a value to a already created config"
+            )
+
+        for key, value in harness_config.items():
+            config_keys[key] = str(value)
+
+        return config_keys
+
+    def _build_harness_headers(self) -> dict[str, str]:
+        """Build the X-Harness-* headers from the loaded config values."""
+        return {f"X-Harness-{re.sub(r'_', '-', key).title()}": value for key, value in self._config_values.items()}
+
+    def _build_harness_config_payload(self) -> dict[str, str]:
+        """Build the harness_config dict for inclusion in request bodies."""
+        return {key.lower(): value for key, value in self._config_values.items()}
 
     def health_check(self) -> Response:
         """
@@ -125,9 +169,12 @@ class TrackerService:
                 task_ids=task_ids,
                 slice_str=slice_str,
                 lambda_function=lambda_function,
+                harness_config=self._build_harness_config_payload(),
             )
 
-            response = self._client.post(f"{self._base_url}/start-benchmark", json=payload.model_dump())
+            body = payload.model_dump()
+
+            response = self._client.post(f"{self._base_url}/start-benchmark", json=body)
 
             return response
         except httpx.HTTPError as e:


### PR DESCRIPTION
### Main changes
- Created a config group for managing user environment variables
- Pulled out required ENV vars
- Introduced configs and credential objects 

### Refactors
- Create a benchmark service client to simplify
- Updated unit tests

### Summary
Added a config feature that allows us to run the tracker using our own credentials even if we are not the ones hosting it. This allows companies like anthropic and xai to get the logs of the benchmarks that they run without us seeing them. This makes the harness more secure and less coupled to the org