### PR TITLE
Add benchmark service auth support

### DIFF
--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -52,6 +52,7 @@ class StartBenchmarkRequest(BaseModel):
     dataset: str | None = None
     harness_config: HarnessConfig
     custom_benchmark_service: str | None = None
+    benchmark_headers: dict[str, str] = {}
 
     @property
     def benchmark_service(self) -> BenchmarkServiceClient:
@@ -63,6 +64,7 @@ class StartBenchmarkRequest(BaseModel):
             url=benchmark_service_url,
             daytona_secret_name=self.harness_config.daytona_secret_name,
             aws=self.harness_config.aws,
+            benchmark_headers=self.benchmark_headers,
         )
 
 

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -52,7 +52,7 @@ class StartBenchmarkRequest(BaseModel):
     dataset: str | None = None
     harness_config: HarnessConfig
     custom_benchmark_service: str | None = None
-    benchmark_headers: dict[str, str] = {}
+    service_headers: dict[str, str] = {}
 
     @property
     def benchmark_service(self) -> BenchmarkServiceClient:
@@ -64,7 +64,7 @@ class StartBenchmarkRequest(BaseModel):
             url=benchmark_service_url,
             daytona_secret_name=self.harness_config.daytona_secret_name,
             aws=self.harness_config.aws,
-            benchmark_headers=self.benchmark_headers,
+            service_headers=self.service_headers,
         )
 
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -78,9 +78,14 @@ def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict
     }
 
 
-def create_benchmark_service_client(url: str, daytona_secret_name: str, aws: AWSCredentials) -> BenchmarkServiceClient:
+def create_benchmark_service_client(
+    url: str, daytona_secret_name: str, aws: AWSCredentials, benchmark_headers: dict[str, str] | None = None
+) -> BenchmarkServiceClient:
     """Create a BenchmarkServiceClient using Daytona credentials from AWS Secrets Manager."""
-    return BenchmarkServiceClient(url=url, headers=fetch_daytona_headers(daytona_secret_name, aws))
+    headers = fetch_daytona_headers(daytona_secret_name, aws)
+    if benchmark_headers:
+        headers.update(benchmark_headers)
+    return BenchmarkServiceClient(url=url, headers=headers)
 
 
 def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest) -> Benchmark:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -79,12 +79,12 @@ def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict
 
 
 def create_benchmark_service_client(
-    url: str, daytona_secret_name: str, aws: AWSCredentials, benchmark_headers: dict[str, str] | None = None
+    url: str, daytona_secret_name: str, aws: AWSCredentials, service_headers: dict[str, str] | None = None
 ) -> BenchmarkServiceClient:
     """Create a BenchmarkServiceClient using Daytona credentials from AWS Secrets Manager."""
     headers = fetch_daytona_headers(daytona_secret_name, aws)
