### PR TITLE
DCF agent: wire to model_library_agent runner and BashTool

### DIFF
--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -19,7 +19,7 @@ class DCFAgentContract(BaseAgentContract):
     @property
     def final_output(self) -> Path:
         # TODO: inherit this from problem definition
-        return Path("/workspace/financial_statement.xlsx")
+        return Path("/workspace/template.xlsx")
 
 
 contract = DCFAgentContract

--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any
 
 from agentic_harness.contract import BaseAgentContract
 
@@ -8,7 +9,6 @@ class DCFAgentContract(BaseAgentContract):
     def name(self) -> str:
         return "dcf_agent"
 
-    @property
     def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
         model = self._agent_config.model
         assert model is not None, "Model must be specified in AgentConfig for DCF Agent"

--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any
 
@@ -11,18 +12,31 @@ class DCFAgentContract(BaseAgentContract):
 
     @property
     def artifacts(self) -> list[str]:
-        return ["requirements.txt"]
+        return ["run.py", "requirements.txt"]
+
+    @property
+    def shared_artifacts(self) -> list[str]:
+        return ["model_library_agent", "tools"]
 
     @property
     def install_cmd(self) -> str:
-        return "pip install -r requirements.txt"  # falsy string to skip
+        return "pip install -r requirements.txt"
 
     def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
-        return f"echo '=== Problem Statement ===' && cat {problem_statement_path} && echo '=== Workspace Files ===' && find /workspace -type f | sort"
+        if not self._agent_config.model:
+            raise ValueError("model is required for DCFAgentContract")
+        model = self._agent_config.model
+        return (
+            f"python /bundle/dcf_agent/run.py {problem_statement_path} {task_id}"
+            f" --model {model} 2>&1 | tee /tmp/dcf_agent.log"
+        )
+
+    @property
+    def env(self) -> dict[str, str]:
+        return {"ANTHROPIC_API_KEY": os.environ["ANTHROPIC_API_KEY"]}
 
     @property
     def final_output(self) -> Path:
-        # TODO: inherit this from problem definition
         return Path("/workspace/template.xlsx")
 
 

--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -10,11 +10,12 @@ class DCFAgentContract(BaseAgentContract):
         return "dcf_agent"
 
     def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
-        model = self._agent_config.model
-        assert model is not None, "Model must be specified in AgentConfig for DCF Agent"
-        return model.query("{{problem_statement}}")
+        return f"echo '=== Problem Statement ===' && cat {problem_statement_path} && echo '=== Workspace Files ===' && find /workspace -type f | sort"
 
     @property
     def final_output(self) -> Path:
         # TODO: inherit this from problem definition
         return Path("/workspace/financial_statement.xlsx")
+
+
+contract = DCFAgentContract

--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -10,8 +10,12 @@ class DCFAgentContract(BaseAgentContract):
         return "dcf_agent"
 
     @property
+    def artifacts(self) -> list[str]:
+        return ["requirements.txt"]
+
+    @property
     def install_cmd(self) -> str:
-        return ""  # falsy string to skip
+        return "pip install -r requirements.txt"  # falsy string to skip
 
     def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
         return f"echo '=== Problem Statement ===' && cat {problem_statement_path} && echo '=== Workspace Files ===' && find /workspace -type f | sort"

--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from agentic_harness.contract import BaseAgentContract
+
+
+class DCFAgentContract(BaseAgentContract):
+    @property
+    def name(self) -> str:
+        return "dcf_agent"
+
+    @property
+    def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
+        model = self._agent_config.model
+        assert model is not None, "Model must be specified in AgentConfig for DCF Agent"
+        return model.query("{{problem_statement}}")
+
+    @property
+    def final_output(self) -> Path:
+        # TODO: inherit this from problem definition
+        return Path("/workspace/financial_statement.xlsx")

--- a/agents/dcf_agent/contract.py
+++ b/agents/dcf_agent/contract.py
@@ -9,6 +9,10 @@ class DCFAgentContract(BaseAgentContract):
     def name(self) -> str:
         return "dcf_agent"
 
+    @property
+    def install_cmd(self) -> str:
+        return ""  # falsy string to skip
+
     def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
         return f"echo '=== Problem Statement ===' && cat {problem_statement_path} && echo '=== Workspace Files ===' && find /workspace -type f | sort"
 

--- a/agents/dcf_agent/requirements.txt
+++ b/agents/dcf_agent/requirements.txt
@@ -1,0 +1,2 @@
+openpyxl
+model-library

--- a/agents/dcf_agent/run.py
+++ b/agents/dcf_agent/run.py
@@ -2,8 +2,11 @@
 
 import argparse
 import asyncio
+import logging
 import sys
 from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout, force=True)
 
 sys.path.insert(0, "/bundle/dcf_agent")
 

--- a/agents/dcf_agent/run.py
+++ b/agents/dcf_agent/run.py
@@ -1,0 +1,32 @@
+"""DCF agent entry point."""
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "/bundle/dcf_agent")
+
+from model_library_agent.run_agent import run_with_tools  # noqa: E402
+from tools import BashTool, StopTool  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the DCF agent on a task.")
+    parser.add_argument("problem_statement_path", help="Path to the problem statement file.")
+    parser.add_argument("task_id", help="Readable task identifier.")
+    parser.add_argument("--model", default="anthropic/claude-opus-4-6", help="Model registry key.")
+    args = parser.parse_args()
+
+    problem = Path(args.problem_statement_path).read_text()
+    asyncio.run(
+        run_with_tools(
+            tools=[BashTool(working_dir="/workspace"), StopTool()],
+            problem_statement=problem,
+            model=args.model,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `run.py` entry point that calls `run_with_tools([BashTool, StopTool], ...)` with the problem statement
- Updates `contract.py` to declare `shared_artifacts = ["model_library_agent", "tools"]` so the bundler includes the shared runners
- `model` is now required (validated in `run_cmd`); `env` injects `ANTHROPIC_API_KEY` from the local environment

## Sandbox layout

```
/bundle/dcf_agent/
  run.py
  requirements.txt
  model_library_agent/   ← from shared_artifacts
    __init__.py
    run_agent.py
  tools/                 ← from shared_artifacts
    __init__.py
    bash.py
/workspace/              ← BashTool cwd; agent writes template.xlsx here
```

## Test plan

- [ ] `agentic-harness benchmark start --agent agents/dcf_agent --model anthropic/claude-opus-4-6 --benchmark <dcf-bench>` — sandbox gets shared folders, `pip install -r requirements.txt` runs, model loop executes bash commands and writes `/workspace/template.xlsx`
- [ ] Bundler produces zip with `dcf_agent/model_library_agent/` and `dcf_agent/tools/` entries
- [ ] Contract raises `ValueError` if `--model` is not passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)