### PR TITLE
fix: pass service_headers through retry/resume endpoint

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -377,6 +377,7 @@ async def retry_or_resume_benchmark(
     retry: bool = Query(default=False),
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
+    service_headers: dict[str, str] = Body(default={}),
     session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
@@ -417,14 +418,14 @@ async def retry_or_resume_benchmark(
     verified_task_ids = await reset_to_in_progress_status(
         benchmark_row=benchmark_row,
         session=session,
-        benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
+        benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws, service_headers=service_headers),
         retry=retry,
         rerun_task_ids=task_ids,
         org=org,
     )
 
     # Ensure that credentials are included with the model dump
-    resume_request_json = benchmark_row.start_benchmark_request(harness_config).model_dump()
+    resume_request_json = benchmark_row.start_benchmark_request(harness_config, service_headers=service_headers).model_dump()
 
     # start the benchmark with the same args used to create it
     # we will delegate inside what tasks we are running

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -173,7 +173,9 @@ class Benchmark(SQLModel, table=True):
 
         return {task_id: (error_message or "No error message was provided") for task_id, error_message in tasks}
 
-    def start_benchmark_request(self, harness_config: "HarnessConfig") -> "StartBenchmarkRequest":
+    def start_benchmark_request(
+        self, harness_config: "HarnessConfig", service_headers: dict[str, str] | None = None
+    ) -> "StartBenchmarkRequest":
         from tracker.types import StartBenchmarkRequest
 
         return StartBenchmarkRequest(
@@ -188,14 +190,17 @@ class Benchmark(SQLModel, table=True):
             custom_benchmark_service=self.custom_benchmark_service,
             webhook_secret_name=self.webhook_secret_name,
             webhook_intervals=self.webhook_intervals,
+            service_headers=service_headers or {},
         )
 
-    def benchmark_service(self, daytona_secret_name: str, aws: "AWSCredentials") -> "BenchmarkServiceClient":
+    def benchmark_service(
+        self, daytona_secret_name: str, aws: "AWSCredentials", service_headers: dict[str, str] | None = None
+    ) -> "BenchmarkServiceClient":
         from tracker.config import create_benchmark_service_url
         from tracker.utils import create_benchmark_service_client
 
         url = self.custom_benchmark_service or create_benchmark_service_url(self.name)
-        return create_benchmark_service_client(url=url, daytona_secret_name=daytona_secret_name, aws=aws)
+        return create_benchmark_service_client(url=url, daytona_secret_name=daytona_secret_name, aws=aws, service_headers=service_headers)
 
     @property
     def benchmark_metadata(self) -> "FetchBenchmarkMetadataResponse":

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -257,7 +257,10 @@ class TestBenchmarkUtils:
         database_session.commit()
 
         # Task id is provided as a force parameter but does not exist in dataset
-        response = client.post(f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false", json=["task_5"])
+        response = client.post(
+            f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false",
+            json={"task_ids": ["task_5"]},
+        )
         assert response.status_code == 500
         assert "task_5" in response.json()["detail"]
 
@@ -273,7 +276,10 @@ class TestBenchmarkUtils:
 
         # Try again with the correct task ids
 
-        response = client.post(f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false", json=task_ids)
+        response = client.post(
+            f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false",
+            json={"task_ids": task_ids},
+        )
         assert response.status_code == 200
         assert response.json() == {"status": "success"}
 

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -799,12 +799,20 @@ def resume(
             if not check_tracker_service_health(tracker):
                 return
 
+            # Resolve service headers from config using the benchmark name
+            benchmark_info = tracker.fetch_benchmark(run_id)
+            service_headers: dict[str, str] = {}
+            auth_credential = TrackerService.get_benchmark_auth(benchmark_info.benchmark_name)
+            if auth_credential:
+                service_headers["Authorization"] = str(auth_credential)
+
             retry_task_ids = task_ids.split(",") if task_ids else []
             _ = tracker.retry_or_resume_benchmark(
                 run_id,
                 retry,
                 concurrency,
                 retry_task_ids,
+                service_headers=service_headers,
             )
             click.echo(click.style("Run continued successfully!", fg="green", bold=True))
             click.echo(

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -427,6 +427,7 @@ class TrackerService:
         retry: bool,
         concurrency: int | None,
         task_ids: list[str],
+        service_headers: dict[str, str] | None = None,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -436,6 +437,7 @@ class TrackerService:
             retry: Whether to retry tasks with the status error
             concurrency: Optional new concurrency level to override original value
             task_ids: List of task ids to force retry
+            service_headers: Optional headers for benchmark service authentication
 
         Returns:
             RetryOrResumeBenchmarkResponse with status and message
@@ -447,10 +449,12 @@ class TrackerService:
             if concurrency:
                 params["concurrency"] = concurrency
 
+            body: dict[str, Any] = {"task_ids": task_ids, "service_headers": service_headers or {}}
+
             response = self._client.post(
                 f"{self._base_url}/retry-or-resume-benchmark/{benchmark_id}",
                 params=params,
-                json=task_ids,
+                json=body,
             )
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)


### PR DESCRIPTION
## Summary
- The retry/resume endpoint calls `verify_task_ids` on the benchmark service, but wasn't forwarding the auth headers set on the original run, causing 401 errors for services that require authorization (e.g. `fab`).
- Added a `service_headers` body parameter on `/retry-or-resume-benchmark/{benchmark_id}` and wired it through to both the `verify_task_ids` call and the resumed `StartBenchmarkRequest`.
- Updated the CLI's `retry_or_resume_benchmark` client to resolve auth from config by benchmark name and pass it in the request body.

## Test plan
- [x] `valk run retry <run-id>` against a benchmark service that requires auth (e.g. `fab`) — verify the request succeeds (no 401)
- [x] Run resume for an interrupted benchmark and confirm the kicked-off tasks use the same auth headers
- [x] Tracker unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
