### PR TITLE
Add eval-only retry state

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -21,7 +21,7 @@ from tracker.auth import (
 )
 from tracker.cloudwatch import get_cloudwatch_url
 from tracker.config import AUTH_REQUIRED
-from tracker.database.models import Benchmark, BenchmarkStatus, Org
+from tracker.database.models import Benchmark, BenchmarkStatus, Org, RetryMode
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
@@ -400,6 +400,7 @@ async def retry_or_resume_benchmark(
     benchmark_id: TrackedBenchmarkId,
     http_request: Request,
     retry: bool = Query(default=False),
+    retry_mode: RetryMode = Query(default=RetryMode.AUTO),
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
@@ -452,6 +453,7 @@ async def retry_or_resume_benchmark(
             harness_config.daytona_secret_name, harness_config.aws, service_headers=effective_service_headers
         ),
         retry=retry,
+        retry_mode=retry_mode,
         rerun_task_ids=task_ids,
         org=org,
     )

--- a/services/tracker/src/tracker/database/migrations/versions/35f2d4a8c9b1_add_eval_resume_state.py
+++ b/services/tracker/src/tracker/database/migrations/versions/35f2d4a8c9b1_add_eval_resume_state.py
@@ -1,0 +1,28 @@
+"""Add evaluation resume state
+
+Revision ID: 35f2d4a8c9b1
+Revises: a9d2e1c8b3f4
+Create Date: 2026-05-04 13:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "35f2d4a8c9b1"
+down_revision: Union[str, Sequence[str], None] = "a9d2e1c8b3f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("task", sa.Column("eval_resume_state", postgresql.JSON(astext_type=sa.Text()), nullable=True))
+    op.alter_column("evaluationresult", "instance_id", existing_type=sa.VARCHAR(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("evaluationresult", "instance_id", existing_type=sa.VARCHAR(), nullable=False)
+    op.drop_column("task", "eval_resume_state")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -69,6 +69,11 @@ class AgentCausedExitReason(str, Enum):
     OS_KILLED = "OS_KILLED"
 
 
+class RetryMode(str, Enum):
+    AUTO = "auto"
+    FROM_SCRATCH = "from_scratch"
+
+
 class AgentContractRequest(BaseModel):
     name: str
     model: str | None = None
@@ -300,6 +305,7 @@ class Task(SQLModel, table=True):
     started_at: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo("UTC")))
     error_message: str | None = Field(default=None)
     finished_at: datetime | None = None
+    eval_resume_state: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     benchmark: UUID = Field(foreign_key="benchmark.id")
 
     @computed_field
@@ -336,6 +342,6 @@ class EvaluationResult(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     org_id: UUID = Field(foreign_key="org.id")
     task: UUID = Field(foreign_key="task.id")
-    instance_id: str = Field(unique=True)
+    instance_id: str | None = Field(default=None, unique=True)
     agent_caused_exit_reason: AgentCausedExitReason | None = Field(default=None)
     result: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -33,6 +33,7 @@ from tracker.database.models import (
     EvaluationResult,
     FinalEvaluation,
     Org,
+    RetryMode,
     Task,
     TaskStatus,
 )
@@ -305,6 +306,13 @@ def buffer_logs(
     loop.run_in_executor(None, cloudwatch_stream, stream_key, message, aws, log_group)
 
 
+def save_eval_resume_state(task_row_id: UUID, org: Org, eval_resume_state: dict[str, Any]) -> None:
+    with Session(bind=engine) as session:
+        task = fetch_task_row(task_row_id, session, org)
+        task.eval_resume_state = eval_resume_state
+        session.commit()
+
+
 @tenacity_retry(
     retry=retry_if_exception_type(SandboxSetupError),
     stop=stop_after_attempt(_PTY_TASK_RETRY_LIMIT + 1),
@@ -366,7 +374,36 @@ async def process_task(
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
+    def on_eval_resume_state(state: dict[str, Any]) -> None:
+        save_eval_resume_state(task_row.id, org, state)
+
     try:
+        if task_row.status == TaskStatus.EVALUATING:
+            assert task_row.eval_resume_state is not None
+            log_output("Resuming evaluation from durable benchmark state\n")
+            evaluation_result = await benchmark_service.resume_evaluation(
+                task_row.task_id,
+                task_row.eval_resume_state,
+                on_message=log_output,
+                on_eval_resume_state=on_eval_resume_state,
+                dataset=start_benchmark_request.dataset,
+            )
+            evaluation_result_row = EvaluationResult(
+                org_id=org.id,
+                task=task_row.id,
+                instance_id=None,
+                result=evaluation_result,
+                agent_caused_exit_reason=None,
+            )
+
+            with Session(bind=engine) as task_session:
+                task = fetch_task_row(task_row.id, task_session, org)
+                task_session.add(evaluation_result_row)
+                task.status = TaskStatus.FINISHED
+                task_session.commit()
+
+                return {task_id: evaluation_result_row.result}
+
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
 
         # Labels that show up in the UI we can use to filter sandboxes
@@ -440,7 +477,11 @@ async def process_task(
                 # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
                 logger.info(f"Evaluating agent {start_benchmark_request.contract.name} in sandbox {sandbox.name}")
                 evaluation_result = await benchmark_service.evaluate_instance(
-                    task_row.task_id, sandbox.id, on_message=log_output, dataset=start_benchmark_request.dataset
+                    task_row.task_id,
+                    sandbox.id,
+                    on_message=log_output,
+                    on_eval_resume_state=on_eval_resume_state,
+                    dataset=start_benchmark_request.dataset,
                 )
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
@@ -502,13 +543,15 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: 
         select(func.count(col(Task.id)))
         .where(col(Task.benchmark) == benchmark_row.id)
         .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS]))
+        .where(
+            col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING])
+        )
     ).one()
 
     # Tasks will be in a non-finished state if something interrupts them while they are running and the state errors here
     if tasks_not_finished:
         raise TrackerServiceError(
-            f"Cannot set final status for run {benchmark_row.id} because tasks are still in the pending or in progress state."
+            f"Cannot set final status for run {benchmark_row.id} because tasks are still runnable."
         )
 
     tasks_stopped: int = session.exec(
@@ -536,7 +579,7 @@ def create_task_rows(
     """
     Create task_rows that do not already exist in the database for the benchmark row.
 
