### PR TITLE
feat: take in problem path directly

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -280,7 +280,7 @@ async def archive_and_upload_output(
 async def run_agent(
     sandbox: AsyncSandbox,
     contract: AgentContractRequest,
-    problem_statement: str,
+    problem_path: str,
     task_id: str,
     log_output: Callable[[str], None],
     cwd: str,
@@ -294,7 +294,7 @@ async def run_agent(
     Args:
         sandbox: The sandbox to run the agent in
         contract: The agent contract configuration
-        problem_statement: Problem statement to pass to the agent
+        problem_path: Path inside the sandbox where the problem statement file was written during setup
         log_output: Callback to log output
         cwd: Working directory to run the agent in
         agent_output_s3_key: S3 key to where we will upload the final output archive to
@@ -309,10 +309,7 @@ async def run_agent(
 
     await install_agent_dependencies(sandbox, contract, log_output)
 
-    problem_statement_path = "/tmp/problem_statement.txt"
-    await sandbox.fs.upload_file(problem_statement.encode(), problem_statement_path)
-
-    run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_statement_path).replace("{task_id}", task_id)
+    run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_path).replace("{task_id}", task_id)
 
     # Run the agent without including task directory dependencies
     await stream_command_output(sandbox, f"cd {cwd} && PYTHONSAFEPATH=1 {run_cmd}", log_output)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -355,7 +355,7 @@ async def process_task(
                 await run_agent(
                     sandbox,
                     start_benchmark_request.contract,
-                    task_data.problem_statement,
+                    task_data.problem_path,
                     task_id,
                     log_output,
                     task_data.cwd,

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -339,12 +339,10 @@ async def process_task(
                     sandbox, start_benchmark_request.contract, harness_config.aws, harness_config.s3_bucket
                 )
 
-                # Setup task if requested
-                if task_data.request_setup:
-                    _ = await benchmark_service.setup_task(task_row.task_id, sandbox.id, on_message=log_output, dataset=start_benchmark_request.dataset)
+                _ = await benchmark_service.setup_task(task_row.task_id, sandbox.id, on_message=log_output, dataset=start_benchmark_request.dataset)
 
-                    # Force flush the logs if anything has been buffered
-                    buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
+                # Force flush the logs if anything has been buffered
+                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None

--- a/services/tracker/tests/integration/test_database_integration.py
+++ b/services/tracker/tests/integration/test_database_integration.py
@@ -223,10 +223,8 @@ class TestDatabaseIntegration:
         database_session.flush()
 
         async with build_task_environment(daytona_client, task_row.task_id, docker_image) as sandbox:
-            request_setup = task_data.request_setup
-            if request_setup:
-                response = await benchmark_service.setup_task(task_id=task_row.task_id, instance_id=str(sandbox.id))
-                assert response.status == "ok"
+            response = await benchmark_service.setup_task(task_id=task_row.task_id, instance_id=str(sandbox.id))
+            assert response.status == "ok"
 
             response = await benchmark_service.evaluate_instance(task_id=task_row.task_id, instance_id=sandbox.id)
 

--- a/services/tracker/tests/integration/test_swebench_service.py
+++ b/services/tracker/tests/integration/test_swebench_service.py
@@ -138,7 +138,7 @@ class TestSWEBenchmarkService:
 
                 assert task_data.docker_image == docker_image_format.format(task_id=task_id)
                 assert task_data.request_setup
-                assert task_data.problem_statement
+                assert task_data.problem_path
 
                 # Verify docker image exists
                 if not await validate_docker_image(task_data.docker_image):

--- a/services/tracker/tests/integration/test_swebench_service.py
+++ b/services/tracker/tests/integration/test_swebench_service.py
@@ -137,7 +137,6 @@ class TestSWEBenchmarkService:
                 task_data = await benchmark_service.retrieve_task(task_id=task_id)
 
                 assert task_data.docker_image == docker_image_format.format(task_id=task_id)
-                assert task_data.request_setup
                 assert task_data.problem_path
 
                 # Verify docker image exists

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -12,7 +12,7 @@ from tracker.utils import start_benchmark_request_to_benchmark
 from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Task, TaskStatus
 from tracker.exceptions import TrackerServiceError
 from benchmark_service.schemas import FinalScoreResponse
-from tracker.types import HarnessConfig, StartBenchmarkRequest
+from tracker.types import StartBenchmarkRequest
 from tests.unit.conftest import TEST_HARNESS_CONFIG
 from tracker.utils import create_task_rows, fetch_benchmark_row, set_benchmark_final_status
 

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -24,7 +24,6 @@ from benchmark_service.schemas import VerifyTaskIdsResponse
 from tracker.types import (
     FetchBenchmarksRequest,
     FinalViewResponse,
-    HarnessConfig,
     StartBenchmarkRequest,
 )
 from tests.unit.conftest import TEST_HARNESS_CONFIG

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -25,7 +25,6 @@ class TestStopAndResume:
         return RetrieveTaskResponse(
             docker_image="test-image:latest",
             problem_path="/tmp/problem_statement.txt",
-            request_setup=False,
             cwd="/testbed",
             resources=Resources(vcpu=2, memory=4, disk=5),
         )

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -24,7 +24,7 @@ class TestStopAndResume:
     async def _mock_request_retrieve_task(*args: Any, **kwargs: Any) -> RetrieveTaskResponse:
         return RetrieveTaskResponse(
             docker_image="test-image:latest",
-            problem_statement="Test problem statement",
+            problem_path="/tmp/problem_statement.txt",
             request_setup=False,
             cwd="/testbed",
             resources=Resources(vcpu=2, memory=4, disk=5),

--- a/src/agentic_harness/contract.py
+++ b/src/agentic_harness/contract.py
@@ -42,7 +42,7 @@ class BaseAgentContract(ABC):
         Command to run the agent on a task.
 
         Args:
-            problem_statement_path: str - Where the problem statement is copied in the sandbox (default: tmp/problem_statement)
+            problem_statement_path: str - Path in the sandbox where the problem statement file was written during setup
             task_id: str - The readable task id (e.x astropy__astropy-12907)
             kwargs: dict[str, Any] - Extra args the user specified at run time
 


### PR DESCRIPTION
benchmark services should upload the problem statement directly versus passing the contents to tracker and having tracker upload it

https://github.com/vals-ai/agentic-harness/issues/161 