### PR TITLE
Remove references to submodules + snippet on agent structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help install style format lint typecheck \
-	tracker-service update-submodules venv_check tool-install build
+	tracker-service venv_check tool-install build
 
 PYTHON_VERSION := 3.12
 
@@ -10,7 +10,6 @@ help:
 	@echo "Setup:"
 	@echo "  make install             Install cli dependencies"
 	@echo "  make tool-install        Install valkyrie as a global executable"
-	@echo "  make update-submodules   Init and update git submodules"
 	@echo ""
 	@echo "Development:"
 	@echo "  make style               Lint & Format"
@@ -49,11 +48,6 @@ build: venv_check
 		--clean \
 		src/valkyrie/cli/main.py
 	@echo "✓ Binary built at dist/valkyrie"
-
-update-submodules:
-	git submodule update --init --recursive
-	git submodule update --remote --merge
-	uv sync
 
 format: venv_check
 	@uv run ruff format .

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -138,19 +138,6 @@ Extra key-value pairs can be passed with `-k` and accessed via `kwargs`:
 valkyrie run start --agent agents/my_agent --benchmark swebench -k temperature 0.7
 ```
 
-## Directory Structure
-
-```
-agents/
-  my_agent/
-    contract.py           # Contract definition (required)
-    setup.sh              # Installation script (optional)
-    submodule/            # Agent code and dependencies (optional)
-      my_agent/
-        pyproject.toml
-        main.py
-```
-
 ## Installation Scripts
 
 The `install_cmd` runs inside the sandbox with the working directory set to `/bundle/<agent_name>/`. Use it to install dependencies and set up your agent.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,14 +25,6 @@ make install
 
 Creates `.venv` and installs dependencies from `pyproject.toml`.
 
-### Submodules
-
-```bash
-make update-submodules
-```
-
-Initializes git submodules for agents and services.
-
 ### Install as a tool globally
 
 ```bash


### PR DESCRIPTION
## Summary
Remove all references to submodules form the documentation. Agent submodules were deprecated a while ago but some references were left on accident. This pr addresses that

## Changes
Removed the following
- Submodule references in the readme
- Submodule references in the Makefile
- Submodule reference for file structure inside of the contract  docs

## Related Issues
Closes https://github.com/vals-ai/Valkyrie/issues/193

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [X  ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ X] Self-reviewed the diff
- [ ] No debug/dead code left in
- [X ] Docs updated if needed