-    NOTE: Only return pending tasks to support resuming the benchmark.
+    NOTE: Only return runnable tasks to support resuming the benchmark.
     """
 
     # Find task ids that already exist so that we can filter them out
@@ -554,12 +597,14 @@ def create_task_rows(
     session.commit()
     session.expire_all()
 
-    # Fetch all task rows with the status of pending
-    pending_task_rows: Sequence[tuple[str, Task]] = session.exec(
-        select(Task.task_id, Task).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.PENDING)
+    runnable_statuses = [TaskStatus.PENDING, TaskStatus.EVALUATING]
+    task_rows: Sequence[tuple[str, Task]] = session.exec(
+        select(Task.task_id, Task)
+        .where(Task.benchmark == benchmark_row.id)
+        .where(col(Task.status).in_(runnable_statuses))
     ).all()
 
-    return pending_task_rows
+    return task_rows
 
 
 async def fetch_missing_tasks(
@@ -1091,6 +1136,7 @@ async def reset_to_in_progress_status(
     session: Session,
     benchmark_service: BenchmarkServiceClient,
     retry: bool,
+    retry_mode: RetryMode,
     rerun_task_ids: list[str],
     org: Org,
 ) -> list[str]:
@@ -1101,7 +1147,7 @@ async def reset_to_in_progress_status(
     Rerun Task IDs: even if task has been finished we restart it
 
     Benchmark - In progress status
-    Tasks - Pending status
+    Tasks - Pending status, or Evaluating status when retrying durable eval state
 
     NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
     """
@@ -1119,11 +1165,8 @@ async def reset_to_in_progress_status(
             ),
         ]
 
-        # Check if there are any tasks that have been stopped
-        task_ids = session.exec(select(Task.id, Task.task_id).where(*filter_query)).all()
-
-        # id is task row primary key, task_id is the task id
-        task_mapping: dict[UUID, str] = {id: task_id for id, task_id in task_ids}
+        task_rows = session.exec(select(Task).where(*filter_query)).all()
+        task_mapping: dict[UUID, str] = {task.id: task.task_id for task in task_rows}
 
         # Ensure we are not missing any tasks that were requested (skips if force is empty)
         missing_task_ids = [task_id for task_id in rerun_task_ids if task_id not in task_mapping.values()]
@@ -1133,7 +1176,7 @@ async def reset_to_in_progress_status(
             )
 
         # Allow re-running the end of the benchmark without running any tasks
