### PR TITLE
Model run preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ harness benchmark start \
   --concurrency 1 \
   --lambda <aws_lambda_function_name> \
   --task-ids "task_1_id,task_2_id" \
-  --slice "start:stop:step"
+  --slice "start:stop:step" \
+  --auto-approve
 ```
 
 Flags
@@ -126,7 +127,12 @@ Flags
 --kwarg (-k): Single kwarg that is passed into the agent run command
 --task-ids: comma separated list of task ids to run
 --task-ids-file: Path to a .txt file with tasks newline separated
+--auto-approve: Skip pre-run plan confirmation (recommended for scripts/automation)
 ```
+
+By default, `harness benchmark start` shows a high-level run plan before kickoff and asks for confirmation.
+The plan includes benchmark/model details, resolved instance count, a task preview sample, and any `-k/--kwarg`
+parameters (for example `temperature`, `top_p`, or `reasoning_effort`).
 
 Starts the benchmark and exits once successfully created.
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -32,6 +32,8 @@ from tracker.types import (
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
+    PreviewBenchmarkRequest,
+    PreviewBenchmarkResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
@@ -58,6 +60,7 @@ from tracker.utils import (
 logger = get_logger(__name__)
 
 app = FastAPI()
+PREVIEW_TASK_IDS_LIMIT = 10
 
 
 # Ignore verbose health check logs
@@ -138,6 +141,41 @@ async def upload_contract_to_s3(
         "status": "success",
         "message": "Contract uploaded successfully",
     }
+
+
+@app.post("/preview-benchmark")
+async def preview_benchmark(request: PreviewBenchmarkRequest) -> PreviewBenchmarkResponse:
+    """
+    Preview benchmark details before creating a benchmark run.
+
+    Usage:
+    curl -X POST http://<endpoint>/preview-benchmark \
+      -H "Content-Type: application/json" \
+      -d '{"benchmark_name": "swebench", "task_ids": ["astropy__astropy-12907"]}'
+
+    Returns:
+        PreviewBenchmarkResponse
+    """
+    benchmark_service = request.benchmark_service
+
+    _ = await benchmark_service.health_check()
+
+    try:
+        verify_response = await benchmark_service.verify_task_ids(
+            task_ids=request.task_ids, slice_str=request.slice_str
+        )
+    except Exception as e:
+        raise TrackerServiceError(f"Failed to preview benchmark: {e}") from e
+
+    task_ids_preview = verify_response.task_ids[:PREVIEW_TASK_IDS_LIMIT]
+    task_count = len(verify_response.task_ids)
+
+    return PreviewBenchmarkResponse(
+        benchmark_name=request.benchmark_name,
+        task_count=task_count,
+        task_ids_preview=task_ids_preview,
+        has_more_tasks=task_count > len(task_ids_preview),
+    )
 
 
 @app.post("/start-benchmark")

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -43,6 +43,25 @@ class StartBenchmarkRequest(BaseModel):
         return create_benchmark_service_client(url=BENCHMARK_SERVICE_URL)
 
 
+class PreviewBenchmarkRequest(BaseModel):
+    benchmark_name: str
+    task_ids: list[str] | None = None
+    slice_str: str | None = None
+
+    @property
+    def benchmark_service(self) -> BenchmarkServiceClient:
+        from tracker.utils import create_benchmark_service_client
+
+        return create_benchmark_service_client(url=BENCHMARK_SERVICE_URL)
+
+
+class PreviewBenchmarkResponse(BaseModel):
+    benchmark_name: str
+    task_count: int
+    task_ids_preview: list[str]
+    has_more_tasks: bool
+
+
 class StartBenchmarkErrorResponse(BaseModel):
     benchmark_id: UUID
     error_message: str

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -114,6 +114,75 @@ class TestFastapiServer:
         assert json_response["agent_name"] == request.contract.name
         assert json_response["concurrency"] == request.concurrency
 
+    async def test_preview_benchmark(self, monkeypatch: MonkeyPatch):
+        """
+        Test preview benchmark endpoint.
+
+        Test Cases:
+            - Returns 200 OK
+            - Returns preview task sample and truncation metadata
+        """
+
+        expected_task_ids = [f"task_{i}" for i in range(15)]
+
+        async def _mock_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=expected_task_ids)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        response = client.post(
+            "/preview-benchmark",
+            json={"benchmark_name": "swebench", "task_ids": ["task_1"], "slice_str": "1-20"},
+        )
+
+        assert response.status_code == 200
+        preview = response.json()
+
+        assert preview["benchmark_name"] == "swebench"
+        assert preview["task_count"] == len(expected_task_ids)
+        assert preview["task_ids_preview"] == expected_task_ids[:10]
+        assert preview["has_more_tasks"] is True
+
+    async def test_preview_benchmark_forwards_verify_params(self, monkeypatch: MonkeyPatch):
+        """
+        Test that preview forwards task filter arguments to benchmark service.
+        """
+
+        captured: dict[str, Any] = {}
+
+        async def _mock_verify_task_ids(*_args: Any, **kwargs: Any) -> VerifyTaskIdsResponse:
+            captured["task_ids"] = kwargs.get("task_ids")
+            captured["slice_str"] = kwargs.get("slice_str")
+            return VerifyTaskIdsResponse(task_ids=["task_1", "task_2"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        task_ids = ["task_a", "task_b"]
+        slice_str = ":20"
+        response = client.post(
+            "/preview-benchmark",
+            json={"benchmark_name": "swebench", "task_ids": task_ids, "slice_str": slice_str},
+        )
+
+        assert response.status_code == 200
+        assert captured["task_ids"] == task_ids
+        assert captured["slice_str"] == slice_str
+
+    async def test_preview_benchmark_error_handling(self, monkeypatch: MonkeyPatch):
+        """
+        Test preview benchmark error handling when verify fails.
+        """
+
+        async def _mock_verify_task_ids_error(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            raise Exception("Preview verification failed")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids_error)
+
+        response = client.post("/preview-benchmark", json={"benchmark_name": "swebench"})
+
+        assert response.status_code == 500
+        assert "Preview verification failed" in response.json().get("detail", "")
+
     async def test_fetch_benchmark(self, database_session: Session, example_benchmark_object: Benchmark):
         """
         Test fetch benchmark of the fastapi server.

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -15,6 +15,7 @@ from agentic_harness.cli.utils import (
     check_tracker_service_health,
     download_agent_outputs,
     download_final_view,
+    format_benchmark_start_plan,
     format_benchmark_status,
     format_start_benchmark_response,
     paginate_benchmarks,
@@ -108,6 +109,12 @@ def agent():
     type=(str, str),
     help="Kwargs as key value (e.g., -k temperature 7 -k max_tokens 1000)",
 )
+@click.option(
+    "--auto-approve",
+    is_flag=True,
+    default=False,
+    help="Skip pre-run plan approval (recommended for programmatic use).",
+)
 def start(
     agent: Path,
     model: str | None,
@@ -118,6 +125,7 @@ def start(
     task_ids_file: Path | None,
     slice_str: str | None,
     kwargs: tuple[tuple[str, str]],
+    auto_approve: bool,
 ):
     """
     Run an agent on a benchmark.
@@ -132,22 +140,11 @@ def start(
         lines = task_ids_file.read_text().splitlines()
         task_ids = ",".join(line.strip() for line in lines if line.strip())
 
-    click.echo("Arguments:")
-    click.echo(f"  - Benchmark: {benchmark}")
-    click.echo(f"  - Agent: {agent}")
-    if model:
-        click.echo(f"  - Model: {model}")
-    click.echo(f"  - Concurrency: {concurrency}")
-    click.echo(f"  - Slice: {slice_str}")
-    if task_ids:
-        click.echo(f"  - Task IDs: {task_ids[:100]}{'...' if len(task_ids) > 100 else ''}")
-    else:
-        click.echo("  - Task IDs: all tasks")
-
     formatted_task_ids: list[str] | None = None
     if task_ids:
-        formatted_task_ids = task_ids.split(",")
-        click.echo(f"Discovered {len(formatted_task_ids)} task IDs")
+        formatted_task_ids = [task_id.strip() for task_id in task_ids.split(",") if task_id.strip()]
+        if not formatted_task_ids:
+            raise click.UsageError("No valid task IDs were provided")
 
     try:
         contract_path = agent / "contract.py"
@@ -157,7 +154,8 @@ def start(
         if model:
             config_kwargs["model"] = model
 
-        config_kwargs["kwargs"] = {key: value for key, value in kwargs}
+        run_kwargs = {key: value for key, value in kwargs}
+        config_kwargs["kwargs"] = run_kwargs
         agent_config = AgentConfig(**config_kwargs)
 
         contract = get_contract(contract_path, agent_config)
@@ -165,6 +163,27 @@ def start(
         with TrackerService() as tracker:
             if not check_tracker_service_health(tracker):
                 return
+
+            if not auto_approve:
+                preview = tracker.preview_benchmark(benchmark, formatted_task_ids, slice_str)
+                format_benchmark_start_plan(
+                    benchmark=benchmark,
+                    agent_path=agent,
+                    agent_name=contract.name,
+                    model=model,
+                    concurrency=concurrency,
+                    task_ids=formatted_task_ids,
+                    slice_str=slice_str,
+                    kwargs=run_kwargs,
+                    lambda_function=lambda_function,
+                    preview=preview,
+                )
+
+                if not click.confirm("Proceed with benchmark start?", default=True):
+                    click.echo(click.style("Benchmark start cancelled.", fg="yellow"))
+                    return
+            else:
+                click.echo(click.style("Auto-approve enabled. Skipping pre-run confirmation.", fg="yellow"))
 
             click.echo("\r\033[KZipping agent artifacts...", nl=False)
 

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -15,6 +15,8 @@ from tracker.types import (
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
     FinalViewResponse,
+    PreviewBenchmarkRequest,
+    PreviewBenchmarkResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
@@ -132,6 +134,32 @@ class TrackerService:
             return response
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to start benchmark: {e}") from e
+
+    def preview_benchmark(
+        self, benchmark_name: str, task_ids: list[str] | None, slice_str: str | None
+    ) -> PreviewBenchmarkResponse:
+        """
+        Preview benchmark run details before creating benchmark row.
+
+        Args:
+            benchmark_name: Name of benchmark dataset
+            task_ids: Optional list of task IDs to run
+            slice_str: Optional task slice string
+
+        Returns:
+            PreviewBenchmarkResponse with resolved task count and sample
+        """
+        try:
+            payload = PreviewBenchmarkRequest(benchmark_name=benchmark_name, task_ids=task_ids, slice_str=slice_str)
+            response = self._client.post(f"{self._base_url}/preview-benchmark", json=payload.model_dump())
+
+            if response.status_code != 200:
+                details = response.json().get("detail", response.text)
+                raise TrackerServiceError(f"Failed to preview benchmark: {details}")
+
+            return PreviewBenchmarkResponse.model_validate(response.json())
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to preview benchmark: {e}") from e
 
     def fetch_benchmark(self, benchmark_id: UUID) -> FetchBenchmarkResponse:
         """

--- a/src/agentic_harness/cli/utils.py
+++ b/src/agentic_harness/cli/utils.py
@@ -16,6 +16,7 @@ from tracker.types import (
     FetchBenchmarksResponse,
     FinalViewResponse,
     Order,
+    PreviewBenchmarkResponse,
     StartBenchmarkResponse,
 )
 
@@ -198,6 +199,54 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
             fg="cyan",
         )
     )
+    click.echo()
+
+
+def format_benchmark_start_plan(
+    benchmark: str,
+    agent_path: Path,
+    agent_name: str,
+    model: str | None,
+    concurrency: int,
+    task_ids: list[str] | None,
+    slice_str: str | None,
+    kwargs: dict[str, str],
+    lambda_function: str | None,
+    preview: PreviewBenchmarkResponse,
+) -> None:
+    task_source = "all tasks"
+    if task_ids:
+        task_source = f"explicit task IDs ({len(task_ids)})"
+    elif slice_str:
+        task_source = f"slice: {slice_str}"
+
+    click.echo()
+    click.echo("┌─ Run Plan " + "─" * 67)
+    click.echo(f"│ Benchmark:         {benchmark}")
+    click.echo(f"│ Agent:             {agent_name} ({agent_path})")
+    click.echo(f"│ Model:             {model or 'contract default'}")
+    click.echo(f"│ Concurrency:       {concurrency}")
+    click.echo(f"│ Task source:       {task_source}")
+    click.echo(f"│ Instances to run:  {preview.task_count}")
+    click.echo(f"│ Lambda:            {lambda_function or 'none'}")
+    click.echo("└" + "─" * 78)
+
+    if kwargs:
+        click.echo(click.style("Model/run parameters:", bold=True))
+        for key, value in sorted(kwargs.items()):
+            click.echo(f"  - {key}: {value}")
+    else:
+        click.echo(click.style("Model/run parameters:", bold=True))
+        click.echo("  - none")
+
+    if preview.task_ids_preview:
+        click.echo(click.style("Task preview:", bold=True))
+        for task_id in preview.task_ids_preview:
+            click.echo(f"  - {task_id}")
+        if preview.has_more_tasks:
+            remaining_count = preview.task_count - len(preview.task_ids_preview)
+            click.echo(f"  ... and {remaining_count} more")
+
     click.echo()
 
 


### PR DESCRIPTION
Add a pre-run plan and confirmation step to `harness benchmark start` to provide transparency and control before execution, with an `--auto-approve` flag for programmatic use.

---
<p><a href="https://cursor.com/agents/bc-7b26ee82-e3c4-486f-9b8c-f616e82b6f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b26ee82-e3c4-486f-9b8c-f616e82b6f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

