### PR TITLE
feat: add model name to benchmark slack notifications (#215)

### DIFF
--- a/services/tracker/src/tracker/notifications.py
+++ b/services/tracker/src/tracker/notifications.py
@@ -32,6 +32,7 @@ class NotificationContext(BaseModel):
     started_at: datetime
     total_tasks: int
     finished_tasks: int
+    model: str | None = None
 
     @classmethod
     def from_benchmark(cls, benchmark_row: Benchmark, session: Session) -> NotificationContext:
@@ -45,6 +46,7 @@ class NotificationContext(BaseModel):
             started_at=benchmark_row.started_at,
             total_tasks=details.total_tasks,
             finished_tasks=details.finished_tasks,
+            model=benchmark_row.arguments.contract.model,
         )
 
 
@@ -68,12 +70,14 @@ def _format_duration(started_at: datetime) -> str:
 
 def _build_progress_message(context: NotificationContext, percent: int) -> str:
     elapsed = _format_duration(context.started_at)
-    return (
-        f"*Benchmark Update* — {context.benchmark_name}\n"
-        f"Agent: {context.agent_name} | Run: {context.benchmark_id}\n"
-        f"Status: In Progress — {percent}% ({context.finished_tasks}/{context.total_tasks} tasks)\n"
-        f"Elapsed: {elapsed}"
-    )
+    lines = [
+        f"*Benchmark Update* — {context.benchmark_name}",
+        f"Agent: {context.agent_name} | Run: {context.benchmark_id}",
+        f"Model: {context.model or 'N/A'}",
+        f"Status: In Progress — {percent}% ({context.finished_tasks}/{context.total_tasks} tasks)",
+        f"Elapsed: {elapsed}",
+    ]
+    return "\n".join(lines)
 
 
 def _build_terminal_message(
@@ -95,6 +99,7 @@ def _build_terminal_message(
     lines = [
         f"*{header}* — {context.benchmark_name}",
         f"Agent: {context.agent_name} | Run: {context.benchmark_id}",
+        f"Model: {context.model or 'N/A'}",
         f"Status: {status.value} — {percent}% ({context.finished_tasks}/{context.total_tasks} tasks)",
     ]
 

--- a/services/tracker/tests/unit/test_notifications.py
+++ b/services/tracker/tests/unit/test_notifications.py
@@ -7,7 +7,7 @@ import httpx
 import pytest
 
 from tracker.database.models import BenchmarkStatus
-from tracker.notifications import NotificationContext, SlackNotifier
+from tracker.notifications import NotificationContext, SlackNotifier, _build_progress_message, _build_terminal_message
 
 
 def _make_context(**overrides: object) -> NotificationContext:
@@ -19,6 +19,7 @@ def _make_context(**overrides: object) -> NotificationContext:
         "started_at": datetime.now(ZoneInfo("UTC")),
         "total_tasks": 100,
         "finished_tasks": 0,
+        "model": "anthropic/claude-sonnet-4-20250514",
     }
     defaults.update(overrides)
     return NotificationContext(**defaults)
@@ -117,6 +118,39 @@ class TestSlackNotifierTerminal:
             mock_send.assert_called_once()
             message = mock_send.call_args[0][0]
             assert "Benchmark Stopped" in message
+
+
+class TestMessageContent:
+    def test_progress_message_contains_all_fields(self) -> None:
+        context = _make_context(finished_tasks=25, model="anthropic/claude-sonnet-4-20250514")
+        message = _build_progress_message(context, percent=25)
+        assert "Benchmark Update" in message
+        assert context.benchmark_name in message
+        assert context.agent_name in message
+        assert str(context.benchmark_id) in message
+        assert "Model: anthropic/claude-sonnet-4-20250514" in message
+        assert "25% (25/100 tasks)" in message
+
+    def test_progress_message_shows_na_when_model_is_none(self) -> None:
+        context = _make_context(finished_tasks=25, model=None)
+        message = _build_progress_message(context, percent=25)
+        assert "Model: N/A" in message
+
+    def test_terminal_message_contains_all_fields(self) -> None:
+        context = _make_context(finished_tasks=100, model="anthropic/claude-sonnet-4-20250514")
+        message = _build_terminal_message(context, status=BenchmarkStatus.FINISHED, final_score=0.42)
+        assert "Benchmark Complete" in message
+        assert context.benchmark_name in message
+        assert context.agent_name in message
+        assert str(context.benchmark_id) in message
+        assert "Model: anthropic/claude-sonnet-4-20250514" in message
+        assert "100% (100/100 tasks)" in message
+        assert "Final Score: 0.42" in message
+
+    def test_terminal_message_shows_na_when_model_is_none(self) -> None:
+        context = _make_context(finished_tasks=100, model=None)
+        message = _build_terminal_message(context, status=BenchmarkStatus.FINISHED, final_score=0.42)
+        assert "Model: N/A" in message
 
 
 class TestSlackNotifierFireAndForget:


### PR DESCRIPTION
* feat: add model name to benchmark slack notifications

* fix: always show model line in notifications, broaden test assertions

## Summary
<!-- What does this PR do? Why is it needed? -->

## Changes
<!-- List the key changes made -->
- 

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed