### PR TITLE
#patch: Prod deploy 4/15 (eventbridge fix)

### DIFF
--- a/infra/shared.py
+++ b/infra/shared.py
@@ -81,7 +81,10 @@ class SharedStack(Stack):
                 source=["aws.cloudformation"],
                 detail_type=["CloudFormation Stack Status Change"],
                 detail={
-                    "stack-id": [{"wildcard": f"*:stack/{name}/*"} for name in stack_names],
+                    "stack-id": [
+                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                        for name in stack_names
+                    ],
                     "status-details": {
                         "status": ["CREATE_COMPLETE", "UPDATE_COMPLETE"],
                     },
@@ -133,7 +136,10 @@ class SharedStack(Stack):
                 source=["aws.cloudformation"],
                 detail_type=["CloudFormation Stack Status Change"],
                 detail={
-                    "stack-id": [{"wildcard": f"*:stack/{name}/*"} for name in stack_names],
+                    "stack-id": [
+                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                        for name in stack_names
+                    ],
                     "status-details": {
                         "status": [
                             "CREATE_FAILED",


### PR DESCRIPTION
## Summary
- Hotfix: simplify EventBridge stack-id pattern to avoid complexity limit (#278)

Follow-up to the failed deploy from #276 — SharedStack rolled back because the wildcard-based EventBridge pattern hit EventBridge's complexity limit once `MonitoringStack` was added ([ref](https://github.com/vals-ai/Valkyrie/actions/runs/24476871526)). The fix swaps `wildcard` for `prefix` matches.