### PR TITLE
First pass deprecating modify for set

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ valkyrie config init
 
 This will prompt for required credentials (AWS, S3 bucket, Daytona secret name) and write them to `~/.config/valkyrie/valkyrie.yaml`. Values can be sourced from the environment or an existing config. These are required to run Valkyrie and be in any environment that you use Valkyrie in.
 
-To update a single key:
+To upsert a single key:
 
 ```bash
-valkyrie config modify <KEY> <VALUE>
+valkyrie config set <KEY> <VALUE>
 ```
 
 ## Agent Management

--- a/README.md
+++ b/README.md
@@ -167,10 +167,10 @@ Valkyrie can send Slack webhook notifications as benchmark runs progress. Config
 
 ```bash
 # Store your Slack webhook URL
-valkyrie config webhook set https://hooks.slack.com/services/T00/B00/xxx
+valkyrie config set webhook https://hooks.slack.com/services/T00/B00/xxx
 
 # Remove the webhook URL
-valkyrie config webhook remove
+valkyrie config remove webhook
 ```
 
 ### Starting a run with notifications

--- a/docs/PROVIDER.md
+++ b/docs/PROVIDER.md
@@ -20,4 +20,4 @@ Upload that key to AWS secrets manager using the following format in plain text
 }
 ```
 
-When using `valkyrie config init` or `valkyrie config modify` add to the key `DAYTONA_SECRET_NAME` with the name of the secret (e.x, DaytonaSecrets)
+When using `valkyrie config init` or `valkyrie config set` add to the key `DAYTONA_SECRET_NAME` with the name of the secret (e.x, DaytonaSecrets)

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -25,6 +25,7 @@ from valkyrie.cli.s3_client import (
 from valkyrie.cli.tracker_service import TrackerService
 from valkyrie.cli.utils import (
     CONFIG_LOCATION,
+    ConfigValue,
     check_tracker_service_health,
     download_agent_outputs,
     download_final_view,
@@ -63,24 +64,25 @@ def config():
     pass
 
 
+# Mapping between the expected key and default value
+# None means its user provided if not found
+_REQUIRED_ENVIRONMENT_VARIABLES: dict[str, str | None | int] = {
+    "AWS_ACCESS_KEY_ID": None,  # AWS ACCESS KEY
+    "AWS_SECRET_ACCESS_KEY": None,  # AWS SECRETS KEY
+    "AWS_DEFAULT_REGION": None,  # What region your secrets are in
+    "S3_BUCKET": None,  # Center point where all agents and benchmark results are uploaded
+    "DAYTONA_SECRET_NAME": None,  # AWS Secrets Manager name for Daytona credentials
+    "LOG_GROUP": "benchmarks",  # the prefix to the cloudwatch logs (e.x. benchmarks/<benchmark_id>)
+    "LOG_RETENTION_POLICY": 365,  # How long logs are kept until auto deleted
+}
+
+
 @config.command()
 def init() -> None:
     """
     Initializes a config we can trust to have references to dependencies to run Valkyrie,
     this becomes our source of truth for secrets required to run Valkyrie
     """
-
-    # Mapping between the expected key and default value
-    # None means its user provided if not found
-    environment_variables: dict[str, str | None | int] = {
-        "AWS_ACCESS_KEY_ID": None,  # AWS ACCESS KEY
-        "AWS_SECRET_ACCESS_KEY": None,  # AWS SECRETS KEY
-        "AWS_DEFAULT_REGION": None,  # What region your secrets are in
-        "S3_BUCKET": None,  # Center point where all agents and benchmark results are uploaded
-        "DAYTONA_SECRET_NAME": None,  # AWS Secrets Manager name for Daytona credentials
-        "LOG_GROUP": "benchmarks",  # the prefix to the cloudwatch logs (e.x. benchmarks/<benchmark_id>)
-        "LOG_RETENTION_POLICY": 365,  # How long logs are kept until auto deleted
-    }
 
     current_config: dict[str, str] = {}
     if CONFIG_LOCATION.exists():
@@ -91,7 +93,7 @@ def init() -> None:
                 pass
 
     collected_keys: dict[str, str] = {}
-    for key, default in environment_variables.items():
+    for key, default in _REQUIRED_ENVIRONMENT_VARIABLES.items():
         sourced = current_config.get(key) or os.environ.get(key)
         if sourced:
             click.echo(
@@ -126,11 +128,11 @@ def init() -> None:
 @config.command()
 @click.argument("key")
 @click.argument("value")
-def modify(key: str, value: str) -> None:
+def set(key: str, value: str) -> None:
     """
-    Modify a single key in the Valkyrie config.
+    Set a single key in the Valkyrie config.
 
-    Example: valkyrie config modify AWS_DEFAULT_REGION us-west-2
+    Example: valkyrie config set AWS_DEFAULT_REGION us-west-2
     """
 
     if not CONFIG_LOCATION.exists():
@@ -139,15 +141,55 @@ def modify(key: str, value: str) -> None:
     with open(CONFIG_LOCATION) as f:
         current: dict[str, str] = yaml.safe_load(f) or {}
 
-    if key not in current:
-        raise click.ClickException(f"Key '{key}' not found in config. Valid keys: {', '.join(current)}")
+    try:
+        config_value = ConfigValue.from_str(key)
+    except ValueError:
+        raise click.ClickException(
+            f"Key '{key}' is not a valid config key. Valid keys: {', '.join(ConfigValue.__members__.keys())}"
+        )
 
-    current[key] = value
+    current[config_value.value] = value
 
     with open(CONFIG_LOCATION, "w") as f:
         yaml.dump(current, f, default_flow_style=False)
 
     click.echo(click.style(f"  {key} updated.", fg="green"))
+
+
+@config.command(name="remove")
+@click.argument("key")
+def config_remove(key: str) -> None:
+    """
+    Remove a single key from the Valkyrie config.
+
+    Example: valkyrie config remove AWS_DEFAULT_REGION
+    """
+
+    if not CONFIG_LOCATION.exists():
+        raise click.ClickException("Config not found. Run `valkyrie config init` first.")
+
+    with open(CONFIG_LOCATION) as f:
+        current: dict[str, str] = yaml.safe_load(f) or {}
+
+    try:
+        config_value = ConfigValue.from_str(key)
+    except ValueError:
+        raise click.ClickException(
+            f"Key '{key}' is not a valid config key. Valid keys: {', '.join(ConfigValue.__members__.keys())}"
+        )
+
+    if config_value.value in _REQUIRED_ENVIRONMENT_VARIABLES:
+        raise click.ClickException(
+            f"Key '{key}' is required and cannot be removed. Consider using `valkyrie config set` to update it."
+        )
+
+    if config_value.value in current:
+        del current[config_value.value]
+
+    with open(CONFIG_LOCATION, "w") as f:
+        yaml.dump(current, f, default_flow_style=False)
+
+    click.echo(click.style(f"  {key} removed.", fg="green"))
 
 
 @config.group()
@@ -302,54 +344,54 @@ def auth_list() -> None:
         click.echo(f"  {name}: {masked}")
 
 
-@config.group()
-def webhook() -> None:
-    """Manage Slack webhook URL for run notifications."""
-    pass
+# @config.group()
+# def webhook() -> None:
+#     """Manage Slack webhook URL for run notifications."""
+#     pass
 
 
-@webhook.command("set")
-@click.argument("url")
-def webhook_set(url: str) -> None:
-    """Set the Slack webhook URL for benchmark notifications.
+# @webhook.command("set")
+# @click.argument("url")
+# def webhook_set(url: str) -> None:
+#     """Set the Slack webhook URL for benchmark notifications.
 
-    Example: valkyrie config webhook set https://hooks.slack.com/services/T00/B00/xxx
-    """
-    if not CONFIG_LOCATION.exists():
-        raise click.ClickException("Config not found. Run `valkyrie config init` first.")
+#     Example: valkyrie config webhook set https://hooks.slack.com/services/T00/B00/xxx
+#     """
+#     if not CONFIG_LOCATION.exists():
+#         raise click.ClickException("Config not found. Run `valkyrie config init` first.")
 
-    with open(CONFIG_LOCATION) as f:
-        harness_config: dict[str, Any] = yaml.safe_load(f) or {}
+#     with open(CONFIG_LOCATION) as f:
+#         harness_config: dict[str, Any] = yaml.safe_load(f) or {}
 
-    harness_config["slack_webhook_url"] = url
+#     harness_config["slack_webhook_url"] = url
 
-    with open(CONFIG_LOCATION, "w") as f:
-        yaml.dump(harness_config, f, default_flow_style=False)
+#     with open(CONFIG_LOCATION, "w") as f:
+#         yaml.dump(harness_config, f, default_flow_style=False)
 
-    click.echo(click.style("Slack webhook URL has been set.", fg="green"))
+#     click.echo(click.style("Slack webhook URL has been set.", fg="green"))
 
 
-@webhook.command("remove")
-def webhook_remove() -> None:
-    """Remove the Slack webhook URL.
+# @webhook.command("remove")
+# def webhook_remove() -> None:
+#     """Remove the Slack webhook URL.
 
-    Example: valkyrie config webhook remove
-    """
-    if not CONFIG_LOCATION.exists():
-        raise click.ClickException("Config not found. Run `valkyrie config init` first.")
+#     Example: valkyrie config webhook remove
+#     """
+#     if not CONFIG_LOCATION.exists():
+#         raise click.ClickException("Config not found. Run `valkyrie config init` first.")
 
-    with open(CONFIG_LOCATION) as f:
-        current: dict[str, Any] = yaml.safe_load(f) or {}
+#     with open(CONFIG_LOCATION) as f:
+#         current: dict[str, Any] = yaml.safe_load(f) or {}
 
-    if "slack_webhook_url" not in current:
-        raise click.ClickException("No Slack webhook URL configured.")
+#     if "slack_webhook_url" not in current:
+#         raise click.ClickException("No Slack webhook URL configured.")
 
-    del current["slack_webhook_url"]
+#     del current["slack_webhook_url"]
 
-    with open(CONFIG_LOCATION, "w") as f:
-        yaml.dump(current, f, default_flow_style=False)
+#     with open(CONFIG_LOCATION, "w") as f:
+#         yaml.dump(current, f, default_flow_style=False)
 
-    click.echo(click.style("Slack webhook URL has been removed.", fg="green"))
+#     click.echo(click.style("Slack webhook URL has been removed.", fg="green"))
 
 
 @run.command(
@@ -966,7 +1008,7 @@ def push(agent_path: Path, name: str | None):
 
 @agent.command(name="remove", help="Remove an installed agent")
 @click.argument("agent_name", type=str)
-def remove(agent_name: str):
+def agent_remove(agent_name: str):
     """Remove an agent from S3.
 
     Example:

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -344,56 +344,6 @@ def auth_list() -> None:
         click.echo(f"  {name}: {masked}")
 
 
-# @config.group()
-# def webhook() -> None:
-#     """Manage Slack webhook URL for run notifications."""
-#     pass
-
-
-# @webhook.command("set")
-# @click.argument("url")
-# def webhook_set(url: str) -> None:
-#     """Set the Slack webhook URL for benchmark notifications.
-
-#     Example: valkyrie config webhook set https://hooks.slack.com/services/T00/B00/xxx
-#     """
-#     if not CONFIG_LOCATION.exists():
-#         raise click.ClickException("Config not found. Run `valkyrie config init` first.")
-
-#     with open(CONFIG_LOCATION) as f:
-#         harness_config: dict[str, Any] = yaml.safe_load(f) or {}
-
-#     harness_config["slack_webhook_url"] = url
-
-#     with open(CONFIG_LOCATION, "w") as f:
-#         yaml.dump(harness_config, f, default_flow_style=False)
-
-#     click.echo(click.style("Slack webhook URL has been set.", fg="green"))
-
-
-# @webhook.command("remove")
-# def webhook_remove() -> None:
-#     """Remove the Slack webhook URL.
-
-#     Example: valkyrie config webhook remove
-#     """
-#     if not CONFIG_LOCATION.exists():
-#         raise click.ClickException("Config not found. Run `valkyrie config init` first.")
-
-#     with open(CONFIG_LOCATION) as f:
-#         current: dict[str, Any] = yaml.safe_load(f) or {}
-
-#     if "slack_webhook_url" not in current:
-#         raise click.ClickException("No Slack webhook URL configured.")
-
-#     del current["slack_webhook_url"]
-
-#     with open(CONFIG_LOCATION, "w") as f:
-#         yaml.dump(current, f, default_flow_style=False)
-
-#     click.echo(click.style("Slack webhook URL has been removed.", fg="green"))
-
-
 @run.command(
     help="Start a run. \n\nExample:\nvalkyrie run start --agent agents/claude_code --benchmark swebench --concurrency 5"
 )

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -145,7 +145,7 @@ def set(key: str, value: str) -> None:
         config_value = ConfigValue.from_str(key)
     except ValueError:
         raise click.ClickException(
-            f"Key '{key}' is not a valid config key. Valid keys: {', '.join(ConfigValue.__members__.keys())}"
+            f"Key '{key}' is not a valid config key. Valid keys: {', '.join(ConfigValue.__members__.values())}"
         )
 
     current[config_value.value] = value

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -24,7 +24,7 @@ def _fetch_bucket_name() -> str:
     config = load_config()
     bucket_name = config.get("S3_BUCKET")
     if not bucket_name:
-        raise click.ClickException("S3_BUCKET key not found. Add it using 'valkyrie config modify' first.")
+        raise click.ClickException("S3_BUCKET key not found. Add it using 'valkyrie config set' first.")
 
     return bucket_name
 

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -27,6 +27,7 @@ from tracker.types import (
 )
 
 from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.utils import ConfigValue
 
 load_dotenv()
 
@@ -128,7 +129,7 @@ class TrackerService:
         with open(config_path) as f:
             harness_config = yaml.safe_load(f) or {}
 
-        url = harness_config.get("slack_webhook_url")
+        url = harness_config.get(ConfigValue.SLACK_WEBHOOK_URL.value)
         return url if url else None
 
     @staticmethod
@@ -146,11 +147,11 @@ class TrackerService:
         if missing:
             raise TrackerServiceError(
                 f"Missing required config keys: {', '.join(sorted(missing))}. "
-                "Run `valkyrie config init` to initialize the Valkyrie config or `valkyrie config modify` to update an existing config"
+                "Run `valkyrie config init` to initialize the Valkyrie config or `valkyrie config set` to update an existing config"
             )
 
         # Keys that are managed separately and should not be sent as harness headers
-        _SKIP_HEADER_KEYS = {"slack_webhook_url"}
+        _SKIP_HEADER_KEYS = {ConfigValue.SLACK_WEBHOOK_URL.value}
 
         # Skip custom_benchmark_services to avoid adding them inside of the header
         for key, value in harness_config.items():

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -6,6 +6,7 @@ import shutil
 import tarfile
 import tempfile
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Any, Coroutine, TypeVar
 from uuid import UUID
@@ -28,6 +29,32 @@ from valkyrie.cli.tracker_service import TrackerService
 CONFIG_LOCATION: Path = Path("~/.config/valkyrie/valkyrie.yaml").expanduser()
 
 T = TypeVar("T")
+
+
+class ConfigValue(str, Enum):
+    SLACK_WEBHOOK_URL = "slack_webhook_url"
+    AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+    AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+    AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION"
+    S3_BUCKET = "S3_BUCKET"
+    DAYTONA_SECRET_NAME = "DAYTONA_SECRET_NAME"
+    LOG_GROUP = "LOG_GROUP"
+    LOG_RETENTION_POLICY = "LOG_RETENTION_POLICY"
+
+    @classmethod
+    def from_str(cls, key: str) -> "ConfigValue":
+        """Convert string value to enum value, raising if value is not an option."""
+        normalized = key.lower()
+        # Extra mapping for aliases, to be used for backwards compatibility
+        aliases = {"webhook": cls.SLACK_WEBHOOK_URL}
+        if normalized in aliases:
+            return aliases[normalized]
+
+        for member in cls:
+            if member.value.lower() == normalized:
+                return member
+
+        raise ValueError(f"Invalid config key: {key!r}")
 
 
 async def run_with_spinner(coro: Coroutine[Any, Any, T], message: str) -> T:
@@ -375,7 +402,9 @@ def format_fetch_benchmarks_response(
     )
 
 
-def format_no_benchmarks_found(agent_name: str | None, benchmark_name: str | None, model: str | None, status: str | None) -> None:
+def format_no_benchmarks_found(
+    agent_name: str | None, benchmark_name: str | None, model: str | None, status: str | None
+) -> None:
     """
     Handle the case where no runs are found matching the specified filters.
 
@@ -676,9 +705,7 @@ def validate_intervals(intervals: tuple[int, ...]) -> list[int]:
     return interval_list
 
 
-def resolve_webhook_config(
-    intervals: tuple[int, ...], webhook_url: str | None
-) -> tuple[str | None, list[int] | None]:
+def resolve_webhook_config(intervals: tuple[int, ...], webhook_url: str | None) -> tuple[str | None, list[int] | None]:
     """Resolve webhook URL and intervals for a benchmark run.
 
     Args:

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -32,7 +32,7 @@ T = TypeVar("T")
 
 
 class ConfigValue(str, Enum):
-    SLACK_WEBHOOK_URL = "slack_webhook_url"
+    SLACK_WEBHOOK_URL = "webhook"
     AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
     AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
     AWS_DEFAULT_REGION = "AWS_DEFAULT_REGION"
@@ -44,14 +44,8 @@ class ConfigValue(str, Enum):
     @classmethod
     def from_str(cls, key: str) -> "ConfigValue":
         """Convert string value to enum value, raising if value is not an option."""
-        normalized = key.lower()
-        # Extra mapping for aliases, to be used for backwards compatibility
-        aliases = {"webhook": cls.SLACK_WEBHOOK_URL}
-        if normalized in aliases:
-            return aliases[normalized]
-
         for member in cls:
-            if member.value.lower() == normalized:
+            if member.value.lower() == key.lower():
                 return member
 
         raise ValueError(f"Invalid config key: {key!r}")


### PR DESCRIPTION
## Summary
As previously discussed a better paradigm for interacting with the config is through `set` rather than `modify`. `set` implies upsert while `modify` is only for changing. Also deprecated the webook group as it overlaps with this functionality. Setting the webhook is trivially close to the original command. We are using the same config key as before `slack_webhook_url` so no parsing logic will need to be changed.

```bash 
valk config set webhook xyz
```

### CLI Command images
**Setting a key that does not exist inside of the config values**
<img width="1085" height="57" alt="image" src="https://github.com/user-attachments/assets/96861b1a-fecf-4e27-a5a7-f7d5df162911" />

**Setting webhook**
```bash
valk config set webhook xy
```
**Key value pair set inside of config**
```yaml
slack_webhook_url: xyz
```

**Removing a key that is optional vs a required key**

```bash
jarettforzano@Jaretts-MacBook-Pro agentic-harness % valk config remove webhook
  webhook removed.
jarettforzano@Jaretts-MacBook-Pro agentic-harness % valk config remove LOG_GROUP
Error: Key 'LOG_GROUP' is required and cannot be removed. Consider using `valkyrie config set` to update it.
```

## Changes
- Changed modify to set
- Created a `class ConfigValue` enum which contains an exhaustive list of 1-1 mappings that exist for the set and remove command
- Deprecated webhook cli group
- Added remove command to the config group
- Pulled out environment variables required by `valk config init` to a constant that can be reused

## Related Issues
<!-- Link any related issues -->
Closes https://github.com/vals-ai/Valkyrie/issues/203

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [ X ] New feature
- [ ] Breaking change
- [ X ] Refactor
- [ X ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ X ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [X  ] Self-reviewed the diff
- [X ] No debug/dead code left in
- [ X] Docs updated if needed