### PR TITLE
feat: add sentry error tracking to tracker and worker

### DIFF
--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -15,6 +15,7 @@ from aws_cdk import (
     aws_rds,
     aws_route53,
     aws_s3,
+    aws_secretsmanager,
     aws_servicediscovery,
 )
 from aws_cdk.aws_ecr_assets import Platform
@@ -127,8 +128,20 @@ class TrackerStack(Stack):
         }
 
         db_secrets = {
-            "DB_USERNAME": aws_ecs.Secret.from_secrets_manager(self.db_credentials, field="username"),
-            "DB_PASSWORD": aws_ecs.Secret.from_secrets_manager(self.db_credentials, field="password"),
+            "DB_USERNAME": aws_ecs.Secret.from_secrets_manager(
+                self.db_credentials, field="username"
+            ),
+            "DB_PASSWORD": aws_ecs.Secret.from_secrets_manager(
+                self.db_credentials, field="password"
+            ),
+        }
+
+        sentry_secret = aws_secretsmanager.Secret.from_secret_name_v2(
+            self, "SentryDsnSecret", "valkyrie/sentry-dsn"
+        )
+
+        sentry_secrets = {
+            "SENTRY_DSN": aws_ecs.Secret.from_secrets_manager(sentry_secret),
         }
 
         # ── Tracker API service ──────────────────────────────────────────
@@ -160,8 +173,12 @@ class TrackerStack(Stack):
                 "REDIS_URL": redis_url,
                 "AUTH_REQUIRED": os.environ.get("AUTH_REQUIRED", "false"),
                 "DESCOPE_PROJECT_ID": os.environ.get("DESCOPE_PROJECT_ID", ""),
+                "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
             },
