### PR TITLE
Ignore custom benchmark services option

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ valkyrie run start \
   -H X-Custom-Header my-value \
   --task-ids "task_1,task_2" \
   --slice "0:10" \
-  -i 25 -i 75
+  -i 25 -i 75 \
+  --ignore-custom-services
 ```
 
 | Flag | Description |
@@ -230,6 +231,7 @@ valkyrie run start \
 | `--dataset` | Dataset variant to run from the benchmark service. A single benchmark can expose multiple datasets (e.g. `default`, `test`, `validation`, `train`, `lite`) representing different task splits or difficulty levels. Defaults to `default` |
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
 | `-i` / `--interval` | Progress percentage threshold for Slack notification. Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
+| `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
 
 ### Monitor a run
 

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -455,8 +455,7 @@ def webhook_remove() -> None:
 @click.option(
     "--ignore-custom-services",
     "--ics",
-    type=bool,
-    default=False,
+    is_flag=True,
     help="Ignore custom benchmark services that have been configured. Provides opt-out for custom services.",
 )
 def start(

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -452,6 +452,13 @@ def webhook_remove() -> None:
     type=int,
     help="Progress percentage threshold for Slack notification (e.g., -i 25 -i 75). Max 3, must be divisible by 5, range 5-100.",
 )
+@click.option(
+    "--ignore-custom-services",
+    "--ics",
+    type=bool,
+    default=False,
+    help="Ignore custom benchmark services that have been configured. Provides opt-out for custom services.",
+)
 def start(
     agent: str,
     model: str | None,
@@ -466,6 +473,7 @@ def start(
     secrets: tuple[tuple[str, str]],
     headers: tuple[tuple[str, str]],
     intervals: tuple[int, ...],
+    ignore_custom_services: bool,
 ):
     """
     Run an agent on a benchmark.
@@ -549,6 +557,7 @@ def start(
                 contract,
                 benchmark,
                 concurrency,
+                ignore_custom_services,
                 formatted_task_ids,
                 slice_str,
                 lambda_function,

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -202,6 +202,7 @@ class TrackerService:
         contract: AgentContractRequest,
         benchmark_name: str,
         concurrency: int,
+        ignore_custom_services: bool,
         task_ids: list[str] | None,
         slice_str: str | None,
         lambda_function: str | None = None,
@@ -237,7 +238,9 @@ class TrackerService:
                 lambda_function=lambda_function,
                 dataset=dataset,
                 harness_config=HarnessConfig.model_validate(self._build_harness_config_payload()),
-                custom_benchmark_service=self.get_benchmark_service_url(benchmark_name),
+                custom_benchmark_service=self.get_benchmark_service_url(benchmark_name)
+                if not ignore_custom_services
+                else None,
                 service_headers=service_headers or {},
                 webhook_url=webhook_url,
                 webhook_intervals=webhook_intervals,


### PR DESCRIPTION
## Summary
Previously introduced a feature allowing users to override the deployed version of a benchmark service and run a custom benchmark service by configuring it with ngrok. It is a bit inconvenient to constantly add and remove the benchmark service when you want to swap between something locally hosted and something in production. By adding a flag that ignores custom benchmark configs this part of the cli will be more usable.

## Changes
- Added `--ignore-custom-services` / `--ics`
- Ignore `get_benchmark_service_url` if `ignore_custom_services` is set

## Related Issues
Closes https://github.com/vals-ai/Valkyrie/issues/160

## Type of Change
- [ ] Bug fix
- [X  ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ X] Manually tested

## Checklist
- [ X] Self-reviewed the diff
- [ ] No debug/dead code left in
- [X ] Docs updated if needed