### PR TITLE
fix: simplify eventbridge stack-id pattern to avoid complexity limit

### DIFF
--- a/infra/shared.py
+++ b/infra/shared.py
@@ -81,7 +81,10 @@ class SharedStack(Stack):
                 source=["aws.cloudformation"],
                 detail_type=["CloudFormation Stack Status Change"],
                 detail={
-                    "stack-id": [{"wildcard": f"*:stack/{name}/*"} for name in stack_names],
+                    "stack-id": [
+                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                        for name in stack_names
+                    ],
                     "status-details": {
                         "status": ["CREATE_COMPLETE", "UPDATE_COMPLETE"],
                     },
@@ -133,7 +136,10 @@ class SharedStack(Stack):
                 source=["aws.cloudformation"],
                 detail_type=["CloudFormation Stack Status Change"],
                 detail={
-                    "stack-id": [{"wildcard": f"*:stack/{name}/*"} for name in stack_names],
+                    "stack-id": [
+                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                        for name in stack_names
+                    ],
                     "status-details": {
                         "status": [
                             "CREATE_FAILED",


### PR DESCRIPTION
## Summary
EventBridge rejected the SharedStack notification rules with "Rule is too complex" once `MonitoringStack` was added to `stack_names` (3 → 4 entries, 6 → 8 wildcards per rule):

https://github.com/vals-ai/Valkyrie/actions/runs/24476871526

Swapped the per-stack `wildcard` match for a `prefix` match on the full stack-id ARN — zero wildcards, strictly more specific, and unblocks the prod deploy.

## Changes
- `infra/shared.py`: replace `{"wildcard": "*:stack/{name}/*"}` with `{"prefix": "arn:aws:cloudformation:{region}:{account}:stack/{name}/"}` in both `StackDeploySuccessRule` and `StackDeployFailureRule`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed