### PR TITLE
Recreate sandbox on connection error

### DIFF
--- a/services/tracker/src/tracker/exceptions.py
+++ b/services/tracker/src/tracker/exceptions.py
@@ -18,6 +18,10 @@ class InvalidSandboxConfigurationError(SandboxError):
     """Exception raised for deterministic sandbox configuration errors."""
 
 
+class PtyCreationError(SandboxError):
+    """Exception raised when PTY session creation fails after all retry attempts."""
+
+
 class S3Error(TrackerServiceError):
     """Exception raised for S3 storage operation errors."""
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -35,7 +35,7 @@ from tenacity import (
     wait_fixed,
 )
 
-from tracker.database.models import AgentContractRequest, AgentCausedExitReason
+from tracker.database.models import AgentCausedExitReason, AgentContractRequest
 from tracker.exceptions import InvalidSandboxConfigurationError, PtyCreationError, SandboxError
 from tracker.logging import get_logger
 from tracker.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
@@ -64,6 +64,9 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     """Delete sandbox if it is not already destroyed or being destroyed"""
     try:
         await sandbox.refresh_data()
+
+        # Set auto-stop interval in-case we fail to delete the sandbox
+        await sandbox.set_autostop_interval(interval=1)
         if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
             await daytona.delete(sandbox)
     except DaytonaNotFoundError:
