### PR TITLE
Add Tracker API contract for Platform benchmark UI

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import joinedload
 from sqlmodel import Session, select
 
 from tracker.cloudwatch import get_cloudwatch_url
-from tracker.database.models import Benchmark, BenchmarkStatus
+from tracker.database.models import Benchmark, BenchmarkStatus, EvaluationResult, Task
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
@@ -27,8 +27,10 @@ from tracker.s3 import (
 )
 from tracker.types import (
     BenchmarkTableRow,
+    BenchmarkTaskRow,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
+    FetchBenchmarkTasksResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
     HarnessConfig,
@@ -233,10 +235,17 @@ async def fetch_benchmark(
     return FetchBenchmarkResponse(
         benchmark_name=benchmark_row.name,
         benchmark_id=benchmark_row.id,
+        agent_name=benchmark_row.arguments.contract.name,
+        model=benchmark_row.arguments.contract.model,
+        concurrency=benchmark_row.arguments.concurrency,
+        cloudwatch_url=get_cloudwatch_url(
+            str(benchmark_row.id), harness_config.aws.aws_default_region, harness_config.log_group
+        ),
         details=benchmark_context.benchmark_details,
         s3_bucket_url=create_benchmark_url(
             str(benchmark_row.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
         ),
+        platform_context=benchmark_row.arguments.platform_context,
     )
 
 
@@ -448,6 +457,38 @@ async def fetch_benchmark_metadata(
         raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
 
     return benchmark_row.benchmark_metadata
+
+
+@app.get("/fetch-benchmark-tasks")
+async def fetch_benchmark_tasks(
+    benchmark_id: TrackedBenchmarkId,
+    session: Session = Depends(get_session),
+) -> FetchBenchmarkTasksResponse:
+    benchmark_row = session.get(Benchmark, benchmark_id)
+    if not benchmark_row:
+        raise HTTPException(status_code=404, detail=f"Benchmark with id {benchmark_id} not found")
+
+    statement = (
+        select(Task, EvaluationResult.result)
+        .where(Task.benchmark == benchmark_id)
+        .join(EvaluationResult, Task.id == EvaluationResult.task, isouter=True)
+        .order_by(Task.task_id)
+    )
+    rows = session.exec(statement).all()
+
+    tasks = [
+        BenchmarkTaskRow(
+            task_id=task.task_id,
+            status=task.status,
+            started_at=task.started_at,
+            finished_at=task.finished_at,
+            error_message=task.error_message,
+            evaluation_result=evaluation_result,
+        )
+        for task, evaluation_result in rows
+    ]
+
+    return FetchBenchmarkTasksResponse(benchmark_id=benchmark_id, tasks=tasks)
 
 
 @app.get("/fetch-agent-outputs/{benchmark_id}")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
@@ -63,6 +63,20 @@ class AgentContractRequest(BaseModel):
     secrets: dict[str, str] = {}
 
 
+class PlatformContext(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    project_id: UUID
+    launch_source: Literal["valkyrie_hosted"]
+    project_slug: str | None = None
+    org: str | None = None
+    run_by: str | None = None
+
+    @field_serializer("project_id")
+    def serialize_project_id(self, value: UUID) -> str:
+        return str(value)
+
+
 class BenchmarkArguments(BaseModel):
     model_config = {"extra": "forbid"}
 
@@ -72,6 +86,7 @@ class BenchmarkArguments(BaseModel):
     slice_str: str | None = None
     lambda_function: str | None = None
     dataset: str | None = None
+    platform_context: PlatformContext | None = None
 
 
 class FinalEvaluation(SQLModel, table=True):
@@ -173,6 +188,7 @@ class Benchmark(SQLModel, table=True):
             slice_str=self.arguments.slice_str,
             lambda_function=self.arguments.lambda_function,
             dataset=self.arguments.dataset,
+            platform_context=self.arguments.platform_context,
             harness_config=harness_config,
             custom_benchmark_service=self.custom_benchmark_service,
             webhook_secret_name=self.webhook_secret_name,

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -16,6 +16,7 @@ from tracker.database.models import (
     BenchmarkArguments,
     BenchmarkStatus,
     FinalEvaluation,
+    PlatformContext,
     TaskStatus,
 )
 
@@ -50,6 +51,7 @@ class StartBenchmarkRequest(BaseModel):
     slice_str: str | None = None
     lambda_function: str | None = None
     dataset: str | None = None
+    platform_context: PlatformContext | None = None
     harness_config: HarnessConfig
     custom_benchmark_service: str | None = None
     service_headers: dict[str, str] = {}
@@ -89,8 +91,13 @@ class StartBenchmarkResponse(BaseModel):
 class FetchBenchmarkResponse(BaseModel):
     benchmark_name: str
     benchmark_id: UUID
+    agent_name: str
+    model: str | None
+    concurrency: int
+    cloudwatch_url: str
     details: BenchmarkDetails
     s3_bucket_url: str
+    platform_context: PlatformContext | None
 
 
 class FinalViewResponse(BaseModel):
@@ -137,6 +144,7 @@ class FetchBenchmarksRequest(BaseModel):
     agent_name: str | None = None
     benchmark_name: str | None = None
     model: str | None = None
+    project_id: UUID | None = None
     status: BenchmarkStatus | None = None
     order_by: Order = Order.DESC  # Order is based off the time the benchmark was started at
 
@@ -166,3 +174,17 @@ class FetchBenchmarkMetadataResponse(BaseModel):
     benchmark_id: UUID
     benchmark_name: str
     benchmark_arguments: BenchmarkArguments
+
+
+class BenchmarkTaskRow(BaseModel):
+    task_id: str
+    status: TaskStatus
+    started_at: datetime
+    finished_at: datetime | None
+    error_message: str | None
+    evaluation_result: dict[str, Any] | None
+
+
+class FetchBenchmarkTasksResponse(BaseModel):
+    benchmark_id: UUID
+    tasks: list[BenchmarkTaskRow]

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -104,6 +104,7 @@ def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest) -> Benc
             slice_str=request.slice_str,
             lambda_function=request.lambda_function,
             dataset=request.dataset,
+            platform_context=request.platform_context,
         ),
     )
 
@@ -849,10 +850,17 @@ async def stream_benchmark_results(
                 response_data = FetchBenchmarkResponse(
                     benchmark_name=fresh_benchmark.name,
                     benchmark_id=fresh_benchmark.id,
+                    agent_name=fresh_benchmark.arguments.contract.name,
+                    model=fresh_benchmark.arguments.contract.model,
+                    concurrency=fresh_benchmark.arguments.concurrency,
+                    cloudwatch_url=get_cloudwatch_url(
+                        str(fresh_benchmark.id), harness_config.aws.aws_default_region, harness_config.log_group
+                    ),
                     details=benchmark_context.benchmark_details,
                     s3_bucket_url=create_benchmark_url(
                         str(fresh_benchmark.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
                     ),
+                    platform_context=fresh_benchmark.arguments.platform_context,
                 )
 
                 yield f"{DATA_PREFIX} {response_data.model_dump_json()}\n\n"
@@ -1096,6 +1104,9 @@ def fetch_filtered_benchmark_rows(request: FetchBenchmarksRequest, session: Sess
 
     if request.model:
         query = query.where(arguments_json["contract"]["model"].as_string() == request.model)
+
+    if request.project_id:
+        query = query.where(arguments_json["platform_context"]["project_id"].as_string() == str(request.project_id))
 
     if request.benchmark_name:
         query = query.where(Benchmark.name == request.benchmark_name)

--- a/services/tracker/tests/conftest.py
+++ b/services/tracker/tests/conftest.py
@@ -1,6 +1,7 @@
 from collections.abc import Generator
 from sqlite3 import Connection, Cursor
 from typing import Any, cast
+from uuid import uuid4
 
 import pytest
 from dotenv import load_dotenv
@@ -9,7 +10,7 @@ from sqlalchemy.pool import ConnectionPoolEntry
 from sqlmodel import Session, SQLModel, StaticPool, create_engine
 
 from tracker.database.models import *  # noqa: F403
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkArguments
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkArguments, PlatformContext
 
 _ = load_dotenv()
 
@@ -48,4 +49,15 @@ def example_benchmark_object(contract: AgentContractRequest) -> Benchmark:
     return Benchmark(
         name="swebench",
         arguments=BenchmarkArguments(contract=contract, concurrency=5, task_ids=None, slice_str=None),
+    )
+
+
+@pytest.fixture
+def platform_context() -> PlatformContext:
+    return PlatformContext(
+        project_id=uuid4(),
+        launch_source="valkyrie_hosted",
+        project_slug="benchmarking",
+        org="vals",
+        run_by="hung@vals.ai",
     )

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -18,6 +18,7 @@ from tracker.database.models import (
     BenchmarkStatus,
     EvaluationResult,
     FinalEvaluation,
+    PlatformContext,
     Task,
     TaskStatus,
 )
@@ -56,6 +57,7 @@ class TestFastapiServer:
     async def test_start_benchmark(
         self,
         contract: AgentContractRequest,
+        platform_context: PlatformContext,
         monkeypatch: MonkeyPatch,
         database_session: Session,
         harness_config: HarnessConfig,
@@ -76,6 +78,7 @@ class TestFastapiServer:
             benchmark_name="swebench",
             concurrency=10,
             task_ids=None,
+            platform_context=platform_context,
             harness_config=harness_config,
         )
 
@@ -108,6 +111,7 @@ class TestFastapiServer:
             concurrency=request.concurrency,
             task_ids=None,
             slice_str=None,
+            platform_context=request.platform_context,
         )
 
         # Test case 3. Start timestamp is in UTC timezone and matches the benchmark row
@@ -121,7 +125,86 @@ class TestFastapiServer:
         assert json_response["agent_name"] == request.contract.name
         assert json_response["concurrency"] == request.concurrency
 
-    async def test_fetch_benchmark(self, database_session: Session, example_benchmark_object: Benchmark):
+    async def test_fetch_benchmark_metadata(
+        self,
+        database_session: Session,
+        contract: AgentContractRequest,
+        platform_context: PlatformContext,
+    ):
+        benchmark_row = Benchmark(
+            name="vcb",
+            arguments=BenchmarkArguments(
+                contract=contract,
+                concurrency=5,
+                task_ids=None,
+                slice_str=None,
+                platform_context=platform_context,
+            ),
+        )
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        response = client.get(f"/fetch-benchmark-metadata/{benchmark_row.id}")
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["benchmark_id"] == str(benchmark_row.id)
+        assert response_json["benchmark_name"] == benchmark_row.name
+        assert response_json["benchmark_arguments"]["platform_context"] == platform_context.model_dump(mode="json")
+
+    async def test_fetch_benchmark_tasks(self, database_session: Session, example_benchmark_object: Benchmark):
+        response = client.get("/fetch-benchmark-tasks", params={"benchmark_id": str(uuid4())})
+        assert response.status_code == 404
+
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        first_task = Task(task_id="task_b", benchmark=benchmark_row.id, status=TaskStatus.FINISHED)
+        second_task = Task(task_id="task_a", benchmark=benchmark_row.id, status=TaskStatus.ERROR, error_message="boom")
+        database_session.add_all([first_task, second_task])
+        database_session.commit()
+
+        database_session.add(
+            EvaluationResult(
+                task=first_task.id,
+                instance_id=str(uuid4()),
+                result={"score": 0.75, "details": {"resolved": True}},
+            )
+        )
+        database_session.commit()
+
+        response = client.get("/fetch-benchmark-tasks", params={"benchmark_id": str(benchmark_row.id)})
+
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json["benchmark_id"] == str(benchmark_row.id)
+        assert [task["task_id"] for task in response_json["tasks"]] == ["task_a", "task_b"]
+
+        first_row, second_row = response_json["tasks"]
+        assert first_row == {
+            "task_id": "task_a",
+            "status": "ERROR",
+            "started_at": first_row["started_at"],
+            "finished_at": first_row["finished_at"],
+            "error_message": "boom",
+            "evaluation_result": None,
+        }
+        assert second_row == {
+            "task_id": "task_b",
+            "status": "FINISHED",
+            "started_at": second_row["started_at"],
+            "finished_at": second_row["finished_at"],
+            "error_message": None,
+            "evaluation_result": {"score": 0.75, "details": {"resolved": True}},
+        }
+
+    async def test_fetch_benchmark(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+        platform_context: PlatformContext,
+    ):
         """
         Test fetch benchmark of the fastapi server.
 
@@ -139,6 +222,7 @@ class TestFastapiServer:
 
         # Add benchmark row to the database to fetch
         benchmark_row = example_benchmark_object
+        benchmark_row.arguments.platform_context = platform_context
 
         database_session.add(benchmark_row)
         database_session.commit()
@@ -154,8 +238,15 @@ class TestFastapiServer:
 
         # Test case 2. Returns 200 OK
         assert response.status_code == 200
-        details = response.json().get("details")
+        response_json = response.json()
+        details = response_json.get("details")
         assert details
+        assert response_json["benchmark_name"] == benchmark_row.name
+        assert response_json["agent_name"] == benchmark_row.arguments.contract.name
+        assert response_json["model"] == benchmark_row.arguments.contract.model
+        assert response_json["concurrency"] == benchmark_row.arguments.concurrency
+        assert response_json["platform_context"] == platform_context.model_dump(mode="json")
+        assert response_json["cloudwatch_url"]
 
         # Test case 3. Benchmark details are returned in the response
         # NOTE: Let's just check the fields that are being tracked and are due to change
@@ -385,7 +476,12 @@ class TestFastapiServer:
         assert benchmark_row.status == BenchmarkStatus.ERROR
         assert benchmark_row.error_message == detail.get("error_message")
 
-    async def test_fetch_benchmarks(self, database_session: Session, example_benchmark_object: Benchmark):
+    async def test_fetch_benchmarks(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+        platform_context: PlatformContext,
+    ):
         """
         Test fetch benchmarks of the fastapi server.
 
@@ -408,6 +504,7 @@ class TestFastapiServer:
         assert response_json.get("total_count") == 0
 
         # Add benchmark row to the database to fetch
+        example_benchmark_object.arguments.platform_context = platform_context
         database_session.add(example_benchmark_object)
         database_session.commit()
 
@@ -444,6 +541,22 @@ class TestFastapiServer:
         database_session.add(unique_benchmark)
         database_session.commit()
 
+        other_project_benchmark = Benchmark(
+            name="vcb",
+            arguments=BenchmarkArguments(
+                contract=example_benchmark_object.arguments.contract,
+                concurrency=5,
+                task_ids=None,
+                slice_str=None,
+                platform_context=PlatformContext(
+                    project_id=uuid4(),
+                    launch_source="valkyrie_hosted",
+                ),
+            ),
+        )
+        database_session.add(other_project_benchmark)
+        database_session.commit()
+
         # Search for the 4 benchmarks just created + the original one we added before
         fetch_benchmarks_request.benchmark_name = "swebench"
         fetch_benchmarks_request.agent_name = "dummy"
@@ -473,11 +586,25 @@ class TestFastapiServer:
         assert response.status_code == 200
         response_json = response.json()
 
-        # There are 6 total benchmarks
-        assert response_json.get("total_count") == 6
+        # There are 7 total benchmarks
+        assert response_json.get("total_count") == 7
 
         # Limit will always be 5
         assert len(response_json.get("benchmarks")) == 5
+
+        fetch_benchmarks_request.project_id = platform_context.project_id
+        response = client.get(
+            "/fetch-benchmarks", params=fetch_benchmarks_request.model_dump(exclude_none=True, mode="json")
+        )
+        assert response.status_code == 200
+        response_json = response.json()
+        assert response_json.get("total_count") == 5
+        assert len(response_json.get("benchmarks")) == 5
+        for row in response_json["benchmarks"]:
+            assert row["name"] == "swebench"
+            assert row["agent_name"] == "dummy"
+
+        fetch_benchmarks_request.project_id = None
 
         # Change benchmark status to finished and search again
         unique_benchmark.status = BenchmarkStatus.FINISHED


### PR DESCRIPTION
## Summary
- add `platform_context` to Tracker benchmark arguments and request metadata
- enrich Tracker benchmark detail/list APIs for Platform benchmark routing and display
- add `fetch-benchmark-tasks` for generic task rows with raw evaluation payloads
- cover the new FastAPI contract with focused unit tests

## Validation
- `cd services/tracker && .venv/bin/python -m pytest tests/unit/test_fastapi_server.py -q`
- `cd services/tracker && .venv/bin/python -m pytest tests/unit/test_benchmark_utils.py tests/unit/test_stop_and_resume.py -q`
- `cd services/tracker && python -m py_compile src/tracker/database/models.py src/tracker/types.py src/tracker/utils.py main.py`