### PR TITLE
Add sandbox provider selection

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.0.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@main",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@ht/modal-integration-rebased",
 ]
 
 [dependency-groups]

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     )
 
 
+SandboxProviderName = Literal["daytona", "modal"]
 DEFAULT_ORG_NAME = "default"
 
 
@@ -87,6 +88,7 @@ class BenchmarkArguments(BaseModel):
     slice_str: str | None = None
     lambda_function: str | None = None
     dataset: str | None = None
+    sandbox_provider: SandboxProviderName = "daytona"
 
 
 class FinalEvaluation(SQLModel, table=True):
@@ -194,6 +196,7 @@ class Benchmark(SQLModel, table=True):
             lambda_function=self.arguments.lambda_function,
             dataset=self.arguments.dataset,
             harness_config=harness_config,
+            sandbox_provider=self.arguments.sandbox_provider,
             custom_benchmark_service=self.custom_benchmark_service,
             webhook_secret_name=self.webhook_secret_name,
             webhook_intervals=self.webhook_intervals,
@@ -207,7 +210,13 @@ class Benchmark(SQLModel, table=True):
         from tracker.utils import create_benchmark_service_client
 
         url = self.custom_benchmark_service or create_benchmark_service_url(self.name)
-        return create_benchmark_service_client(url=url, daytona_secret_name=daytona_secret_name, aws=aws, service_headers=service_headers)
+        return create_benchmark_service_client(
+            url=url,
+            daytona_secret_name=daytona_secret_name,
+            aws=aws,
+            sandbox_provider=self.arguments.sandbox_provider,
+            service_headers=service_headers or {},
+        )
 
     @property
     def benchmark_metadata(self) -> "FetchBenchmarkMetadataResponse":

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,9 +1,7 @@
-"""Sandbox management utilities for the tracker service."""
+"""Provider-generic sandbox utilities for tracker runs."""
 
-import base64
 import logging
 import shlex
-import time
 import uuid
 from asyncio import Semaphore
 from collections import deque
@@ -12,19 +10,17 @@ from contextlib import asynccontextmanager
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
 
