### PR TITLE
feat: add cloudwatch dashboards and alarms 

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -3,6 +3,7 @@
 import os
 
 import aws_cdk as cdk
+from monitoring_stack import MonitoringStack
 from shared import SharedStack
 from tracker_stack import TrackerStack
 from worker_stack import WorkerStack
@@ -44,8 +45,22 @@ worker = WorkerStack(
     env=env,
 )
 
+monitoring = MonitoringStack(
+    app,
+    "MonitoringStack",
+    cluster=shared.cluster,
+    tracker_service=tracker.tracker_fargate_service,
+    worker_service=worker.worker_service,
+    load_balancer=tracker.service.load_balancer,
+    target_group=tracker.service.target_group,
+    database=tracker.database,
+    redis_cluster=shared.redis_cluster,
+    env=env,
+)
+
 # Deployment order
 tracker.add_dependency(shared)
 worker.add_dependency(tracker)
+monitoring.add_dependency(worker)
 
 app.synth()

--- a/infra/dashboards.py
+++ b/infra/dashboards.py
@@ -1,0 +1,862 @@
+"""Factory functions for Valkyrie CloudWatch dashboards.
+
+Each function takes a scope (the MonitoringStack) plus the resource refs
+it needs and returns a configured ``aws_cloudwatch.Dashboard``.
+"""
+
+from __future__ import annotations
+
+import aws_cdk as cdk
+from aws_cdk import (
+    aws_cloudwatch,
+    aws_ecs,
+    aws_elasticache,
+    aws_elasticloadbalancingv2 as aws_elb,
+    aws_rds,
+)
+from constructs import Construct
+
+# Default widget height for dashboard layouts. CloudWatch grids are 24 units wide.
+_WIDGET_HEIGHT = 6
+_SINGLE_VALUE_HEIGHT = 3
+
+
+def create_overview_dashboard(
+    scope: Construct,
+    *,
+    tracker_service: aws_ecs.FargateService,
+    worker_service: aws_ecs.FargateService,
+    load_balancer: aws_elb.ApplicationLoadBalancer,
+    target_group: aws_elb.ApplicationTargetGroup,
+    database: aws_rds.DatabaseInstance,
+    redis_cluster: aws_elasticache.CfnCacheCluster,
+) -> aws_cloudwatch.Dashboard:
+    """`Valkyrie-Overview` - Single-value widgets + sparklines."""
+    dashboard = aws_cloudwatch.Dashboard(
+        scope,
+        "ValkyrieOverviewDashboard",
+        dashboard_name="Valkyrie-Overview",
+        default_interval=cdk.Duration.hours(3),
+        period_override=aws_cloudwatch.PeriodOverride.AUTO,
+    )
+
+    dashboard.add_widgets(
+        aws_cloudwatch.TextWidget(
+            markdown=(
+                "# Valkyrie Overview\n"
+                "Infra health at a glance. Red/green widgets show current alarm state.\n"
+                "For drill-downs: **Valkyrie-ECS**, **Valkyrie-ALB**, "
+                "**Valkyrie-RDS**, **Valkyrie-Redis**."
+            ),
+            width=24,
+            height=2,
+        ),
+    )
+
+    # Row 1: availability signals (single-value)
+    dashboard.add_widgets(
+        aws_cloudwatch.SingleValueWidget(
+            title="Tracker Healthy Hosts",
+            metrics=[
+                target_group.metric_healthy_host_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Minimum",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+        aws_cloudwatch.SingleValueWidget(
+            title="Worker Running Tasks",
+            metrics=[
+                aws_cloudwatch.Metric(
+                    namespace="AWS/ECS",
+                    metric_name="RunningTaskCount",
+                    dimensions_map={
+                        "ClusterName": worker_service.cluster.cluster_name,
+                        "ServiceName": worker_service.service_name,
+                    },
+                    statistic="Maximum",
+                    period=cdk.Duration.minutes(1),
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+        aws_cloudwatch.SingleValueWidget(
+            title="API p99 Latency (s)",
+            metrics=[
+                load_balancer.metric_target_response_time(
+                    period=cdk.Duration.minutes(1),
+                    statistic="p99",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+        aws_cloudwatch.SingleValueWidget(
+            title="API 5XX / 5min",
+            metrics=[
+                load_balancer.metric_http_code_target(
+                    code=aws_elb.HttpCodeTarget.TARGET_5XX_COUNT,
+                    period=cdk.Duration.minutes(5),
+                    statistic="Sum",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+    )
+
+    # Row 2: traffic + ECS saturation
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="API Request Rate",
+            left=[
+                load_balancer.metric_request_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                )
+            ],
+            width=8,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Tracker CPU / Memory (%)",
+            left=[
+                tracker_service.metric_cpu_utilization(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            right=[
+                tracker_service.metric_memory_utilization(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            width=8,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Worker CPU / Memory (%)",
+            left=[
+                worker_service.metric_cpu_utilization(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            right=[
+                worker_service.metric_memory_utilization(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            width=8,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 3: DB health
+    dashboard.add_widgets(
+        aws_cloudwatch.SingleValueWidget(
+            title="DB Connections",
+            metrics=[
+                database.metric_database_connections(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Maximum",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+        aws_cloudwatch.SingleValueWidget(
+            title="DB CPU (%)",
+            metrics=[
+                database.metric_cpu_utilization(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+        aws_cloudwatch.SingleValueWidget(
+            title="DB Free Storage (bytes)",
+            metrics=[
+                database.metric_free_storage_space(
+                    period=cdk.Duration.minutes(5),
+                    statistic="Minimum",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+        aws_cloudwatch.SingleValueWidget(
+            title="Redis Memory Usage (%)",
+            metrics=[
+                redis_metric(
+                    redis_cluster,
+                    "DatabaseMemoryUsagePercentage",
+                    statistic="Average",
+                )
+            ],
+            width=6,
+            height=_SINGLE_VALUE_HEIGHT,
+            sparkline=True,
+        ),
+    )
+
+    # Row 4: Redis evictions (stand-alone so it's visually isolated - should be zero)
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Redis Evictions (should be 0)",
+            left=[
+                redis_metric(
+                    redis_cluster,
+                    "Evictions",
+                    statistic="Sum",
+                    period=cdk.Duration.minutes(5),
+                )
+            ],
+            width=24,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    return dashboard
+
+
+def create_ecs_dashboard(
+    scope: Construct,
+    *,
+    tracker_service: aws_ecs.FargateService,
+    worker_service: aws_ecs.FargateService,
+) -> aws_cloudwatch.Dashboard:
+    """`Valkyrie-ECS` -- detailed Tracker + Worker metrics."""
+    dashboard = aws_cloudwatch.Dashboard(
+        scope,
+        "ValkyrieEcsDashboard",
+        dashboard_name="Valkyrie-ECS",
+        default_interval=cdk.Duration.hours(24),
+        period_override=aws_cloudwatch.PeriodOverride.AUTO,
+    )
+
+    for service, name in ((tracker_service, "Tracker"), (worker_service, "Worker")):
+        dashboard.add_widgets(
+            aws_cloudwatch.TextWidget(
+                markdown=f"## {name} Service",
+                width=24,
+                height=1,
+            ),
+        )
+        dashboard.add_widgets(
+            aws_cloudwatch.GraphWidget(
+                title=f"{name} CPU Utilization (%)",
+                left=[
+                    service.metric_cpu_utilization(
+                        period=cdk.Duration.minutes(1),
+                        statistic="Average",
+                    )
+                ],
+                width=8,
+                height=_WIDGET_HEIGHT,
+            ),
+            aws_cloudwatch.GraphWidget(
+                title=f"{name} Memory Utilization (%)",
+                left=[
+                    service.metric_memory_utilization(
+                        period=cdk.Duration.minutes(1),
+                        statistic="Average",
+                    )
+                ],
+                width=8,
+                height=_WIDGET_HEIGHT,
+            ),
+            aws_cloudwatch.GraphWidget(
+                title=f"{name} Running vs Desired Tasks",
+                left=[
+                    aws_cloudwatch.Metric(
+                        namespace="AWS/ECS",
+                        metric_name="RunningTaskCount",
+                        dimensions_map={
+                            "ClusterName": service.cluster.cluster_name,
+                            "ServiceName": service.service_name,
+                        },
+                        statistic="Maximum",
+                        period=cdk.Duration.minutes(1),
+                        label="Running",
+                    ),
+                    aws_cloudwatch.Metric(
+                        namespace="AWS/ECS",
+                        metric_name="DesiredTaskCount",
+                        dimensions_map={
+                            "ClusterName": service.cluster.cluster_name,
+                            "ServiceName": service.service_name,
+                        },
+                        statistic="Maximum",
+                        period=cdk.Duration.minutes(1),
+                        label="Desired",
+                    ),
+                ],
+                width=8,
+                height=_WIDGET_HEIGHT,
+            ),
+        )
+        dashboard.add_widgets(
+            aws_cloudwatch.GraphWidget(
+                title=f"{name} Network In/Out (bytes)",
+                left=[
+                    ecs_container_insights_metric(
+                        service,
+                        "NetworkRxBytes",
+                        statistic="Sum",
+                    )
+                ],
+                right=[
+                    ecs_container_insights_metric(
+                        service,
+                        "NetworkTxBytes",
+                        statistic="Sum",
+                    )
+                ],
+                width=12,
+                height=_WIDGET_HEIGHT,
+            ),
+            aws_cloudwatch.GraphWidget(
+                title=f"{name} Storage Read/Write (bytes)",
+                left=[
+                    ecs_container_insights_metric(
+                        service,
+                        "StorageReadBytes",
+                        statistic="Sum",
+                    )
+                ],
+                right=[
+                    ecs_container_insights_metric(
+                        service,
+                        "StorageWriteBytes",
+                        statistic="Sum",
+                    )
+                ],
+                width=12,
+                height=_WIDGET_HEIGHT,
+            ),
+        )
+
+    return dashboard
+
+
+def create_alb_dashboard(
+    scope: Construct,
+    *,
+    load_balancer: aws_elb.ApplicationLoadBalancer,
+    target_group: aws_elb.ApplicationTargetGroup,
+) -> aws_cloudwatch.Dashboard:
+    """`Valkyrie-ALB` -- request flow, latencies, errors, connections."""
+    dashboard = aws_cloudwatch.Dashboard(
+        scope,
+        "ValkyrieAlbDashboard",
+        dashboard_name="Valkyrie-ALB",
+        default_interval=cdk.Duration.hours(24),
+        period_override=aws_cloudwatch.PeriodOverride.AUTO,
+    )
+
+    # Row 1: traffic and latency
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Request Count",
+            left=[
+                load_balancer.metric_request_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                )
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Target Response Time (p50 / p90 / p99)",
+            left=[
+                load_balancer.metric_target_response_time(
+                    period=cdk.Duration.minutes(1),
+                    statistic="p50",
+                    label="p50",
+                ),
+                load_balancer.metric_target_response_time(
+                    period=cdk.Duration.minutes(1),
+                    statistic="p90",
+                    label="p90",
+                ),
+                load_balancer.metric_target_response_time(
+                    period=cdk.Duration.minutes(1),
+                    statistic="p99",
+                    label="p99",
+                ),
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 2: HTTP status code breakdown
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="HTTP 2XX",
+            left=[
+                load_balancer.metric_http_code_target(
+                    code=aws_elb.HttpCodeTarget.TARGET_2XX_COUNT,
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                )
+            ],
+            width=8,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="HTTP 4XX",
+            left=[
+                load_balancer.metric_http_code_target(
+                    code=aws_elb.HttpCodeTarget.TARGET_4XX_COUNT,
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                )
+            ],
+            width=8,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="HTTP 5XX (target + ALB-generated)",
+            left=[
+                load_balancer.metric_http_code_target(
+                    code=aws_elb.HttpCodeTarget.TARGET_5XX_COUNT,
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                    label="Target 5XX",
+                ),
+                load_balancer.metric_http_code_elb(
+                    code=aws_elb.HttpCodeElb.ELB_5XX_COUNT,
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                    label="ALB-generated 5XX",
+                ),
+            ],
+            width=8,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 3: target health + connections
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Healthy vs Unhealthy Hosts",
+            left=[
+                target_group.metric_healthy_host_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Minimum",
+                    label="Healthy",
+                ),
+                target_group.metric_unhealthy_host_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Maximum",
+                    label="Unhealthy",
+                ),
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Connections (active / new / rejected)",
+            left=[
+                load_balancer.metric_active_connection_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                    label="Active",
+                ),
+                load_balancer.metric_new_connection_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                    label="New",
+                ),
+                load_balancer.metric_rejected_connection_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                    label="Rejected",
+                ),
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 4: target connection errors
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Target Connection Errors",
+            left=[
+                load_balancer.metric_target_connection_error_count(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Sum",
+                )
+            ],
+            width=24,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    return dashboard
+
+
+def create_rds_dashboard(
+    scope: Construct,
+    *,
+    database: aws_rds.DatabaseInstance,
+    region: str,
+) -> aws_cloudwatch.Dashboard:
+    """`Valkyrie-RDS` -- PostgreSQL metrics + Performance Insights link."""
+    dashboard = aws_cloudwatch.Dashboard(
+        scope,
+        "ValkyrieRdsDashboard",
+        dashboard_name="Valkyrie-RDS",
+        default_interval=cdk.Duration.hours(24),
+        period_override=aws_cloudwatch.PeriodOverride.AUTO,
+    )
+
+    perf_insights_url = (
+        f"https://console.aws.amazon.com/rds/home?region={region}"
+        f"#performance-insights-v20206:/resourceId/{database.instance_resource_id}"
+    )
+    dashboard.add_widgets(
+        aws_cloudwatch.TextWidget(
+            markdown=(
+                "# Valkyrie RDS\n"
+                f"For query-level drill-down, open "
+                f"[Performance Insights]({perf_insights_url}) in the AWS console."
+            ),
+            width=24,
+            height=2,
+        ),
+    )
+
+    # Row 1: CPU / memory / connections / storage
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="CPU Utilization (%)",
+            left=[
+                database.metric_cpu_utilization(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Freeable Memory (bytes)",
+            left=[
+                database.metric_freeable_memory(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Minimum",
+                )
+            ],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Database Connections",
+            left=[
+                database.metric_database_connections(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Maximum",
+                )
+            ],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Free Storage Space (bytes)",
+            left=[
+                database.metric_free_storage_space(
+                    period=cdk.Duration.minutes(5),
+                    statistic="Minimum",
+                )
+            ],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 2: IOPS
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Read IOPS",
+            left=[
+                database.metric_read_iops(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Write IOPS",
+            left=[
+                database.metric_write_iops(
+                    period=cdk.Duration.minutes(1),
+                    statistic="Average",
+                )
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    def rds_metric(name: str, statistic: str = "Average") -> aws_cloudwatch.Metric:
+        return aws_cloudwatch.Metric(
+            namespace="AWS/RDS",
+            metric_name=name,
+            dimensions_map={"DBInstanceIdentifier": database.instance_identifier},
+            statistic=statistic,
+            period=cdk.Duration.minutes(1),
+        )
+
+    # Row 3: latency (stubs lack metric_read_latency/metric_write_latency helpers)
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Read Latency (seconds)",
+            left=[rds_metric("ReadLatency")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Write Latency (seconds)",
+            left=[rds_metric("WriteLatency")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 4: throughput
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Read Throughput (bytes/s)",
+            left=[rds_metric("ReadThroughput")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Write Throughput (bytes/s)",
+            left=[rds_metric("WriteThroughput")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 5: burst balance, network, swap, disk queue
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Burst Balance (%)",
+            left=[rds_metric("BurstBalance", "Minimum")],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Network Throughput (RX / TX bytes/s)",
+            left=[rds_metric("NetworkReceiveThroughput")],
+            right=[rds_metric("NetworkTransmitThroughput")],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Swap Usage (bytes)",
+            left=[rds_metric("SwapUsage", "Average")],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Disk Queue Depth",
+            left=[rds_metric("DiskQueueDepth", "Average")],
+            width=6,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    return dashboard
+
+
+def create_redis_dashboard(
+    scope: Construct,
+    *,
+    redis_cluster: aws_elasticache.CfnCacheCluster,
+) -> aws_cloudwatch.Dashboard:
+    """`Valkyrie-Redis` -- ElastiCache metrics including command breakdown."""
+    dashboard = aws_cloudwatch.Dashboard(
+        scope,
+        "ValkyrieRedisDashboard",
+        dashboard_name="Valkyrie-Redis",
+        default_interval=cdk.Duration.hours(24),
+        period_override=aws_cloudwatch.PeriodOverride.AUTO,
+    )
+
+    # Row 1: CPU utilization (instance-level + engine-level)
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="CPU Utilization (%) - Instance",
+            left=[redis_metric(redis_cluster, "CPUUtilization", statistic="Average")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Engine CPU Utilization (%)",
+            left=[
+                redis_metric(
+                    redis_cluster, "EngineCPUUtilization", statistic="Average"
+                )
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 2: memory
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Memory Used for Cache (bytes)",
+            left=[
+                redis_metric(redis_cluster, "BytesUsedForCache", statistic="Average")
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Memory Usage (%)",
+            left=[
+                redis_metric(
+                    redis_cluster,
+                    "DatabaseMemoryUsagePercentage",
+                    statistic="Average",
+                )
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 3: connections
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Current Connections",
+            left=[
+                redis_metric(redis_cluster, "CurrConnections", statistic="Maximum")
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="New Connections per Minute",
+            left=[redis_metric(redis_cluster, "NewConnections", statistic="Sum")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 4: network + evictions
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Network Bytes In/Out",
+            left=[redis_metric(redis_cluster, "NetworkBytesIn", statistic="Sum")],
+            right=[redis_metric(redis_cluster, "NetworkBytesOut", statistic="Sum")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Evictions / Reclaimed",
+            left=[redis_metric(redis_cluster, "Evictions", statistic="Sum")],
+            right=[redis_metric(redis_cluster, "Reclaimed", statistic="Sum")],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 5: hit/miss + command breakdown
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Cache Hits / Misses",
+            left=[
+                redis_metric(redis_cluster, "CacheHits", statistic="Sum"),
+                redis_metric(redis_cluster, "CacheMisses", statistic="Sum"),
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+        aws_cloudwatch.GraphWidget(
+            title="Command Breakdown (per-second rate)",
+            left=[
+                redis_metric(redis_cluster, "GetTypeCmds", statistic="Sum"),
+                redis_metric(redis_cluster, "SetTypeCmds", statistic="Sum"),
+                redis_metric(redis_cluster, "ListBasedCmds", statistic="Sum"),
+                redis_metric(redis_cluster, "StreamBasedCmds", statistic="Sum"),
+            ],
+            width=12,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    # Row 6: replication bytes (single-node shows 0; kept for future HA consistency)
+    dashboard.add_widgets(
+        aws_cloudwatch.GraphWidget(
+            title="Replication Bytes",
+            left=[
+                redis_metric(redis_cluster, "ReplicationBytes", statistic="Average")
+            ],
+            width=24,
+            height=_WIDGET_HEIGHT,
+        ),
+    )
+
+    return dashboard
+
+
+def redis_metric(
+    redis_cluster: aws_elasticache.CfnCacheCluster,
+    metric_name: str,
+    *,
+    statistic: str = "Average",
+    period: cdk.Duration | None = None,
+) -> aws_cloudwatch.Metric:
+    """Helper: ElastiCache metric with CacheClusterId dimension."""
+    return aws_cloudwatch.Metric(
+        namespace="AWS/ElastiCache",
+        metric_name=metric_name,
+        dimensions_map={"CacheClusterId": redis_cluster.ref},
+        statistic=statistic,
+        period=period or cdk.Duration.minutes(1),
+    )
+
+
+def ecs_container_insights_metric(
+    service: aws_ecs.FargateService,
+    metric_name: str,
+    *,
+    statistic: str = "Average",
+    period: cdk.Duration | None = None,
+) -> aws_cloudwatch.Metric:
+    """Helper: Container Insights metric for a Fargate service."""
+    return aws_cloudwatch.Metric(
+        namespace="ECS/ContainerInsights",
+        metric_name=metric_name,
+        dimensions_map={
+            "ClusterName": service.cluster.cluster_name,
+            "ServiceName": service.service_name,
+        },
+        statistic=statistic,
+        period=period or cdk.Duration.minutes(1),
+    )

--- a/infra/dashboards.py
+++ b/infra/dashboards.py
@@ -716,11 +716,7 @@ def create_redis_dashboard(
         ),
         aws_cloudwatch.GraphWidget(
             title="Engine CPU Utilization (%)",
-            left=[
-                redis_metric(
-                    redis_cluster, "EngineCPUUtilization", statistic="Average"
-                )
-            ],
+            left=[redis_metric(redis_cluster, "EngineCPUUtilization", statistic="Average")],
             width=12,
             height=_WIDGET_HEIGHT,
         ),
@@ -730,9 +726,7 @@ def create_redis_dashboard(
     dashboard.add_widgets(
         aws_cloudwatch.GraphWidget(
             title="Memory Used for Cache (bytes)",
-            left=[
-                redis_metric(redis_cluster, "BytesUsedForCache", statistic="Average")
-            ],
+            left=[redis_metric(redis_cluster, "BytesUsedForCache", statistic="Average")],
             width=12,
             height=_WIDGET_HEIGHT,
         ),
@@ -754,9 +748,7 @@ def create_redis_dashboard(
     dashboard.add_widgets(
         aws_cloudwatch.GraphWidget(
             title="Current Connections",
-            left=[
-                redis_metric(redis_cluster, "CurrConnections", statistic="Maximum")
-            ],
+            left=[redis_metric(redis_cluster, "CurrConnections", statistic="Maximum")],
             width=12,
             height=_WIDGET_HEIGHT,
         ),
@@ -814,9 +806,7 @@ def create_redis_dashboard(
     dashboard.add_widgets(
         aws_cloudwatch.GraphWidget(
             title="Replication Bytes",
-            left=[
-                redis_metric(redis_cluster, "ReplicationBytes", statistic="Average")
-            ],
+            left=[redis_metric(redis_cluster, "ReplicationBytes", statistic="Average")],
             width=24,
             height=_WIDGET_HEIGHT,
         ),

--- a/infra/dashboards.py
+++ b/infra/dashboards.py
@@ -284,7 +284,7 @@ def create_ecs_dashboard(
                 title=f"{name} Running vs Desired Tasks",
                 left=[
                     aws_cloudwatch.Metric(
-                        namespace="AWS/ECS",
+                        namespace="ECS/ContainerInsights",
                         metric_name="RunningTaskCount",
                         dimensions_map={
                             "ClusterName": service.cluster.cluster_name,
@@ -295,7 +295,7 @@ def create_ecs_dashboard(
                         label="Running",
                     ),
                     aws_cloudwatch.Metric(
-                        namespace="AWS/ECS",
+                        namespace="ECS/ContainerInsights",
                         metric_name="DesiredTaskCount",
                         dimensions_map={
                             "ClusterName": service.cluster.cluster_name,

--- a/infra/dashboards.py
+++ b/infra/dashboards.py
@@ -71,7 +71,7 @@ def create_overview_dashboard(
             title="Worker Running Tasks",
             metrics=[
                 aws_cloudwatch.Metric(
-                    namespace="AWS/ECS",
+                    namespace="ECS/ContainerInsights",
                     metric_name="RunningTaskCount",
                     dimensions_map={
                         "ClusterName": worker_service.cluster.cluster_name,

--- a/infra/monitoring_stack.py
+++ b/infra/monitoring_stack.py
@@ -143,7 +143,7 @@ class MonitoringStack(cdk.Stack):
                 "Worker containers not running (min=1 autoscale floor breached)."
             ),
             metric=aws_cloudwatch.Metric(
-                namespace="AWS/ECS",
+                namespace="ECS/ContainerInsights",
                 metric_name="RunningTaskCount",
                 dimensions_map={
                     "ClusterName": worker_service.cluster.cluster_name,

--- a/infra/monitoring_stack.py
+++ b/infra/monitoring_stack.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from typing import Any
+
+import aws_cdk as cdk
+from aws_cdk import (
+    aws_cloudwatch,
+    aws_cloudwatch_actions,
+    aws_ecs,
+    aws_elasticache,
+    aws_elasticloadbalancingv2 as aws_elb,
+    aws_rds,
+    aws_sns,
+)
+from constructs import Construct
+from dashboards import (
+    create_alb_dashboard,
+    create_ecs_dashboard,
+    create_overview_dashboard,
+    create_rds_dashboard,
+    create_redis_dashboard,
+)
+
+
+class MonitoringStack(cdk.Stack):
+    """CloudWatch dashboards and alarms for Valkyrie infrastructure.
+
+    Depends on SharedStack (cluster, Redis), TrackerStack (RDS, ALB,
+    Tracker service), and WorkerStack (Worker service).
+
+    Alarms publish to the ``Valkyrie-Alerts`` SNS topic.
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        id: str,
+        *,
+        cluster: aws_ecs.ICluster,
+        tracker_service: aws_ecs.FargateService,
+        worker_service: aws_ecs.FargateService,
+        load_balancer: aws_elb.ApplicationLoadBalancer,
+        target_group: aws_elb.ApplicationTargetGroup,
+        database: aws_rds.DatabaseInstance,
+        redis_cluster: aws_elasticache.CfnCacheCluster,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        self.cluster = cluster
+        self.tracker_service = tracker_service
+        self.worker_service = worker_service
+        self.load_balancer = load_balancer
+        self.target_group = target_group
+        self.database = database
+        self.redis_cluster = redis_cluster
+
+        # SNS alerts topic. No subscribers yet.
+        self.alerts_topic = aws_sns.Topic(
+            self,
+            "ValkyrieAlertsTopic",
+            topic_name="Valkyrie-Alerts",
+            display_name="Valkyrie infrastructure alerts",
+        )
+
+        self._create_alarms(
+            tracker_service=tracker_service,
+            worker_service=worker_service,
+            load_balancer=load_balancer,
+            target_group=target_group,
+            database=database,
+            redis_cluster=redis_cluster,
+        )
+
+        self.overview_dashboard = create_overview_dashboard(
+            self,
+            tracker_service=tracker_service,
+            worker_service=worker_service,
+            load_balancer=load_balancer,
+            target_group=target_group,
+            database=database,
+            redis_cluster=redis_cluster,
+        )
+        self.ecs_dashboard = create_ecs_dashboard(
+            self,
+            tracker_service=tracker_service,
+            worker_service=worker_service,
+        )
+        self.alb_dashboard = create_alb_dashboard(
+            self,
+            load_balancer=load_balancer,
+            target_group=target_group,
+        )
+        self.rds_dashboard = create_rds_dashboard(
+            self,
+            database=database,
+            region=self.region,
+        )
+        self.redis_dashboard = create_redis_dashboard(
+            self,
+            redis_cluster=redis_cluster,
+        )
+
+    def _create_alarms(
+        self,
+        *,
+        tracker_service: aws_ecs.FargateService,
+        worker_service: aws_ecs.FargateService,
+        load_balancer: aws_elb.ApplicationLoadBalancer,
+        target_group: aws_elb.ApplicationTargetGroup,
+        database: aws_rds.DatabaseInstance,
+        redis_cluster: aws_elasticache.CfnCacheCluster,
+    ) -> None:
+        sns_action: aws_cloudwatch.IAlarmAction = aws_cloudwatch_actions.SnsAction(
+            self.alerts_topic  # type: ignore[arg-type]
+        )
+
+        # Alarm 1: Tracker unhealthy hosts
+        aws_cloudwatch.Alarm(
+            self,
+            "TrackerUnhealthyAlarm",
+            alarm_name="Valkyrie-Tracker-Unhealthy",
+            alarm_description="Tracker ALB has at least one unhealthy target for 2+ minutes",
+            metric=target_group.metric_unhealthy_host_count(
+                period=cdk.Duration.minutes(1),
+                statistic="Maximum",
+            ),
+            threshold=1,
+            evaluation_periods=2,
+            datapoints_to_alarm=2,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 2: Worker service down (min=1 autoscale floor breached)
+        # Note: this alarm assumes min=1 autoscaling.
+        aws_cloudwatch.Alarm(
+            self,
+            "WorkerServiceDownAlarm",
+            alarm_name="Valkyrie-Worker-Service-Down",
+            alarm_description=(
+                "Worker Fargate running task count = 0 for 3+ minutes. "
+                "Worker containers not running (min=1 autoscale floor breached)."
+            ),
+            metric=aws_cloudwatch.Metric(
+                namespace="AWS/ECS",
+                metric_name="RunningTaskCount",
+                dimensions_map={
+                    "ClusterName": worker_service.cluster.cluster_name,
+                    "ServiceName": worker_service.service_name,
+                },
+                period=cdk.Duration.minutes(1),
+                statistic="Maximum",
+            ),
+            threshold=1,
+            evaluation_periods=3,
+            datapoints_to_alarm=3,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 3: High 5xx rate
+        aws_cloudwatch.Alarm(
+            self,
+            "HighFiveXXRateAlarm",
+            alarm_name="Valkyrie-API-5XX-Rate-High",
+            alarm_description="API returning 10+ 5XX responses in a 5-minute window",
+            metric=load_balancer.metric_http_code_target(
+                code=aws_elb.HttpCodeTarget.TARGET_5XX_COUNT,
+                period=cdk.Duration.minutes(5),
+                statistic="Sum",
+            ),
+            threshold=10,
+            evaluation_periods=1,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 4: High API latency (p99)
+        aws_cloudwatch.Alarm(
+            self,
+            "HighApiLatencyAlarm",
+            alarm_name="Valkyrie-API-Latency-High",
+            alarm_description="API target response time p99 >= 5s for 5+ minutes",
+            metric=load_balancer.metric_target_response_time(
+                period=cdk.Duration.minutes(1),
+                statistic="p99",
+            ),
+            threshold=5,
+            evaluation_periods=5,
+            datapoints_to_alarm=5,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 5: DB connections high (> 80% of max for t4g.micro: ~83 connections)
+        # Max connections on t4g.micro is ~83 (LEAST(DBInstanceClassMemory/9531392, 5000))
+        # Set threshold to 65 (roughly 80% of 83)
+        aws_cloudwatch.Alarm(
+            self,
+            "DbConnectionsHighAlarm",
+            alarm_name="Valkyrie-DB-Connections-High",
+            alarm_description="RDS database connections >= 65 (~80% of t4g.micro max)",
+            metric=database.metric_database_connections(
+                period=cdk.Duration.minutes(1),
+                statistic="Maximum",
+            ),
+            threshold=65,
+            evaluation_periods=5,
+            datapoints_to_alarm=5,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 6: DB storage low
+        aws_cloudwatch.Alarm(
+            self,
+            "DbStorageLowAlarm",
+            alarm_name="Valkyrie-DB-Storage-Low",
+            alarm_description="RDS free storage space <= 2 GB",
+            metric=database.metric_free_storage_space(
+                period=cdk.Duration.minutes(5),
+                statistic="Minimum",
+            ),
+            threshold=2 * 1024 * 1024 * 1024,  # 2 GB in bytes
+            evaluation_periods=1,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.LESS_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 7: DB CPU high
+        aws_cloudwatch.Alarm(
+            self,
+            "DbCpuHighAlarm",
+            alarm_name="Valkyrie-DB-CPU-High",
+            alarm_description="RDS CPU utilization >= 80% for 10+ minutes",
+            metric=database.metric_cpu_utilization(
+                period=cdk.Duration.minutes(1),
+                statistic="Average",
+            ),
+            threshold=80,
+            evaluation_periods=10,
+            datapoints_to_alarm=10,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 8: Redis memory high (DatabaseMemoryUsagePercentage >= 80 for 5 min)
+        aws_cloudwatch.Alarm(
+            self,
+            "RedisMemoryHighAlarm",
+            alarm_name="Valkyrie-Redis-Memory-High",
+            alarm_description="Redis memory usage >= 80% for 5+ minutes",
+            metric=aws_cloudwatch.Metric(
+                namespace="AWS/ElastiCache",
+                metric_name="DatabaseMemoryUsagePercentage",
+                dimensions_map={"CacheClusterId": redis_cluster.ref},
+                period=cdk.Duration.minutes(1),
+                statistic="Average",
+            ),
+            threshold=80,
+            evaluation_periods=5,
+            datapoints_to_alarm=5,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)
+
+        # Alarm 9: Redis evictions
+        aws_cloudwatch.Alarm(
+            self,
+            "RedisEvictionsAlarm",
+            alarm_name="Valkyrie-Redis-Evictions",
+            alarm_description="Redis evicted 1+ keys in a 5-minute window (data loss in queue)",
+            metric=aws_cloudwatch.Metric(
+                namespace="AWS/ElastiCache",
+                metric_name="Evictions",
+                dimensions_map={"CacheClusterId": redis_cluster.ref},
+                period=cdk.Duration.minutes(5),
+                statistic="Sum",
+            ),
+            threshold=1,
+            evaluation_periods=1,
+            comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+            treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
+        ).add_alarm_action(sns_action)

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -181,6 +181,7 @@ class SharedStack(Stack):
             "AgenticHarnessCluster",
             vpc=self.vpc,
             cluster_name=CLUSTER_NAME,
+            container_insights=True,
         )
 
         # service discovery namespace for internal communication
@@ -233,7 +234,7 @@ class SharedStack(Stack):
             subnet_ids=[s.subnet_id for s in self.vpc.public_subnets],
         )
 
-        redis_cluster = aws_elasticache.CfnCacheCluster(
+        self.redis_cluster = aws_elasticache.CfnCacheCluster(
             self,
             "RedisCluster",
             cache_node_type=ELASTICACHE_NODE_TYPE,
@@ -248,8 +249,8 @@ class SharedStack(Stack):
             "",
             [
                 "redis://",
-                redis_cluster.attr_redis_endpoint_address,
+                self.redis_cluster.attr_redis_endpoint_address,
                 ":",
-                redis_cluster.attr_redis_endpoint_port,
+                self.redis_cluster.attr_redis_endpoint_port,
             ],
         )

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -71,7 +71,7 @@ class SharedStack(Stack):
         slack.add_notification_topic(notification_topic)  # type: ignore[arg-type]
 
         # Only notify for stacks deployed by this project
-        stack_names = ["SharedStack", "TrackerStack", "WorkerStack"]
+        stack_names = ["SharedStack", "TrackerStack", "WorkerStack", "MonitoringStack"]
 
         # EventBridge rule Slack notification for successful stack deployments
         success_rule = aws_events.Rule(

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -118,7 +118,16 @@ class WorkerStack(Stack):
                 "REDIS_URL": redis_url,
             },
             secrets=db_secrets,
-            command=["uv", "run", "--no-sync", "taskiq", "worker", "--no-configure-logging", "tracker.config:broker", "tracker.utils"],
+            command=[
+                "uv",
+                "run",
+                "--no-sync",
+                "taskiq",
+                "worker",
+                "--no-configure-logging",
+                "tracker.config:broker",
+                "tracker.utils",
+            ],
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),
         )
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the [observability plan](https://www.notion.so/vals-ai/Valkyrie-Observability-3418a877dd8d80249c7edb62a6fe4eae?t=new) — CloudWatch dashboards and alarms for infrastructure health monitoring. Adds a new `MonitoringStack` with five dashboards and nine alarms publishing to a dedicated `Valkyrie-Alerts` SNS topic.

## Changes
- New `MonitoringStack` CDK stack depending on Shared → Tracker → Worker
- New `dashboards.py` with five dashboards: Overview, ECS, ALB, RDS, Redis
- Nine CloudWatch alarms: tracker healthy hosts, worker service down, 5xx rate, API p99 latency, DB connections/storage/CPU, Redis memory/evictions
- `Valkyrie-Alerts` SNS topic (no subscribers yet — Slack channel routing is a follow-up)
- Enable Container Insights on the ECS cluster for network/storage metrics
- Expose `redis_cluster` as a SharedStack attribute for cross-stack reference
- 
<img width="2536" height="1094" alt="Screenshot 2026-04-13 at 5 42 31 PM" src="https://github.com/user-attachments/assets/a0640cb5-b725-452f-8810-eff4148a0e3c" />

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed