### PR TITLE
taskmonitor cancels running tasks when force stop

### DIFF
--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -271,9 +271,13 @@ class Task(SQLModel, table=True):
     @computed_field
     @property
     def alias(self) -> str:
-        """Unique alias for the current task attempt, used when creating sandboxes."""
+        """Unique alias for the current task attempt, used when creating sandboxes.
+
+        Format: {task_id}_{attempt_suffix}
+        - attempt_suffix: hex-encoded microsecond timestamp from started_at, changes on each retry
+        """
         attempt_suffix = f"{int(self.started_at.timestamp() * 1_000_000):x}"
-        return f"{self.task_id}_{self.id.hex[:5]}_{attempt_suffix}"
+        return f"{self.task_id}_{attempt_suffix}"
 
 
 @event.listens_for(Task, "before_insert")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -273,11 +273,11 @@ class Task(SQLModel, table=True):
     def alias(self) -> str:
         """Unique alias for the current task attempt, used when creating sandboxes.
 
-        Format: {task_id}_{attempt_suffix}
-        - attempt_suffix: hex-encoded microsecond timestamp from started_at, changes on each retry
+        Format: {task_id}_{suffix}
+        - suffix: hex-encoded microsecond timestamp from started_at, changes on each retry/resume
         """
-        attempt_suffix = f"{int(self.started_at.timestamp() * 1_000_000):x}"
-        return f"{self.task_id}_{attempt_suffix}"
+        suffix = f"{int(self.started_at.timestamp() * 1_000_000):x}"
+        return f"{self.task_id}_{suffix}"
 
 
 @event.listens_for(Task, "before_insert")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -269,8 +269,9 @@ class Task(SQLModel, table=True):
     @computed_field
     @property
     def alias(self) -> str:
-        """Unique alias for the task that is used to uniquely identify the same task when creating sandboxes"""
-        return f"{self.task_id}_{self.id.hex[:5]}"
+        """Unique alias for the current task attempt, used when creating sandboxes."""
+        attempt_suffix = f"{int(self.started_at.timestamp() * 1_000_000):x}"
+        return f"{self.task_id}_{self.id.hex[:5]}_{attempt_suffix}"
 
 
 @event.listens_for(Task, "before_insert")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -134,6 +134,15 @@ class TrackedTask:
             return await self._task
         except asyncio.CancelledError:
             logger.warning(f"Task {task_row.task_id} was cancelled")
+            with Session(bind=engine) as session:
+                task = fetch_task_row(task_row.id, session)
+                benchmark = fetch_benchmark_row(task.benchmark, session)
+
+                if benchmark.status == BenchmarkStatus.STOPPING or task.status == TaskStatus.STOPPED:
+                    task.status = TaskStatus.STOPPED
+                    session.add(task)
+                    session.commit()
+
             # Need to clean up the coroutine if we cancelled the task
             self._coro.close()
 
@@ -173,8 +182,6 @@ class TaskMonitor:
 
     def _validate_task(self, task_id: str) -> bool:
         """
-        Runs while waiting to be aquired by the semaphore.
-
         If the task status has been set to stopped we return False to exit the task early.
 
         Returns:
@@ -185,29 +192,18 @@ class TaskMonitor:
             benchmark_row = fetch_benchmark_row(self._benchmark_id, session)
             task_row = self._fetch_task_row(task_id)
 
-            # If task has been stopped or benchmark has occured an error we need to exit
-            if task_row.status == TaskStatus.STOPPED or benchmark_row.status == BenchmarkStatus.ERROR:
+            # If task has been stopped or benchmark is stopping / errored we need to exit
+            if task_row.status == TaskStatus.STOPPED or benchmark_row.status in [
+                BenchmarkStatus.ERROR,
+                BenchmarkStatus.STOPPING
+            ]:
                 return False
 
         return True
 
-    def _check_is_waiting(self, task: TrackedTask) -> bool:
-        """
-        Checks if the task is waiting to be aquired by the semaphore.
-
-        Returns:
-            True if the task is waiting to be aquired by the semaphore, False if it has been aquired
-        """
-        if task.task is None or task.status == TrackedTaskStatus.WAITING:
-            return True
-
-        return False
-
     async def track_tasks(self) -> None:
         """
