### PR TITLE
feat: forward descope key to benchmark services

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -12,7 +12,13 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import joinedload
 from sqlmodel import Session
 
-from tracker.auth import extract_api_key, find_org_by_tenant, get_current_org, resolve_descope_tenant
+from tracker.auth import (
+    extract_api_key,
+    find_org_by_tenant,
+    forward_tracker_api_key,
+    get_current_org,
+    resolve_descope_tenant,
+)
 from tracker.cloudwatch import get_cloudwatch_url
 from tracker.config import AUTH_REQUIRED
 from tracker.database.models import Benchmark, BenchmarkStatus, Org
@@ -153,6 +159,7 @@ def init_org(
 
 @app.post("/start-benchmark")
 async def start_benchmark(
+    http_request: Request,
     request: StartBenchmarkRequest,
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
@@ -173,6 +180,14 @@ async def start_benchmark(
     - 400 Bad Request if parameters are invalid
     - 500 Internal Server Error if benchmark fails to start
     """
+    request = request.model_copy(
+        update={
+            "service_headers": forward_tracker_api_key(
+                request.service_headers,
+                http_request.headers.get("x-api-key"),
+            )
+        }
+    )
     logger.info(f"Starting benchmark run - contract: {request.contract.name}, benchmark: {request.benchmark_name}")
 
     benchmark_service = request.benchmark_service
@@ -383,6 +398,7 @@ async def stop_benchmark(
 @app.post("/retry-or-resume-benchmark/{benchmark_id}")
 async def retry_or_resume_benchmark(
     benchmark_id: TrackedBenchmarkId,
+    http_request: Request,
     retry: bool = Query(default=False),
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
@@ -417,6 +433,11 @@ async def retry_or_resume_benchmark(
             detail=f"Run {benchmark_id} is in the {benchmark_row.status} state. Cannot continue a run that is currently running.",
         )
 
+    effective_service_headers = forward_tracker_api_key(
+        service_headers,
+        http_request.headers.get("x-api-key"),
+    )
+
     # NOTE: 0 is not acceptable
     if concurrency:
         benchmark_row.arguments.concurrency = concurrency
@@ -428,7 +449,7 @@ async def retry_or_resume_benchmark(
         benchmark_row=benchmark_row,
         session=session,
         benchmark_service=benchmark_row.benchmark_service(
-            harness_config.daytona_secret_name, harness_config.aws, service_headers=service_headers
+            harness_config.daytona_secret_name, harness_config.aws, service_headers=effective_service_headers
         ),
         retry=retry,
         rerun_task_ids=task_ids,
@@ -437,7 +458,7 @@ async def retry_or_resume_benchmark(
 
     # Ensure that credentials are included with the model dump
     resume_request_json = benchmark_row.start_benchmark_request(
-        harness_config, service_headers=service_headers
+        harness_config, service_headers=effective_service_headers
     ).model_dump()
 
     # start the benchmark with the same args used to create it

--- a/services/tracker/src/tracker/auth.py
+++ b/services/tracker/src/tracker/auth.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from descope import AuthException, DescopeClient
 from fastapi import Depends, HTTPException, Request
 from sqlmodel import Session, select
@@ -12,6 +14,8 @@ from tracker.database.session import get_session
 from tracker.logging import get_logger
 
 logger = get_logger(__name__)
+
+BENCHMARK_SERVICE_API_KEY_HEADER = "X-Descope-Api-Key"
 
 _cached_default_org: Org | None = None
 _descope_client: DescopeClient | None = (
@@ -60,6 +64,26 @@ def resolve_descope_tenant(api_key: str) -> str:
 def find_org_by_tenant(tenant_name: str, session: Session) -> Org | None:
     """Look up an org by Descope tenant name. Returns None if not found."""
     return session.exec(select(Org).where(Org.name == tenant_name)).first()
+
+
+def forward_tracker_api_key(
+    service_headers: Mapping[str, str] | None,
+    tracker_api_key: str | None,
+) -> dict[str, str]:
+    """Copy service headers and inject the tracker API key for benchmark-service auth.
+
+    The downstream benchmark-service auth header must not reuse ``X-Api-Key`` because that
+    header is already reserved for Daytona sandbox credentials.
+    """
+    forwarded_headers = dict(service_headers or {})
+    if not tracker_api_key:
+        return forwarded_headers
+
+    has_explicit_override = any(key.lower() == BENCHMARK_SERVICE_API_KEY_HEADER.lower() for key in forwarded_headers)
+    if not has_explicit_override:
+        forwarded_headers[BENCHMARK_SERVICE_API_KEY_HEADER] = tracker_api_key
+
+    return forwarded_headers
 
 
 def get_current_org(request: Request, session: Session = Depends(get_session)) -> Org:

--- a/services/tracker/tests/unit/test_auth.py
+++ b/services/tracker/tests/unit/test_auth.py
@@ -32,3 +32,33 @@ def test_get_default_org_raises_if_missing(session: Session):
 
     with pytest.raises(RuntimeError, match="Default org not found"):
         auth_module.get_default_org(session)
+
+
+def test_forward_tracker_api_key_adds_benchmark_service_header():
+    from tracker.auth import BENCHMARK_SERVICE_API_KEY_HEADER, forward_tracker_api_key
+
+    headers = forward_tracker_api_key({"Authorization": "Bearer benchmark-token"}, "tracker-api-key")
+
+    assert headers == {
+        "Authorization": "Bearer benchmark-token",
+        BENCHMARK_SERVICE_API_KEY_HEADER: "tracker-api-key",
+    }
+
+
+def test_forward_tracker_api_key_preserves_explicit_override_case_insensitive():
+    from tracker.auth import forward_tracker_api_key
+
+    original_headers = {"x-descope-api-key": "override-key"}
+
+    headers = forward_tracker_api_key(original_headers, "tracker-api-key")
+
+    assert headers == original_headers
+    assert headers is not original_headers
+
+
+def test_forward_tracker_api_key_skips_missing_tracker_key():
+    from tracker.auth import forward_tracker_api_key
+
+    headers = forward_tracker_api_key({"Authorization": "Bearer benchmark-token"}, None)
+
+    assert headers == {"Authorization": "Bearer benchmark-token"}

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -122,6 +122,52 @@ class TestFastapiServer:
         assert json_response["agent_name"] == request.contract.name
         assert json_response["concurrency"] == request.concurrency
 
+    async def test_start_benchmark_forwards_tracker_api_key_to_benchmark_service(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        observed_headers: dict[str, str] = {}
+        captured_request_json: dict[str, Any] = {}
+
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=10,
+            task_ids=None,
+            harness_config=harness_config,
+        )
+
+        async def _mock_health_check(service_client: BenchmarkServiceClient, *args: Any, **kwargs: Any):
+            observed_headers.update(service_client._headers)
+            return {"status": "ok"}
+
+        async def _mock_verify_task_ids(service_client: BenchmarkServiceClient, *args: Any, **kwargs: Any):
+            observed_headers.update(service_client._headers)
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        class _MockKicker:
+            def with_labels(self, **_kwargs: Any) -> "_MockKicker":
+                return self
+
+            async def kiq(self, **kwargs: Any) -> None:
+                captured_request_json.update(kwargs["start_benchmark_request_json"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "health_check", _mock_health_check)
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+        monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+
+        response = client.post(
+            "/start-benchmark",
+            json=request.model_dump(),
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+
+        assert response.status_code == 200
+        assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
+        assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
+
     async def test_fetch_benchmark(self, database_session: Session, example_benchmark_object: Benchmark):
         """
         Test fetch benchmark of the fastapi server.

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -224,7 +224,9 @@ class TestStopAndResume:
         observed_headers: dict[str, str] = {}
         captured_request_json: dict[str, Any] = {}
 
-        async def _mock_reset_to_in_progress_status(*_args: Any, benchmark_service: BenchmarkServiceClient, **_kwargs: Any):
+        async def _mock_reset_to_in_progress_status(
+            *_args: Any, benchmark_service: BenchmarkServiceClient, **_kwargs: Any
+        ):
             observed_headers.update(benchmark_service._headers)
             return ["task_0"]
 

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -209,6 +209,45 @@ class TestStopAndResume:
         for task_row in updated_task_rows:
             assert task_row.alias != original_aliases[task_row.task_id]
 
+    async def test_retry_or_resume_forwards_tracker_api_key_to_benchmark_service(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        observed_headers: dict[str, str] = {}
+        captured_request_json: dict[str, Any] = {}
+
+        async def _mock_reset_to_in_progress_status(*_args: Any, benchmark_service: BenchmarkServiceClient, **_kwargs: Any):
+            observed_headers.update(benchmark_service._headers)
+            return ["task_0"]
+
+        class _MockKicker:
+            def with_labels(self, **_kwargs: Any) -> "_MockKicker":
+                return self
+
+            async def kiq(self, **kwargs: Any) -> None:
+                captured_request_json.update(kwargs["start_benchmark_request_json"])
+
+        monkeypatch.setattr("main.reset_to_in_progress_status", _mock_reset_to_in_progress_status)
+        monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            json={"task_ids": [], "service_headers": {}},
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+
+        assert response.status_code == 200
+        assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
+        assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
+
     async def test_task_monitor_cancels_waiting_stopped_task(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch
     ):


### PR DESCRIPTION
## Summary

Hosted benchmark services need to authenticate inbound calls from the tracker without reusing `X-Api-Key`, which is already reserved for Daytona sandbox credentials. This PR implements the tracker-side half of that flow: it copies the inbound Descope access key (`X-Api-Key`) onto outbound benchmark-service requests as `X-Descope-Api-Key`, so the receiving benchmark service can validate the user's Descope identity directly.

## Changes
- Add `forward_tracker_api_key()` in `services/tracker/src/tracker/auth.py`, which copies `service_headers` and injects the inbound tracker API key as `X-Descope-Api-Key`. Explicit downstream overrides are preserved (case-insensitive match), and a missing tracker key is a no-op.
- Wire the helper into `POST /start-benchmark` and `POST /retry-or-resume-benchmark/{benchmark_id}` so both initial runs and resumed runs carry the same downstream auth header.
- For resume, build the forwarded headers once and reuse them for both the immediate `BenchmarkServiceClient` and the persisted `start_benchmark_request` JSON, so background workers resuming the run also carry the key.
- Export `BENCHMARK_SERVICE_API_KEY_HEADER = "X-Descope-Api-Key"` as the single source of truth for the header name.

## Related
https://www.notion.so/vals-ai/Benchmark-Service-Descope-Authentication-34f8a877dd8d802fa41ac779222be710?t=new
https://github.com/vals-ai/create-benchmark-service/pull/30

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

Not breaking: callers that already supply their own `X-Descope-Api-Key` in `service_headers` are preserved untouched, and callers that don't send `X-Api-Key` see no new headers added.

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

New unit tests in `services/tracker/tests/unit/`:
- `test_auth.py`: `forward_tracker_api_key` adds the header, preserves an explicit override case-insensitively, and is a no-op when the tracker key is missing.
- `test_fastapi_server.py`: `/start-benchmark` forwards `X-Descope-Api-Key` into both the synchronous `BenchmarkServiceClient` headers and the queued `start_benchmark_request` JSON.
- `test_stop_and_resume.py`: `/retry-or-resume-benchmark/{id}` does the same on the resume path.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

## Follow-ups (not in this PR)
1. `create-benchmark-service` patch to validate `X-Descope-Api-Key` on HTTP and WebSocket routes.
2. Tenant allowlist enforcement (`DESCOPE_ALLOWED_TENANTS`).
3. Flip hosted benchmark-service deployments to `AUTH_REQUIRED=true` and remove static `BENCHMARK_API_KEY` after the Descope path is stable.