### PR TITLE
Correctly count all agents on agent list

### DIFF
--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -619,24 +619,22 @@ def format_table(
 
 def format_agents_response(
     agents: list[tuple[str, datetime]],
-    current_page: int = 1,
-    total_pages: int = 1,
+    current_page: int,
+    total_pages: int,
+    total_count: int,
 ) -> None:
     """
     Format and display agents in a table format.
 
     Args:
-        agents: List of tuples (agent_name, last_modified)
+        agents: List of tuples (agent_name, last_modified) for the current page
         current_page: Current page number (1-indexed)
         total_pages: Total number of pages
+        total_count: Total agent count across all pages
     """
-    if not agents:
-        click.echo(click.style("No agents found.", fg="yellow"))
-        return
-
     rows = [{"Agent": name, "Last Modified": local_time(last_modified)} for name, last_modified in agents]
 
-    format_table(rows, ["Agent", "Last Modified"], current_page, total_pages, len(agents), "agent")
+    format_table(rows, ["Agent", "Last Modified"], current_page, total_pages, total_count, "agent")
 
 
 def paginate_agents(agents: list[tuple[str, datetime]], limit: int = 10) -> None:
@@ -660,7 +658,7 @@ def paginate_agents(agents: list[tuple[str, datetime]], limit: int = 10) -> None
             break
 
         page_agents = agents[offset : offset + limit]
-        format_agents_response(page_agents, current_page, total_pages)
+        format_agents_response(page_agents, current_page, total_pages, total_count)
 
         if total_pages <= 1:
             break


### PR DESCRIPTION
## Summary
Correct the total agents shown when using `valk agent list` and remove extra guard.
<img width="533" height="324" alt="image" src="https://github.com/user-attachments/assets/b42f7067-b9b3-4463-b4e3-7d53a92201d8" />

## Changes
- Remove extra guard
- Count total agents instead of just agents on page

## Related Issues
<!-- Link any related issues -->
Closes https://github.com/vals-ai/Valkyrie/issues/280

## Type of Change
<!-- What changed? -->
- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [x ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x ] Self-reviewed the diff
- [x ] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