@@ -115,7 +118,7 @@ async def _create_sandbox(
         return await daytona.create(
             CreateSandboxFromSnapshotParams(
                 auto_stop_interval=0,
-                auto_delete_interval=60,
+                auto_delete_interval=0,
                 name=sandbox_name,
                 labels=labels,
                 snapshot=snapshot_name,
@@ -130,7 +133,7 @@ async def _create_sandbox(
     return await daytona.create(
         CreateSandboxFromImageParams(
             auto_stop_interval=0,
-            auto_delete_interval=60,
+            auto_delete_interval=0,
             name=sandbox_name,
             labels=labels,
             image=image,

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -36,7 +36,7 @@ from tenacity import (
 )
 
 from tracker.database.models import AgentContractRequest, AgentCausedExitReason
-from tracker.exceptions import InvalidSandboxConfigurationError, SandboxError
+from tracker.exceptions import InvalidSandboxConfigurationError, PtyCreationError, SandboxError
 from tracker.logging import get_logger
 from tracker.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.types import AWSCredentials
@@ -575,7 +575,7 @@ async def stream_command_output(
                 sandbox, session_id, on_data, envs={"TERM": "dumb", "LANG": "C.UTF-8"}
             )
         except DaytonaError as e:
-            raise SandboxError(f"Failed to create PTY session after {_PTY_CREATE_MAX_ATTEMPTS} attempts: {e}") from e
+            raise PtyCreationError(f"Failed to create PTY session after {_PTY_CREATE_MAX_ATTEMPTS} attempts: {e}") from e
 
         # Disable echo to suppress command line noise in the output
         await handle.send_input("stty -echo\n")

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -65,9 +65,9 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     try:
         await sandbox.refresh_data()
 
-        # Set auto-stop interval in-case we fail to delete the sandbox
-        await sandbox.set_autostop_interval(interval=1)
         if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+            # Set auto-stop interval in-case we fail to delete the sandbox
+            await sandbox.set_autostop_interval(interval=1)
             await daytona.delete(sandbox)
     except DaytonaNotFoundError:
         # If we error here that means the sandbox has just been deleted before we could refresh the state

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -575,7 +575,9 @@ async def stream_command_output(
                 sandbox, session_id, on_data, envs={"TERM": "dumb", "LANG": "C.UTF-8"}
             )
         except DaytonaError as e:
-            raise PtyCreationError(f"Failed to create PTY session after {_PTY_CREATE_MAX_ATTEMPTS} attempts: {e}") from e
+            raise PtyCreationError(
+                f"Failed to create PTY session after {_PTY_CREATE_MAX_ATTEMPTS} attempts: {e}"
+            ) from e
 
         # Disable echo to suppress command line noise in the output
         await handle.send_input("stty -echo\n")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+import logging
 import time
 import traceback
 from asyncio import Semaphore, gather
@@ -19,6 +20,8 @@ from daytona.common.errors import DaytonaNotFoundError
 from fastapi import Request
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
+from tenacity import before_sleep_log, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry as tenacity_retry
 
 from tracker._lambda import invoke_lambda
 from tracker.cloudwatch import cloudwatch_stream, create_benchmark_group
@@ -35,7 +38,7 @@ from tracker.database.models import (
 )
 from tracker.database.scoping import scoped_select
 from tracker.database.session import engine
-from tracker.exceptions import TrackerServiceError
+from tracker.exceptions import PtyCreationError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.s3 import (
@@ -61,6 +64,7 @@ from tracker.types import (
 logger = get_logger(__name__)
 
 _SANDBOX_CREATION_CAP: int = 10
+_PTY_TASK_RETRY_LIMIT: int = 1
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -301,6 +305,13 @@ def buffer_logs(
     loop.run_in_executor(None, cloudwatch_stream, stream_key, message, aws, log_group)
 
 
+@tenacity_retry(
+    retry=retry_if_exception_type(PtyCreationError),
+    stop=stop_after_attempt(_PTY_TASK_RETRY_LIMIT + 1),
+    wait=wait_fixed(2),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
 async def process_task(
     task_row: Task,
     start_benchmark_request: StartBenchmarkRequest,
@@ -459,6 +470,8 @@ async def process_task(
                         return {task_id: None}
 
                 raise e from e
+    except PtyCreationError:
+        raise
     except Exception as e:
         error_message = str(e)
         logger.error(error_message, exc_info=True)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -470,7 +470,8 @@ async def process_task(
                         return {task_id: None}
 
                 raise e from e
-    except PtyCreationError:
+    except PtyCreationError as e:
+        log_output(f"\n[ERROR] {e}")
         raise
     except Exception as e:
         error_message = str(e)

--- a/services/tracker/tests/integration/test_sandbox_lifecycle.py
+++ b/services/tracker/tests/integration/test_sandbox_lifecycle.py
@@ -1,0 +1,41 @@
+"""Integration tests for parallel sandbox create and delete."""
+
+import asyncio
+from asyncio import Semaphore
+
+import pytest
+from benchmark_service.schemas import Resources
+from daytona import AsyncDaytona
+from daytona.common.errors import DaytonaNotFoundError
+
+from tests.utils import random_task_id
+from tracker.sandbox import create_sandbox
+
+
+class TestSandboxLifecycle:
+    async def test_parallel_create_and_immediate_delete(
+        self,
+        daytona_client: AsyncDaytona,
+        test_resources: Resources,
+        test_image: str,
+    ) -> None:
+        """
+        Create and delete sandboxes at the same time to ensure that the set_autostop_interval inside of the delete_sandbox method works
+
+        Test Cases:
+        - Sandboxes do not exist after we exit
+        - Able to delete all sandboxes with no errors
+        """
+        TASKS_TO_CREATE = 10
+        semaphore = Semaphore(TASKS_TO_CREATE)
+        names = [f"test-parallel-delete-{random_task_id()}" for _ in range(TASKS_TO_CREATE)]
+
+        async def _create_and_delete(name: str) -> None:
+            async with create_sandbox(daytona_client, name, test_image, test_resources, semaphore):
+                await asyncio.sleep(2)
+
+        await asyncio.gather(*[_create_and_delete(name) for name in names])
+
+        for name in names:
+            with pytest.raises(DaytonaNotFoundError):
+                await daytona_client.get(name)

--- a/services/tracker/tests/integration/test_sandbox_lifecycle.py
+++ b/services/tracker/tests/integration/test_sandbox_lifecycle.py
@@ -1,5 +1,3 @@
-"""Integration tests for parallel sandbox create and delete."""
-
 import asyncio
 from asyncio import Semaphore
 

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -1,0 +1,109 @@
+from asyncio import Semaphore
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from benchmark_service.client import BenchmarkServiceClient
+from benchmark_service.schemas import Resources, RetrieveTaskResponse
+from sqlmodel import Session
+
+from tests.conftest import TEST_ORG_ID
+from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.exceptions import PtyCreationError
+from tracker.types import HarnessConfig, StartBenchmarkRequest
+from tracker.utils import process_task, start_benchmark_request_to_benchmark
+
+
+class TestPtyRetry:
+    _test_org = Org(id=TEST_ORG_ID, name="default")
+
+    async def test_process_task_retries_on_pty_creation_error(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """
+        When run_agent raises PtyCreationError on the first attempt, process_task should
+        delete the sandbox, create a fresh one, and complete successfully on the retry.
+
+        Test Cases:
+            - run_agent raises PtyCreationError on the first attempt
+            - process_task retries with a new sandbox
+            - Task ends in FINISHED state after the retry succeeds
+            - The sandbox context manager is entered twice (one per attempt)
+        """
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        sandbox_entry_count = 0
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            nonlocal sandbox_entry_count
+            sandbox_entry_count += 1
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = f"mock-sandbox-{sandbox_entry_count}"
+            mock_sandbox.name = f"mock-sandbox-{sandbox_entry_count}"
+            yield mock_sandbox
+
+        run_agent_call_count = 0
+
+        async def _run_agent_fails_first(*_args: Any, **_kwargs: Any) -> None:
+            nonlocal run_agent_call_count
+            run_agent_call_count += 1
+            if run_agent_call_count == 1:
+                raise PtyCreationError("Failed to create PTY session after 5 attempts: connection refused")
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse(
+                docker_image="test-image:latest",
+                problem_path="/tmp/problem.txt",
+                cwd="/testbed",
+                resources=Resources(vcpu=2, memory=4, disk=5),
+            )
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr("tracker.utils.run_agent", _run_agent_fails_first)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+
+        # Two sandbox entries: first attempt (PTY failed) and retry
+        assert sandbox_entry_count == 2
+        assert run_agent_call_count == 2
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Before a certain point all errors are critical, when the pty is being created for the sake of installing the dependencies or when we want to start the agent. We know that this is sometimes consistent which leads to critical errors since we don't realize till 2 hours later that a task needs to be retried.

A simpler solution is to just rebuild the sandbox itself if the connection does not work. I also enabled the auto stop and auto delete for sandboxes we try to remove to ensure that even if the delete fails they will be removed later on.

## Changes
<!-- List the key changes made -->
- Added a PTY exception we allow to be reraised and caught by the tenacity retrier
- Added unit tests to confirm functionality works as expected
- Set auto stop to 1 minute on delete
- Set auto delete to instant since before we never stopped sandboxes so it was not being used

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [x ] Added/updated unit tests
- [x ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x ] Self-reviewed the diff
- [x ] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