-from benchmark_service.schemas import Resources as TrackerResources
-from daytona import (
-    AsyncDaytona,
-    AsyncSandbox,
-    CreateSandboxFromImageParams,
-    CreateSandboxFromSnapshotParams,
-    DaytonaNotFoundError,
-    ExecuteResponse,
-    Resources,
-    SandboxState,
+from benchmark_service.sandbox import (
+    ExecResult,
+    ImageSandboxCreateRequest,
+    Sandbox,
+    SandboxNotFoundError,
+    SandboxProvider,
+    SandboxResources,
+    SnapshotSandboxCreateRequest,
 )
-from daytona.common.errors import DaytonaError
-from daytona.handle.async_pty_handle import AsyncPtyHandle
+from benchmark_service.sandbox import SandboxError as ProviderSandboxError
+from benchmark_service.schemas import Resources as TrackerResources
 from tenacity import (
     before_sleep_log,
     retry,
@@ -35,7 +31,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from tracker.database.models import AgentContractRequest, AgentCausedExitReason
+from tracker.database.models import AgentCausedExitReason, AgentContractRequest
 from tracker.exceptions import InvalidSandboxConfigurationError, SandboxError
 from tracker.logging import get_logger
 from tracker.s3 import create_presigned_url, get_contract_s3_key, upload_to_s3
@@ -43,36 +39,19 @@ from tracker.types import AWSCredentials
 
 logger = get_logger(__name__)
 
-
 bundle_path = PurePosixPath("/bundle")
 SNAPSHOT_IMAGE_PREFIX = "snapshot:"
+_TIMEOUT_EXIT_CODE = 124
+_OS_KILL_EXIT_CODE = 137
+_SUCCESS_EXIT_CODE = 0
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
-    """Get the path to a contract in the sandbox."""
     return bundle_path / contract_name
 
 
-@retry(
-    retry=retry_if_exception_type(DaytonaError),
-    stop=stop_after_attempt(3),
-    wait=wait_fixed(2),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
-    reraise=True,
-)
-async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
-    """Delete sandbox if it is not already destroyed or being destroyed"""
-    try:
-        await sandbox.refresh_data()
-        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-            await daytona.delete(sandbox)
-    except DaytonaNotFoundError:
-        # If we error here that means the sandbox has just been deleted before we could refresh the state
-        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
-    except DaytonaError:
-        raise
-    except Exception as e:
-        logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
+def _resources(resources: TrackerResources) -> SandboxResources:
+    return SandboxResources(cpu=resources.vcpu, memory=resources.memory, disk=resources.disk)
 
 
 @retry(
@@ -83,126 +62,89 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     reraise=True,
 )
 async def _create_sandbox(
-    daytona: AsyncDaytona,
+    provider: SandboxProvider,
     sandbox_name: str,
     image: str,
     resources: TrackerResources,
-    labels: dict[str, str] | None = None,
-    env_vars: dict[str, str] | None = None,
-) -> AsyncSandbox:
-    """
-    Creates a sandbox and takes into account timeouts and retries.
-
-    This retry only works in the following case:
-    - Client times out while sandbox is being created
-    """
-
-    # If the container already exists we reuse it
+    labels: dict[str, str],
+    env_vars: dict[str, str],
+) -> Sandbox:
     try:
-        sandbox = await daytona.get(sandbox_name)
-
-        await sandbox.wait_for_sandbox_start(timeout=0)
-
+        sandbox = await provider.get_sandbox(sandbox_name)
+        await sandbox.wait_until_ready()
         return sandbox
-    except DaytonaNotFoundError:
+    except SandboxNotFoundError:
         pass
 
+    sandbox_resources = _resources(resources)
     if image.startswith(SNAPSHOT_IMAGE_PREFIX):
-        snapshot_name = image[len(SNAPSHOT_IMAGE_PREFIX) :].strip()
-        if not snapshot_name:
+        snapshot = image[len(SNAPSHOT_IMAGE_PREFIX) :].strip()
+        if not snapshot:
             raise InvalidSandboxConfigurationError("Snapshot-based sandbox requested without a snapshot name")
-
-        return await daytona.create(
-            CreateSandboxFromSnapshotParams(
-                auto_stop_interval=0,
-                auto_delete_interval=60,
+        return await provider.create_sandbox(
+            SnapshotSandboxCreateRequest(
+                snapshot=snapshot,
                 name=sandbox_name,
                 labels=labels,
-                snapshot=snapshot_name,
-                language="python",
-                network_block_all=False,
                 env_vars=env_vars,
-            ),
-            timeout=360,
+                resources=sandbox_resources,
+                auto_delete_interval=60,
+                creation_timeout=360,
+            )
         )
 
-    # Create a new sandbox from scratch, if it stops we delete it within a minute
-    return await daytona.create(
-        CreateSandboxFromImageParams(
-            auto_stop_interval=0,
-            auto_delete_interval=60,
+    return await provider.create_sandbox(
+        ImageSandboxCreateRequest(
+            image=image,
             name=sandbox_name,
             labels=labels,
-            image=image,
-            network_block_all=False,
-            resources=Resources(
-                cpu=resources.vcpu,
-                memory=resources.memory,
-                disk=resources.disk,
-            ),
             env_vars=env_vars,
-        ),
-        timeout=360,
+            resources=sandbox_resources,
+            auto_delete_interval=60,
+            creation_timeout=360,
+        )
     )
 
 
 @asynccontextmanager
 async def create_sandbox(
-    daytona: AsyncDaytona,
+    provider: SandboxProvider,
     sandbox_name: str,
     image: str,
     resources: TrackerResources,
     creation_semaphore: Semaphore,
-    labels: dict[str, str] | None = None,
-    env_vars: dict[str, str] | None = None,
-) -> AsyncGenerator[AsyncSandbox, Any]:
-    """
-    Yeild a sandbox to be used within a context manager.
-
-    Args:
-        daytona: The daytona client
-        sandbox_name: The name of the sandbox
-        image: The image to use for the sandbox
-        resources: The resources to use for the sandbox
-        labels: The labels to use for the sandbox
-        env_vars: The environment variables to use for the sandbox
-        creation_semaphore: Per-benchmark semaphore to limit concurrent sandbox creation.
-
-    Returns:
-        A context manager that yields the sandbox
-    """
+    labels: dict[str, str],
+    env_vars: dict[str, str],
+) -> AsyncGenerator[Sandbox, Any]:
     logger.info(f"Creating sandbox {sandbox_name} with image {image}")
 
-    # If we run too many at once it can cause hanging issues
-    # NOTE does not block how many context managers we can have open, just how many sandboxes we can create at once
     async with creation_semaphore:
-        sandbox = await _create_sandbox(daytona, sandbox_name, image, resources, labels, env_vars)
+        sandbox = await _create_sandbox(provider, sandbox_name, image, resources, labels, env_vars)
 
     try:
         yield sandbox
-    except Exception as e:
-        logger.error(f"Error during sandbox execution {sandbox.name}: {e}")
-        raise
     finally:
-        await delete_sandbox(sandbox, daytona)
+        await provider.delete_sandbox(sandbox)
+
+
+@retry(
+    retry=retry_if_exception_type(ProviderSandboxError), reraise=True, stop=stop_after_attempt(3), wait=wait_fixed(2)
+)
+async def _exec(sandbox: Sandbox, command: str) -> ExecResult:
+    return await sandbox.exec(command)
+
+
+def _tail(result: ExecResult, output: deque[str]) -> str:
+    lines = "".join(output).strip().splitlines()
+    if not lines:
+        lines = f"{result.stdout}{result.stderr}".strip().splitlines()
+    return "\n".join(lines[-10:]) or "(no output)"
 
 
 @retry(retry=retry_if_exception_type(SandboxError), reraise=True, stop=stop_after_attempt(3))
 async def upload_agent_artifacts(
-    sandbox: AsyncSandbox, contract: AgentContractRequest, aws: AWSCredentials, s3_bucket: str
+    sandbox: Sandbox, contract: AgentContractRequest, aws: AWSCredentials, s3_bucket: str
 ) -> None:
-    """
-    Download and extract the agent contract zip directly inside the sandbox. We generate a presigned S3 URL and have the sandbox curl + unzip it directly.
-
-    Args:
-        sandbox: The sandbox to download and extract files in
-        contract: The agent contract configuration
-        aws: AWS credentials for presigned URL generation
-        s3_bucket: S3 bucket name
-
-    Raises:
-        SandboxError: If download or extraction fails inside the sandbox
-    """
     logger.info(f"Uploading contract {contract.name} to sandbox {sandbox.name}")
 
     contract_s3_key = get_contract_s3_key(contract.name)
@@ -213,8 +155,6 @@ async def upload_agent_artifacts(
     bundle_dir = shlex.quote(str(bundle_path))
     quoted_url = shlex.quote(presigned_url)
 
-    # Install required dependencies inside of the instance
-    # Tracks if curl or unzip are missing and installs them if needed
     install_deps = (
         "NEED='';"
         " command -v curl >/dev/null 2>&1 || NEED='curl';"
@@ -229,7 +169,6 @@ async def upload_agent_artifacts(
         "  fi;"
         " fi"
     )
-
     steps = [
         install_deps,
         f"curl -sfL -o {zip_path} {quoted_url}",
@@ -238,411 +177,67 @@ async def upload_agent_artifacts(
         f"rm -f {zip_path}",
         f"mkdir -p {contract_dir}",
     ]
-
-    script = " && ".join(steps)
-
-    try:
-        result = await _exec(sandbox, script)
-
-        if result.exit_code != 0:
-            raise RuntimeError(f"Command failed with exit code {result.exit_code}: {result.result}")
-
-    except Exception as e:
-        raise SandboxError(f"Failed to upload contract {contract.name} to sandbox {sandbox.name}: {e}") from e
+    result = await _exec(sandbox, " && ".join(steps))
+    if result.exit_code != _SUCCESS_EXIT_CODE:
+        raise SandboxError(f"Failed to upload contract {contract.name}: {result.stdout}{result.stderr}")
 
 
 @retry(retry=retry_if_exception_type(SandboxError), reraise=True, stop=stop_after_attempt(3))
 async def install_agent_dependencies(
-    sandbox: AsyncSandbox,
+    sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
 ) -> None:
-    """Install agent dependencies in the sandbox."""
     if not contract.install_cmd:
         return
 
     log_output(f"Installing dependencies for contract: {contract.name}")
-
     contract_path = get_contract_path(contract.name)
-
-    await stream_command_output(sandbox, f"cd {shlex.quote(str(contract_path))} && {contract.install_cmd}", log_output)
-
+    exit_reason = await stream_command_output(
+        sandbox, f"cd {shlex.quote(str(contract_path))} && {contract.install_cmd}", log_output
+    )
+    if exit_reason is not None:
+        raise SandboxError(f"Install command exited with {exit_reason}")
     log_output(f"Finished installing dependencies for contract: {contract.name}")
 
 
-# NOTE: If this gets too big move it into a mapping
-# these are decoupled since its just 2 exit codes we need to track
-_TIMEOUT_EXIT_CODE: int = 124
-_OS_KILL_EXIT_CODE: int = 137
-_SUCCESS_EXIT_CODE: int = 0
-
-# Process exec retry settings
-_EXEC_MAX_ATTEMPTS: int = 3
-_EXEC_DELAY_SECONDS: float = 2.0
-
-# Reconnect to the PTY retry settings
-_PTY_RECONNECT_MAX_ATTEMPTS: int = 10
-_PTY_RECONNECT_DELAY_SECONDS: float = 1.0
-
-# Creating a PTY retry settings
-_PTY_CREATE_MAX_ATTEMPTS: int = 5
-_PTY_CREATE_DELAY_SECONDS: float = 2.0
-
-# Process-global cap on concurrent PTY WebSocket handshakes.
-# Daytona starts failing above ~500 concurrent handshakes; 100 held 800 PTYs cleanly in testing.
-# Temporarily effectively unbounded while validating the new Daytona SDK.
-_PTY_HANDSHAKE_CAP: int = 1_000_000
-_PTY_HANDSHAKE_SLOW_LOG_THRESHOLD: float = 2.0
-
-_pty_handshake_semaphore: Semaphore = Semaphore(_PTY_HANDSHAKE_CAP)
-
-# States that determine if the sandbox has been killed
-_DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED)
-
-
-@asynccontextmanager
-async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator[None, None]:
-    """
-    Gate a PTY WebSocket handshake with a process-global semaphore. Released as soon as the
-    handshake call returns, so the PTY's subsequent lifetime (wait, send_input, etc.) is not gated.
-
-    Logs when the gate is saturated on entry or when the handshake itself is slow.
-    """
-    gate_full_on_entry = _pty_handshake_semaphore.locked()
-
-    wait_start = time.monotonic()
-    async with _pty_handshake_semaphore:
-        wait_duration = time.monotonic() - wait_start
-
-        if gate_full_on_entry:
-            logger.info(
-                f"PTY handshake gate full: {operation} session={session_id} "
-                f"cap={_PTY_HANDSHAKE_CAP} waited={wait_duration:.2f}s"
-            )
-
-        handshake_start = time.monotonic()
-        try:
-            yield
-        finally:
-            handshake_duration = time.monotonic() - handshake_start
-            if handshake_duration > _PTY_HANDSHAKE_SLOW_LOG_THRESHOLD:
-                logger.warning(
-                    f"PTY handshake slow: {operation} session={session_id} duration={handshake_duration:.2f}s"
-                )
-
-
-@retry(
-    retry=retry_if_exception_type(DaytonaError),
-    stop=stop_after_attempt(_EXEC_MAX_ATTEMPTS),
-    wait=wait_fixed(_EXEC_DELAY_SECONDS),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
-    reraise=True,
-)
-async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
-    """
-    Execute a command inside the sandbox with retries for transient network failures.
-
-    Raises:
-        DaytonaError: If all retry attempts are exhausted
-    """
-
-    return await sandbox.process.exec(command)
-
-
-@retry(
-    retry=retry_if_exception_type(DaytonaError),
-    stop=stop_after_attempt(_PTY_CREATE_MAX_ATTEMPTS),
-    wait=wait_fixed(_PTY_CREATE_DELAY_SECONDS),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
-    reraise=True,
-)
-async def _create_pty_session(
-    sandbox: AsyncSandbox,
-    session_id: str,
-    on_data: Callable[[bytes], None],
-    envs: dict[str, str] | None = None,
-) -> tuple[AsyncPtyHandle, str]:
-    """
-    Create a PTY session, retried since network errors do happen.
-
-    Raises:
-        DaytonaError: If all retry attempts are exhausted
-    """
-
-    # Salt the session id to ensure that no collisions occur
-    salted_id = f"{session_id}-{uuid.uuid4().hex[:8]}"
-
-    # Each time we run this we want it to be logged, makes debugging easier
-    on_data(f"[Debug]: Creating PTY session with the following id {salted_id}\n".encode())
-
-    # Attempt to make the PTY session, timeouts occur under load
-    async with _pty_handshake_slot("create", salted_id):
-        handle = await sandbox.process.create_pty_session(id=salted_id, on_data=on_data, envs=envs)
-
-    # Handle to access the PTY and the session id to pass on
-    return handle, salted_id
-
-
-async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
-    """
-    Checks if we can connect to a sandbox
-
-    Raises:
-         SandboxError: if the sandbox cannot be connected to
-    """
-    try:
-        await sandbox.refresh_data()
-        if sandbox.state in _DEAD_SANDBOX_STATES:
-            raise SandboxError(f"Sandbox {sandbox.name} crashed during command execution (state: {sandbox.state})")
-    except SandboxError:
-        raise
-    except Exception as e:
-        raise SandboxError(f"Failed to check sandbox {sandbox.name} health: {e}") from e
-
-
-@retry(
-    retry=retry_if_not_exception_type(SandboxError),
-    stop=stop_after_attempt(_PTY_RECONNECT_MAX_ATTEMPTS),
-    wait=wait_fixed(_PTY_RECONNECT_DELAY_SECONDS),
-    reraise=True,
-)
-async def _reconnect_and_wait_pty(
-    sandbox: AsyncSandbox,
-    session_id: str,
-    on_data: Callable[[bytes], None],
-    on_output: Callable[[str], None],
-) -> None:
-    """
-    Reconnect to a PTY session and wait for it to close,
-    Used to determine if a connection issue happened or if the sandbox was killed while the run was in progress
-
-    Raises:
-        SandboxError: If we cannot successfully check the sandbox health status
-    """
-
-    # Check if the sandbox has been closed
-    await _check_sandbox_health(sandbox)
-
-    # Log so the user can see we have seen a disconnection from the websocket (easier to pickup in logs)
-    on_output("[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n")
-
-    # Reconnect to the PTY. Only the connect handshake is gated; handle.wait() runs ungated below.
-    async with _pty_handshake_slot("reconnect", session_id):
-        handle = await sandbox.process.connect_pty_session(session_id, on_data)
-
-    # Wait until the command has finished running
-    await handle.wait()
-
-
-async def _wait_for_pty(
-    sandbox: AsyncSandbox,
-    session_id: str,
-    handle: Any,
-    on_data: Callable[[bytes], None],
-    on_output: Callable[[str], None],
-    status_path: str,
-) -> None:
-    """
-    Wait for the PTY to close, reconnecting on WebSocket failures.
-    If the PTY closes prematurely (e.g. WebSocket idle timeout) but the status file
-    hasn't been written yet, reconnect and wait again until the command actually finishes.
-
-    Raises:
-        SandboxError: Failed to wait until the command has been completed
-    """
-    try:
-        await handle.wait()
-        on_output("[Debug]: PTY has been disconnected, handler has stopped polling\n")
-    except Exception as e:
-        on_output(f"[Debug]: PTY stream has been disconnected (Attempting reconnection): {e}\n")
-        try:
-            await _reconnect_and_wait_pty(sandbox, session_id, on_data, on_output)
-        except SandboxError:
-            raise
-        except Exception as e:
-            raise SandboxError(f"PTY reconnect failed after {_PTY_RECONNECT_MAX_ATTEMPTS} attempts") from e
-
-    # If the PTY closed cleanly but the command is still running (e.g. idle WebSocket timeout),
-    # breaks when the file with the command status code is made
-    while True:
-        await _check_sandbox_health(sandbox)
-        if (await _exec(sandbox, f"test -e {status_path}")).exit_code == 0:
-            break
-
-        on_output("[Debug]: PTY closed but status file not written yet, reconnecting\n")
-        try:
-            await _reconnect_and_wait_pty(sandbox, session_id, on_data, on_output)
-        except SandboxError:
-            raise
-        except Exception as e:
-            raise SandboxError(f"PTY reconnect failed after {_PTY_RECONNECT_MAX_ATTEMPTS} attempts") from e
-
-
-async def _read_exit_code(sandbox: AsyncSandbox, status_path: str) -> int:
-    """
-    Read the command exit code from the status file (Important to determine reason for exiting)
-
-    Raises:
-        SandboxError: If we fail to read the exit code from the status file
-    """
-    try:
-        # Read the status file, extracting the exit code
-        result = await _exec(sandbox, f"cat {status_path}")
-
-        # If file does not exist or we have no content the command has not produced an exit code
-        # That would suggest the sandbox was killed or something interrupted the program
-        if result.exit_code != 0 or not result.result.strip():
-            raise SandboxError(f"Failed to read exit status from {status_path}")
-
-        # Should always be a integer
-        return int(result.result.strip())
-
-    except SandboxError:
-        raise
-    except Exception as e:
-        raise SandboxError(f"Failed to read exit status from {status_path}: {e}") from e
-
-
-async def _disconnect_pty(handle: AsyncPtyHandle | None) -> None:
-    """
-    Disconnect from the PTY, ignoring exit errors
-    """
-
-    # Don't need to disconnect if it does not exist
-    if not handle:
-        return
-
-    # Ignore exceptions raised when disconnecting
-    # Most likely would be a network connection error
-    try:
-        await handle.disconnect()
-    except Exception:
-        pass
-
-
-async def _kill_pty_session(sandbox: AsyncSandbox, session_id: str | None) -> None:
-    """
-    Kill a PTY session, ignoring errors if raised or if session was never created
-    """
-    if not session_id:
-        return
-
-    try:
-        await sandbox.process.kill_pty_session(session_id)
-    except Exception:
-        logger.warning(f"Failed to kill PTY session {session_id}")
-
-
 async def stream_command_output(
-    sandbox: AsyncSandbox,
-    command: str,
-    on_output: Callable[[str], None],
+    sandbox: Sandbox, command: str, on_output: Callable[[str], None]
 ) -> AgentCausedExitReason | None:
-    """
-    Execute a command inside a sandbox using a PTY session, reconnecting on errors
+    output: deque[str] = deque(maxlen=50)
 
-    The exit code is written to a status file rather than relying on
-    the PTY WebSocket close frame, which doesn't reliably propagate it.
+    def collect(data: str) -> None:
+        on_output(data)
+        output.append(data)
 
-    Return:
-        AgentCausedExitReason if the command terminated abnormally but recoverably
-        (e.g., timeout or OS kill), None on clean exit.
-    """
-    pty_id = uuid.uuid4().hex
-    session_id = f"{sandbox.id}:pty-{pty_id}"
-    status_dir = "/tmp/.valkyrie"
-    status_path = f"{status_dir}/{pty_id}.status"
-    handle: AsyncPtyHandle | None = None
-    last_output: deque[str] = deque(maxlen=50)
-
-    def on_data(data: bytes) -> None:
-        text = data.decode("utf-8", errors="replace")
-        on_output(text)
-        last_output.append(text)
-
-    try:
-        # Create a PTY session, this is where our agent will be running
-        # Set term to DUMB and LANG to UTF-8 to account for terminal colors and unsupported unicode characters
-        try:
-            handle, session_id = await _create_pty_session(
-                sandbox, session_id, on_data, envs={"TERM": "dumb", "LANG": "C.UTF-8"}
-            )
-        except DaytonaError as e:
-            raise SandboxError(f"Failed to create PTY session after {_PTY_CREATE_MAX_ATTEMPTS} attempts: {e}") from e
-
-        # Disable echo to suppress command line noise in the output
-        await handle.send_input("stty -echo\n")
-
-        # Capture exit code in a status file
-        await handle.send_input(f"mkdir -p {status_dir} && {command}; echo $? > {status_path}; exit\n")
-
-        # Wait for the PTY to finish running the agent, logging data returned
-        await _wait_for_pty(sandbox, session_id, handle, on_data, on_output, status_path)
-
-        # Verify sandbox is still alive before reading the status file
-        await _check_sandbox_health(sandbox)
-
-        # Read the exit code of the process running the agent
-        exit_code = await _read_exit_code(sandbox, status_path)
-
-        # Timeout error has a special handle since its caused by the benchmark service
-        # Exit codes are waterfalled
-        if exit_code == _TIMEOUT_EXIT_CODE:
-            return AgentCausedExitReason.TIMEOUT
-
-        # OS killed the process
-        if exit_code == _OS_KILL_EXIT_CODE:
-            return AgentCausedExitReason.OS_KILLED
-
-        # Failed error code handling (truncate error shown to the user)
-        # Final log is shown to the user, ignore traceback since it provides no insight as to what actually happened in the sandbox
-        if exit_code != _SUCCESS_EXIT_CODE:
-            tail = "".join(last_output).strip().splitlines()
-            recent = "\n".join(tail[-10:]) if tail else "(no output)"
-            raise SandboxError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
-
+    result = await sandbox.exec(command, on_stdout=collect, on_stderr=collect)
+    if result.exit_code == _SUCCESS_EXIT_CODE:
         return None
-
-    finally:
-        # Disconnect form PTY, ignoring exception if raised
-        await _disconnect_pty(handle)
-
-        # Kill the PTY session, ignoring exception if raised
-        await _kill_pty_session(sandbox, session_id)
-
-        # Remove the status file, ignoring exception if raised
-        try:
-            await _exec(sandbox, f"rm -f {status_path}")
-        except Exception:
-            pass
+    if result.exit_code == _TIMEOUT_EXIT_CODE:
+        return AgentCausedExitReason.TIMEOUT
+    if result.exit_code == _OS_KILL_EXIT_CODE:
+        return AgentCausedExitReason.OS_KILLED
+    raise SandboxError(
+        f"Failed to run command {command}, exit code: {result.exit_code}\nLast output:\n{_tail(result, output)}"
+    )
 
 
 async def archive_and_upload_output(
-    sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str, aws: AWSCredentials, s3_bucket: str
+    sandbox: Sandbox, output_path: str, agent_output_s3_key: str, aws: AWSCredentials, s3_bucket: str
 ) -> None:
-    """Compress a file in the sandbox into a tar.gz and upload it to S3"""
     archive_path = f"/tmp/{uuid.uuid4().hex}.tar.gz"
-
     tar_result = await _exec(sandbox, f"tar -czf {shlex.quote(archive_path)} {shlex.quote(output_path)}")
-    if tar_result.exit_code != 0:
+    if tar_result.exit_code != _SUCCESS_EXIT_CODE:
         raise SandboxError(f"Failed to create archive from {output_path}")
 
     try:
-        b64_result = await _exec(sandbox, f"base64 {shlex.quote(archive_path)}")
-        if b64_result.exit_code != 0:
-            raise SandboxError(f"Failed to read archive from {output_path}")
-
-        await upload_to_s3(base64.b64decode(b64_result.result), agent_output_s3_key, aws, s3_bucket)
+        await upload_to_s3(await sandbox.download_file(archive_path), agent_output_s3_key, aws, s3_bucket)
     finally:
-        # Remove the file if it exists `-f` exits silently if the file does not exist
-        try:
-            await _exec(sandbox, f"rm -f {shlex.quote(archive_path)}")
-        except Exception:
-            pass
+        await _exec(sandbox, f"rm -f {shlex.quote(archive_path)}")
 
 
 async def run_agent(
-    sandbox: AsyncSandbox,
+    sandbox: Sandbox,
     contract: AgentContractRequest,
     problem_path: str,
     task_id: str,
@@ -653,57 +248,29 @@ async def run_agent(
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
 ) -> AgentCausedExitReason | None:
-    """
-    Run the agent inside the sandbox for a given task.
-
-    Args:
-        sandbox: The sandbox to run the agent in
-        contract: The agent contract configuration
-        problem_path: Path inside the sandbox where the problem statement file was written during setup
-        log_output: Callback to log output
-        cwd: Working directory to run the agent in
-        agent_output_s3_key: S3 key to where we will upload the final output archive to
-        agent_timeout: Optional timeout in seconds to enforce on the agent command
-
-    Returns:
-        AgentCausedExitReason if the agent was terminated abnormally but recoverably
-        (timeout or OS kill), None on clean exit.
-
-    Raises:
-        SandboxError: If the agent fails to run or times out
-    """
     log_output(f"Running agent {contract.name}")
 
     await install_agent_dependencies(sandbox, contract, log_output)
 
     run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_path).replace("{task_id}", task_id)
-
-    # Apply timeout if specified
     if agent_timeout is not None:
         run_cmd = f"timeout {agent_timeout} {run_cmd}"
 
-    # Create cwd if it does not already exist
     await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
-
-    # Run the agent without including task directory dependencies
     exit_reason = await stream_command_output(
         sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output
     )
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         log_output(
-            f"[WARNING]:`{contract.name}` has reached the designated timeout provided by the benchmark service for this task: `{agent_timeout}`. The process has been terminated and evaluation will proceed."
+            f"[WARNING]:`{contract.name}` reached the task timeout `{agent_timeout}`. The process was terminated and evaluation will proceed."
         )
-    elif exit_reason == AgentCausedExitReason.OS_KILLED:
-        log_output(
-            f"[WARNING]:`{contract.name}` was killed by the OS (exit code {_OS_KILL_EXIT_CODE}, likely out-of-memory). The process has been terminated and evaluation will proceed."
-        )
+    if exit_reason == AgentCausedExitReason.OS_KILLED:
+        log_output(f"[WARNING]:`{contract.name}` was killed by the sandbox OS. Evaluation will proceed.")
 
-    # Upload any output from the agent to S3
     if contract.final_output:
         result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
         if result.exit_code == _SUCCESS_EXIT_CODE and agent_output_s3_key:
             await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, aws, s3_bucket)
 
-    # Return why the agent terminated abnormally, or None on clean exit
     return exit_reason

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from benchmark_service.client import BenchmarkServiceClient
@@ -18,6 +18,9 @@ from tracker.database.models import (
     FinalEvaluation,
     TaskStatus,
 )
+
+
+SandboxProviderName = Literal["daytona", "modal"]
 
 
 class BenchmarkDetails(BaseModel):
@@ -52,6 +55,7 @@ class StartBenchmarkRequest(BaseModel):
     dataset: str | None = None
     harness_config: HarnessConfig
     custom_benchmark_service: str | None = None
+    sandbox_provider: SandboxProviderName = "daytona"
     service_headers: dict[str, str] = {}
     webhook_secret_name: str | None = None
     webhook_intervals: list[int] | None = None
@@ -66,6 +70,7 @@ class StartBenchmarkRequest(BaseModel):
             url=benchmark_service_url,
             daytona_secret_name=self.harness_config.daytona_secret_name,
             aws=self.harness_config.aws,
+            sandbox_provider=self.sandbox_provider,
             service_headers=self.service_headers,
         )
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -14,8 +14,7 @@ from zoneinfo import ZoneInfo
 
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from daytona.common.errors import DaytonaNotFoundError
+from benchmark_service.sandbox import Sandbox, SandboxProvider, SandboxQuery
 from fastapi import Request
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
@@ -44,7 +43,7 @@ from tracker.s3 import (
     get_agent_result_s3_key,
     upload_to_s3,
 )
-from tracker.sandbox import create_sandbox, delete_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
 from tracker.secrets import fetch_aws_secret, resolve_secrets
 from tracker.types import (
     AWSCredentials,
@@ -87,10 +86,15 @@ def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict
 
 
 def create_benchmark_service_client(
-    url: str, daytona_secret_name: str, aws: AWSCredentials, service_headers: dict[str, str] | None = None
+    url: str,
+    daytona_secret_name: str,
+    aws: AWSCredentials,
+    sandbox_provider: str = "daytona",
+    service_headers: dict[str, str] | None = None,
 ) -> BenchmarkServiceClient:
-    """Create a BenchmarkServiceClient using Daytona credentials from AWS Secrets Manager."""
-    headers = fetch_daytona_headers(daytona_secret_name, aws)
+    headers = {"x-sandbox-provider": sandbox_provider}
+    if sandbox_provider == "daytona":
+        headers.update(fetch_daytona_headers(daytona_secret_name, aws))
     if service_headers:
         headers.update(service_headers)
     return BenchmarkServiceClient(url=url, headers=headers)
@@ -111,6 +115,7 @@ def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest, org: Or
             slice_str=request.slice_str,
             lambda_function=request.lambda_function,
             dataset=request.dataset,
+            sandbox_provider=request.sandbox_provider,
         ),
     )
 
@@ -370,8 +375,9 @@ async def process_task(
             task.status = TaskStatus.BUILDING
             task_session.commit()
 
+        sandbox_provider = await benchmark_service.get_sandbox_provider()
         async with create_sandbox(
-            daytona=benchmark_service.daytona_client,
+            provider=sandbox_provider,
             sandbox_name=task_row.alias,
             image=task_data.docker_image,
             labels=labels,
@@ -959,68 +965,18 @@ async def initiate_stop_benchmark(benchmark_row: Benchmark, session: Session, fo
         raise TrackerServiceError(f"Unexpected error stopping run {benchmark_row.id}: {str(e)}") from e
 
 
-async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> str | None:
+async def _delete_sandbox(sandbox: Sandbox, provider: SandboxProvider) -> str | None:
     try:
-        # Wait for the sandbox to be in a valid deletion state
-        await sandbox.wait_for_sandbox_start(timeout=0)
-
-        # Delete the sandbox
-        await delete_sandbox(sandbox, daytona_client)
-
-        return None
-    except DaytonaNotFoundError:
-        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
+        await provider.delete_sandbox(sandbox)
         return None
     except Exception as e:
         return f"{str(e)}: {traceback.format_exc()}"
 
 
-async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona, page: int) -> AsyncPaginatedSandboxes:
-    return await daytona_client.list(
-        labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page
-    )
-
-
-async def sandbox_generator(
-    benchmark_row: Benchmark, daytona_client: AsyncDaytona
-) -> AsyncGenerator[AsyncSandbox, None]:
-    """
-    Generator that yields all sandboxes for a given benchmark in paginated chunks of 10.
-
-    NOTE: At the time of this implementation there are several things weird with the dayyona api
-        1. If you delete the sandboxes in the list, the next page should be the first page (repopulated)
-        2. Final state is not DESTROYED, but rather DESTROYING
-        3. The total_pages count is not updated as you delete sandboxes
-    """
-
-    paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(benchmark_row, daytona_client, 1)
-
-    total_pages = paginated_sandboxes.total_pages
-    while (paginated_sandboxes.page <= total_pages) and paginated_sandboxes.items:
-        sandboxes = paginated_sandboxes.items
-        for sandbox in sandboxes:
-            if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-                continue
-
-            yield sandbox
-
-        # NOTE: Since we deleted the first 10 the first page will be populated with the next 10 sandboxes
-        paginated_sandboxes = await fetch_sandboxes(benchmark_row, daytona_client, int(paginated_sandboxes.page))
-
-
 async def force_stop_sandboxes(
     benchmark_row: Benchmark, session: Session, daytona_secret_name: str, aws: AWSCredentials, org: Org
 ) -> None:
-    """
-    Stops and deletes all sandboxes which are in progress or evaluating.
-    NOTE: If task is not in progress but sandbox exists, we kill it and leave the task status as is.
-
-    Raises:
-        TrackerServiceError: If there are any errors stopping the sandboxes
-    """
-    daytona_client: AsyncDaytona = benchmark_row.benchmark_service(daytona_secret_name, aws).daytona_client
-
-    # Update all tasks being processed to stopped
+    """Stop and delete all provider sandboxes for a benchmark."""
     session.exec(
         update(Task)
         .where(col(Task.benchmark) == benchmark_row.id)
@@ -1028,23 +984,19 @@ async def force_stop_sandboxes(
         .where(col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
         .values(status=TaskStatus.STOPPED)
     )
-
     session.commit()
 
-    # Iterate through each running sandbox and stop it, collecting error messages
+    benchmark_service = benchmark_row.benchmark_service(daytona_secret_name, aws)
+    provider = await benchmark_service.get_sandbox_provider()
+    query = SandboxQuery(labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=1000)
+
     results: dict[str, str | None] = {}
-    async for sandbox in sandbox_generator(benchmark_row, daytona_client):
-        result = await stop_sandbox(sandbox, daytona_client)
+    async for sandbox in provider.list_sandboxes(query):
+        assert isinstance(sandbox.name, str)
+        results[sandbox.name] = await _delete_sandbox(sandbox, provider)
 
-        results[sandbox.name] = result
-
-    error_message: str = "\n".join(
-        f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
-    )
-
-    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
-    finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
-    tasks_still_running: int = session.exec(
+    finished_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+    tasks_still_running = session.exec(
         select(func.count(col(Task.id)))
         .where(col(Task.benchmark) == benchmark_row.id)
         .where(col(Task.org_id) == org.id)
@@ -1056,6 +1008,9 @@ async def force_stop_sandboxes(
         session.add(benchmark_row)
         session.commit()
 
+    error_message = "\n".join(
+        f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
+    )
     if error_message:
         raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1,92 +1,145 @@
-import asyncio
-from typing import Any
-from unittest.mock import Mock
+from asyncio import Semaphore
+from collections.abc import AsyncIterator, Callable, Mapping
+from pathlib import Path
 
 import pytest
+from benchmark_service.sandbox import (
+    ExecResult,
+    ImageSandboxCreateRequest,
+    Sandbox,
+    SandboxCreateRequest,
+    SandboxFile,
+    SandboxNotFoundError,
+    SandboxProvider,
+    SandboxQuery,
+    SnapshotSandboxCreateRequest,
+)
+from benchmark_service.schemas import Resources
 
-from tracker import sandbox as sandbox_module
-from tracker.sandbox import _create_pty_session
+from tracker.database.models import AgentCausedExitReason
+from tracker.exceptions import SandboxError
+from tracker.sandbox import create_sandbox, stream_command_output
 
 
-class TestPtyHandshakeSemaphore:
-    async def test_semaphore_caps_concurrent_handshakes(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """
-        Concurrent _create_pty_session calls never exceed the cap on in-flight
-        sandbox.process.create_pty_session calls.
+class FakeSandbox(Sandbox):
+    def __init__(self, provider: SandboxProvider, result: ExecResult | None = None) -> None:
+        super().__init__(provider=provider, id="sandbox-id", name="sandbox-name")
+        self.result = result or ExecResult(exit_code=0, stdout="ok")
 
-        Regression guard: if someone removes the `async with _pty_handshake_slot(...)`
-        wrapper around the handshake call, concurrency becomes unbounded.
-        """
-        cap = 5
-        total = 25
-        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(cap))
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout: float | None = None,
+        on_stdout: Callable[[str], None] | None = None,
+        on_stderr: Callable[[str], None] | None = None,
+    ) -> ExecResult:
+        if on_stdout and self.result.stdout:
+            on_stdout(self.result.stdout)
+        if on_stderr and self.result.stderr:
+            on_stderr(self.result.stderr)
+        return self.result
 
-        concurrent = 0
-        max_concurrent = 0
+    async def upload_file(self, file: SandboxFile) -> None:
+        raise AssertionError(file)
 
-        async def fake_create_pty_session(*_args: Any, **_kwargs: Any) -> Mock:
-            nonlocal concurrent, max_concurrent
+    async def upload_local_file(self, local_path: Path, remote_path: str) -> None:
+        raise AssertionError((local_path, remote_path))
 
-            concurrent += 1
-            max_concurrent = max(max_concurrent, concurrent)
+    async def upload_files(self, files: list[SandboxFile]) -> None:
+        raise AssertionError(files)
 
-            # Hold long enough for other tasks to pile up behind the gate
-            await asyncio.sleep(0.05)
+    async def download_file(self, remote_path: str) -> bytes:
+        raise AssertionError(remote_path)
 
-            concurrent -= 1
-            return Mock()
+    async def wait_until_ready(self) -> None:
+        return None
 
-        mock_sandbox = Mock()
-        mock_sandbox.process.create_pty_session = fake_create_pty_session
+    async def wait_until_stopped(self) -> None:
+        return None
 
-        results = await asyncio.gather(
-            *[_create_pty_session(mock_sandbox, f"session-{i}", lambda _data: None) for i in range(total)]
+
+class FakeProvider(SandboxProvider):
+    def __init__(self, result: ExecResult | None = None) -> None:
+        self.sandbox = FakeSandbox(self, result)
+        self.create_request: SandboxCreateRequest | None = None
+        self.deleted: Sandbox | None = None
+
+    @classmethod
+    async def from_headers(cls, headers: Mapping[str, str]) -> "FakeProvider":
+        raise AssertionError(headers)
+
+    async def get_sandbox(self, id: str) -> FakeSandbox:
+        raise SandboxNotFoundError()
+
+    async def create_sandbox(self, request: SandboxCreateRequest) -> FakeSandbox:
+        self.create_request = request
+        return self.sandbox
+
+    async def delete_sandbox(self, sandbox: Sandbox) -> None:
+        self.deleted = sandbox
+
+    def list_sandboxes(self, query: SandboxQuery | None = None) -> AsyncIterator[Sandbox]:
+        raise AssertionError(query)
+
+
+async def test_create_sandbox_uses_image_request() -> None:
+    provider = FakeProvider()
+
+    async with create_sandbox(
+        provider=provider,
+        sandbox_name="task-alias",
+        image="python:3.12",
+        resources=Resources(vcpu=2, memory=4, disk=8),
+        creation_semaphore=Semaphore(1),
+        labels={"Task": "task-id"},
+        env_vars={"A": "B"},
+    ) as sandbox:
+        assert sandbox is provider.sandbox
+
+    assert isinstance(provider.create_request, ImageSandboxCreateRequest)
+    assert provider.create_request.image == "python:3.12"
+    assert provider.create_request.name == "task-alias"
+    assert provider.create_request.resources
+    assert provider.create_request.resources.cpu == 2
+    assert provider.deleted is provider.sandbox
+
+
+async def test_create_sandbox_uses_snapshot_request() -> None:
+    provider = FakeProvider()
+
+    async with create_sandbox(
+        provider=provider,
+        sandbox_name="task-alias",
+        image="snapshot:vcb-ready",
+        resources=Resources(vcpu=2, memory=4, disk=8),
+        creation_semaphore=Semaphore(1),
+        labels={},
+        env_vars={},
+    ):
+        pass
+
+    assert isinstance(provider.create_request, SnapshotSandboxCreateRequest)
+    assert provider.create_request.snapshot == "vcb-ready"
+
+
+async def test_stream_command_output_maps_agent_exit_reasons() -> None:
+    assert await stream_command_output(FakeProvider(ExecResult(exit_code=0)).sandbox, "cmd", lambda _data: None) is None
+    assert (
+        await stream_command_output(FakeProvider(ExecResult(exit_code=124)).sandbox, "cmd", lambda _data: None)
+        == AgentCausedExitReason.TIMEOUT
+    )
+    assert (
+        await stream_command_output(FakeProvider(ExecResult(exit_code=137)).sandbox, "cmd", lambda _data: None)
+        == AgentCausedExitReason.OS_KILLED
+    )
+
+
+async def test_stream_command_output_raises_on_unknown_failure() -> None:
+    with pytest.raises(SandboxError, match="exit code: 128"):
+        await stream_command_output(
+            FakeProvider(ExecResult(exit_code=128, stderr="control server refused")).sandbox,
+            "cmd",
+            lambda _data: None,
         )
-
-        assert len(results) == total
-        assert max_concurrent <= cap
-        # Sanity: without the cap we'd see total concurrency; confirm contention actually happened
-        assert max_concurrent > 1
-
-    async def test_semaphore_released_after_handshake_returns(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """
-        The semaphore slot is released as soon as the handshake call returns, before the
-        caller does anything else with the handle (handle.wait, send_input, etc.).
-
-        Regression guard: if someone widens the `async with _pty_handshake_slot(...)` scope
-        — e.g. wraps code after create_pty_session returns, or wraps the whole caller flow
-        around handle.wait() — a second concurrent handshake would block until the first
-        task finishes its session lifetime. With cap=1 and a simulated long-running
-        post-handshake step, that regression turns this test into a timeout.
-        """
-        cap = 1
-        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(cap))
-
-        async def fake_create_pty_session(*_args: Any, **_kwargs: Any) -> Mock:
-            return Mock()
-
-        mock_sandbox = Mock()
-        mock_sandbox.process.create_pty_session = fake_create_pty_session
-
-        events: list[str] = []
-
-        async def task_holding_handle() -> None:
-            await _create_pty_session(mock_sandbox, "s1", lambda _data: None)
-            events.append("a:handshake_done")
-
-            # Simulate a long-running handle.wait() AFTER the handshake.
-            # The slot must already be released, otherwise the other task can't acquire.
-            await asyncio.sleep(0.2)
-            events.append("a:post_handshake_done")
-
-        async def task_needing_slot() -> None:
-            # Tiny delay so task A acquires the slot first
-            await asyncio.sleep(0.01)
-            await _create_pty_session(mock_sandbox, "s2", lambda _data: None)
-            events.append("b:handshake_done")
-
-        await asyncio.wait_for(asyncio.gather(task_holding_handle(), task_needing_slot()), timeout=1.0)
-
-        # Task B's handshake must complete BEFORE task A's post-handshake work finishes.
-        # That ordering is only reachable if the slot was released at handshake exit.
-        assert events.index("b:handshake_done") < events.index("a:post_handshake_done")

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -29,6 +29,7 @@ client = TestClient(app)
 
 class TestStopAndResume:
     _test_org = Org(id=TEST_ORG_ID, name="default")
+
     @staticmethod
     async def _mock_request_retrieve_task(*args: Any, **kwargs: Any) -> RetrieveTaskResponse:
         return RetrieveTaskResponse(
@@ -178,7 +179,10 @@ class TestStopAndResume:
         database_session.add(benchmark_row)
         database_session.commit()
 
-        task_rows = [Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STOPPED) for i in range(2)]
+        task_rows = [
+            Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STOPPED)
+            for i in range(2)
+        ]
         database_session.add_all(task_rows)
         database_session.commit()
 
@@ -276,13 +280,16 @@ class TestStopAndResume:
         await initiate_stop_benchmark(benchmark_row, database_session, force=True, org=self._test_org)
         assert benchmark_row.status == BenchmarkStatus.STOPPING
 
-        # Mock daytona client since its not required
-        mock_daytona = AsyncMock()
-        mock_daytona.list = AsyncMock(return_value=AsyncMock(items=[], total_pages=0, page=1))
+        async def empty_sandboxes(_query):
+            if False:
+                yield Mock()
+
+        mock_provider = Mock(list_sandboxes=lambda query: empty_sandboxes(query), delete_sandbox=AsyncMock())
+        mock_benchmark_service = Mock(get_sandbox_provider=AsyncMock(return_value=mock_provider))
         monkeypatch.setattr(
             Benchmark,
             "benchmark_service",
-            lambda *_args, **_kwargs: Mock(daytona_client=mock_daytona),  # type: ignore
+            lambda *_args, **_kwargs: mock_benchmark_service,  # type: ignore
         )
 
         # Force stopping the sandboxes results in the benchmark row being stopped

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -207,6 +207,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.0.0rc1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/b3/f214d75da0bcac9aff418fcbf7a4587a2f1d2a46f992039c4e937574075c/cbor2-6.0.0rc1.tar.gz", hash = "sha256:a57e921fc8289efd882636366a6cb6a15bfe90907a0b9be919921546c367df63", size = 83987, upload-time = "2026-03-25T22:57:42.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/19/3825a17973c36fa85408201877dbc58f5f994fc2a474b78adef6e6dfe901/cbor2-6.0.0rc1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a9b23291b8d8e1bbf286e1606c473774c840de9168d17b466727d04de92607f", size = 405116, upload-time = "2026-03-25T22:57:03.022Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f9/44306682d5b1e978a814bd10480f6f2645dcef92c1a5c0af141a8822bb96/cbor2-6.0.0rc1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0f00dcf841a76cf996b0cc94c2c7b8717f5c1a19a9e752ede1cd71a32858bfa8", size = 448560, upload-time = "2026-03-25T22:57:04.359Z" },
+    { url = "https://files.pythonhosted.org/packages/76/30/7c007cf34996fd5e57c7f64d72a8b8caf94532042ddbf5f4601de601ae56/cbor2-6.0.0rc1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:53ab38387b213cca6dae722ed6b6733db240eed7f59e12b9c85d0b08a51414cb", size = 463536, upload-time = "2026-03-25T22:57:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e7/2e1343194c09d2eb7cfd065e4e2fa86634c8b3ecc875151ba9f07f8163fc/cbor2-6.0.0rc1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cdc80f6bb9820ac99463f31075c1a31f109b803d04184b069a805a9cc7098e1f", size = 513697, upload-time = "2026-03-25T22:57:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9e/a44525a1fe4b23512a6cffc559692185add957e7481773ec5ac937dd254f/cbor2-6.0.0rc1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4e4626d6ab57a81eb70394bd18ea90152d0676e8ccd16a5901f2170e17f46a3", size = 529819, upload-time = "2026-03-25T22:57:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c9/bd2e3165e26e95d2b9ca1db3d22fd7a008cd1b2903d102a8f137f743c657/cbor2-6.0.0rc1-cp312-cp312-win_amd64.whl", hash = "sha256:397dc9e20de2f2d2a2a308901774b8361040f127a6527467d57c2edee5595582", size = 287780, upload-time = "2026-03-25T22:57:09.945Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/a3/8b982494944a7b9d519465eecf74753691c68f05e8d877274f468090c5d7/cbor2-6.0.0rc1-cp312-cp312-win_arm64.whl", hash = "sha256:4a6b53cedbcde5ae68f70b60430b7964119e28c42375fc0f1b524ce7810a0d60", size = 278338, upload-time = "2026-03-25T22:57:11.348Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -287,13 +302,14 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#0d06ceecd2b0d886cbef8fa8dec0a62543774598" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=ht%2Fmodal-integration-rebased#45b9b31406291452d34acbc8bf5252461f7ccbd1" }
 dependencies = [
     { name = "click" },
     { name = "daytona" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "modal" },
     { name = "tenacity" },
     { name = "websockets" },
 ]
@@ -639,12 +655,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -688,6 +739,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -813,6 +873,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.4.3.dev4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/06/77f752afbbfc5c613d00cd0ca147becb6988c2304c32342e96cb89f232bb/modal-1.4.3.dev4.tar.gz", hash = "sha256:8e5d9789130098a49552b1d8f8668a935a3bf44eeee87bdfe62969ed251ea3e5", size = 703918, upload-time = "2026-04-21T01:00:55.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/5b/2ea3a8365869465eb26ec68c02f60c6e85cffea2fdcfbf7b0c11e6addf24/modal-1.4.3.dev4-py3-none-any.whl", hash = "sha256:18bb2b56388a05097f41b2d47adc0ea3e355f678e4462739249f7d9e17777a63", size = 807408, upload-time = "2026-04-21T01:00:53.214Z" },
 ]
 
 [[package]]
@@ -1583,6 +1667,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/5e/50ea27817003665c7cc4f5bdad309f13d6329037f657848ee87fe06c3740/synchronicity-0.12.2.tar.gz", hash = "sha256:6fd605a5035d1ec74ce48fffaca80ea00345c84ca34223914e2436fb4f162ff9", size = 60018, upload-time = "2026-04-06T15:06:15.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/44/4f6ba4e2c171847e6f9a460213b196bbf26edea43d0e66889c7ccc55d368/synchronicity-0.12.2-py3-none-any.whl", hash = "sha256:9dbaca81fb7f2b57c6dea326e514e1c80e9ccfd9c9618515e84fa6091026273b", size = 41312, upload-time = "2026-04-06T15:06:14.459Z" },
+]
+
+[[package]]
 name = "taskiq"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1695,7 +1791,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=ht%2Fmodal-integration-rebased" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
@@ -1746,12 +1842,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
 ]
 
 [[package]]

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -22,7 +22,7 @@ from valkyrie.cli.s3_client import (
     push_agent,
     remove_agent,
 )
-from valkyrie.cli.tracker_service import TrackerService
+from valkyrie.cli.tracker_service import SandboxProviderName, TrackerService
 from valkyrie.cli.utils import (
     CONFIG_LOCATION,
     ConfigValue,
@@ -75,7 +75,6 @@ _REQUIRED_ENVIRONMENT_VARIABLES: dict[str, str | None | int] = {
     "LOG_GROUP": "benchmarks",  # the prefix to the cloudwatch logs (e.x. benchmarks/<benchmark_id>)
     "LOG_RETENTION_POLICY": 365,  # How long logs are kept until auto deleted
 }
-
 
 
 @config.command()
@@ -469,6 +468,13 @@ def auth_list() -> None:
     help="Progress percentage threshold for Slack notification (e.g., -i 25 -i 75). Max 3, must be divisible by 5, range 5-100.",
 )
 @click.option(
+    "--sandbox-provider",
+    type=click.Choice(["daytona", "modal"]),
+    default="daytona",
+    show_default=True,
+    help="Sandbox provider to use for this run.",
+)
+@click.option(
     "--ignore-custom-services",
     "--ics",
     is_flag=True,
@@ -488,6 +494,7 @@ def start(
     secrets: tuple[tuple[str, str]],
     headers: tuple[tuple[str, str]],
     intervals: tuple[int, ...],
+    sandbox_provider: SandboxProviderName,
     ignore_custom_services: bool,
 ):
     """
@@ -509,6 +516,7 @@ def start(
     if model:
         click.echo(f"  - Model: {model}")
     click.echo(f"  - Concurrency: {concurrency}")
+    click.echo(f"  - Sandbox provider: {sandbox_provider}")
     click.echo(f"  - Slice: {slice_str}")
     if dataset:
         click.echo(f"  - Dataset: {dataset}")
@@ -586,6 +594,7 @@ def start(
                 lambda_function,
                 dataset,
                 service_headers=service_headers or None,
+                sandbox_provider=sandbox_provider,
                 webhook_secret_name=webhook_secret if webhook_intervals else None,
                 webhook_intervals=webhook_intervals,
             )

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -4,7 +4,7 @@ import os
 import re
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 import httpx
@@ -27,6 +27,8 @@ from tracker.types import (
 )
 
 from valkyrie.cli.exceptions import TrackerServiceError
+
+SandboxProviderName = Literal["daytona", "modal"]
 
 load_dotenv()
 
@@ -246,6 +248,7 @@ class TrackerService:
         lambda_function: str | None = None,
         dataset: str | None = None,
         service_headers: dict[str, str] | None = None,
+        sandbox_provider: SandboxProviderName = "daytona",
         webhook_secret_name: str | None = None,
         webhook_intervals: list[int] | None = None,
     ) -> Response:
@@ -280,6 +283,7 @@ class TrackerService:
                 if not ignore_custom_services
                 else None,
                 service_headers=service_headers or {},
+                sandbox_provider=sandbox_provider,
                 webhook_secret_name=webhook_secret_name,
                 webhook_intervals=webhook_intervals,
             )

--- a/uv.lock
+++ b/uv.lock
@@ -311,6 +311,42 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.0.0rc1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/b3/f214d75da0bcac9aff418fcbf7a4587a2f1d2a46f992039c4e937574075c/cbor2-6.0.0rc1.tar.gz", hash = "sha256:a57e921fc8289efd882636366a6cb6a15bfe90907a0b9be919921546c367df63", size = 83987, upload-time = "2026-03-25T22:57:42.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/19/3825a17973c36fa85408201877dbc58f5f994fc2a474b78adef6e6dfe901/cbor2-6.0.0rc1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4a9b23291b8d8e1bbf286e1606c473774c840de9168d17b466727d04de92607f", size = 405116, upload-time = "2026-03-25T22:57:03.022Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f9/44306682d5b1e978a814bd10480f6f2645dcef92c1a5c0af141a8822bb96/cbor2-6.0.0rc1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0f00dcf841a76cf996b0cc94c2c7b8717f5c1a19a9e752ede1cd71a32858bfa8", size = 448560, upload-time = "2026-03-25T22:57:04.359Z" },
+    { url = "https://files.pythonhosted.org/packages/76/30/7c007cf34996fd5e57c7f64d72a8b8caf94532042ddbf5f4601de601ae56/cbor2-6.0.0rc1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:53ab38387b213cca6dae722ed6b6733db240eed7f59e12b9c85d0b08a51414cb", size = 463536, upload-time = "2026-03-25T22:57:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e7/2e1343194c09d2eb7cfd065e4e2fa86634c8b3ecc875151ba9f07f8163fc/cbor2-6.0.0rc1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:cdc80f6bb9820ac99463f31075c1a31f109b803d04184b069a805a9cc7098e1f", size = 513697, upload-time = "2026-03-25T22:57:07.159Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9e/a44525a1fe4b23512a6cffc559692185add957e7481773ec5ac937dd254f/cbor2-6.0.0rc1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f4e4626d6ab57a81eb70394bd18ea90152d0676e8ccd16a5901f2170e17f46a3", size = 529819, upload-time = "2026-03-25T22:57:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c9/bd2e3165e26e95d2b9ca1db3d22fd7a008cd1b2903d102a8f137f743c657/cbor2-6.0.0rc1-cp312-cp312-win_amd64.whl", hash = "sha256:397dc9e20de2f2d2a2a308901774b8361040f127a6527467d57c2edee5595582", size = 287780, upload-time = "2026-03-25T22:57:09.945Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/a3/8b982494944a7b9d519465eecf74753691c68f05e8d877274f468090c5d7/cbor2-6.0.0rc1-cp312-cp312-win_arm64.whl", hash = "sha256:4a6b53cedbcde5ae68f70b60430b7964119e28c42375fc0f1b524ce7810a0d60", size = 278338, upload-time = "2026-03-25T22:57:11.348Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/46/fecc9d0590f745f6e856ad260d19bb8352ba2beb0880054c95e0db389100/cbor2-6.0.0rc1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ad76185ddeb0ab604867d3e9d5fea6cf0a6a1fd02312085b81f97f3addb203d2", size = 404981, upload-time = "2026-03-25T22:57:12.696Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/03/c2b47158f688b3190b2cd7a60bee6581518ceb209e3f1ac0988a7c52f67c/cbor2-6.0.0rc1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b3eb6c00baaec4079a0c160c65b6904acce0cbfb6ce2a368a1881ae837ffd7bb", size = 448804, upload-time = "2026-03-25T22:57:14.042Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e7/faff5fbd0ece841e7b72dc9d4a57e372cfdfe7d623f9b3b5f978dff48957/cbor2-6.0.0rc1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:777031b2822e7a1f06c7a7318266f27019431b87aa0f836b9c83f72db56777a8", size = 463146, upload-time = "2026-03-25T22:57:15.517Z" },
+    { url = "https://files.pythonhosted.org/packages/98/03/339b3b1f6a7f47a7174d9f9c103c8f2be7faea6ff2102f301ee0b8eaf781/cbor2-6.0.0rc1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:093144e1f7288ff126fc1ddf5afa113657724efd995a57991d0810cdb7fa4b3f", size = 513896, upload-time = "2026-03-25T22:57:17.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d6/5f707d05ce2e072705be3acbb6d4020ed550e93085802d99f63684362fa9/cbor2-6.0.0rc1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cd1618c5f1b3fb55d95d23a181df613e927f00eb6ab9c1e9d990db49ad1e0a32", size = 529778, upload-time = "2026-03-25T22:57:18.306Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/08/bbc88a364130888263ce8feeab6d22aa6bd7b0953cdf4033381e6d85bb30/cbor2-6.0.0rc1-cp313-cp313-win_amd64.whl", hash = "sha256:4ba02739cc058f4bbea88d0d50d149f67c37f9e1841e6b7402dee613a7fe5985", size = 287614, upload-time = "2026-03-25T22:57:19.741Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f0/a8e23fb6fc110ab2ad0f2a39afd6e0c98fd38db71aead9b866b8b4d0c508/cbor2-6.0.0rc1-cp313-cp313-win_arm64.whl", hash = "sha256:ecbe4f8202204d5502f7d2921b955e77d7b6a0ef715b286dbf32f3b67758b7eb", size = 277791, upload-time = "2026-03-25T22:57:21.139Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/2534037501749aa80bbf269ed6be80b72eea7e3f623a9224c9ffa0b34892/cbor2-6.0.0rc1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32bd16f7c52e85319e6548e7b757d951a1ac18918d9864696d0f7f6f54c6e5cb", size = 403082, upload-time = "2026-03-25T22:57:22.397Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/1e/ef047c411de347014a9606a21f3e91d61508fda9adfaeb5bfa7ec791e19d/cbor2-6.0.0rc1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:833831d60b86804f6f55caf9f5686d9f827916b8768d436d2ba17bd2f2d52ba0", size = 446773, upload-time = "2026-03-25T22:57:23.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/d9/9d139d9129161470bf38bbc2ac488b0d63f6a87b2e98d5e1ceee5b445531/cbor2-6.0.0rc1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:0d5924509e56895bb7e8990854ccc2aac13cad503fd600f3a934b8a92e64424b", size = 459991, upload-time = "2026-03-25T22:57:25.457Z" },
+    { url = "https://files.pythonhosted.org/packages/61/4f/42fff735b0bb269a75482144b928a7b7aa5c99399797088defb5a9b52523/cbor2-6.0.0rc1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:16371b2045bf957031108d5bdfd086b106160473b543d848f5c714c4ad698ebe", size = 512492, upload-time = "2026-03-25T22:57:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/38/70/34f5eb7437b65906ccfc67edb030700c9b3dea22816e16a4b744f8786efe/cbor2-6.0.0rc1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:04b22314bb67cdef12189e451c11a5c63af95cdc51139ce93897acceb9a3f2e3", size = 527331, upload-time = "2026-03-25T22:57:28.477Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/dc/5808cb83e32588cfce13d33085914ad548d3bb3ae35d5a7e462cc6b45563/cbor2-6.0.0rc1-cp314-cp314-win_amd64.whl", hash = "sha256:da6e9734e8beedbda4d7adaa9ec319e5fa7f19645412a5077cb52a873a4f2246", size = 294701, upload-time = "2026-03-25T22:57:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/28/b759efbfac4e86591e1f679904ca46bf58c5396314835f544d809536fec7/cbor2-6.0.0rc1-cp314-cp314-win_arm64.whl", hash = "sha256:44a66f9e513f479f5243228b6723193db4c3c0a73cf60a24fae929b7fdb69444", size = 286174, upload-time = "2026-03-25T22:57:31.218Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2f/527c774f1741fcea7089eef970f9d7881a93d0a8e52f4746a81464ab3a0f/cbor2-6.0.0rc1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1dea1404f1930c3dff361e8779274e6e2e775bd0c137a2b82b84b424e9c7d9fe", size = 398645, upload-time = "2026-03-25T22:57:32.819Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/89/973f545b8fa2282e5c58e03b95501bef46fdc1d9bbf85eb85eb15b3549a0/cbor2-6.0.0rc1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:36c50136151524833837133157a5beecc40a2a40240c2f71947ae1e78e7e5408", size = 439845, upload-time = "2026-03-25T22:57:34.183Z" },
+    { url = "https://files.pythonhosted.org/packages/14/28/e9d651746ee1cad3ce746ead64a3b985a5430d6617b11a73e24507b69876/cbor2-6.0.0rc1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:4909fb1162f7256ce64c295a0e81e23b8260ecfcbe3b68b9ff12155f9028d899", size = 456764, upload-time = "2026-03-25T22:57:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/db/69/6294d334a7e94bcdfb6ba457d39276e4d3a4964b01ebc34a8cc39b8779ab/cbor2-6.0.0rc1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d5a3f2c1a6b9dbfd82416e3a2c7dbda72d72ad815a2e90c1b93b0bb9ecac3892", size = 505243, upload-time = "2026-03-25T22:57:37.349Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6d/dbc7cf17436fe2832e48a477914538ef6d0427ecdbcc6b5ef889a0049dcf/cbor2-6.0.0rc1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:64d1a5edd0eedfabb28757cf9d893eccdd422ec35c35840e34ac8ff958db5bab", size = 522924, upload-time = "2026-03-25T22:57:38.79Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/bc0738372024f4b7b57fbe787376c9ddf93f0fafc5e3c1e4e4d22790b7fc/cbor2-6.0.0rc1-cp314-cp314t-win_amd64.whl", hash = "sha256:f56711dceb69b3446d169456337ccc64b47c852508f6e911a9fc3d684e460b66", size = 289956, upload-time = "2026-03-25T22:57:40.044Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/33ad0741c7e304cc17e013482e5fd148d31ef8a87527318b1420c84f8b0b/cbor2-6.0.0rc1-cp314-cp314t-win_arm64.whl", hash = "sha256:41007a13a90807062c086192ab886c97c2cd0b95502b01d9f3a68985fccbbcb9", size = 278765, upload-time = "2026-03-25T22:57:41.469Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -473,13 +509,14 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#0d06ceecd2b0d886cbef8fa8dec0a62543774598" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=ht%2Fmodal-integration-rebased#45b9b31406291452d34acbc8bf5252461f7ccbd1" }
 dependencies = [
     { name = "click" },
     { name = "daytona" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "modal" },
     { name = "tenacity" },
     { name = "websockets" },
 ]
@@ -960,12 +997,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
 ]
 
 [[package]]
@@ -1023,6 +1095,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1204,6 +1285,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.4.3.dev4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/06/77f752afbbfc5c613d00cd0ca147becb6988c2304c32342e96cb89f232bb/modal-1.4.3.dev4.tar.gz", hash = "sha256:8e5d9789130098a49552b1d8f8668a935a3bf44eeee87bdfe62969ed251ea3e5", size = 703918, upload-time = "2026-04-21T01:00:55.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/5b/2ea3a8365869465eb26ec68c02f60c6e85cffea2fdcfbf7b0c11e6addf24/modal-1.4.3.dev4-py3-none-any.whl", hash = "sha256:18bb2b56388a05097f41b2d47adc0ea3e355f678e4462739249f7d9e17777a63", size = 807408, upload-time = "2026-04-21T01:00:53.214Z" },
 ]
 
 [[package]]
@@ -2328,6 +2433,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/5e/50ea27817003665c7cc4f5bdad309f13d6329037f657848ee87fe06c3740/synchronicity-0.12.2.tar.gz", hash = "sha256:6fd605a5035d1ec74ce48fffaca80ea00345c84ca34223914e2436fb4f162ff9", size = 60018, upload-time = "2026-04-06T15:06:15.447Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/44/4f6ba4e2c171847e6f9a460213b196bbf26edea43d0e66889c7ccc55d368/synchronicity-0.12.2-py3-none-any.whl", hash = "sha256:9dbaca81fb7f2b57c6dea326e514e1c80e9ccfd9c9618515e84fa6091026273b", size = 41312, upload-time = "2026-04-06T15:06:14.459Z" },
+]
+
+[[package]]
 name = "taskiq"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2413,7 +2530,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=ht%2Fmodal-integration-rebased" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
@@ -2464,12 +2581,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds sandbox provider selection to Valkyrie for vals-ai/valkyrie-ticket-library#21.

- Adds `--sandbox-provider` to the run CLI with `daytona` as the default.
- Sends `x-sandbox-provider` to benchmark services.
- Uses the shared CBS sandbox provider interface for sandbox creation, command execution, uploads, cleanup, and force-stop.
- Preserves Daytona behavior by only sending Daytona credentials for Daytona runs.

## Stack

Depends on vals-ai/create-benchmark-service#29.

## Validation

- `.venv/bin/ruff check src/valkyrie/cli/main.py src/valkyrie/cli/tracker_service.py services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py services/tracker/src/tracker/types.py services/tracker/src/tracker/database/models.py services/tracker/tests/unit/test_sandbox.py`
- `.venv/bin/basedpyright src/valkyrie/cli/main.py src/valkyrie/cli/tracker_service.py services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py services/tracker/src/tracker/types.py services/tracker/src/tracker/database/models.py services/tracker/tests/unit/test_sandbox.py`
- `.venv/bin/python -m pytest services/tracker/tests/unit -q`

## Notes

The dependency lock points at the CBS feature branch and should be moved back to the merged CBS commit/main once that PR lands.
