### PR TITLE
Support mini-swe-agent for running swebench

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = agents/sweagent/sweagent
 	url = git@github.com:vals-ai/SWE-bench.git
 	branch = jf/agent-harness
+[submodule "agents/mini_sweagent/mini_sweagent"]
+	path = agents/mini_sweagent/mini_sweagent
+	url = git@github.com:vals-ai/mini-swe-agent.git
+	branch = main

--- a/agents/mini_sweagent/contract.py
+++ b/agents/mini_sweagent/contract.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from typing import Any, override
+
+from agentic_harness.contract import BaseAgentContract
+
+
+class MiniSWEAgentContract(BaseAgentContract):
+    """Mini SWE Agent Contract"""
+
+    @property
+    def name(self) -> str:
+        return "mini_sweagent"
+
+    @property
+    def artifacts(self) -> list[str]:
+        return ["setup.sh", "mini_sweagent", "run_with_task_file.py"]
+
+    @property
+    def install_cmd(self) -> str:
+        return "bash setup.sh"
+
+    @property
+    def final_output(self) -> Path | None:
+        return Path("/logs/mini_sweagent")
+
+    @override
+    def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, Any]) -> str:
+        model_name = self._agent_config.model
+
+        if not model_name:
+            raise ValueError(
+                "Model key not detected, model is required to run mini_sweagent. Use --model to assign a model to run"
+            )
+        args = [
+            f"python3 /bundle/mini_sweagent/run_with_task_file.py {problem_statement_path}",
+            "--config=swebench.yaml",
+            "--environment-class=local",
+            f"--config=model.model_name={model_name}",
+            "--output=/logs/mini_sweagent/trajectory.json",
+            "--agent-class=default",
+            "--exit-immediately",
+            "--yolo",
+        ]
+
+        for key, value in kwargs.items():
+            args.append(f"--config={key}={value}")
+
+        return " ".join(args)
+
+
+contract = MiniSWEAgentContract

--- a/agents/mini_sweagent/run_with_task_file.py
+++ b/agents/mini_sweagent/run_with_task_file.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Usage: run_with_task_file.py <task-file> [mini args...]")
+
+    task_file = sys.argv[1]
+    mini_args = sys.argv[2:]
+
+    with open(task_file, "r", encoding="utf-8") as f:
+        task = f.read()
+
+    os.execvp("mini", ["mini", *mini_args, "--task", task])
+
+
+if __name__ == "__main__":
+    main()

--- a/agents/mini_sweagent/setup.sh
+++ b/agents/mini_sweagent/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script assumes Debian-based image (i.e. SWE-bench task images)
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y curl
+
+# Install uv
+curl -LsSf https://astral.sh/uv/0.7.13/install.sh | sh
+
+# Source uv so it's available in this session
+source "$HOME/.local/bin/env" 2>/dev/null || true
+
+# Install the mini_sweagent Python package
+cd mini_sweagent && uv sync
+
+# Wrapper script so `mini` is on PATH
+# Pre-create global config to skip interactive first-run wizard
+mkdir -p /root/.config/mini-swe-agent
+echo 'MSWEA_CONFIGURED=true' > /root/.config/mini-swe-agent/.env
+
+cat > /usr/local/bin/mini << 'WRAPPER'
+#!/bin/bash
+source /bundle/mini_sweagent/mini_sweagent/.venv/bin/activate
+exec -a mini python -m minisweagent.run.mini "$@"
+WRAPPER
+chmod +x /usr/local/bin/mini


### PR DESCRIPTION
https://github.com/vals-ai/mini-swe-agent is the internal version of mini-swe-agent that uses model library with specific headless agent configuration for running in the harness (non-interactive mode, 150 max steps, no cost limits). 
This PR integrates the agent as a submodule.

The one thing to note here is the run_with_task_file.py which takes in the problem_statement_path and passes its contents to the `mini` cli with `--task` to avoid certain tasks where the description would be interpreted by the shell if we called `mini` directly with the contents.

Two test runs were conducted on SWE-Bench Verified:

1. Haiku 4.5 Reasoning (benchmark_id fa5ed7fe-1781-41c6-a164-867f857285e7)
   - 69% Resolved $0.33/task vs 66.6% $0.33/task official (https://www.swebench.com/)
   - Trajs on Docent: https://docent.transluce.org/dashboard/16c48e03-21d4-4d1d-85bc-5bb77973e04e/agent_run
   - 6 instances reached max steps
2. GPT-5-Mini (benchmark_id 55dd5e0c-8969-42fe-8402-b2c38574f25f)
   - 59.6% Resolved $0.07/task vs 56.2% $0.05/task official
   - Trajs on Docent: https://docent.transluce.org/dashboard/f35586ec-cfb1-4463-8d1d-66f2a9150f9a/agent_run

our results are 3% better than official results but could mostly be attributed to single run variance.