-        Tracks all the tasks and removes the tasks that are no longer waiting to be aquired by the semaphore.
-
-        Removes the tasks that are no longer waiting to be aquired by the semaphore.
+        Tracks tasks and cancels them when they are no longer valid.
         """
 
         exit_condition_met: bool = False
@@ -217,14 +213,12 @@ class TaskMonitor:
             for task_id in tasks_to_check:
                 task = self._task_tracking[task_id]
 
-                if not self._check_is_waiting(task):
+                if task.status == TrackedTaskStatus.DONE:
                     del self._task_tracking[task_id]
+                    continue
 
-                if not self._validate_task(task_id) and task.task:
+                if not self._validate_task(task_id) and task.task is not None and not task.task.done():
                     task.task.cancel(f"Task {task_id} has been invalidated. Benchmark has been requested to stop")
-
-                    if task_id in self._task_tracking:
-                        del self._task_tracking[task_id]
 
             if not self._task_tracking:
                 exit_condition_met = True

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -135,15 +135,6 @@ class TrackedTask:
             return await self._task
         except asyncio.CancelledError:
             logger.warning(f"Task {task_row.task_id} was cancelled")
-            with Session(bind=engine) as session:
-                task = fetch_task_row(task_row.id, session)
-                benchmark = fetch_benchmark_row(task.benchmark, session)
-
-                if benchmark.status == BenchmarkStatus.STOPPING or task.status == TaskStatus.STOPPED:
-                    task.status = TaskStatus.STOPPED
-                    session.add(task)
-                    session.commit()
-
             # Need to clean up the coroutine if we cancelled the task
             self._coro.close()
 
@@ -193,11 +184,8 @@ class TaskMonitor:
             benchmark_row = fetch_benchmark_row(self._benchmark_id, session)
             task_row = self._fetch_task_row(task_id)
 
-            # If task has been stopped or benchmark is stopping / errored we need to exit
-            if task_row.status == TaskStatus.STOPPED or benchmark_row.status in [
-                BenchmarkStatus.ERROR,
-                BenchmarkStatus.STOPPING
-            ]:
+            # If task has been stopped or benchmark has errored we need to exit
+            if task_row.status == TaskStatus.STOPPED or benchmark_row.status == BenchmarkStatus.ERROR:
                 return False
 
         return True

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -227,29 +227,3 @@ class TestStopAndResume:
         assert monitor._task_tracking == {}
         tracked_task._coro.close()
 
-    async def test_tracked_task_cancel_marks_task_stopped_when_benchmark_is_stopping(
-        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
-    ):
-        benchmark_row = example_benchmark_object
-        benchmark_row.status = BenchmarkStatus.STOPPING
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(task_id="task_1", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
-        database_session.add(task_row)
-        database_session.commit()
-
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
-
-        tracked_task = TrackedTask(asyncio.sleep(10))
-        semaphore = asyncio.Semaphore(1)
-
-        run_task = asyncio.create_task(tracked_task.run(semaphore, task_row))
-        await asyncio.sleep(0)
-        run_task.cancel()
-
-        result = await run_task
-        database_session.refresh(task_row)
-
-        assert result == {"task_1": None}
-        assert task_row.status == TaskStatus.STOPPED

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -216,7 +216,7 @@ class TestStopAndResume:
             tracked_task._status = TrackedTaskStatus.DONE  # type: ignore[attr-defined]
 
         cancel_mock.side_effect = _cancel
-        tracked_task.task = Mock(cancel=cancel_mock, done=lambda: False)
+        tracked_task._task = Mock(cancel=cancel_mock, done=lambda: False)  # type: ignore[assignment]
 
         monitor = TaskMonitor(benchmark_row.id, {task_row.task_id: tracked_task})
         monitor._TRACK_INTERVAL = 0

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -1,6 +1,7 @@
+import asyncio
 from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
@@ -9,10 +10,10 @@ from sqlmodel import Session, select
 from main import app
 from benchmark_service.client import BenchmarkServiceClient
 from tracker.utils import start_benchmark_request_to_benchmark
-from tracker.database.models import AgentContractRequest, BenchmarkStatus, Task, TaskStatus
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Task, TaskStatus
 from benchmark_service.schemas import FinalScoreResponse, Resources, RetrieveTaskResponse, VerifyTaskIdsResponse
-from tracker.types import HarnessConfig, StartBenchmarkRequest
-from tracker.utils import initiate_stop_benchmark, process_benchmark, reset_to_in_progress_status
+from tracker.types import StartBenchmarkRequest
+from tracker.utils import TaskMonitor, TrackedTask, TrackedTaskStatus, initiate_stop_benchmark, process_benchmark, reset_to_in_progress_status
 from tests.unit.conftest import TEST_HARNESS_CONFIG
 
 client = TestClient(app)
@@ -154,3 +155,101 @@ class TestStopAndResume:
 
         database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.FINISHED, benchmark_row.error_message
+
+    async def test_resume_changes_task_alias_per_attempt(
+        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_rows = [
+            Task(task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STOPPED) for i in range(2)
+        ]
+        database_session.add_all(task_rows)
+        database_session.commit()
+
+        original_aliases = {task_row.task_id: task_row.alias for task_row in task_rows}
+
+        async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=[task_row.task_id for task_row in task_rows])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        # resets the start time of the task, so the alias will be different the next time we run the task
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(
+                TEST_HARNESS_CONFIG.daytona_secret_name, TEST_HARNESS_CONFIG.aws
+            ),
+            retry=True,
+            rerun_task_ids=[],
+        )
+
+        assert set(verified_task_ids) == set(original_aliases.keys())
+
+        updated_task_rows = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        for task_row in updated_task_rows:
+            assert task_row.alias != original_aliases[task_row.task_id]
+
+    async def test_task_monitor_cancels_waiting_stopped_task(
+        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
+    ):
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.STOPPED)
+        database_session.add(task_row)
+        database_session.commit()
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+
+        tracked_task = TrackedTask(asyncio.sleep(0))
+        tracked_task._status = TrackedTaskStatus.WAITING  # type: ignore[attr-defined]
+
+        cancel_mock = Mock()
+
+        def _cancel(*_args: Any, **_kwargs: Any) -> None:
+            tracked_task._status = TrackedTaskStatus.DONE  # type: ignore[attr-defined]
+
+        cancel_mock.side_effect = _cancel
+        tracked_task.task = Mock(cancel=cancel_mock, done=lambda: False)
+
+        monitor = TaskMonitor(benchmark_row.id, {task_row.task_id: tracked_task})
+        monitor._TRACK_INTERVAL = 0
+
+        await monitor.track_tasks()
+
+        cancel_mock.assert_called_once()
+        assert monitor._task_tracking == {}
+        tracked_task._coro.close()
+
+    async def test_tracked_task_cancel_marks_task_stopped_when_benchmark_is_stopping(
+        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPING
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(task_id="task_1", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+        database_session.add(task_row)
+        database_session.commit()
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+
+        tracked_task = TrackedTask(asyncio.sleep(10))
+        semaphore = asyncio.Semaphore(1)
+
+        run_task = asyncio.create_task(tracked_task.run(semaphore, task_row))
+        await asyncio.sleep(0)
+        run_task.cancel()
+
+        result = await run_task
+        database_session.refresh(task_row)
+
+        assert result == {"task_1": None}
+        assert task_row.status == TaskStatus.STOPPED

--- a/services/tracker/tests/unit/test_tracker.py
+++ b/services/tracker/tests/unit/test_tracker.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from sqlmodel import Session
 
-from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
+from tracker.database.models import Benchmark, Task, TaskStatus
 from tracker.utils import TaskMonitor, TrackedTask, TrackedTaskStatus
 
 
@@ -44,7 +44,6 @@ class TestTracker:
         Test Cases:
             - _validate_task fetches from updates database
             - _validate_task returns false if the task status has been set to stopped
-            - _validate_task returns false if the benchmark is stopping
             - running tasks remain tracked until they finish
         """
         benchmark_row = example_benchmark_object
