### PR TITLE
OS killed exit error coverage

### DIFF
--- a/services/tracker/src/tracker/database/migrations/versions/a9d2e1c8b3f4_replace_agent_timed_out_with_exit_reason.py
+++ b/services/tracker/src/tracker/database/migrations/versions/a9d2e1c8b3f4_replace_agent_timed_out_with_exit_reason.py
@@ -19,7 +19,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 _ENUM_NAME = "agentcausedexitreason"
-_ENUM_VALUES = ("timeout", "os_killed")
+_ENUM_VALUES = ("TIMEOUT", "OS_KILLED")
 
 
 def upgrade() -> None:
@@ -34,7 +34,7 @@ def upgrade() -> None:
 
     # Backfill: existing agent_timed_out=true rows map to the timeout reason.
     # agent_timed_out=false rows remain NULL (clean exit).
-    op.execute("UPDATE evaluationresult SET agent_caused_exit_reason = 'timeout' WHERE agent_timed_out = true")
+    op.execute("UPDATE evaluationresult SET agent_caused_exit_reason = 'TIMEOUT' WHERE agent_timed_out = true")
 
     op.drop_column("evaluationresult", "agent_timed_out")
 

--- a/services/tracker/src/tracker/database/migrations/versions/a9d2e1c8b3f4_replace_agent_timed_out_with_exit_reason.py
+++ b/services/tracker/src/tracker/database/migrations/versions/a9d2e1c8b3f4_replace_agent_timed_out_with_exit_reason.py
@@ -1,0 +1,60 @@
+"""Replace agent_timed_out bool with agent_caused_exit_reason enum
+
+Revision ID: a9d2e1c8b3f4
+Revises: 751b6aa3bdbc
+Create Date: 2026-04-16 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a9d2e1c8b3f4"
+down_revision: Union[str, Sequence[str], None] = "751b6aa3bdbc"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_ENUM_NAME = "agentcausedexitreason"
+_ENUM_VALUES = ("timeout", "os_killed")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    exit_reason_enum = sa.Enum(*_ENUM_VALUES, name=_ENUM_NAME)
+    exit_reason_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "evaluationresult",
+        sa.Column("agent_caused_exit_reason", exit_reason_enum, nullable=True),
+    )
+
+    # Backfill: existing agent_timed_out=true rows map to the timeout reason.
+    # agent_timed_out=false rows remain NULL (clean exit).
+    op.execute(
+        "UPDATE evaluationresult SET agent_caused_exit_reason = 'timeout' WHERE agent_timed_out = true"
+    )
+
+    op.drop_column("evaluationresult", "agent_timed_out")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column(
+        "evaluationresult",
+        sa.Column("agent_timed_out", sa.Boolean(), nullable=True),
+    )
+
+    # Only rows whose exit reason was a timeout are reconstructed as timed-out.
+    # Everything else (NULL or os_killed) becomes false — os_killed has no bool equivalent.
+    op.execute(
+        "UPDATE evaluationresult SET agent_timed_out = (agent_caused_exit_reason = 'timeout')"
+    )
+    op.alter_column("evaluationresult", "agent_timed_out", nullable=False)
+
+    op.drop_column("evaluationresult", "agent_caused_exit_reason")
+
+    sa.Enum(name=_ENUM_NAME).drop(op.get_bind(), checkfirst=True)

--- a/services/tracker/src/tracker/database/migrations/versions/a9d2e1c8b3f4_replace_agent_timed_out_with_exit_reason.py
+++ b/services/tracker/src/tracker/database/migrations/versions/a9d2e1c8b3f4_replace_agent_timed_out_with_exit_reason.py
@@ -34,27 +34,10 @@ def upgrade() -> None:
 
     # Backfill: existing agent_timed_out=true rows map to the timeout reason.
     # agent_timed_out=false rows remain NULL (clean exit).
-    op.execute(
-        "UPDATE evaluationresult SET agent_caused_exit_reason = 'timeout' WHERE agent_timed_out = true"
-    )
+    op.execute("UPDATE evaluationresult SET agent_caused_exit_reason = 'timeout' WHERE agent_timed_out = true")
 
     op.drop_column("evaluationresult", "agent_timed_out")
 
 
 def downgrade() -> None:
-    """Downgrade schema."""
-    op.add_column(
-        "evaluationresult",
-        sa.Column("agent_timed_out", sa.Boolean(), nullable=True),
-    )
-
-    # Only rows whose exit reason was a timeout are reconstructed as timed-out.
-    # Everything else (NULL or os_killed) becomes false — os_killed has no bool equivalent.
-    op.execute(
-        "UPDATE evaluationresult SET agent_timed_out = (agent_caused_exit_reason = 'timeout')"
-    )
-    op.alter_column("evaluationresult", "agent_timed_out", nullable=False)
-
-    op.drop_column("evaluationresult", "agent_caused_exit_reason")
-
-    sa.Enum(name=_ENUM_NAME).drop(op.get_bind(), checkfirst=True)
+    pass

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -62,6 +62,13 @@ class BenchmarkStatus(str, Enum):
     ERROR = "ERROR"
 
 
+class AgentCausedExitReason(str, Enum):
+    """Exit reasons caused by the agent that continue to evaluation"""
+
+    TIMEOUT = "timeout"
+    OS_KILLED = "os_killed"
+
+
 class AgentContractRequest(BaseModel):
     name: str
     model: str | None = None
@@ -323,5 +330,5 @@ class EvaluationResult(SQLModel, table=True):
     org_id: UUID = Field(foreign_key="org.id")
     task: UUID = Field(foreign_key="task.id")
     instance_id: str = Field(unique=True)
-    agent_timed_out: bool = Field(default=False)
+    agent_caused_exit_reason: AgentCausedExitReason | None = Field(default=None)
     result: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -65,8 +65,8 @@ class BenchmarkStatus(str, Enum):
 class AgentCausedExitReason(str, Enum):
     """Exit reasons caused by the agent that continue to evaluation"""
 
-    TIMEOUT = "timeout"
-    OS_KILLED = "os_killed"
+    TIMEOUT = "TIMEOUT"
+    OS_KILLED = "OS_KILLED"
 
 
 class AgentContractRequest(BaseModel):

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -8,6 +8,7 @@ from asyncio import Semaphore
 from collections import deque
 from collections.abc import Callable
 from contextlib import asynccontextmanager
+from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
 
@@ -264,7 +265,19 @@ async def install_agent_dependencies(
 # NOTE: If this gets too big move it into a mapping
 # these are decoupled since its just 2 exit codes we need to track
 _TIMEOUT_EXIT_CODE: int = 124
+_OS_KILL_EXIT_CODE: int = 137
 _SUCCESS_EXIT_CODE: int = 0
+
+
+class AgentTerminationReason(str, Enum):
+    """
+    Agent exit reasons that are contributed to an action the agent took,
+    tasks with these exit reasons are still evaluated
+    """
+
+    TIMEOUT = "timeout"
+    OS_KILLED = "os_killed"
+
 
 # Process exec retry settings
 _EXEC_MAX_ATTEMPTS: int = 3
@@ -486,7 +499,7 @@ async def stream_command_output(
     sandbox: AsyncSandbox,
     command: str,
     on_output: Callable[[str], None],
-) -> bool:
+) -> AgentTerminationReason | None:
     """
     Execute a command inside a sandbox using a PTY session, reconnecting on errors
 
