### PR TITLE
feat: add docent ingestion

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -223,3 +223,7 @@ chmod +x /usr/local/bin/my_agent
 ```
 
 The entire agent directory is bundled to `/bundle/<agent_name>/` in the sandbox (`contract.yaml` will be excluded).
+
+## Integrations
+
+- **Docent ingestion** — set `ingest_lambda` in `contract.yaml` (or override the property in `contract.py`) to declare which AWS Lambda converts this agent's output into a Docent `AgentRun`. Triggered post-run via `valk run analyze <run_id>`. See [DOCENT.md](DOCENT.md).

--- a/docs/DOCENT.md
+++ b/docs/DOCENT.md
@@ -1,0 +1,59 @@
+# Docent ingestion
+
+Optional post-hoc analysis: upload a finished run's transcripts to [Transluce Docent](https://docent.transluce.org) and auto-generate an error-analysis report.
+
+## Enable
+
+Declare the agent's analyzer Lambda in `contract.yaml`:
+
+```yaml
+ingest_lambda: analysis-model-library
+```
+
+The Lambda is resolved from the agent's **current** pushed contract, not the run's snapshot — so adding `ingest_lambda` and re-pushing makes past runs analyzable too.
+
+## Trigger
+
+```bash
+valk run analyze <run_id>
+```
+
+Streams progress over SSE from the tracker, which invokes the analyzer Lambda using the run's stored AWS credentials. The Lambda converts each task's `agent_output.tar.gz` into a `docent.data_models.AgentRun`, uploads to a collection named after the benchmark, and submits a 2-step reading plan (`valkyrie-ingest:{benchmark}:{run_id}`):
+
+1. **Per-run summary** — 2-3 sentences per AgentRun (`openai/gpt-5.4-mini`).
+2. **Comprehensive error analysis** — markdown report aggregating all summaries (`openai/gpt-5.4`).
+
+On success the command prints a Docent reading URL — open it to see the error-analysis report and drill into individual AgentRuns / transcripts.
+
+`--no-cache` bypasses the stored URL and re-fires ingestion — useful after fixing an analyzer or after adding more tasks.
+
+The reading-plan URL and status (`IDLE` / `RUNNING` / `ERROR` / `DONE`) live on the benchmark row, so repeated calls short-circuit to the cached URL. `valk run fetch <run_id>` surfaces the URL inline once available.
+
+The CLI blocks for up to 15 min (the Lambda's hard ceiling). If the Lambda hits its timeout, the reading plan was already submitted and keeps running server-side — just open Docent. Reruns are additive at the collection level (sort by `metadata.ingested_at`).
+
+## Going deeper
+
+The auto-generated report is a **first pass**. For real investigation, paste reading URLs into Claude Code (with the Docent plugin):
+
+```
+Here's the error-analysis reading from our latest run — what are the
+top failure modes, and which look like model issues vs. harness issues?
+https://docent.transluce.org/.../readings/<reading_id>
+```
+
+Cross-run comparisons work the same way — paste multiple URLs and ask Claude to compare (different agents on the same benchmark, or one agent across model upgrades).
+
+## Writing an analyzer Lambda
+
+Each agent's output shape needs its own analyzer Lambda. To scaffold one with Claude Code:
+
+1. **Install the Transluce Docent plugin** — see [quickstart](https://docs.transluce.org/quickstart#instructions).
+2. **Install the Vals `docent-analyzer` plugin**:
+
+   ```
+   /plugin marketplace add vals-ai/claude-plugins
+   /plugin install docent-analyzer@vals-plugins
+   /reload-plugins
+   ```
+
+3. Ask Claude *"Set up Docent ingestion for run `<run_id>`"*. The skill resolves the agent + bucket from the run, inspects a sample task output, generates `handler.py` / `Dockerfile` / `deploy.sh`, deploys to AWS, and wires `ingest_lambda` into the contract.

--- a/services/tracker/Makefile
+++ b/services/tracker/Makefile
@@ -50,7 +50,7 @@ clean:
 	@echo "Stopping services and removing images..."
 	@$(COMPOSE) down --rmi local
 logs:
-	@$(COMPOSE) logs -f tracker
+	@$(COMPOSE) logs -f tracker worker
 tracker-service: build run logs
 
 # --- Tests ---

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1,7 +1,7 @@
 import logging
 import tarfile
 import traceback
-from typing import Annotated
+from typing import Annotated, Any
 from uuid import UUID
 
 import httpx
@@ -37,14 +37,18 @@ from tracker.aws.s3 import (
     s3_object_exists,
 )
 from tracker.config import AUTH_REQUIRED, ENVIRONMENT, create_benchmark_service_url
-from tracker.database.models import Benchmark, BenchmarkStatus, FinalEvaluation, Org, RetryMode
+from tracker.database.models import Benchmark, BenchmarkStatus, DocentReadingStatus, FinalEvaluation, Org, RetryMode
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
 from tracker.middleware import RequestContextMiddleware
 from tracker.observability import configure_observability
+from tracker.docent_analysis import (
+    analyze_event_stream,
+)
 from tracker.types import (
+    AnalyzeBenchmarkRequest,
     BenchmarkTableRow,
     FetchBenchmarkTasksRequest,
     FetchBenchmarkMetadataResponse,
@@ -356,6 +360,72 @@ async def fetch_benchmark(
         s3_bucket_url=create_benchmark_url(
             str(benchmark_row.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
         ),
+    )
+
+
+@app.post("/analyze-benchmark/{benchmark_id}", response_model=None)
+async def analyze_benchmark(
+    benchmark_id: TrackedBenchmarkId,
+    body: AnalyzeBenchmarkRequest,
+    session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+    org: Org = Depends(get_current_org),
+) -> dict[str, str] | StreamingResponse:
+    """
+    Invoke the Docent analyzer Lambda for a benchmark and stream progress over SSE.
+
+    Cache short-circuit: when the benchmark already has docent_reading_status=DONE and
+    no_cache=false, returns the existing reading_plan_url without invoking the Lambda.
+    """
+    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+
+    if benchmark_row.status != BenchmarkStatus.FINISHED:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot analyze run {benchmark_id}: status is {benchmark_row.status.value} (must be FINISHED).",
+        )
+
+    if (
+        not body.no_cache
+        and benchmark_row.docent_reading_status == DocentReadingStatus.DONE
+        and benchmark_row.docent_reading_url
+    ):
+        return {
+            "status": "done",
+            "reading_plan_url": benchmark_row.docent_reading_url,
+        }
+
+    if not body.lambda_function:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"No ingest_lambda provided for agent '{benchmark_row.arguments.contract.name}'. "
+                "The CLI normally resolves this from the agent's pushed contract — if you're "
+                "calling this endpoint directly, supply `lambda_function` in the request body."
+            ),
+        )
+
+    payload: dict[str, Any] = {
+        "benchmark_id": str(benchmark_id),
+        "benchmark_name": benchmark_row.name,
+        "s3_bucket": harness_config.s3_bucket,
+        "contract": {"name": benchmark_row.arguments.contract.name},
+    }
+
+    return StreamingResponse(
+        analyze_event_stream(
+            benchmark_row=benchmark_row,
+            session=session,
+            lambda_function=body.lambda_function,
+            payload=payload,
+            aws=harness_config.aws,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/services/tracker/src/tracker/_lambda.py
+++ b/services/tracker/src/tracker/_lambda.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 from typing import Any
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from tracker.exceptions import LambdaError
@@ -10,30 +11,28 @@ from tracker.types import AWSCredentials
 
 
 @lru_cache(maxsize=32)
-def _lambda_client(aws: AWSCredentials) -> Any:
-    """Lambda client cached to share instances."""
+def lambda_client(aws: AWSCredentials, config: Config | None = None) -> Any:
+    """Build a boto3 Lambda client. The caller chooses the Config — defaults
+    (60s read timeout, standard retries) are appropriate for short-running
+    Lambdas; long-running invocations (e.g. analyzer Lambdas) should pass a
+    Config with an extended read_timeout."""
     return boto3.client(  # pyright: ignore[reportUnknownMemberType]
         "lambda",
         aws_access_key_id=aws.aws_access_key_id,
         aws_secret_access_key=aws.aws_secret_access_key,
         aws_session_token=aws.aws_session_token,
         region_name=aws.aws_default_region,
+        config=config,
     )
 
 
-def invoke_lambda(function_name: str, payload: dict[str, Any], aws: AWSCredentials):
+def invoke_lambda(client: Any, function_name: str, payload: dict[str, Any]) -> Any:
+    """Invoke a Lambda using the provided boto3 client and return its parsed payload.
+
+    Raises LambdaError on AWS errors, Lambda-side FunctionError, or statusCode >= 400.
     """
-    Invokes lambda method provided the function name and the payload.
-
-    Uses the user's AWS credentials so the lambda runs in their account/region.
-
-    Raises LambdaError if the invocation fails or the Lambda returns an error.
-    """
-
     try:
-        lambda_client = _lambda_client(aws)
-
-        response = lambda_client.invoke(
+        response = client.invoke(
             FunctionName=function_name,
             Payload=json.dumps(payload),
         )
@@ -41,17 +40,17 @@ def invoke_lambda(function_name: str, payload: dict[str, Any], aws: AWSCredentia
         function_error = response.get("FunctionError")
         response_payload = json.loads(response["Payload"].read())
 
-        # Check if the Lambda function errored
         if function_error:
             raise LambdaError(
                 f"Lambda function '{function_name}' returned error: {json.dumps(response_payload, indent=4)}"
             )
 
-        # Check for errors returned from the lambda itself
         payload_status = response_payload.get("statusCode") if isinstance(response_payload, dict) else None
         if payload_status and payload_status >= 400:
             raise LambdaError(
                 f"Lambda function '{function_name}' returned status {payload_status}: {json.dumps(response_payload, indent=4)}"
             )
+
+        return response_payload
     except ClientError as e:
         raise LambdaError(f"Failed to invoke lambda function '{function_name}': {e}") from e

--- a/services/tracker/src/tracker/database/migrations/versions/9eef5075bc60_docent_reading_columns.py
+++ b/services/tracker/src/tracker/database/migrations/versions/9eef5075bc60_docent_reading_columns.py
@@ -1,0 +1,47 @@
+"""docent_reading_columns
+
+Revision ID: 9eef5075bc60
+Revises: a92e64afa650
+Create Date: 2026-05-18 16:00:37.964833
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from typing import Sequence, Union
+
+
+# revision identifiers, used by Alembic.
+revision: str = "9eef5075bc60"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+DOCENT_READING_STATUS_VALUES = ("IDLE", "RUNNING", "ERROR", "DONE")
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    docent_status_enum = sa.Enum(*DOCENT_READING_STATUS_VALUES, name="docentreadingstatus")
+    docent_status_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "benchmark",
+        sa.Column(
+            "docent_reading_status",
+            docent_status_enum,
+            nullable=False,
+            server_default="IDLE",
+        ),
+    )
+    op.add_column(
+        "benchmark",
+        sa.Column("docent_reading_url", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("benchmark", "docent_reading_url")
+    op.drop_column("benchmark", "docent_reading_status")
+    sa.Enum(name="docentreadingstatus").drop(op.get_bind(), checkfirst=True)

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -62,6 +62,13 @@ class BenchmarkStatus(str, Enum):
     ERROR = "ERROR"
 
 
+class DocentReadingStatus(str, Enum):
+    IDLE = "IDLE"
+    RUNNING = "RUNNING"
+    ERROR = "ERROR"
+    DONE = "DONE"
+
+
 class AgentCausedExitReason(str, Enum):
     """Exit reasons caused by the agent that continue to evaluation"""
 
@@ -164,6 +171,8 @@ class Benchmark(SQLModel, table=True):
     )
     started_by_id: str | None = Field(default=None)
     started_by_email: str | None = Field(default=None, index=True)
+    docent_reading_status: DocentReadingStatus = Field(default=DocentReadingStatus.IDLE)
+    docent_reading_url: str | None = Field(default=None)
     final_evaluation: Mapped[FinalEvaluation | None] = Relationship(
         sa_relationship_kwargs={"foreign_keys": "[FinalEvaluation.benchmark]"}
     )

--- a/services/tracker/src/tracker/docent_analysis.py
+++ b/services/tracker/src/tracker/docent_analysis.py
@@ -1,0 +1,98 @@
+"""Tracker-side Docent analyzer Lambda invocation.
+
+Used by the SSE endpoint behind `valk run analyze` (manual trigger).
+Sets docent_reading_status to RUNNING on entry, DONE on success (with
+the URL), ERROR on failure. try/finally guarantees no stuck-RUNNING rows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from botocore.config import Config
+from sqlmodel import Session as _Session
+
+from tracker._lambda import invoke_lambda, lambda_client
+from tracker.database.models import Benchmark, DocentReadingStatus
+from tracker.types import AWSCredentials
+
+# Analyzer Lambdas can run up to 15 min (AWS Lambda's ceiling); retries
+# disabled because the Lambda is non-idempotent (a retry would re-ingest).
+# Hoisted to a module-level constant so lambda_client's lru_cache actually
+# deduplicates across calls (Config instances aren't equal by value).
+_ANALYZER_CONFIG = Config(read_timeout=905, retries={"max_attempts": 1})
+
+
+def invoke_analyzer(
+    *,
+    benchmark: Benchmark,
+    session: _Session,
+    lambda_function: str,
+    payload: dict[str, Any],
+    aws: AWSCredentials,
+) -> dict[str, Any]:
+    """Invoke an analyzer Lambda and persist status/URL onto the Benchmark row.
+
+    try/finally guarantees status is always set before returning, so no row is
+    left at RUNNING on failure.
+    """
+    benchmark.docent_reading_status = DocentReadingStatus.RUNNING
+    session.add(benchmark)
+    session.commit()
+
+    try:
+        result = invoke_lambda(lambda_client(aws, _ANALYZER_CONFIG), lambda_function, payload)
+        reading_plan_url = result.get("reading_plan_url")
+        if reading_plan_url:
+            benchmark.docent_reading_url = str(reading_plan_url)
+        benchmark.docent_reading_status = DocentReadingStatus.DONE
+        return result
+    except Exception:
+        benchmark.docent_reading_status = DocentReadingStatus.ERROR
+        raise
+    finally:
+        session.add(benchmark)
+        session.commit()
+
+
+async def analyze_event_stream(
+    *,
+    benchmark_row: Benchmark,
+    session: _Session,
+    lambda_function: str,
+    payload: dict[str, Any],
+    aws: AWSCredentials,
+) -> AsyncGenerator[str, None]:
+    """SSE event stream: started → heartbeats → done|error."""
+    yield f"event: started\ndata: {json.dumps({'lambda_function': lambda_function})}\n\n"
+
+    invoke_task = asyncio.create_task(
+        asyncio.to_thread(
+            invoke_analyzer,
+            benchmark=benchmark_row,
+            session=session,
+            lambda_function=lambda_function,
+            payload=payload,
+            aws=aws,
+        )
+    )
+
+    while not invoke_task.done():
+        try:
+            await asyncio.wait_for(asyncio.shield(invoke_task), timeout=10.0)
+        except asyncio.TimeoutError:
+            yield "event: heartbeat\ndata: {}\n\n"
+        except Exception:
+            # Real error from the invocation — break out and let the block below
+            # format the `error` event. Without this, the exception escapes the
+            # generator and FastAPI logs "response already started".
+            break
+
+    try:
+        result = await invoke_task
+        yield f"event: done\ndata: {json.dumps(result)}\n\n"
+    except Exception as e:
+        yield f"event: error\ndata: {json.dumps({'message': str(e)})}\n\n"

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -15,6 +15,7 @@ from tracker.database.models import (
     AgentContractRequest,
     BenchmarkArguments,
     BenchmarkStatus,
+    DocentReadingStatus,
     FinalEvaluation,
     TaskStatus,
 )
@@ -26,6 +27,8 @@ class BenchmarkDetails(BaseModel):
     total_tasks: int
     finished_tasks: int
     task_breakdown: dict[TaskStatus, int]
+    docent_reading_status: DocentReadingStatus
+    docent_reading_url: str | None = None
 
 
 class AWSCredentials(BaseModel, frozen=True):
@@ -186,3 +189,11 @@ class FetchBenchmarkMetadataResponse(BaseModel):
     benchmark_name: str
     benchmark_arguments: BenchmarkArguments
     started_by_email: str | None
+
+
+class AnalyzeBenchmarkRequest(BaseModel):
+    no_cache: bool = False
+    # CLI resolves the analyzer Lambda from the agent's current pushed contract
+    # (handles YAML and Python contracts) and passes it here so the tracker
+    # doesn't have to parse arbitrary contract code.
+    lambda_function: str | None = None

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -24,7 +24,7 @@ from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, u
 from tenacity import retry as tenacity_retry
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
 
-from tracker._lambda import invoke_lambda
+from tracker._lambda import invoke_lambda, lambda_client
 from tracker.auth import RequestIdentity
 from tracker.aws.cloudwatch_logs import create_benchmark_log_group, write_benchmark_log_event
 from tracker.aws.s3 import (
@@ -40,6 +40,7 @@ from tracker.database.models import (
     Benchmark,
     BenchmarkArguments,
     BenchmarkStatus,
+    DocentReadingStatus,
     EvaluationResult,
     FinalEvaluation,
     Org,
@@ -747,6 +748,7 @@ async def process_benchmark(
     benchmark_id: UUID = UUID(benchmark_id_str)
     benchmark_service = start_benchmark_request.benchmark_service
     harness_config: HarnessConfig = start_benchmark_request.harness_config
+
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
     trace.get_current_span().set_attributes(
@@ -890,7 +892,7 @@ async def process_benchmark(
                 lambda_payload: dict[str, Any] = arguments.model_dump()
                 lambda_payload["benchmark_id"] = str(benchmark_id)
 
-                invoke_lambda(arguments.lambda_function, lambda_payload, harness_config.aws)
+                invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
 
     except Exception as e:
         logfire.exception("process_benchmark failed")
@@ -996,6 +998,8 @@ class BenchmarkContext:
             total_tasks=self._task_counts.total_tasks,
             finished_tasks=self._task_counts.finished_tasks,
             task_breakdown=self._task_breakdown,
+            docent_reading_status=self._benchmark_row.docent_reading_status,
+            docent_reading_url=self._benchmark_row.docent_reading_url,
         )
 
 
@@ -1082,6 +1086,13 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
         .values(status=TaskStatus.ERROR, error_message="Undetected exit of task")
     )
     session.commit()
+
+    # Sweep stale RUNNING analyzer invocations to ERROR. The invoke_analyzer
+    # helper uses try/finally so this only fires when the worker process was
+    # killed mid-invocation (no try/finally cleanup ran).
+    if benchmark_row.docent_reading_status == DocentReadingStatus.RUNNING:
+        benchmark_row.docent_reading_status = DocentReadingStatus.ERROR
+        session.add(benchmark_row)
 
     # Force benchmark to ERROR so that the user knows they can retry any failed tasks
     commit_benchmark_error(

--- a/services/tracker/tests/unit/test_docent_analysis.py
+++ b/services/tracker/tests/unit/test_docent_analysis.py
@@ -1,0 +1,117 @@
+"""Unit tests for invoke_analyzer status-transition behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlmodel import Session
+
+from tracker.database.models import Benchmark, BenchmarkStatus, DocentReadingStatus
+from tracker.docent_analysis import invoke_analyzer
+from tracker.utils import catch_errors_during_cleanup
+from tracker.types import AWSCredentials
+
+
+@pytest.fixture
+def aws() -> AWSCredentials:
+    return AWSCredentials(
+        aws_access_key_id="x",
+        aws_secret_access_key="y",
+        aws_session_token=None,
+        aws_default_region="us-east-1",
+    )
+
+
+def test_invoke_analyzer_success_sets_done_and_url(monkeypatch: pytest.MonkeyPatch, aws: AWSCredentials) -> None:
+    benchmark = MagicMock(spec=Benchmark)
+    benchmark.docent_reading_status = DocentReadingStatus.IDLE
+    benchmark.docent_reading_url = None
+    session = MagicMock()
+
+    fake_response = {"reading_plan_url": "https://x.test/r/123", "ingested": 5}
+    monkeypatch.setattr("tracker.docent_analysis.invoke_lambda", lambda *a, **kw: fake_response)
+
+    result = invoke_analyzer(
+        benchmark=benchmark,
+        session=session,
+        lambda_function="analysis-foo",
+        payload={"benchmark_id": "x"},
+        aws=aws,
+    )
+
+    assert benchmark.docent_reading_status == DocentReadingStatus.DONE
+    assert benchmark.docent_reading_url == "https://x.test/r/123"
+    assert result == fake_response
+
+
+def test_invoke_analyzer_failure_sets_error_and_raises(monkeypatch: pytest.MonkeyPatch, aws: AWSCredentials) -> None:
+    benchmark = MagicMock(spec=Benchmark)
+    benchmark.docent_reading_status = DocentReadingStatus.IDLE
+    benchmark.docent_reading_url = None
+    session = MagicMock()
+
+    def boom(*a: object, **kw: object) -> None:
+        raise RuntimeError("lambda exploded")
+
+    monkeypatch.setattr("tracker.docent_analysis.invoke_lambda", boom)
+
+    with pytest.raises(RuntimeError, match="lambda exploded"):
+        invoke_analyzer(
+            benchmark=benchmark,
+            session=session,
+            lambda_function="analysis-foo",
+            payload={"benchmark_id": "x"},
+            aws=aws,
+        )
+
+    assert benchmark.docent_reading_status == DocentReadingStatus.ERROR
+    assert benchmark.docent_reading_url is None
+
+
+def test_invoke_analyzer_no_url_still_marks_done(monkeypatch: pytest.MonkeyPatch, aws: AWSCredentials) -> None:
+    """Lambda returned successfully but no reading_plan_url — still DONE; URL remains untouched."""
+    benchmark = MagicMock(spec=Benchmark)
+    benchmark.docent_reading_status = DocentReadingStatus.IDLE
+    benchmark.docent_reading_url = None
+    session = MagicMock()
+
+    monkeypatch.setattr("tracker.docent_analysis.invoke_lambda", lambda *a, **kw: {"ingested": 0})
+
+    invoke_analyzer(
+        benchmark=benchmark,
+        session=session,
+        lambda_function="analysis-foo",
+        payload={},
+        aws=aws,
+    )
+
+    assert benchmark.docent_reading_status == DocentReadingStatus.DONE
+    assert benchmark.docent_reading_url is None
+
+
+"""Integration-flavored test: cleanup sweeps a stuck RUNNING row."""
+
+
+def test_cleanup_sweeps_running_docent_status_to_error(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+) -> None:
+    """A benchmark stuck at IN_PROGRESS with docent_reading_status=RUNNING is
+    swept to ERROR (both the benchmark itself and the analyzer status)."""
+    from tracker.database.models import Org
+    from tests.conftest import TEST_ORG_ID
+
+    example_benchmark_object.status = BenchmarkStatus.IN_PROGRESS
+    example_benchmark_object.docent_reading_status = DocentReadingStatus.RUNNING
+    database_session.add(example_benchmark_object)
+    database_session.commit()
+
+    org = database_session.get(Org, TEST_ORG_ID)
+    assert org is not None
+
+    catch_errors_during_cleanup(example_benchmark_object.id, database_session, org)
+
+    database_session.refresh(example_benchmark_object)
+    assert example_benchmark_object.docent_reading_status == DocentReadingStatus.ERROR
+    assert example_benchmark_object.status == BenchmarkStatus.ERROR

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.12.*"
 
 [options]
@@ -159,16 +159,16 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.42.90"
+version = "1.43.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/17/510f31d7d6190c01725710d95415733e467f4406d450a106f6eacfd3a94d/boto3-1.42.90.tar.gz", hash = "sha256:bafb5bb1dea262ac95f9afb1e415f06a9490f05cb203bdd897d0afdcd17733c6", size = 113174, upload-time = "2026-04-16T20:27:43.012Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/27/ae1a71e945ce7bde39b0677b252fe7d8a0ad7fa3d6b724d78b81469c08fe/boto3-1.43.10.tar.gz", hash = "sha256:27342e5d5f6170fcc8d1e21cdd939af2448d58ac56b08d494250eaad998e30c7", size = 113159, upload-time = "2026-05-18T20:42:34.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/bd/a0c5011a8eddce39a9b613b13a75057bf960ef2145ff4d1583ed81a2599b/boto3-1.42.90-py3-none-any.whl", hash = "sha256:fde7f7bcad6ec8342d6bf18f56d118d0cb6df189310cfaf73e2eb6443b1cb418", size = 140554, upload-time = "2026-04-16T20:27:40.226Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1b/439234598449f846b17333e67ec63c3dd8f8880c13de9089383b4bab58c3/boto3-1.43.10-py3-none-any.whl", hash = "sha256:83918184d95967e4c6e9ed1e9a2f58250b291e6ea2cb847ab0825d52596b39e5", size = 140534, upload-time = "2026-05-18T20:42:32.009Z" },
 ]
 
 [[package]]
@@ -191,16 +191,16 @@ s3 = [
 
 [[package]]
 name = "botocore"
-version = "1.42.90"
+version = "1.43.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/cf/4eaa0b7ab2ba0b2a0c93e277779b1385127e2f07876a08d698b529affdae/botocore-1.42.90.tar.gz", hash = "sha256:234c39492cd3088acb021d999e3392a4d50238ae3e70b9d9ae1504c30d9009d1", size = 15209231, upload-time = "2026-04-16T20:27:29.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/4e/c127dd0628c551f10cb890e279a9c0e367523b880c4cd3e81a1e76886174/botocore-1.43.10.tar.gz", hash = "sha256:2f4af585b41dbccdfc9f49677d7bd72d713a12ef89a1dc9c8538a927649498bf", size = 15365344, upload-time = "2026-05-18T20:42:21.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/1e/44afcdc3b526b6e1569dd142083c6ed1cb8b92b4141de1c78ded883b449a/botocore-1.42.90-py3-none-any.whl", hash = "sha256:5c95504720346990adc8e3ae1023eb46f9409084b79688e4773ba7099c5fd3db", size = 14892274, upload-time = "2026-04-16T20:27:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/41f64d6c267edf03f4fe8f461edc4c644243e77c8d5a1fef1e0166ac4ed0/botocore-1.43.10-py3-none-any.whl", hash = "sha256:8a0176d8c2f8bebe95d4f923a824a1ace04b02f360e220681c388e097f32c3b6", size = 15043571, upload-time = "2026-05-18T20:42:16.664Z" },
 ]
 
 [[package]]
@@ -1639,14 +1639,14 @@ wheels = [
 
 [[package]]
 name = "s3transfer"
-version = "0.16.0"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
 ]
 
 [[package]]

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import sys
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -19,6 +20,7 @@ from valkyrie.cli.s3_client import (
     download_agent,
     download_s3_path,
     get_contract_from_s3,
+    get_ingest_lambda_from_s3,
     install_agent,
     list_agents,
     push_agent,
@@ -828,6 +830,90 @@ def stop(run_id: UUID, force: bool):
             click.echo("└" + "─" * 79)
     except TrackerServiceError as e:
         raise click.ClickException(str(e))
+
+
+@run.command(
+    name="analyze",
+    help="Trigger Docent ingestion + error analysis for a finished run.",
+)
+@click.argument("run_id", type=UUID)
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Bypass the cached reading-plan URL and re-fire ingestion.",
+)
+def analyze(run_id: UUID, no_cache: bool) -> None:
+    """Trigger Docent ingestion + error analysis for a finished run."""
+    try:
+        with TrackerService() as tracker:
+            if not check_tracker_service_health(tracker):
+                raise click.ClickException("Tracker service is unhealthy.")
+
+            # Resolve the analyzer Lambda from the agent's current pushed contract
+            # (handles both YAML and Python contracts).
+            metadata = tracker.fetch_benchmark_metadata(run_id)
+            contract_name = metadata.benchmark_arguments.contract.name
+            try:
+                lambda_function = asyncio.run(get_ingest_lambda_from_s3(contract_name))
+            except S3Error as e:
+                raise click.ClickException(
+                    f"Could not load contract for agent '{contract_name}' from S3: {e}\n\n"
+                    "If the agent has never been pushed, run `valk agent push ./<agent_dir>`."
+                )
+            if not lambda_function:
+                raise click.ClickException(
+                    f"Agent '{contract_name}' has no `ingest_lambda` set in its current contract. "
+                    "Declare it in contract.yaml (or override the `ingest_lambda` property in "
+                    "contract.py) and re-push with `valk agent push ./<agent_dir>`."
+                )
+
+            terminal: tuple[str, dict[str, Any]] | None = None
+            for event, data in tracker.analyze_benchmark(
+                run_id,
+                no_cache=no_cache,
+                lambda_function=lambda_function,
+            ):
+                if event == "started":
+                    click.echo(f"  Invoking {data.get('lambda_function')}...")
+                elif event == "heartbeat":
+                    click.echo(".", nl=False)
+                elif event == "done":
+                    terminal = (event, data)
+                elif event == "error":
+                    raise click.ClickException(data.get("message") or "analyzer Lambda failed")
+
+            click.echo()
+
+            if not terminal:
+                return
+
+            event, data = terminal
+            url = data.get("reading_plan_url")
+            if url:
+                click.echo(f"  Reading plan: {click.style(url, fg='blue', underline=True)}")
+            else:
+                click.echo(
+                    click.style(
+                        "Analysis completed but no reading plan URL was produced.",
+                        fg="yellow",
+                    )
+                )
+    except TrackerServiceError as e:
+        # "Cannot analyze run X: status is IN_PROGRESS (must be FINISHED)." —
+        # not really an error, just "come back later." Render it cleanly.
+        msg = str(e)
+        if "must be FINISHED" in msg:
+            for status, line in (
+                ("IN_PROGRESS", f"Run {run_id} is still in progress. Try again after it finishes."),
+                ("STOPPING", f"Run {run_id} is stopping. Try again once it settles."),
+                ("STOPPED", f"Run {run_id} was stopped before completion — nothing to analyze."),
+                ("ERROR", f"Run {run_id} errored before completing — nothing to analyze."),
+            ):
+                if f"status is {status}" in msg:
+                    click.echo(click.style(line, fg="yellow"))
+                    sys.exit(1)
+        raise click.ClickException(msg)
 
 
 @run.command(

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -1,4 +1,6 @@
 import asyncio
+import importlib.util
+import io
 import re
 import tempfile
 import zipfile
@@ -8,6 +10,7 @@ from typing import cast
 
 import aioboto3
 import click
+import yaml
 from botocore.exceptions import ClientError
 from tracker import handle_s3_error
 from tracker.database.models import AgentContractRequest
@@ -366,6 +369,57 @@ async def download_s3_path(s3_path: str, output_dir: Path) -> int:
             await asyncio.gather(*(download_object(key) for key in batch))
 
         return len(keys)
+
+
+async def get_ingest_lambda_from_s3(agent_name: str) -> str | None:
+    """Read just the ``ingest_lambda`` field from the currently-pushed agent contract.
+
+    Resolves to the latest pushed version, ignoring whatever snapshot is stored on a
+    benchmark run. This lets ``valk run analyze`` work on past runs after their
+    contract is updated to declare an analyzer Lambda.
+
+    Supports YAML contracts directly; for Python contracts, instantiates with an
+    empty ``AgentConfig`` and reads the ``ingest_lambda`` property without invoking
+    ``run_cmd`` (which would require model validation).
+    """
+    bucket_name = _fetch_bucket_name()
+
+    async with aioboto3.Session().client("s3") as s3_client:
+        try:
+            response = await s3_client.get_object(Bucket=bucket_name, Key=f"agents/{agent_name}.zip")
+            zip_bytes: bytes = cast(bytes, await response["Body"].read())
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
+                raise S3Error(f"Agent '{agent_name}' not found in S3.")
+            raise
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+
+        with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+            names = zf.namelist()
+
+            for ext in (".yaml", ".yml"):
+                member = f"{agent_name}/contract{ext}"
+                if member in names:
+                    zf.extract(member, tmp_path)
+                    with open(tmp_path / member, "r") as f:
+                        return cast(dict[str, object], yaml.safe_load(f) or {}).get("ingest_lambda")  # type: ignore[return-value]
+
+            # TODO: remove this branch when we migrate off of Python contracts.
+            py_member = f"{agent_name}/contract.py"
+            if py_member in names:
+                zf.extractall(tmp_path)
+                contract_path = tmp_path / py_member
+                spec = importlib.util.spec_from_file_location("contract", contract_path)
+                if not spec or not spec.loader:
+                    return None
+                module = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(module)
+                contract_cls = module.contract
+                return contract_cls(AgentConfig()).ingest_lambda
+
+    return None
 
 
 async def get_contract_from_s3(agent_name: str, agent_config: AgentConfig) -> AgentContractRequest:

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -1,8 +1,9 @@
 """Client for interacting with the tracker service."""
 
+import json
 import os
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Iterator
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -325,6 +326,49 @@ class TrackerService:
             return FetchBenchmarkResponse.model_validate(response.json())
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch run: {e}") from e
+
+    def analyze_benchmark(
+        self,
+        benchmark_id: UUID,
+        *,
+        no_cache: bool,
+        lambda_function: str | None,
+    ) -> Iterator[tuple[str, dict[str, Any]]]:
+        """Trigger Docent analysis. Yields ``(event_name, data)`` SSE events
+        (``started``, ``heartbeat``, ``done``, ``error``) until terminal."""
+        url = f"{self._base_url}/analyze-benchmark/{benchmark_id}"
+        body = {"no_cache": no_cache, "lambda_function": lambda_function}
+
+        try:
+            with self._client.stream("POST", url, json=body, timeout=None) as response:
+                if response.status_code != 200:
+                    response.read()
+                    details = _response_error_detail(response)
+                    raise TrackerServiceError(f"analyze-benchmark failed: {details}")
+
+                # Cached short-circuit returns a single JSON body; fresh
+                # invocations return SSE. Normalize both to a ("done", payload)
+                # yield for the caller's event loop.
+                content_type = response.headers.get("content-type", "")
+                if "text/event-stream" not in content_type:
+                    payload = json.loads(response.read())
+                    yield ("done", payload)
+                    return
+
+                event_name = ""
+                for raw_line in response.iter_lines():
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    if line.startswith("event: "):
+                        event_name = line.removeprefix("event: ").strip()
+                    elif line.startswith("data: "):
+                        data = json.loads(line.removeprefix("data: "))
+                        yield (event_name, data)
+                        if event_name in ("done", "error"):
+                            return
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"analyze-benchmark failed: {e}") from e
 
     def stream_benchmark(self, benchmark_id: UUID) -> Generator[str, None, None]:
         """

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -17,8 +17,9 @@ from uuid import UUID
 import click
 import yaml
 from httpx import Response
-from tracker.database.models import BenchmarkStatus, TaskStatus
+from tracker.database.models import BenchmarkStatus, DocentReadingStatus, TaskStatus
 from tracker.types import (
+    BenchmarkDetails,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
@@ -253,11 +254,30 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     click.echo(f"│ {'Run ID:':<12} {benchmark_response.benchmark_id}")
     click.echo(f"│ {'Started at:':<12} {local_time(details.started_at)}")
     click.echo(f"│ {'S3:':<12} {benchmark_response.s3_bucket_url}")
+    analysis_line = _format_docent_analysis(details, benchmark_response.benchmark_id)
+    if analysis_line is not None:
+        click.echo(f"│ {'Analysis:':<12} {analysis_line}")
     click.echo("├" + "─" * 79)
     click.echo(f"│ {progress_line}")
     if breakdown_text:
         click.echo(f"│ {breakdown_text}")
     click.echo("└" + "─" * 79)
+
+
+def _format_docent_analysis(details: BenchmarkDetails, run_id: UUID) -> str | None:
+    """Render the docent analysis row for `valk run fetch`.
+
+    Returns None for IDLE (no analysis run yet) so the caller can skip the row entirely.
+    """
+
+    status = details.docent_reading_status
+    if status == DocentReadingStatus.DONE and details.docent_reading_url:
+        return details.docent_reading_url
+    if status == DocentReadingStatus.RUNNING:
+        return "running..."
+    if status == DocentReadingStatus.ERROR:
+        return f"failed (re-run with `valk run analyze {run_id} --no-cache`)"
+    return None
 
 
 COLUMN_WIDTH = 14

--- a/src/valkyrie/contract.py
+++ b/src/valkyrie/contract.py
@@ -79,6 +79,12 @@ class BaseAgentContract(ABC):
         return {}
 
     @property
+    def ingest_lambda(self) -> str | None:
+        """Analyzer Lambda invoked by ``valk run analyze`` to ingest this agent's
+        output. Override to opt in. See docs/DOCENT.md."""
+        return None
+
+    @property
     @abstractmethod
     def final_output(self) -> Path | None:
         """

--- a/src/valkyrie/schemas.py
+++ b/src/valkyrie/schemas.py
@@ -133,6 +133,17 @@ class AgentContract(BaseModel):
     ```
     """
 
+    ingest_lambda: str | None = None
+    """
+    Name of the AWS Lambda function that converts this agent's output shape
+    into a Docent `AgentRun` and uploads it (invoked by `valk run analyze`).
+    Each output shape needs its own analyzer Lambda. See docs/DOCENT.md.
+
+    ```yaml
+    ingest_lambda: analysis-model-library
+    ```
+    """
+
     defaults: dict[str, Parameter] = {}
     """
     Pre-defined parameters with configurable required/default behavior.

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -2665,7 +2665,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
-    { name = "boto3", specifier = ">=1.42.20" },
+    { name = "boto3", specifier = ">=1.40" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
     { name = "daytona", specifier = "==0.176.1a1" },


### PR DESCRIPTION
## Summary
Add post-hoc Docent ingestion + error analysis for finished benchmark runs. Operators trigger it manually with `valk run analyze <run_id>`, which routes through the tracker to invoke a per-agent AWS Lambda. The Lambda converts each task's output into a [Docent](https://docent.transluce.org) `AgentRun`, uploads them to a per-benchmark collection, submits a 2-step reading plan (per-run summary + comprehensive error analysis), and returns the reading-plan URL. The CLI prints the URL on success; `valk run fetch <run_id>` surfaces it inline thereafter.

Agents opt in by declaring `ingest_lambda: <function-name>` in their contract. The CLI resolves the Lambda name from the agent's **current** pushed contract (handles both YAML and Python contracts), so adding `ingest_lambda` and re-pushing makes past runs analyzable too — no run-start opt-in required.

## Architecture

```
valk run analyze <run_id>
   │
   ├─ CLI resolves ingest_lambda from S3 (get_ingest_lambda_from_s3)
   │
   └─ POST /analyze-benchmark/{id}  ← tracker
         │
         ├─ Cache short-circuit: status=DONE → return docent_reading_url
         ├─ Else SSE: invoke_analyzer (try/finally persists status)
         │     ├─ status RUNNING → invoke_lambda → status DONE+URL or ERROR
         │     └─ heartbeats every 10s during the (up to 15-min) wait
         └─ stream `started` / `heartbeat` / `done` | `error` events
```

## Changes

**Tracker** (`feat(tracker): Docent analyzer Lambda invoker`)
- Migration: `docent_reading_status` (enum: IDLE | RUNNING | ERROR | DONE) + `docent_reading_url` on `benchmark`.
- `invoke_analyzer` helper persists status transitions, try/finally guarantees no stuck RUNNING rows.
- `POST /analyze-benchmark/{run_id}` SSE endpoint with cached short-circuit, rejects non-FINISHED runs upfront.
- `catch_errors_during_cleanup` sweeps stale RUNNING → ERROR on worker exit.
- `_lambda.invoke_lambda` returns parsed payload (was discarded); 905s read timeout aligned with Lambda's 15-min ceiling.

**CLI** (`feat(cli): valk run analyze + fetch surfaces analysis URL`)
- `valk run analyze <run_id> [--no-cache]`: SSE consumer; resolves analyzer Lambda name from current pushed contract and passes it to the tracker.
- `valk run fetch <run_id>`: renders an `Analysis:` row when status is RUNNING / ERROR / DONE+URL (IDLE hides the row).
- `AgentContract` / `BaseAgentContract` get `ingest_lambda` field/property.
- `get_ingest_lambda_from_s3` lightweight reader (no kwargs/model validation needed).

**Docs**
- `docs/DOCENT.md` rewritten for the tracker-routed flow.
- `docs/CONTRACTS.md` mentions the new field.

## Analyzer Lambdas

Already deployed and wired up:

| Lambda | Agents |
|---|---|
| `analysis-model-library` | model_library_agent |
| `analysis-mini-sweagent` | mini_sweagent |
| `analysis-openhands` | openhands |
| `analysis-proof-bench` | proof_bench_agent |
| `analysis-conductor` | snap_agent |
| `analysis-terminus2` | terminus2 |

Contracts wiring these are in [vals-ai/agent-registry#feat/ingest-lambda](https://github.com/vals-ai/agent-registry).

To scaffold a new analyzer Lambda for a new agent, install the Vals plugin marketplace and ask Claude Code:

```
/plugin marketplace add vals-ai/claude-plugins
/plugin install docent-analyzer@vals-plugins
```

The `writing-docent-analyzer-lambda` skill is run_id-driven: it pulls a sample task output, generates handler/Dockerfile/deploy script, deploys, and wires `ingest_lambda` into the contract.

## How to test

```bash
valk run analyze <RUN_ID>             # fresh ingest → URL
valk run analyze <RUN_ID>             # second call hits the cache instantly
valk run analyze <RUN_ID> --no-cache  # force fresh re-ingest
valk run fetch <RUN_ID>               # see the URL inline
```

Smoke-tested locally end-to-end on a finished mini_sweagent / swebench run: cached short-circuit + fresh invocation both work; status transitions IDLE → RUNNING → DONE persist correctly; failure path emits a live SSE error.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor

## Checklist
- [x] Self-reviewed
- [x] Typecheck + format clean
- [x] End-to-end smoke test on real data
- [x] Docs updated