@@ -89,13 +88,7 @@ class TestTracker:
         # NOTE: ensures that the database change gets picked up by the session
         assert not monitor._validate_task("task_id_1")  # type: ignore
 
-        # Test case 3. Validate task returns false if the benchmark is stopping
-        benchmark_row.status = BenchmarkStatus.STOPPING
-        database_session.add(benchmark_row)
-        database_session.commit()
-        assert not monitor._validate_task("task_id_1")  # type: ignore
-
-        # Test case 4. Running tasks stay tracked until they are done
+        # Test case 3. Running tasks stay tracked until they are done
         await monitor.track_tasks()
         assert task_tracking["task_id_1"].task
         cancel_mock.assert_called_once()
@@ -103,12 +96,7 @@ class TestTracker:
         assert monitor._task_tracking == {}
         task_tracking["task_id_1"]._coro.close()  # type: ignore[attr-defined]
 
-    async def test_tracked_task(
-        self,
-        database_session: Session,
-        example_benchmark_object: Benchmark,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
+    async def test_tracked_task(self) -> None:
         """
         Test functionality of the TrackedTask class
 
@@ -162,20 +150,12 @@ class TestTracker:
         assert tracked_task_2.task.result() == {"task_id_2": None}
 
         # Test case 3. When the task is cancelled, it is in the done state and default response is returned
-        benchmark_row = example_benchmark_object
-        benchmark_row.status = BenchmarkStatus.STOPPING
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(task_id="task_id_3", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
-        database_session.add(task_row)
-        database_session.commit()
-
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        mock_task_row_3 = MagicMock(spec=Task)
+        mock_task_row_3.task_id = "task_id_3"
 
         tracked_task = TrackedTask(coro=self._mock_coro(task_id="task_id_3"))
         semaphore = Semaphore(value=1)
-        run_task = asyncio.create_task(tracked_task.run(semaphore, task_row))
+        run_task = asyncio.create_task(tracked_task.run(semaphore, mock_task_row_3))
 
         # Wait for the task to start running and ensure that the status is running
         await asyncio.sleep(1)
@@ -190,8 +170,6 @@ class TestTracker:
 
         # The response of the tracked result should be None since the task was cancelled
         assert tracked_task.task is not None
-        database_session.refresh(task_row)
-        assert task_row.status == TaskStatus.STOPPED
 
         # Ensurance of cancellation
         with pytest.raises(asyncio.CancelledError):
@@ -200,19 +178,18 @@ class TestTracker:
         assert result == {"task_id_3": None}
 
         # Test case 4. When a task is waiting to be aquired it is kept inside of the waiting state
+        mock_task_row_4 = MagicMock(spec=Task)
+        mock_task_row_4.task_id = "task_id_4"
+        mock_task_row_5 = MagicMock(spec=Task)
+        mock_task_row_5.task_id = "task_id_5"
+
         running_task = TrackedTask(coro=self._mock_coro(task_id="task_id_4"))
         waiting_task = TrackedTask(coro=self._mock_coro(task_id="task_id_5"))
 
-        running_task_row = Task(task_id="task_id_4", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
-        waiting_task_row = Task(task_id="task_id_5", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
-        database_session.add(running_task_row)
-        database_session.add(waiting_task_row)
-        database_session.commit()
-
         semaphore = Semaphore(value=1)
 
-        running_task_coro = running_task.run(semaphore, running_task_row)
-        waiting_task_coro = waiting_task.run(semaphore, waiting_task_row)
+        running_task_coro = running_task.run(semaphore, mock_task_row_4)
+        waiting_task_coro = waiting_task.run(semaphore, mock_task_row_5)
 
         results = asyncio.gather(running_task_coro, waiting_task_coro)
 

--- a/services/tracker/tests/unit/test_tracker.py
+++ b/services/tracker/tests/unit/test_tracker.py
@@ -1,12 +1,12 @@
 import asyncio
 from asyncio import Semaphore, gather
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from sqlmodel import Session
 
-from tracker.database.models import Benchmark, Task, TaskStatus
+from tracker.database.models import Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.utils import TaskMonitor, TrackedTask, TrackedTaskStatus
 
 
@@ -42,10 +42,10 @@ class TestTracker:
         had to use type: ignore to satisfy the type checker.
 
         Test Cases:
-            - _check_is_waiting returns true if the task is not running
             - _validate_task fetches from updates database
             - _validate_task returns false if the task status has been set to stopped
-            - track_tasks cancels the task if the task status has been set to stopped
+            - _validate_task returns false if the benchmark is stopping
+            - running tasks remain tracked until they finish
         """
         benchmark_row = example_benchmark_object
         database_session.add(benchmark_row)
@@ -64,17 +64,17 @@ class TestTracker:
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monitor = TaskMonitor(benchmark_row.id, task_tracking.copy())
 
-        # Test case 1. returns true if task is not running
-        assert monitor._check_is_waiting(task_tracking["task_id_1"])  # type: ignore
-
         # Change task status to running and add a task to the object
         task_tracking["task_id_1"]._status = TrackedTaskStatus.RUNNING  # type: ignore
-        task_tracking["task_id_1"]._task = asyncio.create_task(task_tracking["task_id_1"]._coro)  # type: ignore
+        cancel_mock = Mock()
 
-        # Returns false if the task is not in a waiting state
-        assert not monitor._check_is_waiting(task_tracking["task_id_1"])  # type: ignore
+        def _cancel(*_args: Any, **_kwargs: Any) -> None:
+            task_tracking["task_id_1"]._status = TrackedTaskStatus.DONE  # type: ignore
 
-        # Test case 2. Validate task returns true if the task is not stopped
+        cancel_mock.side_effect = _cancel
+        task_tracking["task_id_1"]._task = Mock(cancel=cancel_mock, done=lambda: False)  # type: ignore
+
+        # Test case 1. Validate task returns true if the task is not stopped
         assert monitor._validate_task("task_id_1")  # type: ignore
 
         # Change the task status to stopped to make sure that it gets invalidated inside of the validate task method
@@ -85,21 +85,30 @@ class TestTracker:
         database_session.add(task_row)
         database_session.commit()
 
-        # Test case 3. Validate task returns false if the task status has been set to stopped
+        # Test case 2. Validate task returns false if the task status has been set to stopped
         # NOTE: ensures that the database change gets picked up by the session
         assert not monitor._validate_task("task_id_1")  # type: ignore
 
-        # Test case 4. track_tasks cancels the task if the task status has been set to stopped
-        # Run the track_tasks method and ensure that the task is cancelled
+        # Test case 3. Validate task returns false if the benchmark is stopping
+        benchmark_row.status = BenchmarkStatus.STOPPING
+        database_session.add(benchmark_row)
+        database_session.commit()
+        assert not monitor._validate_task("task_id_1")  # type: ignore
+
+        # Test case 4. Running tasks stay tracked until they are done
         await monitor.track_tasks()
         assert task_tracking["task_id_1"].task
-        assert task_tracking["task_id_1"].task.cancelled()
+        cancel_mock.assert_called_once()
 
-        # Need to await the result to avoid getting a warning at the end of the test
-        with pytest.raises(asyncio.CancelledError):
-            await task_tracking["task_id_1"].task
+        assert monitor._task_tracking == {}
+        task_tracking["task_id_1"]._coro.close()  # type: ignore[attr-defined]
 
-    async def test_tracked_task(self) -> None:
+    async def test_tracked_task(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """
         Test functionality of the TrackedTask class
 
@@ -153,15 +162,20 @@ class TestTracker:
         assert tracked_task_2.task.result() == {"task_id_2": None}
 
         # Test case 3. When the task is cancelled, it is in the done state and default response is returned
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPING
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(task_id="task_id_3", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+        database_session.add(task_row)
+        database_session.commit()
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+
         tracked_task = TrackedTask(coro=self._mock_coro(task_id="task_id_3"))
-
-        mock_task_row_3 = MagicMock(spec=Task)
-        mock_task_row_3.task_id = "task_id_3"
-
         semaphore = Semaphore(value=1)
-        mock_task_row = MagicMock(spec=Task)
-        mock_task_row.task_id = "task_id_3"
-        run_task = asyncio.create_task(tracked_task.run(semaphore, mock_task_row))
+        run_task = asyncio.create_task(tracked_task.run(semaphore, task_row))
 
         # Wait for the task to start running and ensure that the status is running
         await asyncio.sleep(1)
@@ -176,6 +190,8 @@ class TestTracker:
 
         # The response of the tracked result should be None since the task was cancelled
         assert tracked_task.task is not None
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.STOPPED
 
         # Ensurance of cancellation
         with pytest.raises(asyncio.CancelledError):
@@ -187,19 +203,16 @@ class TestTracker:
         running_task = TrackedTask(coro=self._mock_coro(task_id="task_id_4"))
         waiting_task = TrackedTask(coro=self._mock_coro(task_id="task_id_5"))
 
-        mock_task_row_4 = MagicMock(spec=Task)
-        mock_task_row_4.task_id = "task_id_4"
-        mock_task_row_5 = MagicMock(spec=Task)
-        mock_task_row_5.task_id = "task_id_5"
+        running_task_row = Task(task_id="task_id_4", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+        waiting_task_row = Task(task_id="task_id_5", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+        database_session.add(running_task_row)
+        database_session.add(waiting_task_row)
+        database_session.commit()
 
         semaphore = Semaphore(value=1)
-        mock_task_row = MagicMock(spec=Task)
-        mock_task_row.task_id = "task_id_4"
-        mock_task_row_2 = MagicMock(spec=Task)
-        mock_task_row_2.task_id = "task_id_5"
 
-        running_task_coro = running_task.run(semaphore, mock_task_row)
-        waiting_task_coro = waiting_task.run(semaphore, mock_task_row_2)
+        running_task_coro = running_task.run(semaphore, running_task_row)
+        waiting_task_coro = waiting_task.run(semaphore, waiting_task_row)
 
         results = asyncio.gather(running_task_coro, waiting_task_coro)
 


### PR DESCRIPTION
TaskMonitor should track all tasks until they reach the DONE state, so that if we force stop the benchmark it can cancel the tasks directly. Currently, force stop can take a while to actually reach the benchmark STOPPED state because we no longer have a handle to the task and can't cancel them if they have already acquired the semaphore.