-    if benchmark_headers:
-        headers.update(benchmark_headers)
+    if service_headers:
+        headers.update(service_headers)
     return BenchmarkServiceClient(url=url, headers=headers)
 
 

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -434,15 +434,15 @@ def start(
     else:
         click.echo("  - Task IDs: all tasks")
 
-    benchmark_headers: dict[str, str] = {}
+    service_headers: dict[str, str] = {}
     auth_token = TrackerService.get_benchmark_auth(benchmark)
     if auth_token:
-        benchmark_headers["Authorization"] = str(auth_token)
+        service_headers["Authorization"] = str(auth_token)
     for name, value in headers:
-        benchmark_headers[name] = value
+        service_headers[name] = value
 
-    if benchmark_headers:
-        click.echo(f"  - Benchmark headers: {', '.join(benchmark_headers.keys())}")
+    if service_headers:
+        click.echo(f"  - Service headers: {', '.join(service_headers.keys())}")
 
     formatted_task_ids: list[str] | None = None
     if task_ids:
@@ -485,7 +485,7 @@ def start(
                 slice_str,
                 lambda_function,
                 dataset,
-                benchmark_headers=benchmark_headers or None,
+                service_headers=service_headers or None,
             )
 
             click.echo("\r\033[K", nl=False)

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -227,17 +227,17 @@ def service_list() -> None:
 
 @config.group()
 def auth() -> None:
-    """Manage benchmark service auth tokens."""
+    """Manage benchmark service auth credentials."""
     pass
 
 
 @auth.command("set")
 @click.argument("name")
-@click.argument("token")
-def auth_set(name: str, token: str) -> None:
-    """Set an auth token for a benchmark service.
+@click.argument("credential")
+def auth_set(name: str, credential: str) -> None:
+    """Set an auth credential for a benchmark service.
 
-    Example: harness config auth set swebench my-secret-token
+    Example: harness config auth set swebench my-secret-credential
     """
     if not CONFIG_LOCATION.exists():
         raise click.ClickException("Config not found. Run `harness config init` first.")
@@ -248,7 +248,7 @@ def auth_set(name: str, token: str) -> None:
     if "benchmark_auth" not in harness_config:
         harness_config["benchmark_auth"] = {}
 
-    harness_config["benchmark_auth"][name] = token
+    harness_config["benchmark_auth"][name] = credential
 
     with open(CONFIG_LOCATION, "w") as f:
         yaml.dump(harness_config, f, default_flow_style=False)
@@ -259,7 +259,7 @@ def auth_set(name: str, token: str) -> None:
 @auth.command("remove")
 @click.argument("name")
 def auth_remove(name: str) -> None:
-    """Remove an auth token for a benchmark service.
+    """Remove an auth credential for a benchmark service.
 
     Example: harness config auth remove swebench
     """
@@ -269,12 +269,12 @@ def auth_remove(name: str) -> None:
     with open(CONFIG_LOCATION) as f:
         current: dict[str, Any] = yaml.safe_load(f) or {}
 
-    auth_tokens = current.get("benchmark_auth") or {}
-    if name not in auth_tokens:
+    auth_credentials = current.get("benchmark_auth") or {}
+    if name not in auth_credentials:
         raise click.ClickException(f"Auth for '{name}' not configured.")
 
-    del auth_tokens[name]
-    current["benchmark_auth"] = auth_tokens
+    del auth_credentials[name]
+    current["benchmark_auth"] = auth_credentials
 
     with open(CONFIG_LOCATION, "w") as f:
         yaml.dump(current, f, default_flow_style=False)
@@ -284,20 +284,20 @@ def auth_remove(name: str) -> None:
 
 @auth.command("list")
 def auth_list() -> None:
-    """List all configured benchmark auth tokens."""
+    """List all configured benchmark auth credentials."""
     if not CONFIG_LOCATION.exists():
         raise click.ClickException("Config not found. Run `harness config init` first.")
 
     with open(CONFIG_LOCATION) as f:
         current: dict[str, Any] = yaml.safe_load(f) or {}
 
-    auth_tokens: dict[str, str] = current.get("benchmark_auth") or {}
-    if not auth_tokens:
-        click.echo(click.style("No benchmark auth tokens configured.", fg="yellow"))
+    auth_credentials: dict[str, str] = current.get("benchmark_auth") or {}
+    if not auth_credentials:
+        click.echo(click.style("No benchmark auth credentials configured.", fg="yellow"))
         return
 
-    for name, token in auth_tokens.items():
-        masked = token[:4] + "***" if len(token) > 4 else "***"
+    for name, credential in auth_credentials.items():
+        masked = credential[:4] + "***" if len(credential) > 4 else "***"
         click.echo(f"  {name}: {masked}")
 
 
@@ -391,7 +391,7 @@ def auth_list() -> None:
     multiple=True,
     nargs=2,
     type=(str, str),
-    help="Custom header for benchmark service requests (e.g., -H Authorization my-token)",
+    help="Custom header for benchmark service requests (e.g., -H Authorization my-credential)",
 )
 def start(
     agent: str,
@@ -435,9 +435,9 @@ def start(
         click.echo("  - Task IDs: all tasks")
 
     service_headers: dict[str, str] = {}
-    auth_token = TrackerService.get_benchmark_auth(benchmark)
-    if auth_token:
-        service_headers["Authorization"] = str(auth_token)
+    auth_credential = TrackerService.get_benchmark_auth(benchmark)
+    if auth_credential:
+        service_headers["Authorization"] = str(auth_credential)
     for name, value in headers:
         service_headers[name] = value
 

--- a/src/agentic_harness/cli/main.py
+++ b/src/agentic_harness/cli/main.py
@@ -225,6 +225,82 @@ def service_list() -> None:
     paginate_services(services_list)
 
 
+@config.group()
+def auth() -> None:
+    """Manage benchmark service auth tokens."""
+    pass
+
+
+@auth.command("set")
+@click.argument("name")
+@click.argument("token")
+def auth_set(name: str, token: str) -> None:
+    """Set an auth token for a benchmark service.
+
+    Example: harness config auth set swebench my-secret-token
+    """
+    if not CONFIG_LOCATION.exists():
+        raise click.ClickException("Config not found. Run `harness config init` first.")
+
+    with open(CONFIG_LOCATION) as f:
+        harness_config: dict[str, Any] = yaml.safe_load(f) or {}
+
+    if "benchmark_auth" not in harness_config:
+        harness_config["benchmark_auth"] = {}
+
+    harness_config["benchmark_auth"][name] = token
+
+    with open(CONFIG_LOCATION, "w") as f:
+        yaml.dump(harness_config, f, default_flow_style=False)
+
+    click.echo(click.style(f"Auth for '{name}' has been set.", fg="green"))
+
+
+@auth.command("remove")
+@click.argument("name")
+def auth_remove(name: str) -> None:
+    """Remove an auth token for a benchmark service.
+
+    Example: harness config auth remove swebench
+    """
+    if not CONFIG_LOCATION.exists():
+        raise click.ClickException("Config not found. Run `harness config init` first.")
+
+    with open(CONFIG_LOCATION) as f:
+        current: dict[str, Any] = yaml.safe_load(f) or {}
+
+    auth_tokens = current.get("benchmark_auth") or {}
+    if name not in auth_tokens:
+        raise click.ClickException(f"Auth for '{name}' not configured.")
+
+    del auth_tokens[name]
+    current["benchmark_auth"] = auth_tokens
+
+    with open(CONFIG_LOCATION, "w") as f:
+        yaml.dump(current, f, default_flow_style=False)
+
+    click.echo(click.style(f"Auth for '{name}' has been removed.", fg="green"))
+
+
+@auth.command("list")
+def auth_list() -> None:
+    """List all configured benchmark auth tokens."""
+    if not CONFIG_LOCATION.exists():
+        raise click.ClickException("Config not found. Run `harness config init` first.")
+
+    with open(CONFIG_LOCATION) as f:
+        current: dict[str, Any] = yaml.safe_load(f) or {}
+
+    auth_tokens: dict[str, str] = current.get("benchmark_auth") or {}
+    if not auth_tokens:
+        click.echo(click.style("No benchmark auth tokens configured.", fg="yellow"))
+        return
+
+    for name, token in auth_tokens.items():
+        masked = token[:4] + "***" if len(token) > 4 else "***"
+        click.echo(f"  {name}: {masked}")
+
+
 @benchmark.command(
     help="Start a benchmark run. \n\nExample:\nharness benchmark start --agent agents/claude_code --benchmark swebench --concurrency 5"
 )
@@ -308,6 +384,15 @@ def service_list() -> None:
     type=(str, str),
     help="Secret as ENV_VAR aws_secret_name (e.g., -s ANTHROPIC_API_KEY devEvalInfraAnthropicKey)",
 )
+@click.option(
+    "--header",
+    "-H",
+    "headers",
+    multiple=True,
+    nargs=2,
+    type=(str, str),
+    help="Custom header for benchmark service requests (e.g., -H Authorization my-token)",
+)
 def start(
     agent: str,
     model: str | None,
@@ -320,6 +405,7 @@ def start(
     dataset: str | None,
     kwargs: tuple[tuple[str, str]],
     secrets: tuple[tuple[str, str]],
+    headers: tuple[tuple[str, str]],
 ):
     """
     Run an agent on a benchmark.
@@ -347,6 +433,16 @@ def start(
         click.echo(f"  - Task IDs: {task_ids[:100]}{'...' if len(task_ids) > 100 else ''}")
     else:
         click.echo("  - Task IDs: all tasks")
+
+    benchmark_headers: dict[str, str] = {}
+    auth_token = TrackerService.get_benchmark_auth(benchmark)
+    if auth_token:
+        benchmark_headers["Authorization"] = str(auth_token)
+    for name, value in headers:
+        benchmark_headers[name] = value
+
+    if benchmark_headers:
+        click.echo(f"  - Benchmark headers: {', '.join(benchmark_headers.keys())}")
 
     formatted_task_ids: list[str] | None = None
     if task_ids:
@@ -389,6 +485,7 @@ def start(
                 slice_str,
                 lambda_function,
                 dataset,
+                benchmark_headers=benchmark_headers or None,
             )
 
             click.echo("\r\033[K", nl=False)

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -95,13 +95,13 @@ class TrackerService:
     @staticmethod
     def get_benchmark_auth(benchmark_name: str) -> str | None:
         """
-        Get benchmark auth token from config if it exists.
+        Get benchmark auth credential from config if it exists.
 
         Args:
             benchmark_name: Name of the benchmark
 
         Returns:
-            Auth token if configured, None otherwise
+            Auth credential if configured, None otherwise
         """
         config_path = _CONFIG_LOCATION.expanduser()
         if not config_path.exists():

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -93,6 +93,27 @@ class TrackerService:
         return services.get(benchmark_name)
 
     @staticmethod
+    def get_benchmark_auth(benchmark_name: str) -> str | None:
+        """
+        Get benchmark auth token from config if it exists.
+
+        Args:
+            benchmark_name: Name of the benchmark
+
+        Returns:
+            Auth token if configured, None otherwise
+        """
+        config_path = _CONFIG_LOCATION.expanduser()
+        if not config_path.exists():
+            return None
+
+        with open(config_path) as f:
+            harness_config = yaml.safe_load(f) or {}
+
+        auth = harness_config.get("benchmark_auth") or {}
+        return auth.get(benchmark_name)
+
+    @staticmethod
     def parse_config_keys() -> dict[str, str]:
         """Parses expected config keys and handles edge cases"""
         config_path: Path = _CONFIG_LOCATION.expanduser()
@@ -164,6 +185,7 @@ class TrackerService:
         slice_str: str | None,
         lambda_function: str | None = None,
         dataset: str | None = None,
+        benchmark_headers: dict[str, str] | None = None,
     ) -> Response:
         """
         Start a benchmark run on the tracker service.
@@ -193,6 +215,7 @@ class TrackerService:
                 dataset=dataset,
                 harness_config=HarnessConfig.model_validate(self._build_harness_config_payload()),
                 custom_benchmark_service=self.get_benchmark_service_url(benchmark_name),
+                benchmark_headers=benchmark_headers or {},
             )
 
             body = payload.model_dump()

--- a/src/agentic_harness/cli/tracker_service.py
+++ b/src/agentic_harness/cli/tracker_service.py
@@ -185,7 +185,7 @@ class TrackerService:
         slice_str: str | None,
         lambda_function: str | None = None,
         dataset: str | None = None,
-        benchmark_headers: dict[str, str] | None = None,
+        service_headers: dict[str, str] | None = None,
     ) -> Response:
         """
         Start a benchmark run on the tracker service.
@@ -215,7 +215,7 @@ class TrackerService:
                 dataset=dataset,
                 harness_config=HarnessConfig.model_validate(self._build_harness_config_payload()),
                 custom_benchmark_service=self.get_benchmark_service_url(benchmark_name),
-                benchmark_headers=benchmark_headers or {},
+                service_headers=service_headers or {},
             )
 
             body = payload.model_dump()


### PR DESCRIPTION
## Summary
- Add `benchmark_auth` config section in `~/.config/harness/harness.yaml` for per-benchmark auth tokens (sent as `Authorization` header)
- Add `harness config auth set/remove/list` CLI commands to manage auth tokens
- Add `--header/-H` flag on `harness benchmark start` for arbitrary benchmark service headers
- Plumb benchmark headers through TrackerService -> StartBenchmarkRequest -> BenchmarkServiceClient

Auth failure should look something like (depends on how the benchmark service handles):
```
Benchmark failed to start!
{"detail":"{\"benchmark_id\":\"fe013b97-2f62-4624-b984-c9d65bc34249\",\"error_message\":\"Verify task ids failed with status code 401, response: {\\\"detail\\\":\\\"Unauthorized\\\"}\\nTraceback (most recent call last):\\n  File \\\"/app/main.py\\\", line 140, in start_benchmark\\n    verify_response = await benchmark_service.verify_task_ids(\\n                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\\n  File \\\"/app/.venv/lib/python3.12/site-packages/benchmark_service/client.py\\\", line 150, in verify_task_ids\\n    raise BenchmarkServiceError(\\nbenchmark_service.client.BenchmarkServiceError: Verify task ids failed with status code 401, response: {\\\"detail\\\":\\\"Unauthorized\\\"}\\n\"}"}
```

## Config example
```yaml
benchmark_auth:
  my-benchmark: "my-secret-token"
  another-benchmark: "different-token"
```

## CLI usage
```bash
# Set auth via config (one-time)
harness config auth set swebench my-secret-token

# Start with config auth (automatic) + optional extra headers
harness benchmark start --benchmark swebench --agent my-agent -H X-Custom value
```