### PR TITLE
Clear stale final evaluation on retry

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -497,12 +497,14 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: 
     Delegates status depending on if any tasks have been stopped.
     """
 
-    # Check if any tasks are still in the pending or in progress state
+    task_terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+
+    # Check if any tasks are still running.
     tasks_not_finished: int = session.exec(
         select(func.count(col(Task.id)))
         .where(col(Task.benchmark) == benchmark_row.id)
         .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS]))
+        .where(col(Task.status).notin_(task_terminal_statuses))
     ).one()
 
     # Tasks will be in a non-finished state if something interrupts them while they are running and the state errors here
@@ -1142,8 +1144,13 @@ async def reset_to_in_progress_status(
             task_ids=list(task_mapping.values()), slice_str=None, dataset=benchmark_row.arguments.dataset
         )
 
-        # Set the benchmark status to in progress to flag resuming the benchmark
+        if benchmark_row.final_evaluation:
+            session.delete(benchmark_row.final_evaluation)
+
+        # Set the benchmark status to in progress to flag resuming the benchmark.
         benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        benchmark_row.finished_at = None
+        benchmark_row.error_message = None
         session.add(benchmark_row)
         session.commit()
 

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -358,6 +358,13 @@ class TestBenchmarkUtils:
         with pytest.raises(TrackerServiceError):
             set_benchmark_final_status(benchmark_row, database_session, self._test_org)
 
+        task_rows[0][1].status = TaskStatus.EVALUATING
+        database_session.add(task_rows[0][1])
+        database_session.commit()
+
+        with pytest.raises(TrackerServiceError):
+            set_benchmark_final_status(benchmark_row, database_session, self._test_org)
+
         # Make all tasks in finished state
         # NOTE: Need to manually set the finished_at timestamp because the event listener is not triggered with bulk updates
         database_session.exec(

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -11,7 +11,16 @@ from sqlmodel import Session, select
 
 from main import app
 from tests.conftest import TEST_ORG_ID
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkStatus,
+    EvaluationResult,
+    FinalEvaluation,
+    Org,
+    Task,
+    TaskStatus,
+)
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     TaskMonitor,
@@ -249,6 +258,72 @@ class TestStopAndResume:
         assert response.status_code == 200
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
         assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
+
+    async def test_retry_clears_stale_final_evaluation(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.FINISHED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        finished_task = Task(
+            org_id=TEST_ORG_ID,
+            task_id="finished_task",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.FINISHED,
+        )
+        retry_task = Task(
+            org_id=TEST_ORG_ID,
+            task_id="retry_task",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.ERROR,
+        )
+        database_session.add_all([finished_task, retry_task])
+        database_session.commit()
+
+        database_session.add(
+            FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark_row.id, final_score=50.0, properties={})
+        )
+        database_session.add(
+            EvaluationResult(org_id=TEST_ORG_ID, task=finished_task.id, instance_id="finished", result={"score": 1})
+        )
+        database_session.add(
+            EvaluationResult(org_id=TEST_ORG_ID, task=retry_task.id, instance_id="retry", result={"score": 0})
+        )
+        database_session.commit()
+
+        async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=["retry_task"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
+            retry=True,
+            rerun_task_ids=[],
+            org=self._test_org,
+        )
+
+        database_session.expire_all()
+        benchmark_row = database_session.get(Benchmark, benchmark_row.id)
+        assert benchmark_row
+        retry_task = database_session.exec(select(Task).where(Task.task_id == "retry_task")).one()
+        evaluation_rows = database_session.exec(select(EvaluationResult)).all()
+
+        assert verified_task_ids == ["retry_task"]
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+        assert benchmark_row.finished_at is None
+        assert benchmark_row.final_evaluation is None
+        assert retry_task.status == TaskStatus.PENDING
+        assert retry_task.finished_at is None
+        assert [row.instance_id for row in evaluation_rows] == ["finished"]
 
     async def test_task_monitor_cancels_waiting_stopped_task(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch


### PR DESCRIPTION
## Summary
- clear stale `FinalEvaluation`, `finished_at`, and prior benchmark error state when retry/resume reopens tasks
- treat every non-terminal task status as blocking final benchmark finalization, including `EVALUATING`
- add focused tests for retry cleanup and final-status validation

## Root Cause
Retrying tasks inside an existing benchmark can set tasks back to `PENDING`/`IN_PROGRESS` while leaving the previous benchmark-level final evaluation visible. That lets `retrieve-results` expose stale final-score metadata while `fetch-benchmark` correctly reports the run as still in progress.

## Validation
- `uv run pytest tests/unit/test_stop_and_resume.py tests/unit/test_benchmark_utils.py -q`
- `uv run ruff check src/tracker/utils.py tests/unit/test_stop_and_resume.py tests/unit/test_benchmark_utils.py`
- `git diff --check`
