### PR TITLE
fix: treat already-destroyed sandboxes as success in stop_sandbox

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
+from daytona.common.errors import DaytonaNotFoundError
 from fastapi import Request
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
@@ -966,6 +967,9 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
         # Delete the sandbox
         await delete_sandbox(sandbox, daytona_client)
 
+        return None
+    except DaytonaNotFoundError:
+        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
         return None
     except Exception as e:
         return f"{str(e)}: {traceback.format_exc()}"


### PR DESCRIPTION
## Summary
`force_stop_sandboxes` reports success/failure per sandbox via `stop_sandbox`, which calls `sandbox.wait_for_sandbox_start(timeout=0)` as a pre-delete refresh. If the sandbox has already been destroyed by a concurrent deleter — another force-stop iteration, a `create_sandbox` CM's `finally: delete_sandbox`, or Daytona's own GC — that call raises `DaytonaNotFoundError`, and the catch-all at `utils.py:970` turns it into an error string. `force_stop_sandboxes` then aggregates that into a `TrackerServiceError`.

An already-destroyed sandbox is the desired end state of `stop_sandbox`. This PR swallows `DaytonaNotFoundError` and logs a warning, matching the pattern `delete_sandbox` already uses (`sandbox.py:71`).

## Changes
- `services/tracker/src/tracker/utils.py`: add `except DaytonaNotFoundError` in `stop_sandbox` that logs and returns `None`. Import `DaytonaNotFoundError` from `daytona.common.errors`.

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ ] Manually tested

No new test added — the change is a two-line scoped exception tolerance matching an existing adjacent pattern in `delete_sandbox`. `test_force_stop_sandboxes` (integration) already exercises the failing path and should now pass deterministically.

**How this surfaced:** `test_force_stop_sandboxes` has been failing on `dev` (observed on #296) because `create_sandbox` CMs in the test delete their sandbox as soon as `wait_for_sandbox_start` returns. When sandbox startup finishes before the test's `asyncio.sleep(2)`, `force_stop_sandboxes` then iterates over sandboxes that are partially/fully gone and `stop_sandbox` surfaces the `DaytonaNotFoundError` as a failure. This fix makes `stop_sandbox` idempotent w.r.t. missing sandboxes.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed