### PR TITLE
Revert blocking session command polling

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -236,7 +236,6 @@ async def install_agent_dependencies(
     log_output(f"Finished installing dependencies for contract: {contract.name}")
 
 
-SESSION_COMMAND_POLL_INTERVAL_SECONDS = 5.0
 LOG_STREAM_RETRY_DELAY_SECONDS = 1.0
 WEBSOCKET_STREAM_ERRORS = ("websocket", "http 502", "opening handshake", "no close frame", "1011")
 
@@ -287,20 +286,6 @@ async def stream_session_command_logs(
         on_output(f"[WARNING] {warning}\n")
 
 
-async def wait_for_session_command_completion(
-    sandbox: AsyncSandbox,
-    session_id: str,
-    command_id: str,
-    poll_interval_seconds: float = SESSION_COMMAND_POLL_INTERVAL_SECONDS,
-) -> Any:
-    """Poll command status until the command exits."""
-    while True:
-        cmd = await sandbox.process.get_session_command(session_id, command_id)
-        if cmd.exit_code is not None:
-            return cmd
-        await asyncio.sleep(poll_interval_seconds)
-
-
 async def stream_command_output(
     sandbox: AsyncSandbox,
     command: str,
@@ -308,7 +293,7 @@ async def stream_command_output(
 ) -> None:
     """
     Execute a command inside of a sandbox using a session and stream the output to the given callbacks.
-    Command completion is authoritative; log streaming is best-effort only.
+    Log streaming is best-effort. Command status is checked once before cleanup.
     """
     session_id = f"{sandbox.id}:{str(uuid.uuid4())}"
     log_task: asyncio.Task[None] | None = None
@@ -327,14 +312,20 @@ async def stream_command_output(
                 on_output=on_output,
             )
         )
-        cmd = await wait_for_session_command_completion(sandbox, session_id, cmd_id)
         if log_task is not None and not log_task.done():
             with suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(asyncio.shield(log_task), timeout=1)
 
-        # Exit code 124 = timeout(1) killed the process; treat as success so evaluation still runs
-        if cmd.exit_code not in (0, 124):
-            raise SandboxError(f"Failed to run command {command}, exit code: {cmd.exit_code}")
+        try:
+            cmd = await sandbox.process.get_session_command(session_id, cmd_id)
+
+            # Exit code 124 = timeout(1) killed the process; treat as success so evaluation still runs
+            if cmd.exit_code not in (0, 124):
+                raise SandboxError(f"Failed to run command {command}, exit code: {cmd.exit_code}")
+        except SandboxError:
+            raise
+        except Exception as error:
+            logger.warning(f"Failed to get session command for {session_id}: {error}")
 
     finally:
         if log_task is not None and not log_task.done():


### PR DESCRIPTION
## Summary
- revert the blocking `get_session_command(...)` polling loop
- keep Daytona websocket log streaming best-effort fallback intact
- restore the old one-shot command status lookup before session cleanup

## Why
The websocket fallback change also changed `get_session_command(...)` from a one-shot best-effort check into a blocking loop. If Daytona transiently loses command lookup, that amplifies task failures. This PR keeps the log-stream fix while removing that stronger command-status dependency.