-            secrets=db_secrets,
+            secrets={
+                **db_secrets,
+                **sentry_secrets,
+            },
             command=["uv", "run", "--no-sync", "python", "-m", "tracker.serve"],
             health_check=aws_ecs.HealthCheck(
                 command=["CMD-SHELL", f"curl -f http://localhost:{TRACKER_PORT}/health || exit 1"],

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -4,6 +4,7 @@ Deployed independently from the tracker so that long-running benchmark
 tasks can finish while a new worker version is rolled out.
 """
 
+import os
 from typing import Any
 
 import aws_cdk as cdk
@@ -16,6 +17,7 @@ from aws_cdk import (
     aws_logs,
     aws_rds,
     aws_s3,
+    aws_secretsmanager,
 )
 from aws_cdk.aws_ecr_assets import Platform
 from constants import (
@@ -90,6 +92,14 @@ class WorkerStack(Stack):
             "DB_PASSWORD": aws_ecs.Secret.from_secrets_manager(db_credentials, field="password"),
         }
 
+        sentry_secret = aws_secretsmanager.Secret.from_secret_name_v2(
+            self, "SentryDsnSecret", "valkyrie/sentry-dsn"
+        )
+
+        sentry_secrets = {
+            "SENTRY_DSN": aws_ecs.Secret.from_secrets_manager(sentry_secret),
+        }
+
         # ── Worker service ────────────────────────────────────────────────
 
         worker_task_def = aws_ecs.FargateTaskDefinition(
@@ -116,8 +126,12 @@ class WorkerStack(Stack):
                 **shared_env,
                 **db_env,
                 "REDIS_URL": redis_url,
+                "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
             },
-            secrets=db_secrets,
+            secrets={
+                **db_secrets,
+                **sentry_secrets,
+            },
             command=[
                 "uv",
                 "run",

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -4,6 +4,7 @@ import traceback
 from typing import Annotated
 from uuid import UUID
 
+import sentry_sdk
 from benchmark_service.client import BenchmarkServiceError
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
@@ -20,6 +21,7 @@ from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
 from tracker.middleware import RequestContextMiddleware
+from tracker.sentry import init_sentry
 from tracker.s3 import (
     S3_BENCHMARKS_PREFIX,
     create_benchmark_url,
@@ -61,6 +63,7 @@ from tracker.utils import (
 )
 
 configure_logging()
+init_sentry("valkyrie-tracker")
 
 logger = get_logger(__name__)
 
@@ -91,12 +94,14 @@ TrackedBenchmarkId = Annotated[UUID, Depends(bind_benchmark_id)]
 @app.exception_handler(TrackerServiceError)
 async def tracker_service_error_handler(_request: Request, exc: TrackerServiceError):
     logger.error(exc, exc_info=True)
+    sentry_sdk.capture_exception(exc)
     raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @app.exception_handler(BenchmarkServiceError)
 async def benchmark_service_error_handler(_request: Request, exc: BenchmarkServiceError):
     logger.error(exc, exc_info=True)
+    sentry_sdk.capture_exception(exc)
     raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
@@ -195,12 +200,16 @@ async def start_benchmark(
 
         raise TrackerServiceError(error_response.model_dump_json()) from e
 
-    await process_benchmark.kicker().with_labels(
-        request_id=request_id_var.get(),
-    ).kiq(
-        start_benchmark_request_json=request.model_dump(),
-        benchmark_id_str=str(benchmark_row.id),
-        verified_task_ids=verify_response.task_ids,
+    await (
+        process_benchmark.kicker()
+        .with_labels(
+            request_id=request_id_var.get(),
+        )
+        .kiq(
+            start_benchmark_request_json=request.model_dump(),
+            benchmark_id_str=str(benchmark_row.id),
+            verified_task_ids=verify_response.task_ids,
+        )
     )
 
     return StartBenchmarkResponse(
@@ -419,12 +428,16 @@ async def retry_or_resume_benchmark(
 
     # start the benchmark with the same args used to create it
     # we will delegate inside what tasks we are running
-    await process_benchmark.kicker().with_labels(
-        request_id=request_id_var.get(),
-    ).kiq(
-        start_benchmark_request_json=resume_request_json,
-        benchmark_id_str=str(benchmark_row.id),
-        verified_task_ids=verified_task_ids,
+    await (
+        process_benchmark.kicker()
+        .with_labels(
+            request_id=request_id_var.get(),
+        )
+        .kiq(
+            start_benchmark_request_json=resume_request_json,
+            benchmark_id_str=str(benchmark_row.id),
+            verified_task_ids=verified_task_ids,
+        )
     )
 
     return RetryOrResumeBenchmarkResponse(

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "alembic>=1.18.4",
     "descope>=0.9.0",
     "tenacity>=8.5.0,<9.0.0",
+    "sentry-sdk[fastapi]>=2.0.0",
     "python-json-logger>=3.2.1",
     "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@main",
 ]

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -4,7 +4,7 @@ import os
 from typing import Any
 
 from dotenv import load_dotenv
-from taskiq import InMemoryBroker
+from taskiq import InMemoryBroker, TaskiqEvents
 from taskiq_redis import RedisStreamBroker
 from taskiq_redis.redis_backend import RedisAsyncResultBackend
 
@@ -14,7 +14,6 @@ from tracker.sentry import init_sentry
 
 load_dotenv()
 configure_logging()
-init_sentry("valkyrie-worker")
 
 
 _BENCHMARK_SERVICE_NAMESPACE: str = "local"
@@ -65,6 +64,12 @@ broker = (
     .with_result_backend(result_backend)
     .with_middlewares(TaskProtectionMiddleware(), LoggingContextMiddleware())
 )
+
+
+@broker.on_event(TaskiqEvents.WORKER_STARTUP)
+async def _init_worker_sentry(*_args: object, **_kwargs: object) -> None:  # pyright: ignore[reportUnusedFunction]
+    init_sentry("valkyrie-worker")
+
 
 # Auth settings
 AUTH_REQUIRED = os.environ.get("AUTH_REQUIRED", "false").lower() == "true"

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -10,9 +10,11 @@ from taskiq_redis.redis_backend import RedisAsyncResultBackend
 
 from tracker.logging import configure_logging
 from tracker.middleware import LoggingContextMiddleware, TaskProtectionMiddleware
+from tracker.sentry import init_sentry
 
 load_dotenv()
 configure_logging()
+init_sentry("valkyrie-worker")
 
 
 _BENCHMARK_SERVICE_NAMESPACE: str = "local"

--- a/services/tracker/src/tracker/sentry.py
+++ b/services/tracker/src/tracker/sentry.py
@@ -1,0 +1,58 @@
+"""Sentry SDK initialization shared by the Tracker API and Worker processes."""
+
+import os
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.types import Event, Hint
+
+from tracker.logging.context import benchmark_id_var, request_id_var, task_id_var
+
+
+def _before_send(
+    event: Event,
+    hint: Hint,
+) -> Event | None:
+    """Inject structured logging context vars as Sentry tags on every event."""
+    if "tags" not in event:
+        event["tags"] = {}
+
+    request_id = request_id_var.get("")
+    benchmark_id = benchmark_id_var.get("")
+    task_id = task_id_var.get("")
+
+    if request_id:
+        event["tags"]["request_id"] = request_id
+    if benchmark_id:
+        event["tags"]["benchmark_id"] = benchmark_id
+    if task_id:
+        event["tags"]["task_id"] = task_id
+
+    return event
+
+
+def init_sentry(service_name: str) -> None:
+    """Initialize Sentry SDK. No-op if SENTRY_DSN is not set.
+
+    Args:
+        service_name: Identifies the process in Sentry (e.g. "valkyrie-tracker", "valkyrie-worker").
+    """
+    dsn = os.environ.get("SENTRY_DSN", "")
+    if not dsn:
+        return
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.environ.get("ENVIRONMENT", "development"),
+        release=os.environ.get("SENTRY_RELEASE", ""),
+        server_name=service_name,
+        traces_sample_rate=0,
+        send_default_pii=False,
+        before_send=_before_send,
+        integrations=[
+            LoggingIntegration(
+                level=None,
+                event_level=None,
+            ),
+        ],
+    )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from fastapi import Request
+import sentry_sdk
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
 
@@ -157,6 +158,7 @@ class TrackedTask:
         except Exception as e:
             error_message = f"Task error was not handled: {str(e)}\n{traceback.format_exc()}"
             logger.error(error_message)
+            sentry_sdk.capture_exception(e)
             with Session(bind=engine) as session:
                 task = fetch_task_row(task_row.id, session, self._org)
                 commit_task_error(task, session, error_message)
@@ -311,6 +313,8 @@ async def process_task(
     the evaluation will fail since the instance no longer exists. We handle this inside of the exception caught.
     """
     task_id_var.set(task_id)
+    sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
+    sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
 
     with Session(bind=engine) as task_session:
         benchmark_row = fetch_benchmark_row(benchmark_id, task_session, org)
@@ -425,7 +429,11 @@ async def process_task(
                 # Save the evaluation result to the database with the task row
                 # Flag the agent timed out when trying to complete the task (expected)
                 evaluation_result_row = EvaluationResult(
-                    org_id=org.id, task=task_row.id, instance_id=sandbox.id, result=evaluation_result, agent_timed_out=agent_timed_out
+                    org_id=org.id,
+                    task=task_row.id,
+                    instance_id=sandbox.id,
+                    result=evaluation_result,
+                    agent_timed_out=agent_timed_out,
                 )
 
                 with Session(bind=engine) as task_session:
@@ -445,6 +453,8 @@ async def process_task(
     except Exception as e:
         error_message = str(e)
         logger.error(error_message, exc_info=True)
+
+        sentry_sdk.capture_exception(e)
 
         # include the error message
         log_output(f"\n[ERROR] {error_message}")
@@ -560,6 +570,8 @@ async def process_benchmark(
     benchmark_id: UUID = UUID(benchmark_id_str)
     benchmark_service = start_benchmark_request.benchmark_service
     harness_config: HarnessConfig = start_benchmark_request.harness_config
+    sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
+    sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
 
     # Create notifier if webhook is configured
     notifier: SlackNotifier | None = None
@@ -678,6 +690,8 @@ async def process_benchmark(
                 invoke_lambda(arguments.lambda_function, lambda_payload, harness_config.aws)
 
     except Exception as e:
+        sentry_sdk.capture_exception(e)
+
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
@@ -626,7 +626,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -1507,6 +1506,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/64/982e07b93219cb52e1cca5d272cb579e2f3eb001956c9e7a9a6d106c9473/sentry_sdk-2.57.0-py2.py3-none-any.whl", hash = "sha256:812c8bf5ff3d2f0e89c82f5ce80ab3a6423e102729c4706af7413fd1eb480585", size = 456489, upload-time = "2026-03-31T09:39:27.524Z" },
 ]
 
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
 [[package]]
 name = "shellingham"
 version = "1.5.4"
@@ -1662,6 +1666,7 @@ dependencies = [
     { name = "moto", extra = ["s3"] },
     { name = "psycopg2-binary" },
     { name = "python-json-logger" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlmodel" },
     { name = "taskiq" },
     { name = "taskiq-redis" },
@@ -1692,6 +1697,7 @@ requires-dist = [
     { name = "moto", extras = ["s3"] },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-json-logger", specifier = ">=3.2.1" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "taskiq", specifier = ">=0.12.1" },
     { name = "taskiq-redis", specifier = ">=1.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -910,7 +910,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -919,7 +918,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
-    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -928,7 +926,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -937,7 +934,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -2203,6 +2199,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/53/39/be412cc86bc6247b8f69e9383d7950711bd86f8d0a4a4b0fe8fad685bc21/sentry_sdk-2.54.0-py2.py3-none-any.whl", hash = "sha256:fd74e0e281dcda63afff095d23ebcd6e97006102cdc8e78a29f19ecdf796a0de", size = 439198, upload-time = "2026-03-02T15:12:39.546Z" },
 ]
 
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
+]
+
 [[package]]
 name = "setuptools"
 version = "82.0.0"
@@ -2377,6 +2378,7 @@ dependencies = [
     { name = "moto", extra = ["s3"] },
     { name = "psycopg2-binary" },
     { name = "python-json-logger" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlmodel" },
     { name = "taskiq" },
     { name = "taskiq-redis" },
@@ -2390,12 +2392,13 @@ requires-dist = [
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main" },
     { name = "daytona", specifier = ">=0.161.0" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "descope", specifier = ">=0.9.0" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "moto", extras = ["s3"] },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-json-logger", specifier = ">=3.2.1" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "taskiq", specifier = ">=0.12.1" },
     { name = "taskiq-redis", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Summary

Wire up Sentry SDK in both the Tracker API (FastAPI) and Worker (Taskiq) so unhandled exceptions are captured automatically and caught errors in existing try/except blocks are explicitly reported with full context.

## Changes

- Add `sentry-sdk[fastapi]` dependency
- Create shared `tracker/sentry.py` with `init_sentry()` and `_before_send` hook that promotes structured logging context vars (`request_id`, `benchmark_id`, `task_id`) to Sentry tags
- Initialize Sentry at startup in Tracker API (`main.py`) and Worker (`config.py`)
- Add `capture_exception()` in catch-and-swallow error paths in `utils.py` and FastAPI exception handlers in `main.py`
- Wire `SENTRY_DSN` (from Secrets Manager secret `valkyrie/sentry-dsn`) and `SENTRY_RELEASE` env vars into TrackerStack and WorkerStack CDK definitions (we can set `SENTRY_RELEASE` during deploy to indicate which release of Valkyrie errors are coming from)
- Some formatting changes


## Type of Change

- [x] New feature

## Testing

- [x] Manually tested
- [x] unit tests pass
- [x] CDK synth succeeds for all stacks
- [x] Verified Sentry is no-op without SENTRY_DSN
- [x] Smoke tested with real DSN - event appears in Sentry UI with correct tags

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
