### PR TITLE
Cap concurrent PTY WebSocket handshakes in tracker

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -291,11 +291,9 @@ _PTY_CREATE_DELAY_SECONDS: float = 2.0
 # Process-global cap on concurrent PTY WebSocket handshakes.
 # Daytona starts failing above ~500 concurrent handshakes; 100 held 800 PTYs cleanly in testing.
 _PTY_HANDSHAKE_CAP: int = 100
-_PTY_HANDSHAKE_WAIT_LOG_THRESHOLD: float = 0.1
 _PTY_HANDSHAKE_SLOW_LOG_THRESHOLD: float = 2.0
 
 _pty_handshake_semaphore: Semaphore = Semaphore(_PTY_HANDSHAKE_CAP)
-_pty_handshake_inflight: int = 0
 
 # States that determine if the sandbox has been killed
 _DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED)
@@ -307,20 +305,18 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
     Gate a PTY WebSocket handshake with a process-global semaphore. Released as soon as the
     handshake call returns, so the PTY's subsequent lifetime (wait, send_input, etc.) is not gated.
 
-    Logs when we queue behind the cap or when the handshake itself is slow.
+    Logs when the gate is saturated on entry or when the handshake itself is slow.
     """
-    global _pty_handshake_inflight
+    gate_full_on_entry = _pty_handshake_semaphore.locked()
 
     wait_start = time.monotonic()
     async with _pty_handshake_semaphore:
         wait_duration = time.monotonic() - wait_start
-        _pty_handshake_inflight += 1
-        inflight = _pty_handshake_inflight
 
-        if wait_duration > _PTY_HANDSHAKE_WAIT_LOG_THRESHOLD:
+        if gate_full_on_entry:
             logger.info(
-                f"PTY handshake queued: {operation} session={session_id} "
-                f"waited={wait_duration:.2f}s inflight={inflight}/{_PTY_HANDSHAKE_CAP}"
+                f"PTY handshake gate full: {operation} session={session_id} "
+                f"cap={_PTY_HANDSHAKE_CAP} waited={wait_duration:.2f}s"
             )
 
         handshake_start = time.monotonic()
@@ -328,11 +324,9 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
             yield
         finally:
             handshake_duration = time.monotonic() - handshake_start
-            _pty_handshake_inflight -= 1
             if handshake_duration > _PTY_HANDSHAKE_SLOW_LOG_THRESHOLD:
                 logger.warning(
-                    f"PTY handshake slow: {operation} session={session_id} "
-                    f"duration={handshake_duration:.2f}s inflight={inflight}/{_PTY_HANDSHAKE_CAP}"
+                    f"PTY handshake slow: {operation} session={session_id} duration={handshake_duration:.2f}s"
                 )
 
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -3,6 +3,7 @@
 import base64
 import logging
 import shlex
+import time
 import uuid
 from asyncio import Semaphore
 from collections import deque
@@ -287,8 +288,52 @@ _PTY_RECONNECT_DELAY_SECONDS: float = 1.0
 _PTY_CREATE_MAX_ATTEMPTS: int = 5
 _PTY_CREATE_DELAY_SECONDS: float = 2.0
 
+# Process-global cap on concurrent PTY WebSocket handshakes.
+# Daytona starts failing above ~500 concurrent handshakes; 100 held 800 PTYs cleanly in testing.
+_PTY_HANDSHAKE_CAP: int = 100
+_PTY_HANDSHAKE_WAIT_LOG_THRESHOLD: float = 0.1
+_PTY_HANDSHAKE_SLOW_LOG_THRESHOLD: float = 2.0
+
+_pty_handshake_semaphore: Semaphore = Semaphore(_PTY_HANDSHAKE_CAP)
+_pty_handshake_inflight: int = 0
+
 # States that determine if the sandbox has been killed
 _DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED)
+
+
+@asynccontextmanager
+async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator[None, None]:
+    """
+    Gate a PTY WebSocket handshake with a process-global semaphore. Released as soon as the
+    handshake call returns, so the PTY's subsequent lifetime (wait, send_input, etc.) is not gated.
+
+    Logs when we queue behind the cap or when the handshake itself is slow.
+    """
+    global _pty_handshake_inflight
+
+    wait_start = time.monotonic()
+    async with _pty_handshake_semaphore:
+        wait_duration = time.monotonic() - wait_start
+        _pty_handshake_inflight += 1
+        inflight = _pty_handshake_inflight
+
+        if wait_duration > _PTY_HANDSHAKE_WAIT_LOG_THRESHOLD:
+            logger.info(
+                f"PTY handshake queued: {operation} session={session_id} "
+                f"waited={wait_duration:.2f}s inflight={inflight}/{_PTY_HANDSHAKE_CAP}"
+            )
+
+        handshake_start = time.monotonic()
+        try:
+            yield
+        finally:
+            handshake_duration = time.monotonic() - handshake_start
+            _pty_handshake_inflight -= 1
+            if handshake_duration > _PTY_HANDSHAKE_SLOW_LOG_THRESHOLD:
+                logger.warning(
+                    f"PTY handshake slow: {operation} session={session_id} "
+                    f"duration={handshake_duration:.2f}s inflight={inflight}/{_PTY_HANDSHAKE_CAP}"
+                )
 
 
 @retry(
@@ -336,7 +381,8 @@ async def _create_pty_session(
     on_data(f"[Debug]: Creating PTY session with the following id {salted_id}\n".encode())
 
     # Attempt to make the PTY session, timeouts occur under load
-    handle = await sandbox.process.create_pty_session(id=salted_id, on_data=on_data, envs=envs)
+    async with _pty_handshake_slot("create", salted_id):
+        handle = await sandbox.process.create_pty_session(id=salted_id, on_data=on_data, envs=envs)
 
     # Handle to access the PTY and the session id to pass on
     return handle, salted_id
@@ -385,8 +431,9 @@ async def _reconnect_and_wait_pty(
     # Log so the user can see we have seen a disconnection from the websocket (easier to pickup in logs)
     on_output("[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n")
 
-    # Reconnect to the PTY
-    handle = await sandbox.process.connect_pty_session(session_id, on_data)
+    # Reconnect to the PTY. Only the connect handshake is gated; handle.wait() runs ungated below.
+    async with _pty_handshake_slot("reconnect", session_id):
+        handle = await sandbox.process.connect_pty_session(session_id, on_data)
 
     # Wait until the command has finished running
     await handle.wait()

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1,0 +1,92 @@
+import asyncio
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from tracker import sandbox as sandbox_module
+from tracker.sandbox import _create_pty_session
+
+
+class TestPtyHandshakeSemaphore:
+    async def test_semaphore_caps_concurrent_handshakes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        Concurrent _create_pty_session calls never exceed the cap on in-flight
+        sandbox.process.create_pty_session calls.
+
+        Regression guard: if someone removes the `async with _pty_handshake_slot(...)`
+        wrapper around the handshake call, concurrency becomes unbounded.
+        """
+        cap = 5
+        total = 25
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(cap))
+
+        concurrent = 0
+        max_concurrent = 0
+
+        async def fake_create_pty_session(*_args: Any, **_kwargs: Any) -> Mock:
+            nonlocal concurrent, max_concurrent
+
+            concurrent += 1
+            max_concurrent = max(max_concurrent, concurrent)
+
+            # Hold long enough for other tasks to pile up behind the gate
+            await asyncio.sleep(0.05)
+
+            concurrent -= 1
+            return Mock()
+
+        mock_sandbox = Mock()
+        mock_sandbox.process.create_pty_session = fake_create_pty_session
+
+        results = await asyncio.gather(
+            *[_create_pty_session(mock_sandbox, f"session-{i}", lambda _data: None) for i in range(total)]
+        )
+
+        assert len(results) == total
+        assert max_concurrent <= cap
+        # Sanity: without the cap we'd see total concurrency; confirm contention actually happened
+        assert max_concurrent > 1
+
+    async def test_semaphore_released_after_handshake_returns(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """
+        The semaphore slot is released as soon as the handshake call returns, before the
+        caller does anything else with the handle (handle.wait, send_input, etc.).
+
+        Regression guard: if someone widens the `async with _pty_handshake_slot(...)` scope
+        — e.g. wraps code after create_pty_session returns, or wraps the whole caller flow
+        around handle.wait() — a second concurrent handshake would block until the first
+        task finishes its session lifetime. With cap=1 and a simulated long-running
+        post-handshake step, that regression turns this test into a timeout.
+        """
+        cap = 1
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(cap))
+
+        async def fake_create_pty_session(*_args: Any, **_kwargs: Any) -> Mock:
+            return Mock()
+
+        mock_sandbox = Mock()
+        mock_sandbox.process.create_pty_session = fake_create_pty_session
+
+        events: list[str] = []
+
+        async def task_holding_handle() -> None:
+            await _create_pty_session(mock_sandbox, "s1", lambda _data: None)
+            events.append("a:handshake_done")
+
+            # Simulate a long-running handle.wait() AFTER the handshake.
+            # The slot must already be released, otherwise the other task can't acquire.
+            await asyncio.sleep(0.2)
+            events.append("a:post_handshake_done")
+
+        async def task_needing_slot() -> None:
+            # Tiny delay so task A acquires the slot first
+            await asyncio.sleep(0.01)
+            await _create_pty_session(mock_sandbox, "s2", lambda _data: None)
+            events.append("b:handshake_done")
+
+        await asyncio.wait_for(asyncio.gather(task_holding_handle(), task_needing_slot()), timeout=1.0)
+
+        # Task B's handshake must complete BEFORE task A's post-handshake work finishes.
+        # That ordering is only reachable if the slot was released at handshake exit.
+        assert events.index("b:handshake_done") < events.index("a:post_handshake_done")


