### PR TITLE
Fix tracker Sentry noise and transient sandbox health #patch

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -310,6 +310,16 @@ _pty_handshake_semaphore: Semaphore = Semaphore(_PTY_HANDSHAKE_CAP)
 _DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED)
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(2),
+    before_sleep=before_sleep_log(logger, logging.WARNING),
+    reraise=True,
+)
+async def _refresh_sandbox_data(sandbox: AsyncSandbox) -> None:
+    await sandbox.refresh_data()
+
+
 @asynccontextmanager
 async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator[None, None]:
     """
@@ -401,7 +411,7 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
          SandboxError: if the sandbox cannot be connected to
     """
     try:
-        await sandbox.refresh_data()
+        await _refresh_sandbox_data(sandbox)
         if sandbox.state in _DEAD_SANDBOX_STATES:
             raise SandboxError(f"Sandbox {sandbox.name} crashed during command execution (state: {sandbox.state})")
     except SandboxError:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -819,11 +819,6 @@ class BenchmarkContext:
 
         result = self._session.exec(statement).all()
 
-        if not result:
-            raise TrackerServiceError(
-                f"No tasks have been discovered for run {self._benchmark_row.id}, cannot provide task breakdown"
-            )
-
         return {TaskStatus(status): count for status, count in result}
 
     @cached_property

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -246,6 +246,22 @@ class TestFastapiServer:
         assert details.get("total_tasks") and details["total_tasks"] == 10
         assert details.get("finished_tasks") and details["finished_tasks"] == 6
 
+    async def test_fetch_benchmark_with_no_discovered_tasks(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ):
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        response = client.get("/fetch-benchmark", params={"benchmark_id": str(example_benchmark_object.id)})
+
+        assert response.status_code == 200
+        details = response.json()["details"]
+        assert details["total_tasks"] == 0
+        assert details["finished_tasks"] == 0
+        assert details["task_breakdown"] == {}
+
     async def test_retrieve_results(self, database_session: Session, example_benchmark_object: Benchmark):
         """
         Test the retrieve results endpoint of the fastapi server.

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1,8 +1,9 @@
 import asyncio
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+from tenacity import wait_fixed
 
 from tracker import sandbox as sandbox_module
 from tracker.sandbox import _create_pty_session
@@ -90,3 +91,15 @@ class TestPtyHandshakeSemaphore:
         # Task B's handshake must complete BEFORE task A's post-handshake work finishes.
         # That ordering is only reachable if the slot was released at handshake exit.
         assert events.index("b:handshake_done") < events.index("a:post_handshake_done")
+
+
+class TestSandboxHealth:
+    async def test_refresh_sandbox_data_retries_transient_failure(self) -> None:
+        mock_sandbox = AsyncMock()
+        mock_sandbox.refresh_data.side_effect = [RuntimeError("502 Bad Gateway"), None]
+
+        refresh = sandbox_module._refresh_sandbox_data.retry_with(wait=wait_fixed(0))
+
+        await refresh(mock_sandbox)
+
+        assert mock_sandbox.refresh_data.await_count == 2


### PR DESCRIPTION
## Summary\n- Return an empty task breakdown for runs that have not discovered tasks yet\n- Retry transient Daytona sandbox refresh failures before surfacing health errors\n\n## Tests\n- uv run pytest services/tracker/tests/unit/test_fastapi_server.py::TestFastapiServer::test_fetch_benchmark_with_no_discovered_tasks services/tracker/tests/unit/test_sandbox.py::TestSandboxHealth::test_refresh_sandbox_data_retries_transient_failure\n- uv run ruff check services/tracker/src/tracker/utils.py services/tracker/src/tracker/sandbox.py services/tracker/tests/unit/test_fastapi_server.py services/tracker/tests/unit/test_sandbox.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/324" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->