-        if not task_ids:
+        if not task_rows:
             return []
 
         # Verify the task ids are still valid before priming to resume
@@ -1147,17 +1190,18 @@ async def reset_to_in_progress_status(
         session.add(benchmark_row)
         session.commit()
 
-        # Set the task status to pending to flag resuming the tasks
-        session.exec(
-            update(Task)
-            .where(*filter_query)
-            .values(  # Reset to defaults
-                status=TaskStatus.PENDING,
-                started_at=datetime.now(ZoneInfo("UTC")),
-                error_message=None,
-                finished_at=None,
+        for task in task_rows:
+            task.status = (
+                TaskStatus.EVALUATING
+                if retry_mode == RetryMode.AUTO and task.eval_resume_state is not None
+                else TaskStatus.PENDING
             )
-        )
+            task.started_at = datetime.now(ZoneInfo("UTC"))
+            task.error_message = None
+            task.finished_at = None
+            if retry_mode == RetryMode.FROM_SCRATCH:
+                task.eval_resume_state = None
+            session.add(task)
 
         # Delete all evaluation results for the tasks (unlikely they exist)
         session.exec(

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import FinalScoreResponse, Resources, RetrieveTaskResponse, VerifyTaskIdsResponse
 from fastapi.testclient import TestClient
@@ -11,7 +12,16 @@ from sqlmodel import Session, select
 
 from main import app
 from tests.conftest import TEST_ORG_ID
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkStatus,
+    EvaluationResult,
+    Org,
+    RetryMode,
+    Task,
+    TaskStatus,
+)
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     TaskMonitor,
@@ -20,6 +30,7 @@ from tracker.utils import (
     force_stop_sandboxes,
     initiate_stop_benchmark,
     process_benchmark,
+    process_task,
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
 )
@@ -150,6 +161,7 @@ class TestStopAndResume:
             session=database_session,
             benchmark_service=start_benchmark_request.benchmark_service,
             retry=False,
+            retry_mode=RetryMode.AUTO,
             rerun_task_ids=[],
             org=self._test_org,
         )
@@ -199,6 +211,7 @@ class TestStopAndResume:
             session=database_session,
             benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
             retry=True,
+            retry_mode=RetryMode.AUTO,
             rerun_task_ids=[],
             org=self._test_org,
         )
@@ -208,6 +221,124 @@ class TestStopAndResume:
         updated_task_rows = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         for task_row in updated_task_rows:
             assert task_row.alias != original_aliases[task_row.task_id]