### PR DESCRIPTION
## Summary
Under load, Daytona begins failing PTY WebSocket handshakes above ~500 concurrent connects ([context](https://valsai.slack.com/archives/C0A4M9VB318/p1776699130377729?thread_ts=1776669359.717209&cid=C0A4M9VB318)). This PR gates PTY handshakes in the tracker service with a process-global semaphore capped at 100 — the ceiling that held 800 PTYs with zero failures in our testing. The semaphore only gates the WebSocket connect step; `handle.wait()`, `send_input`, and the rest of the PTY session lifetime remain ungated.

## Changes
- Add `_pty_handshake_slot` async context manager in `services/tracker/src/tracker/sandbox.py` backed by a module-level `asyncio.Semaphore(100)`. Scope is process-global, not per-benchmark, because the limit we care about is total in-flight handshakes hitting Daytona from the tracker process.
- Wrap `sandbox.process.create_pty_session` in `_create_pty_session` and `sandbox.process.connect_pty_session` in `_reconnect_and_wait_pty` with the new gate. Released immediately on return.
- Add observability logs: INFO when a task queues behind the cap (>100ms wait for a slot), WARNING when an individual handshake is slow (>2s). Both include current in-flight count out of cap (e.g. `inflight=97/100`) so CloudWatch filters can surface saturation directly.
- Add two unit tests (`services/tracker/tests/unit/test_sandbox.py`):
  - `test_semaphore_caps_concurrent_handshakes` — 25 concurrent calls against cap=5 never exceed the cap. Verified to fail if the gate is removed.
  - `test_semaphore_released_after_handshake_returns` — with cap=1, a task doing simulated post-handshake work must not block a second task's handshake. Verified to fail if the gate scope is widened beyond the handshake call.

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Unit tests cover cap enforcement and early release. Each test was also verified to fail under the specific regression it guards against (gate removed / gate scope widened).

Should deploy and do stress test on prod.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed