### PR TITLE
Patch edge case with race condition

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -973,6 +973,19 @@ async def force_stop_sandboxes(
         f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
     )
 
+    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
+    finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+    tasks_still_running: int = session.exec(
+        select(func.count(col(Task.id)))
+        .where(col(Task.benchmark) == benchmark_row.id)
+        .where(col(Task.status).notin_(finished_statuses))
+    ).one()
+
+    if not tasks_still_running:
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        session.add(benchmark_row)
+        session.commit()
+
     if error_message:
         raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
 

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -124,9 +124,21 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tracker.cloudwatch.cloudwatch_stream", _mock_cloudwatch_stream)
     monkeypatch.setattr("tracker.utils.create_benchmark_group", _mock_create_benchmark_group)
     monkeypatch.setattr("tracker.utils.cloudwatch_stream", _mock_cloudwatch_stream)
+    monkeypatch.setattr("tracker.utils.reset_cloudwatch_stream", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("tracker.utils.upload_final_view", _mock_upload_final_view)
     monkeypatch.setattr("tracker.secrets.fetch_aws_secret", _mock_fetch_aws_secret)
     monkeypatch.setattr("tracker.utils.fetch_aws_secret", _mock_fetch_aws_secret)
+
+
+@pytest.fixture(autouse=True)
+def mock_sandbox_operations(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mocks sandbox operations so unit tests never run real sandbox commands"""
+
+    async def _noop(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    monkeypatch.setattr("tracker.utils.upload_agent_artifacts", _noop)
+    monkeypatch.setattr("tracker.utils.run_agent", _noop)
 
 
 @pytest.fixture(autouse=True)

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -16,6 +16,7 @@ from tracker.utils import (
     TaskMonitor,
     TrackedTask,
     TrackedTaskStatus,
+    force_stop_sandboxes,
     initiate_stop_benchmark,
     process_benchmark,
     reset_to_in_progress_status,
@@ -232,3 +233,58 @@ class TestStopAndResume:
         cancel_mock.assert_called_once()
         assert monitor._task_tracking == {}
         tracked_task._coro.close()
+
+    async def test_force_stop_edge_case(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        """
+        Reproduces the bug where force stop is called after the worker has already
+        finished processing all tasks. The benchmark gets set to STOPPING but nothing
+        transitions it to STOPPED because the worker's process_benchmark has already exited.
+
+        Test Case:
+        - All tasks are in a finished state
+        - Benchmark status is set to stopping
+        - Force stopping results in the benchmark status being STOPPED
+        """
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        # All tasks are already in a finished state
+        tasks = [
+            Task(task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+            Task(task_id="task_1", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+            Task(task_id="task_2", benchmark=benchmark_row.id, status=TaskStatus.ERROR),
+            Task(task_id="task_3", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+        ]
+        database_session.add_all(tasks)
+        database_session.commit()
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+
+        # Set benchmark status to STOPPING
+        await initiate_stop_benchmark(benchmark_row, database_session, force=True)
+        assert benchmark_row.status == BenchmarkStatus.STOPPING
+
+        # Mock daytona client since its not required
+        mock_daytona = AsyncMock()
+        mock_daytona.list = AsyncMock(return_value=AsyncMock(items=[], total_pages=0, page=1))
+        monkeypatch.setattr(
+            Benchmark,
+            "benchmark_service",
+            lambda *_args, **_kwargs: Mock(daytona_client=mock_daytona),  # type: ignore
+        )
+
+        # Force stopping the sandboxes results in the benchmark row being stopped
+        await force_stop_sandboxes(
+            benchmark_row, database_session, harness_config.daytona_secret_name, harness_config.aws
+        )
+
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.STOPPED


### PR DESCRIPTION
## Summary
There is an edge case which causes the benchmark to be stuck in a STOPPING status. This is caused when the worker exits before the force stop benchmark endpoint finishes running. The solution is simple, do not assume the worker task is running and instead clean up the final task manually inside of the endpoint.

## Changes
- At the end of the endpoint, check and update the final benchmark status if no tasks are being processed
- Add regression tests (confirmed applied patch works)

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [ X ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X  ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ X] Added/updated unit tests
- [ X] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ X] Self-reviewed the diff
- [ X] No debug/dead code left in
- [ ] Docs updated if needed