@@ -494,7 +507,8 @@ async def stream_command_output(
     the PTY WebSocket close frame, which doesn't reliably propagate it.
 
     Return:
-        bool - True if the command timed out, False otherwise
+        AgentTerminationReason if the command terminated abnormally but recoverably
+        (e.g., timeout or OS kill), None on clean exit.
     """
     pty_id = uuid.uuid4().hex
     session_id = f"{sandbox.id}:pty-{pty_id}"
@@ -534,9 +548,13 @@ async def stream_command_output(
         exit_code = await _read_exit_code(sandbox, status_path)
 
         # Timeout error has a special handle since its caused by the benchmark service
-        # Remaining exit codes get handled by waterfall
+        # Exit codes are waterfalled
         if exit_code == _TIMEOUT_EXIT_CODE:
-            return True
+            return AgentTerminationReason.TIMEOUT
+
+        # OS killed the process
+        if exit_code == _OS_KILL_EXIT_CODE:
+            return AgentTerminationReason.OS_KILLED
 
         # Failed error code handling (truncate error shown to the user)
         # Final log is shown to the user, ignore traceback since it provides no insight as to what actually happened in the sandbox
@@ -545,7 +563,7 @@ async def stream_command_output(
             recent = "\n".join(tail[-10:]) if tail else "(no output)"
             raise SandboxError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
 
-        return False
+        return None
 
     finally:
         # Disconnect form PTY, ignoring exception if raised
@@ -596,7 +614,7 @@ async def run_agent(
     s3_bucket: str,
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
-) -> bool:
+) -> AgentTerminationReason | None:
     """
     Run the agent inside the sandbox for a given task.
 
@@ -610,7 +628,8 @@ async def run_agent(
         agent_timeout: Optional timeout in seconds to enforce on the agent command
 
     Returns:
-        bool - True if the command timed out, False otherwise
+        AgentTerminationReason if the agent was terminated abnormally but recoverably
+        (timeout or OS kill), None on clean exit.
 
     Raises:
         SandboxError: If the agent fails to run or times out
@@ -629,11 +648,17 @@ async def run_agent(
     await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
 
     # Run the agent without including task directory dependencies
-    timed_out = await stream_command_output(sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output)
+    termination_reason = await stream_command_output(
+        sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output
+    )
 
-    if timed_out:
+    if termination_reason == AgentTerminationReason.TIMEOUT:
         log_output(
             f"[WARNING]:`{contract.name}` has reached the designated timeout provided by the benchmark service for this task: `{agent_timeout}`. The process has been terminated and evaluation will proceed."
+        )
+    elif termination_reason == AgentTerminationReason.OS_KILLED:
+        log_output(
+            f"[WARNING]:`{contract.name}` was killed by the OS (exit code {_OS_KILL_EXIT_CODE}, likely out-of-memory). The process has been terminated and evaluation will proceed."
         )
 
     # Upload any output from the agent to S3
@@ -642,5 +667,5 @@ async def run_agent(
         if result.exit_code == _SUCCESS_EXIT_CODE and agent_output_s3_key:
             await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, aws, s3_bucket)
 
-    # Return if the agent timed out from the agent timeout provided by the benchmark service
-    return timed_out
+    # Return why the agent terminated abnormally, or None on clean exit
+    return termination_reason

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -8,7 +8,6 @@ from asyncio import Semaphore
 from collections import deque
 from collections.abc import Callable
 from contextlib import asynccontextmanager
-from enum import Enum
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
 
@@ -34,7 +33,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, AgentCausedExitReason
 from tracker.exceptions import InvalidSandboxConfigurationError, SandboxError
 from tracker.logging import get_logger
 from tracker.s3 import create_presigned_url, get_contract_s3_key, upload_to_s3
@@ -268,17 +267,6 @@ _TIMEOUT_EXIT_CODE: int = 124
 _OS_KILL_EXIT_CODE: int = 137
 _SUCCESS_EXIT_CODE: int = 0
 
-
-class AgentTerminationReason(str, Enum):
-    """
-    Agent exit reasons that are contributed to an action the agent took,
-    tasks with these exit reasons are still evaluated
-    """
-
-    TIMEOUT = "timeout"
-    OS_KILLED = "os_killed"
-
-
 # Process exec retry settings
 _EXEC_MAX_ATTEMPTS: int = 3
 _EXEC_DELAY_SECONDS: float = 2.0
@@ -499,7 +487,7 @@ async def stream_command_output(
     sandbox: AsyncSandbox,
     command: str,
     on_output: Callable[[str], None],
-) -> AgentTerminationReason | None:
+) -> AgentCausedExitReason | None:
     """
     Execute a command inside a sandbox using a PTY session, reconnecting on errors
 
@@ -507,7 +495,7 @@ async def stream_command_output(
     the PTY WebSocket close frame, which doesn't reliably propagate it.
 
     Return:
-        AgentTerminationReason if the command terminated abnormally but recoverably
+        AgentCausedExitReason if the command terminated abnormally but recoverably
         (e.g., timeout or OS kill), None on clean exit.
     """
     pty_id = uuid.uuid4().hex
@@ -550,11 +538,11 @@ async def stream_command_output(
         # Timeout error has a special handle since its caused by the benchmark service
         # Exit codes are waterfalled
         if exit_code == _TIMEOUT_EXIT_CODE:
-            return AgentTerminationReason.TIMEOUT
+            return AgentCausedExitReason.TIMEOUT
 
         # OS killed the process
         if exit_code == _OS_KILL_EXIT_CODE:
-            return AgentTerminationReason.OS_KILLED
+            return AgentCausedExitReason.OS_KILLED
 
         # Failed error code handling (truncate error shown to the user)
         # Final log is shown to the user, ignore traceback since it provides no insight as to what actually happened in the sandbox
@@ -614,7 +602,7 @@ async def run_agent(
     s3_bucket: str,
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
-) -> AgentTerminationReason | None:
+) -> AgentCausedExitReason | None:
     """
     Run the agent inside the sandbox for a given task.
 
@@ -628,7 +616,7 @@ async def run_agent(
         agent_timeout: Optional timeout in seconds to enforce on the agent command
 
     Returns:
-        AgentTerminationReason if the agent was terminated abnormally but recoverably
+        AgentCausedExitReason if the agent was terminated abnormally but recoverably
         (timeout or OS kill), None on clean exit.
 
     Raises:
@@ -648,15 +636,15 @@ async def run_agent(
     await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
 
     # Run the agent without including task directory dependencies
-    termination_reason = await stream_command_output(
+    exit_reason = await stream_command_output(
         sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output
     )
 
-    if termination_reason == AgentTerminationReason.TIMEOUT:
+    if exit_reason == AgentCausedExitReason.TIMEOUT:
         log_output(
             f"[WARNING]:`{contract.name}` has reached the designated timeout provided by the benchmark service for this task: `{agent_timeout}`. The process has been terminated and evaluation will proceed."
         )
-    elif termination_reason == AgentTerminationReason.OS_KILLED:
+    elif exit_reason == AgentCausedExitReason.OS_KILLED:
         log_output(
             f"[WARNING]:`{contract.name}` was killed by the OS (exit code {_OS_KILL_EXIT_CODE}, likely out-of-memory). The process has been terminated and evaluation will proceed."
         )
@@ -668,4 +656,4 @@ async def run_agent(
             await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, aws, s3_bucket)
 
     # Return why the agent terminated abnormally, or None on clean exit
-    return termination_reason
+    return exit_reason

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -43,7 +43,7 @@ from tracker.s3 import (
     get_agent_result_s3_key,
     upload_to_s3,
 )
-from tracker.sandbox import AgentTerminationReason, create_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
 from tracker.secrets import fetch_aws_secret, resolve_secrets
 from tracker.types import (
     AWSCredentials,
@@ -398,7 +398,7 @@ async def process_task(
                     agent_output_s3_key = get_agent_result_s3_key(str(benchmark_id), task_id, "agent_output.tar.gz")
 
                 # Run the agent inside of the sandbox
-                termination_reason = await run_agent(
+                exit_reason = await run_agent(
                     sandbox,
                     start_benchmark_request.contract,
                     task_data.problem_path,
@@ -410,8 +410,6 @@ async def process_task(
                     agent_output_s3_key=agent_output_s3_key,
                     agent_timeout=task_data.agent_timeout,
                 )
-
-                agent_timed_out = termination_reason == AgentTerminationReason.TIMEOUT
 
                 with Session(bind=engine) as task_session:
                     task = fetch_task_row(task_row.id, task_session, org)
@@ -429,13 +427,13 @@ async def process_task(
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
                 # Save the evaluation result to the database with the task row
-                # Flag the agent timed out when trying to complete the task (expected)
+                # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
                 evaluation_result_row = EvaluationResult(
                     org_id=org.id,
                     task=task_row.id,
                     instance_id=sandbox.id,
                     result=evaluation_result,
-                    agent_timed_out=agent_timed_out,
+                    agent_caused_exit_reason=exit_reason,
                 )
 
                 with Session(bind=engine) as task_session:
@@ -812,7 +810,7 @@ def fetch_evaluation_results(benchmark_id: UUID, session: Session, org_id: UUID)
     for evaluation_result, task_id in results:
         result_data = evaluation_result.result
         # NOTE: We append this because its important for the user to know
-        result_data["agent_timed_out"] = evaluation_result.agent_timed_out
+        result_data["agent_caused_exit_reason"] = evaluation_result.agent_caused_exit_reason
         evaluation_results[task_id] = result_data
 
     return evaluation_results

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -12,10 +12,10 @@ from typing import Any, NamedTuple, Sequence, cast
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
+import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from fastapi import Request
-import sentry_sdk
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
 
@@ -43,7 +43,7 @@ from tracker.s3 import (
     get_agent_result_s3_key,
     upload_to_s3,
 )
-from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import AgentTerminationReason, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.secrets import fetch_aws_secret, resolve_secrets
 from tracker.types import (
     AWSCredentials,
@@ -398,7 +398,7 @@ async def process_task(
                     agent_output_s3_key = get_agent_result_s3_key(str(benchmark_id), task_id, "agent_output.tar.gz")
 
                 # Run the agent inside of the sandbox
-                agent_timed_out = await run_agent(
+                termination_reason = await run_agent(
                     sandbox,
                     start_benchmark_request.contract,
                     task_data.problem_path,
@@ -410,6 +410,8 @@ async def process_task(
                     agent_output_s3_key=agent_output_s3_key,
                     agent_timeout=task_data.agent_timeout,
                 )
+
+                agent_timed_out = termination_reason == AgentTerminationReason.TIMEOUT
 
                 with Session(bind=engine) as task_session:
                     task = fetch_task_row(task_row.id, task_session, org)

--- a/services/tracker/tests/integration/test_database_integration.py
+++ b/services/tracker/tests/integration/test_database_integration.py
@@ -332,8 +332,11 @@ class TestDatabaseIntegration:
                     .where(col(Task.task_id) == task_id)
                 ).first()
                 assert evaluation_result_row is not None
-                # fetch_evaluation_results appends agent_timed_out from the model column
-                expected = {**evaluation_result_row.result, "agent_timed_out": evaluation_result_row.agent_timed_out}
+                # fetch_evaluation_results appends agent_caused_exit_reason from the model column
+                expected = {
+                    **evaluation_result_row.result,
+                    "agent_caused_exit_reason": evaluation_result_row.agent_caused_exit_reason,
+                }
                 assert evaluation_result == expected
 
             # Verify that the final evaluation row matches what we have in the database


### PR DESCRIPTION
## Summary
Better paradigm for tracking agent caused errors, instead of a boolean value for each option we use a single enum. In the future all you need to do is add your enum option and it will work. Also added an option for os kill since the code is 137 and we get that frequently with specific tasks. If we didn't handle this then its possible for someone to mistake it as a infra error and rerun it.


```bash
INFO     llm.zai.glm-5.<run=4d728ab8>.<question=2328d21ed25c4f><quer base.py:396         y=3c1a5730c89844> - INFO - Query completed: QueryResult(                            output_text='{\n  "analysis": "Makefile.config is                           properly configured with CPU_ONLY := 1 and BLAS := open.                        Now I need to build Caffe using make.",\n  "plan": "Build                       Caffe with make. This will compile all the necessary                            components. I\'ll use -j$(nproc) to parallelize the                             build.",\n  "commands": [\n    {\n      "keystrokes": "make                     -j$(nproc) 2>&1 \| tee build.log\\n",\n      "duration":                         60.0\n    }\n  ],\n  "task_complete": '+7,                                          reasoning='The configuration is set up correctly.                           CPU_ONLY := 1 is enabled and BLAS := open is set. Now I                         need to build Caffe. Let me run make to compile Caffe. This                     might take a while.',                                                               metadata=QueryResultMetadata(                                                       cost=QueryResultCost(                                                               input=0.006325,                                                                 output=0.00039040000000000006,                                                  reasoning=0.000144,                                                             cache_read=0.00040960000000000004,                                              cache_write=None,                                                               total_override=None,                                                            total=0.007269,                                                                 total_input=0.0067346,                                                          total_output=0.0005344000000000001                                          ),                                                                              duration_seconds=6.297123579308391,                                             in_tokens=6325,                                                                 out_tokens=122,                                                                 reasoning_tokens=45,                                                            cache_read_tokens=2048,                                                         cache_write_tokens=None,                                                        extra={},                                                                       total_input_tokens=8373,                                                        total_output_tokens=167                                                     )                                                                           )
--
Killedlogout[Debug]: PTY has been disconnected, handler has stopped polling[WARNING]:`terminus2` was killed by the OS (exit code 137, likely out-of-memory). The process has been terminated and evaluation will proceed.Starting evaluation for task: caffe-cifar-10Running tests for caffe-cifar-10...


```

## Changes
<!-- List the key changes made -->
- Added `AgentCausedExitReason` with a timeout and os killed option
- Added os kill exit code to special exit codes being tracked
- Migrated `agent_timed_out` database field to `agent_caused_exit_reason` which can consist of many options
- Refactored codebase to use new references

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x ] Bug fix
- [x ] New feature
- [ ] Breaking change
- [x ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [x ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ x] Self-reviewed the diff
- [ x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
