### PR TITLE
add model_library_agent runner and shared_artifacts bundler support

### DIFF
--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -1,0 +1,9 @@
+"""Agent tools — BashTool plus re-exports from model-library."""
+
+from model_library.agent.tool import Tool, ToolOutput
+from model_library.agent.tools.stop import StopTool
+from model_library.agent.tools.submit import SubmitTool
+
+from .bash import BashTool
+
+__all__ = ["BashTool", "StopTool", "SubmitTool", "Tool", "ToolOutput"]

--- a/agents/tools/bash.py
+++ b/agents/tools/bash.py
@@ -1,0 +1,69 @@
+"""Stateless bash tool for agent use in sandbox environments."""
+
+import json
+import logging
+import subprocess
+from typing import Any
+
+from model_library.agent.tool import Tool, ToolOutput
+
+
+class BashTool(Tool):
+    """
+    Run a bash command in a sandbox environment.
+
+    Each call is a new subprocess — working directory does NOT persist between
+    calls. All commands run from the fixed working_dir. Use absolute paths or
+    chain commands with && for multi-step operations.
+    """
+
+    def __init__(self, working_dir: str = "/workspace", timeout: int = 120):
+        self._working_dir = working_dir
+        self._timeout = timeout
+        super().__init__(
+            name="bash",
+            description=(
+                f"Run a bash command. "
+                f"All commands execute from {working_dir}; the working directory "
+                f"does NOT persist between calls. "
+                f"Use absolute paths or chain steps with && for multi-step operations."
+            ),
+            parameters={
+                "command": {
+                    "type": "string",
+                    "description": "The bash command to execute.",
+                }
+            },
+            required=["command"],
+        )
+
+    async def execute(self, args: dict[str, Any], state: dict[str, Any], logger: logging.Logger) -> ToolOutput:
+        command = args["command"]
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                cwd=self._working_dir,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+            )
+        except subprocess.TimeoutExpired:
+            output = json.dumps({"exit_code": -1, "stdout": "", "stderr": f"Command timed out after {self._timeout}s"})
+            return ToolOutput(output=output, error=output)
+        except Exception as e:
+            output = json.dumps({"exit_code": -1, "stdout": "", "stderr": str(e)})
+            return ToolOutput(output=output, error=output)
+
+        payload = json.dumps(
+            {
+                "exit_code": result.returncode,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+            }
+        )
+
+        if result.returncode != 0:
+            return ToolOutput(output=payload, error=payload)
+
+        return ToolOutput(output=payload)


### PR DESCRIPTION
Agents can now declare shared_artifacts (paths relative to agents/) to bundle shared modules alongside their own artifacts. The bundler copies them into bundle_dir/<relative_path> so they land at the expected sandbox paths (e.g. /bundle/<agent>/model_library_agent/).

Also adds the reusable run_with_tools() runner backed by model-library's Agent loop, available to any agent via shared_artifacts.