### PR TITLE
Version control streams

### DIFF
--- a/services/tracker/src/tracker/cloudwatch.py
+++ b/services/tracker/src/tracker/cloudwatch.py
@@ -88,35 +88,6 @@ def create_benchmark_group(benchmark_id: str, aws: "AWSCredentials", log_group: 
     return log_group_name
 
 
-@handle_cloudwatch_error(message="Failed to delete log stream")
-def reset_cloudwatch_stream(stream_key: str, aws: "AWSCredentials", log_group: str) -> None:
-    """
-    Delete and recreate a CloudWatch log stream to reset it.
-
-    Used when restarting a task to clear old logs from previous runs.
-
-    Args:
-        stream_key: The stream key (benchmark_id:task_id)
-        aws: AWS credentials for CloudWatch client
-        log_group: The root log group name
-    """
-    benchmark_id, task_id = stream_key.split(":")
-
-    if not benchmark_id or not task_id:
-        raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
-
-    client = _cloudwatch_client(aws)
-    log_group_name = f"{log_group}/{benchmark_id}"
-
-    try:
-        client.delete_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
-    except ClientError as e:
-        if e.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
-            raise
-
-    _created_streams.discard(stream_key)
-
-
 @handle_cloudwatch_error(message="Failed to create cloudwatch stream")
 def cloudwatch_stream(stream_key: str, message: str, aws: "AWSCredentials", log_group: str) -> None:
     """
@@ -133,7 +104,7 @@ def cloudwatch_stream(stream_key: str, message: str, aws: "AWSCredentials", log_
     if not message.strip():
         return
 
-    benchmark_id, task_id = stream_key.split(":")
+    benchmark_id, task_id = stream_key.split(":", 1)
 
     if not benchmark_id or not task_id:
         raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -332,7 +332,7 @@ async def process_task(
 
     # Setup logging infrastructure before try block so it's always available
     # Suffix is required to version control streams, never delete between retires
-    stream_suffix = task_row.started_at.strftime("%m%d-%H%M")
+    stream_suffix = f"{int(task_row.started_at.timestamp() * 1_000_000):x}"
     stream_key: str = f"{benchmark_id}:{task_id}_{stream_suffix}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -21,7 +21,7 @@ from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
 
 from tracker._lambda import invoke_lambda
-from tracker.cloudwatch import cloudwatch_stream, create_benchmark_group, reset_cloudwatch_stream
+from tracker.cloudwatch import cloudwatch_stream, create_benchmark_group
 from tracker.config import broker
 from tracker.database.models import (
     Benchmark,
@@ -331,11 +331,10 @@ async def process_task(
             return {task_id: None}
 
     # Setup logging infrastructure before try block so it's always available
-    stream_key: str = f"{benchmark_id}:{task_id}"
+    # Suffix is required to version control streams, never delete between retires
+    stream_suffix = task_row.started_at.strftime("%m%d-%H%M")
+    stream_key: str = f"{benchmark_id}:{task_id}_{stream_suffix}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
-
-    # If we are retrying the task we clear logs from previous run
-    reset_cloudwatch_stream(stream_key, harness_config.aws, harness_config.log_group)
 
     last_log_time: float = time.monotonic()
 

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -140,7 +140,6 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tracker.cloudwatch.cloudwatch_stream", _mock_cloudwatch_stream)
     monkeypatch.setattr("tracker.utils.create_benchmark_group", _mock_create_benchmark_group)
     monkeypatch.setattr("tracker.utils.cloudwatch_stream", _mock_cloudwatch_stream)
-    monkeypatch.setattr("tracker.utils.reset_cloudwatch_stream", lambda *_args, **_kwargs: None)
     monkeypatch.setattr("tracker.utils.upload_final_view", _mock_upload_final_view)
     monkeypatch.setattr("tracker.secrets.fetch_aws_secret", _mock_fetch_aws_secret)
     monkeypatch.setattr("tracker.utils.fetch_aws_secret", _mock_fetch_aws_secret)


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Version controls logs to allow us to access previous ones when we retry or resume a benchmark. Before we would delete and reset the history, only keeping the latest as the source of truth. A solution is to suffix the logs and sort by recently created to find the one you are looking for. This will allow us to debug past runs more easier.

Change is minimal and testing was easy
<img width="922" height="161" alt="image" src="https://github.com/user-attachments/assets/840980e9-3011-41cc-aac1-7eeb772c7fe4" />


## Changes
<!-- List the key changes made -->
- Removed `reset_cloudwatch_stream`
- Added suffix to the log stream `%m%d-%H%M` (from left to right the highest number is the latest)

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [ x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ x] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ x] Self-reviewed the diff
- [ x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/312" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
