### PR TITLE
75-200

### DIFF
--- a/services/tracker/src/tracker/cloudwatch.py
+++ b/services/tracker/src/tracker/cloudwatch.py
@@ -21,7 +21,7 @@ def _cloudwatch_client(aws: "AWSCredentials") -> Any:
         aws_access_key_id=aws.aws_access_key_id,
         aws_secret_access_key=aws.aws_secret_access_key,
         region_name=aws.aws_default_region,
-        config=Config(max_pool_connections=75),
+        config=Config(max_pool_connections=200),
     )
 
 


### PR DESCRIPTION
## Summary
Changed the max pool connections from 75 to 200. This was done in an attempt to reduce connection bottleneck that occurs under high load

## Changes
Changed the max pool connections from 75 to 200
- 

## Related Issues
None

## Type of Change
<!-- What changed? -->
- [X  ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ X ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [X  ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ X ] Self-reviewed the diff
- [X  ] No debug/dead code left in
- [ ] Docs updated if needed