### PR TITLE
Added git action to validate prod pr contians semantic versioning tag

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,18 @@
+name: Semantic versioning check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [prod]
+
+jobs:
+  check-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR title for version tag
+        run: |
+          TITLE="${{ github.event.pull_request.title }}"
+          if [[ ! "$TITLE" =~ \#(minor|major|patch) ]]; then
+            echo "❌ PR title must contain #minor, #major or #patch. Visit https://github.com/vals-ai/Valkyrie/blob/dev/docs/DEVELOPMENT.md#versioning to learn more."
+            exit 1
+          fi

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,11 +68,11 @@ make typecheck   # basedpyright (strict mode)
 
 ## Versioning
 
-Commit message tags control automatic release bumps on the `dev` branch:
+Semantic versioning is used for the prod branch. Below demonstrates what is acceptable to include in the pr title for a deploy. Valkyrie uses [github-tag-action](https://github.com/anothrNick/github-tag-action) to automatically handle release versions as long as the pr title contains a required tag.  
 
 | Tag | Effect | Example |
 | --- | --- | --- |
-| _(none)_ | Patch bump | v0.4.0 -> v0.4.1 |
+| `#patch` | Patch bump | v0.4.0 -> v0.4.1 |
 | `#minor` | Minor bump | v0.4.1 -> v0.5.0 |
 | `#major` | Major bump | v0.5.0 -> v1.0.0 |
 


### PR DESCRIPTION
## Summary
Adds a git action that only runs when a prod pr has been opened. This git action checks if the pr title contains one of the valid tags to increment the version (#patch, #minor, #major).

I was able to test this by opening a pr from this branch to prod

## Changes
- Git action to run when we open a prod pr
- Updated docs for semantic versioning since it was outadated

## Related Issues
Closes https://github.com/vals-ai/Valkyrie/issues/197

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [X ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ X] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [X] Self-reviewed the diff
- [ ] No debug/dead code left in
- [X ] Docs updated if needed