### PR TITLE
Deprecate localhost fallback

### DIFF
--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -25,7 +25,6 @@ from constants import (
     CONTAINER_HEALTH_RETRIES,
     CONTAINER_HEALTH_START_PERIOD_SECONDS,
     CONTAINER_HEALTH_TIMEOUT_SECONDS,
-    NAMESPACE,
     POSTGRES_DB,
     POSTGRES_PORT,
     POSTGRES_USER,
@@ -81,7 +80,6 @@ class TrackerStack(Stack):
         # Shared environment variables
         shared_env = {
             "BROKER_ENVIRONMENT": "production",
-            "BENCHMARK_SERVICE_NAMESPACE": NAMESPACE,
             "AWS_S3_BUCKET": bucket.bucket_name,
         }
 

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -19,7 +19,6 @@ from aws_cdk import (
 )
 from aws_cdk.aws_ecr_assets import Platform
 from constants import (
-    NAMESPACE,
     POSTGRES_DB,
     WORKER_CPU,
     WORKER_MAX_TASKS,
@@ -76,7 +75,6 @@ class WorkerStack(Stack):
 
         shared_env = {
             "BROKER_ENVIRONMENT": "production",
-            "BENCHMARK_SERVICE_NAMESPACE": NAMESPACE,
             "AWS_S3_BUCKET": bucket.bucket_name,
         }
 

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -12,8 +12,8 @@ from tracker.task_protection import TaskProtectionMiddleware
 
 load_dotenv()
 
-BENCHMARK_SERVICE_NAMESPACE = os.environ.get("BENCHMARK_SERVICE_NAMESPACE")
-BENCHMARK_SERVICE_PORT = 8001
+_BENCHMARK_SERVICE_NAMESPACE: str = "local"
+_BENCHMARK_SERVICE_PORT = 8001
 
 
 def create_benchmark_service_url(benchmark_name: str) -> str:
@@ -22,8 +22,8 @@ def create_benchmark_service_url(benchmark_name: str) -> str:
 
     NOTE: If we are running this locally the namespace is blank
     """
-    host = f"{benchmark_name}.{BENCHMARK_SERVICE_NAMESPACE}" if BENCHMARK_SERVICE_NAMESPACE else benchmark_name
-    return f"http://{host}:{BENCHMARK_SERVICE_PORT}"
+    host = f"{benchmark_name}.{_BENCHMARK_SERVICE_NAMESPACE}"
+    return f"http://{host}:{_BENCHMARK_SERVICE_PORT}"
 
 
 AWS_S3_BUCKET = os.environ.get("AWS_S3_BUCKET", "agentic-harness")


### PR DESCRIPTION
## Summary
Deprecate the localhost fallback we used to have with the tracker service. This used to work when we had a docker compose file with the benchmark service on the same internal network as the tracker service but we removed it in favor of a reverse tunnel since it was a more realistic way for users to test. This code is removed to reduce confusion.

NOTE: Nothing changes

## Changes
- Removed `BENCHMARK_SERVICE_NAMESPACE` env var and instead just made it a const in the tracker
- Removed `BENCHMARK_SERVICE_NAMESPACE` references from inside of the infra/ folder since its not hardcoded

## Related Issues
Closes https://github.com/vals-ai/Valkyrie/issues/198

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ X ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [X ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ X] Self-reviewed the diff
- [ X] No debug/dead code left in
- [ ] Docs updated if needed