+
+    @pytest.mark.parametrize(
+        ("retry_mode", "expected_status", "expected_state"),
+        [
+            (RetryMode.AUTO, TaskStatus.EVALUATING, {"artifact_prefix": "s3://bucket/run"}),
+            (RetryMode.FROM_SCRATCH, TaskStatus.PENDING, None),
+        ],
+    )
+    async def test_reset_handles_eval_resume_state(
+        self,
+        retry_mode: RetryMode,
+        expected_status: TaskStatus,
+        expected_state: dict[str, str] | None,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.STOPPED,
+            eval_resume_state={"artifact_prefix": "s3://bucket/run"},
+        )
+        database_session.add(benchmark_row)
+        database_session.add(task_row)
+        database_session.commit()
+
+        async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=[task_row.task_id])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
+            retry=False,
+            retry_mode=retry_mode,
+            rerun_task_ids=[],
+            org=self._test_org,
+        )
+
+        database_session.refresh(task_row)
+        assert verified_task_ids == [task_row.task_id]
+        assert task_row.status == expected_status
+        assert task_row.eval_resume_state == expected_state
+
+    async def test_process_task_resumes_evaluation_without_sandbox(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        request = StartBenchmarkRequest(
+            benchmark_name="vcb",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(request, self._test_org)
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.EVALUATING,
+            eval_resume_state={"artifact_prefix": "s3://bucket/run"},
+        )
+        database_session.add(task_row)
+        database_session.commit()
+
+        @asynccontextmanager
+        async def _unexpected_create_sandbox(*_args: Any, **_kwargs: Any):
+            raise AssertionError("eval resume should not create a sandbox")
+            yield
+
+        async def _mock_resume_evaluation(
+            _self: BenchmarkServiceClient,
+            task_id: str,
+            eval_resume_state: dict[str, Any],
+            *_args: Any,
+            on_eval_resume_state: Any,
+            **_kwargs: Any,
+        ) -> dict[str, Any]:
+            assert task_id == "task_0"
+            assert eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
+            on_eval_resume_state({"artifact_prefix": "s3://bucket/run", "job_id": "job-1"})
+            return {"score": 1.0}
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _unexpected_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await process_task(
+            task_row,
+            request,
+            request.benchmark_service,
+            benchmark_row.id,
+            task_row.task_id,
+            harness_config,
+            self._test_org,
+            creation_semaphore=asyncio.Semaphore(1),
+        )
+
+        database_session.refresh(task_row)
+        evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+        assert result == {"task_0": {"score": 1.0}}
+        assert task_row.status == TaskStatus.FINISHED
+        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        assert evaluation.instance_id is None
 
     async def test_retry_or_resume_forwards_tracker_api_key_to_benchmark_service(
         self,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import click
 import yaml
-from tracker.database.models import BenchmarkStatus
+from tracker.database.models import BenchmarkStatus, RetryMode
 from tracker.exceptions import S3Error
 from tracker.types import FinalViewResponse, Order, RetrieveResultsResponse, StartBenchmarkResponse
 
@@ -776,6 +776,12 @@ def stop(run_id: UUID, force: bool):
     default=False,
     help="Refresh the frozen agent copy from the current agents/<name>.zip in S3 before resuming.",
 )
+@click.option(
+    "--from-scratch",
+    is_flag=True,
+    default=False,
+    help="Clear durable eval state and rerun generation.",
+)
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -785,6 +791,7 @@ def resume(
     task_ids: str | None,
     task_ids_file: Path | None,
     update_agent: bool,
+    from_scratch: bool,
 ):
     """
     Resume a run by its run id.
@@ -826,6 +833,7 @@ def resume(
             _ = tracker.retry_or_resume_benchmark(
                 run_id,
                 retry,
+                RetryMode.FROM_SCRATCH if from_scratch else RetryMode.AUTO,
                 concurrency,
                 retry_task_ids,
                 service_headers=service_headers,

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -11,7 +11,7 @@ import httpx
 import yaml
 from dotenv import load_dotenv
 from httpx._models import Response
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, RetryMode
 from tracker.types import (
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
@@ -425,6 +425,7 @@ class TrackerService:
         self,
         benchmark_id: UUID,
         retry: bool,
+        retry_mode: RetryMode,
         concurrency: int | None,
         task_ids: list[str],
         service_headers: dict[str, str] | None = None,
@@ -443,7 +444,7 @@ class TrackerService:
             RetryOrResumeBenchmarkResponse with status and message
         """
         try:
-            params: dict[str, Any] = {"retry": retry}
+            params: dict[str, Any] = {"retry": retry, "retry_mode": retry_mode.value}
 
             # NOTE: 0 is not acceptable
             if concurrency:


### PR DESCRIPTION
## Summary

Adds tracker support for eval-only retry when a benchmark service has already submitted durable evaluation work:

- stores opaque `eval_resume_state` on `Task`
- allows `EVALUATING` tasks to resume through `BenchmarkServiceClient.resume_evaluation()` without creating a new sandbox
- records final eval results with nullable `EvaluationResult.instance_id`
- adds retry mode selection: default `auto`, plus `--from-scratch` to clear stored eval state and rerun from generation

## Dependency

Stacked on vals-ai/create-benchmark-service#37. Before this merges, update the dependency/lock to a create-benchmark-service commit that includes that PR.

## Validation

Validated with the local create-benchmark-service branch installed as an editable overlay:

- `UV_NO_SYNC=1 uv run ruff check services/tracker/main.py services/tracker/src/tracker/database/models.py services/tracker/src/tracker/utils.py services/tracker/tests/unit/test_stop_and_resume.py src/valkyrie/cli/main.py src/valkyrie/cli/tracker_service.py`
- `UV_NO_SYNC=1 uv run basedpyright services/tracker/src/tracker/database/models.py services/tracker/src/tracker/utils.py src/valkyrie/cli/tracker_service.py src/valkyrie/cli/main.py`
- `UV_NO_SYNC=1 uv run pytest services/tracker/tests/unit -q` (`79 passed`)
- after final cleanup: `UV_NO_SYNC=1 uv run pytest services/tracker/tests/unit/test_stop_and_resume.py -q` (`8 passed`)