### PR TITLE
Add eval-only retry state

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ valkyrie run resume <id> --concurrency 20
 | `--task-ids` | Comma-separated task IDs to resume/retry |
 | `--task-ids-file` | Path to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
+| `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
 
 ### List runs
 

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -11,16 +11,6 @@ The service runs as two separate containers:
 
 Redis and PostgreSQL run as shared infrastructure. The worker can continue processing benchmarks independently of the tracker API, allowing the tracker to be restarted without interrupting running benchmarks.
 
-## Eval-only retry
-
-Some benchmark services can persist enough evaluation state to retry evaluation without rerunning agent generation.
-
-During fresh evaluation, the tracker still creates a Daytona sandbox, runs the agent, and calls `evaluate_instance`. If the benchmark service emits an `eval_resume_state` stream chunk, the tracker stores that opaque object on the task row.
-
-On retry, tasks with stored `eval_resume_state` start in `EVALUATING`. The worker skips sandbox creation and calls `evaluate_response` with the saved state. The benchmark service owns the state shape and decides how to resume. For example, the state can point at uploaded artifacts, an external eval job, or completed partial checks.
-
-Use retry-from-scratch when generation itself must be rerun; eval-only retry is only for reusing existing generated output.
-
 ## Running
 
 ```bash

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -11,6 +11,16 @@ The service runs as two separate containers:
 
 Redis and PostgreSQL run as shared infrastructure. The worker can continue processing benchmarks independently of the tracker API, allowing the tracker to be restarted without interrupting running benchmarks.
 
+## Eval-only retry
+
+Some benchmark services can persist enough evaluation state to retry evaluation without rerunning agent generation.
+
+During fresh evaluation, the tracker still creates a Daytona sandbox, runs the agent, and calls `evaluate_instance`. If the benchmark service emits an `eval_resume_state` stream chunk, the tracker stores that opaque object on the task row.
+
+On retry, tasks with stored `eval_resume_state` start in `EVALUATING`. The worker skips sandbox creation and calls `evaluate_response` with the saved state. The benchmark service owns the state shape and decides how to resume. For example, the state can point at uploaded artifacts, an external eval job, or completed partial checks.
+
+Use retry-from-scratch when generation itself must be rerun; eval-only retry is only for reusing existing generated output.
+
 ## Running
 
 ```bash

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -23,7 +23,7 @@ from tracker.auth import (
 )
 from tracker.cloudwatch import get_cloudwatch_url
 from tracker.config import AUTH_REQUIRED, ENVIRONMENT
-from tracker.database.models import Benchmark, BenchmarkStatus, Org
+from tracker.database.models import Benchmark, BenchmarkStatus, Org, RetryMode
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
@@ -410,6 +410,7 @@ async def retry_or_resume_benchmark(
     benchmark_id: TrackedBenchmarkId,
     http_request: Request,
     retry: bool = Query(default=False),
+    retry_mode: RetryMode = Query(default=RetryMode.AUTO),
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
@@ -462,6 +463,7 @@ async def retry_or_resume_benchmark(
             harness_config.daytona_secret_name, harness_config.aws, service_headers=effective_service_headers
         ),
         retry=retry,
+        retry_mode=retry_mode,
         rerun_task_ids=task_ids,
         org=org,
     )

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@dc4e1428dd03a687e1221cc6e3665fba7aec2536",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@45e6db696fc465c0a621121cf2773606f72c8e24",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@5c1ee06d9584336010e11d3ec440fa9ceae064d7",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@dc4e1428dd03a687e1221cc6e3665fba7aec2536",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@main",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@5c1ee06d9584336010e11d3ec440fa9ceae064d7",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@45e6db696fc465c0a621121cf2773606f72c8e24",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@a83e56a768134eb855ffa3e9f7052ab6476605ed",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@64763260a4f6db73229591a311d7e92fde59e498",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b",
 ]
 
 [dependency-groups]

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@a83e56a768134eb855ffa3e9f7052ab6476605ed",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@64763260a4f6db73229591a311d7e92fde59e498",
 ]
 
 [dependency-groups]

--- a/services/tracker/src/tracker/database/migrations/versions/35f2d4a8c9b1_add_eval_resume_state.py
+++ b/services/tracker/src/tracker/database/migrations/versions/35f2d4a8c9b1_add_eval_resume_state.py
@@ -1,0 +1,28 @@
+"""Add evaluation resume state
+
+Revision ID: 35f2d4a8c9b1
+Revises: a9d2e1c8b3f4
+Create Date: 2026-05-04 13:55:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "35f2d4a8c9b1"
+down_revision: Union[str, Sequence[str], None] = "a9d2e1c8b3f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("task", sa.Column("eval_resume_state", postgresql.JSON(astext_type=sa.Text()), nullable=True))
+    op.alter_column("evaluationresult", "instance_id", existing_type=sa.VARCHAR(), nullable=True)
+
+
+def downgrade() -> None:
+    op.alter_column("evaluationresult", "instance_id", existing_type=sa.VARCHAR(), nullable=False)
+    op.drop_column("task", "eval_resume_state")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -69,6 +69,11 @@ class AgentCausedExitReason(str, Enum):
     OS_KILLED = "OS_KILLED"
 
 
+class RetryMode(str, Enum):
+    AUTO = "auto"
+    FROM_SCRATCH = "from_scratch"
+
+
 class AgentContractRequest(BaseModel):
     name: str
     model: str | None = None
@@ -300,6 +305,7 @@ class Task(SQLModel, table=True):
     started_at: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo("UTC")))
     error_message: str | None = Field(default=None)
     finished_at: datetime | None = None
+    eval_resume_state: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     benchmark: UUID = Field(foreign_key="benchmark.id")
 
     @computed_field
@@ -336,6 +342,6 @@ class EvaluationResult(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     org_id: UUID = Field(foreign_key="org.id")
     task: UUID = Field(foreign_key="task.id")
-    instance_id: str = Field(unique=True)
+    instance_id: str | None = Field(default=None, unique=True)
     agent_caused_exit_reason: AgentCausedExitReason | None = Field(default=None)
     result: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -392,27 +392,35 @@ async def process_task(
     try:
         if task_row.status == TaskStatus.EVALUATING:
             assert task_row.eval_resume_state is not None
-            log_output("Resuming evaluation from durable benchmark state\n")
-            evaluation_result = await benchmark_service.evaluate_response(
-                task_row.task_id,
-                eval_resume_state=task_row.eval_resume_state,
-                dataset=start_benchmark_request.dataset,
-            )
-            evaluation_result_row = EvaluationResult(
-                org_id=org.id,
-                task=task_row.id,
-                instance_id=None,
-                result=evaluation_result,
-                agent_caused_exit_reason=None,
-            )
+            try:
+                log_output("Resuming evaluation from durable benchmark state\n")
+                evaluation_result = await benchmark_service.evaluate_response(
+                    task_row.task_id,
+                    eval_resume_state=task_row.eval_resume_state,
+                    dataset=start_benchmark_request.dataset,
+                )
+                evaluation_result_row = EvaluationResult(
+                    org_id=org.id,
+                    task=task_row.id,
+                    instance_id=None,
+                    result=evaluation_result,
+                    agent_caused_exit_reason=None,
+                )
 
-            with Session(bind=engine) as task_session:
-                task = fetch_task_row(task_row.id, task_session, org)
-                task_session.add(evaluation_result_row)
-                task.status = TaskStatus.FINISHED
-                task_session.commit()
+                with Session(bind=engine) as task_session:
+                    task = fetch_task_row(task_row.id, task_session, org)
+                    task_session.add(evaluation_result_row)
+                    task.status = TaskStatus.FINISHED
+                    task_session.commit()
 
-                return {task_id: evaluation_result_row.result}
+                    return {task_id: evaluation_result_row.result}
+            except Exception as e:
+                with Session(bind=engine) as task_session:
+                    task = fetch_task_row(task_row.id, task_session, org)
+                    if task.status == TaskStatus.STOPPED:
+                        return {task_id: None}
+
+                raise e from e
 
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -391,12 +391,15 @@ async def process_task(
 
     try:
         if task_row.status == TaskStatus.EVALUATING:
-            assert task_row.eval_resume_state is not None
+            if task_row.eval_resume_state is None:
+                raise ValueError("Cannot resume evaluation without eval_resume_state")
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
                 evaluation_result = await benchmark_service.evaluate_response(
                     task_row.task_id,
                     eval_resume_state=task_row.eval_resume_state,
+                    on_message=log_output,
+                    on_eval_resume_state=on_eval_resume_state,
                     dataset=start_benchmark_request.dataset,
                 )
                 evaluation_result_row = EvaluationResult(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -35,6 +35,7 @@ from tracker.database.models import (
     EvaluationResult,
     FinalEvaluation,
     Org,
+    RetryMode,
     Task,
     TaskStatus,
 )
@@ -308,6 +309,13 @@ def buffer_logs(
     loop.run_in_executor(None, cloudwatch_stream, stream_key, message, aws, log_group)
 
 
+def save_eval_resume_state(task_row_id: UUID, org: Org, eval_resume_state: dict[str, Any]) -> None:
+    with Session(bind=engine) as session:
+        task = fetch_task_row(task_row_id, session, org)
+        task.eval_resume_state = eval_resume_state
+        session.commit()
+
+
 @logfire.instrument("process_task")
 @tenacity_retry(
     retry=retry_if_exception_type(SandboxSetupError),
@@ -378,7 +386,36 @@ async def process_task(
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
+    def on_eval_resume_state(state: dict[str, Any]) -> None:
+        save_eval_resume_state(task_row.id, org, state)
+
     try:
+        if task_row.status == TaskStatus.EVALUATING:
+            assert task_row.eval_resume_state is not None
+            log_output("Resuming evaluation from durable benchmark state\n")
+            evaluation_result = await benchmark_service.resume_evaluation(
+                task_row.task_id,
+                task_row.eval_resume_state,
+                on_message=log_output,
+                on_eval_resume_state=on_eval_resume_state,
+                dataset=start_benchmark_request.dataset,
+            )
+            evaluation_result_row = EvaluationResult(
+                org_id=org.id,
+                task=task_row.id,
+                instance_id=None,
+                result=evaluation_result,
+                agent_caused_exit_reason=None,
+            )
+
+            with Session(bind=engine) as task_session:
+                task = fetch_task_row(task_row.id, task_session, org)
+                task_session.add(evaluation_result_row)
+                task.status = TaskStatus.FINISHED
+                task_session.commit()
+
+                return {task_id: evaluation_result_row.result}
+
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
 
         # Labels that show up in the UI we can use to filter sandboxes
@@ -461,7 +498,11 @@ async def process_task(
                 # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
                 logger.info(f"Evaluating agent {start_benchmark_request.contract.name} in sandbox {sandbox.name}")
                 evaluation_result = await benchmark_service.evaluate_instance(
-                    task_row.task_id, sandbox.id, on_message=log_output, dataset=start_benchmark_request.dataset
+                    task_row.task_id,
+                    sandbox.id,
+                    on_message=log_output,
+                    on_eval_resume_state=on_eval_resume_state,
+                    dataset=start_benchmark_request.dataset,
                 )
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
@@ -524,13 +565,17 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: 
         select(func.count(col(Task.id)))
         .where(col(Task.benchmark) == benchmark_row.id)
         .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS]))
+        .where(
+            col(Task.status).in_(
+                [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
+            )
+        )
     ).one()
 
     # Tasks will be in a non-finished state if something interrupts them while they are running and the state errors here
     if tasks_not_finished:
         raise TrackerServiceError(
-            f"Cannot set final status for run {benchmark_row.id} because tasks are still in the pending or in progress state."
+            f"Cannot set final status for run {benchmark_row.id} because tasks are still runnable."
         )
 
     tasks_stopped: int = session.exec(
@@ -558,7 +603,7 @@ def create_task_rows(
     """
     Create task_rows that do not already exist in the database for the benchmark row.
 
-    NOTE: Only return pending tasks to support resuming the benchmark.
+    NOTE: Only return runnable tasks to support resuming the benchmark.
     """
 
     # Find task ids that already exist so that we can filter them out
@@ -576,12 +621,14 @@ def create_task_rows(
     session.commit()
     session.expire_all()
 
-    # Fetch all task rows with the status of pending
-    pending_task_rows: Sequence[tuple[str, Task]] = session.exec(
-        select(Task.task_id, Task).where(Task.benchmark == benchmark_row.id).where(Task.status == TaskStatus.PENDING)
+    runnable_statuses = [TaskStatus.PENDING, TaskStatus.EVALUATING]
+    task_rows: Sequence[tuple[str, Task]] = session.exec(
+        select(Task.task_id, Task)
+        .where(Task.benchmark == benchmark_row.id)
+        .where(col(Task.status).in_(runnable_statuses))
     ).all()
 
-    return pending_task_rows
+    return task_rows
 
 
 async def fetch_missing_tasks(
@@ -1122,6 +1169,7 @@ async def reset_to_in_progress_status(
     session: Session,
     benchmark_service: BenchmarkServiceClient,
     retry: bool,
+    retry_mode: RetryMode,
     rerun_task_ids: list[str],
     org: Org,
 ) -> list[str]:
@@ -1132,7 +1180,7 @@ async def reset_to_in_progress_status(
     Rerun Task IDs: even if task has been finished we restart it
 
     Benchmark - In progress status
-    Tasks - Pending status
+    Tasks - Pending status, or Evaluating status when retrying durable eval state
 
     NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
     """
@@ -1150,11 +1198,8 @@ async def reset_to_in_progress_status(
             ),
         ]
 
-        # Check if there are any tasks that have been stopped
-        task_ids = session.exec(select(Task.id, Task.task_id).where(*filter_query)).all()
-
-        # id is task row primary key, task_id is the task id
-        task_mapping: dict[UUID, str] = {id: task_id for id, task_id in task_ids}
+        task_rows = session.exec(select(Task).where(*filter_query)).all()
+        task_mapping: dict[UUID, str] = {task.id: task.task_id for task in task_rows}
 
         # Ensure we are not missing any tasks that were requested (skips if force is empty)
         missing_task_ids = [task_id for task_id in rerun_task_ids if task_id not in task_mapping.values()]
@@ -1164,7 +1209,7 @@ async def reset_to_in_progress_status(
             )
 
         # Allow re-running the end of the benchmark without running any tasks
-        if not task_ids:
+        if not task_rows:
             return []
 
         # Verify the task ids are still valid before priming to resume
@@ -1178,17 +1223,18 @@ async def reset_to_in_progress_status(
         session.add(benchmark_row)
         session.commit()
 
-        # Set the task status to pending to flag resuming the tasks
-        session.exec(
-            update(Task)
-            .where(*filter_query)
-            .values(  # Reset to defaults
-                status=TaskStatus.PENDING,
-                started_at=datetime.now(ZoneInfo("UTC")),
-                error_message=None,
-                finished_at=None,
+        for task in task_rows:
+            task.status = (
+                TaskStatus.EVALUATING
+                if retry_mode == RetryMode.AUTO and task.eval_resume_state is not None
+                else TaskStatus.PENDING
             )
-        )
+            task.started_at = datetime.now(ZoneInfo("UTC"))
+            task.error_message = None
+            task.finished_at = None
+            if retry_mode == RetryMode.FROM_SCRATCH:
+                task.eval_resume_state = None
+            session.add(task)
 
         # Delete all evaluation results for the tasks (unlikely they exist)
         session.exec(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -393,11 +393,9 @@ async def process_task(
         if task_row.status == TaskStatus.EVALUATING:
             assert task_row.eval_resume_state is not None
             log_output("Resuming evaluation from durable benchmark state\n")
-            evaluation_result = await benchmark_service.resume_evaluation(
+            evaluation_result = await benchmark_service.evaluate_response(
                 task_row.task_id,
-                task_row.eval_resume_state,
-                on_message=log_output,
-                on_eval_resume_state=on_eval_resume_state,
+                eval_resume_state=task_row.eval_resume_state,
                 dataset=start_benchmark_request.dataset,
             )
             evaluation_result_row = EvaluationResult(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -393,7 +393,7 @@ async def process_task(
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
-                evaluation_result = await benchmark_service.evaluate_response(
+                evaluation_result = await benchmark_service.resume_evaluation(
                     task_row.task_id,
                     eval_resume_state=task_row.eval_resume_state,
                     on_message=log_output,

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1049,7 +1049,7 @@ async def initiate_stop_benchmark(benchmark_row: Benchmark, session: Session, fo
             update(Task)
             .where(col(Task.benchmark) == benchmark_row.id)
             .where(col(Task.org_id) == org.id)
-            .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING]))
+            .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]))
             .values(status=TaskStatus.STOPPED)
         )
         session.commit()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -390,9 +390,7 @@ async def process_task(
         save_eval_resume_state(task_row.id, org, state)
 
     try:
-        if task_row.status == TaskStatus.EVALUATING:
-            if task_row.eval_resume_state is None:
-                raise ValueError("Cannot resume evaluation without eval_resume_state")
+        if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
                 evaluation_result = await benchmark_service.evaluate_response(

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -50,9 +50,13 @@ class TestBenchmarkUtils:
             initial_task_rows.append(
                 Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.PENDING)
             )
-        for i in range(5, 10):
+        for i in range(5, 8):
             initial_task_rows.append(
                 Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+            )
+        for i in range(8, 10):
+            initial_task_rows.append(
+                Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.EVALUATING)
             )
         database_session.add_all(initial_task_rows)
         database_session.commit()
@@ -81,7 +85,7 @@ class TestBenchmarkUtils:
             .where(Task.benchmark == benchmark_row.id)
             .where(Task.status == TaskStatus.STOPPED)
         ).one()
-        assert task_rows == 5
+        assert task_rows == 7
 
         # The remaining tasks have been left alone in in progress state
         task_rows = database_session.exec(
@@ -90,7 +94,7 @@ class TestBenchmarkUtils:
             .where(Task.status == TaskStatus.IN_PROGRESS)
         ).one()
 
-        assert task_rows == 5
+        assert task_rows == 3
 
     def test_stop_benchmark_edge_cases(self, example_benchmark_object: Benchmark, database_session: Session):
         """

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -312,7 +312,7 @@ class TestStopAndResume:
             raise AssertionError("eval resume should not create a sandbox")
             yield
 
-        async def _mock_evaluate_response(
+        async def _mock_resume_evaluation(
             _self: BenchmarkServiceClient,
             task_id: str,
             *_args: Any,
@@ -327,7 +327,7 @@ class TestStopAndResume:
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.create_sandbox", _unexpected_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_response", _mock_evaluate_response, raising=False)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
         result = await process_task(
             task_row,
@@ -375,7 +375,7 @@ class TestStopAndResume:
         database_session.add(task_row)
         database_session.commit()
 
-        async def _mock_evaluate_response(
+        async def _mock_resume_evaluation(
             _self: BenchmarkServiceClient,
             task_id: str,
             *_args: Any,
@@ -392,7 +392,7 @@ class TestStopAndResume:
             raise RuntimeError("evaluation interrupted")
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
-        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_response", _mock_evaluate_response, raising=False)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
         result = await process_task(
             task_row,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -338,6 +338,70 @@ class TestStopAndResume:
         assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
         assert evaluation.instance_id is None
 
+    async def test_process_task_keeps_stopped_eval_resume_task_stopped(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        request = StartBenchmarkRequest(
+            benchmark_name="vcb",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(request, self._test_org)
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.EVALUATING,
+            eval_resume_state={"artifact_prefix": "s3://bucket/run"},
+        )
+        database_session.add(task_row)
+        database_session.commit()
+
+        async def _mock_evaluate_response(
+            _self: BenchmarkServiceClient,
+            task_id: str,
+            *_args: Any,
+            eval_resume_state: dict[str, Any],
+            **_kwargs: Any,
+        ) -> dict[str, Any]:
+            assert task_id == "task_0"
+            assert eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
+            task = database_session.get(Task, task_row.id)
+            assert task is not None
+            task.status = TaskStatus.STOPPED
+            database_session.add(task)
+            database_session.commit()
+            raise RuntimeError("evaluation interrupted")
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_response", _mock_evaluate_response, raising=False)
+
+        result = await process_task(
+            task_row,
+            request,
+            request.benchmark_service,
+            benchmark_row.id,
+            task_row.task_id,
+            harness_config,
+            self._test_org,
+            creation_semaphore=asyncio.Semaphore(1),
+        )
+
+        database_session.refresh(task_row)
+        evaluations = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).all()
+        assert result == {"task_0": None}
+        assert task_row.status == TaskStatus.STOPPED
+        assert evaluations == []
+
     async def test_retry_or_resume_forwards_tracker_api_key_to_benchmark_service(
         self,
         example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -223,15 +223,22 @@ class TestStopAndResume:
             assert task_row.alias != original_aliases[task_row.task_id]
 
     @pytest.mark.parametrize(
-        ("retry_mode", "expected_status", "expected_state"),
+        ("retry_mode", "eval_resume_state", "expected_status", "expected_state"),
         [
-            (RetryMode.AUTO, TaskStatus.EVALUATING, {"artifact_prefix": "s3://bucket/run"}),
-            (RetryMode.FROM_SCRATCH, TaskStatus.PENDING, None),
+            (
+                RetryMode.AUTO,
+                {"artifact_prefix": "s3://bucket/run"},
+                TaskStatus.EVALUATING,
+                {"artifact_prefix": "s3://bucket/run"},
+            ),
+            (RetryMode.AUTO, None, TaskStatus.PENDING, None),
+            (RetryMode.FROM_SCRATCH, {"artifact_prefix": "s3://bucket/run"}, TaskStatus.PENDING, None),
         ],
     )
     async def test_reset_handles_eval_resume_state(
         self,
         retry_mode: RetryMode,
+        eval_resume_state: dict[str, str] | None,
         expected_status: TaskStatus,
         expected_state: dict[str, str] | None,
         example_benchmark_object: Benchmark,
@@ -246,7 +253,7 @@ class TestStopAndResume:
             task_id="task_0",
             benchmark=benchmark_row.id,
             status=TaskStatus.STOPPED,
-            eval_resume_state={"artifact_prefix": "s3://bucket/run"},
+            eval_resume_state=eval_resume_state,
         )
         database_session.add(benchmark_row)
         database_session.add(task_row)

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -310,10 +310,12 @@ class TestStopAndResume:
             task_id: str,
             *_args: Any,
             eval_resume_state: dict[str, Any],
+            on_eval_resume_state: Any,
             **_kwargs: Any,
         ) -> dict[str, Any]:
             assert task_id == "task_0"
             assert eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
+            on_eval_resume_state({"artifact_prefix": "s3://bucket/run", "job_id": "job-1"})
             return {"score": 1.0}
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
@@ -335,7 +337,7 @@ class TestStopAndResume:
         evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
         assert result == {"task_0": {"score": 1.0}}
         assert task_row.status == TaskStatus.FINISHED
-        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
+        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
         assert evaluation.instance_id is None
 
     async def test_process_task_keeps_stopped_eval_resume_task_stopped(

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import FinalScoreResponse, Resources, RetrieveTaskResponse, VerifyTaskIdsResponse
 from fastapi.testclient import TestClient
@@ -11,7 +12,16 @@ from sqlmodel import Session, select
 
 from main import app
 from tests.conftest import TEST_ORG_ID
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkStatus,
+    EvaluationResult,
+    Org,
+    RetryMode,
+    Task,
+    TaskStatus,
+)
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     TaskMonitor,
@@ -20,6 +30,7 @@ from tracker.utils import (
     force_stop_sandboxes,
     initiate_stop_benchmark,
     process_benchmark,
+    process_task,
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
 )
@@ -150,6 +161,7 @@ class TestStopAndResume:
             session=database_session,
             benchmark_service=start_benchmark_request.benchmark_service,
             retry=False,
+            retry_mode=RetryMode.AUTO,
             rerun_task_ids=[],
             org=self._test_org,
         )
@@ -199,6 +211,7 @@ class TestStopAndResume:
             session=database_session,
             benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
             retry=True,
+            retry_mode=RetryMode.AUTO,
             rerun_task_ids=[],
             org=self._test_org,
         )
@@ -208,6 +221,124 @@ class TestStopAndResume:
         updated_task_rows = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         for task_row in updated_task_rows:
             assert task_row.alias != original_aliases[task_row.task_id]
+
+    @pytest.mark.parametrize(
+        ("retry_mode", "expected_status", "expected_state"),
+        [
+            (RetryMode.AUTO, TaskStatus.EVALUATING, {"artifact_prefix": "s3://bucket/run"}),
+            (RetryMode.FROM_SCRATCH, TaskStatus.PENDING, None),
+        ],
+    )
+    async def test_reset_handles_eval_resume_state(
+        self,
+        retry_mode: RetryMode,
+        expected_status: TaskStatus,
+        expected_state: dict[str, str] | None,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.STOPPED,
+            eval_resume_state={"artifact_prefix": "s3://bucket/run"},
+        )
+        database_session.add(benchmark_row)
+        database_session.add(task_row)
+        database_session.commit()
+
+        async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=[task_row.task_id])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
+            retry=False,
+            retry_mode=retry_mode,
+            rerun_task_ids=[],
+            org=self._test_org,
+        )
+
+        database_session.refresh(task_row)
+        assert verified_task_ids == [task_row.task_id]
+        assert task_row.status == expected_status
+        assert task_row.eval_resume_state == expected_state
+
+    async def test_process_task_resumes_evaluation_without_sandbox(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        request = StartBenchmarkRequest(
+            benchmark_name="vcb",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(request, self._test_org)
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.EVALUATING,
+            eval_resume_state={"artifact_prefix": "s3://bucket/run"},
+        )
+        database_session.add(task_row)
+        database_session.commit()
+
+        @asynccontextmanager
+        async def _unexpected_create_sandbox(*_args: Any, **_kwargs: Any):
+            raise AssertionError("eval resume should not create a sandbox")
+            yield
+
+        async def _mock_resume_evaluation(
+            _self: BenchmarkServiceClient,
+            task_id: str,
+            eval_resume_state: dict[str, Any],
+            *_args: Any,
+            on_eval_resume_state: Any,
+            **_kwargs: Any,
+        ) -> dict[str, Any]:
+            assert task_id == "task_0"
+            assert eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
+            on_eval_resume_state({"artifact_prefix": "s3://bucket/run", "job_id": "job-1"})
+            return {"score": 1.0}
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _unexpected_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await process_task(
+            task_row,
+            request,
+            request.benchmark_service,
+            benchmark_row.id,
+            task_row.task_id,
+            harness_config,
+            self._test_org,
+            creation_semaphore=asyncio.Semaphore(1),
+        )
+
+        database_session.refresh(task_row)
+        evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+        assert result == {"task_0": {"score": 1.0}}
+        assert task_row.status == TaskStatus.FINISHED
+        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        assert evaluation.instance_id is None
 
     async def test_retry_or_resume_forwards_tracker_api_key_to_benchmark_service(
         self,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -305,22 +305,20 @@ class TestStopAndResume:
             raise AssertionError("eval resume should not create a sandbox")
             yield
 
-        async def _mock_resume_evaluation(
+        async def _mock_evaluate_response(
             _self: BenchmarkServiceClient,
             task_id: str,
-            eval_resume_state: dict[str, Any],
             *_args: Any,
-            on_eval_resume_state: Any,
+            eval_resume_state: dict[str, Any],
             **_kwargs: Any,
         ) -> dict[str, Any]:
             assert task_id == "task_0"
             assert eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
-            on_eval_resume_state({"artifact_prefix": "s3://bucket/run", "job_id": "job-1"})
             return {"score": 1.0}
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.create_sandbox", _unexpected_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_response", _mock_evaluate_response, raising=False)
 
         result = await process_task(
             task_row,
@@ -337,7 +335,7 @@ class TestStopAndResume:
         evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
         assert result == {"task_0": {"score": 1.0}}
         assert task_row.status == TaskStatus.FINISHED
-        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run"}
         assert evaluation.instance_id is None
 
     async def test_retry_or_resume_forwards_tracker_api_key_to_benchmark_service(

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24#45e6db696fc465c0a621121cf2773606f72c8e24" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed#a83e56a768134eb855ffa3e9f7052ab6476605ed" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1840,7 +1840,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7#5c1ee06d9584336010e11d3ec440fa9ceae064d7" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536#dc4e1428dd03a687e1221cc6e3665fba7aec2536" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1840,7 +1840,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -216,6 +216,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -320,10 +329,12 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#0d06ceecd2b0d886cbef8fa8dec0a62543774598" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7#5c1ee06d9584336010e11d3ec440fa9ceae064d7" }
 dependencies = [
+    { name = "cachetools" },
     { name = "click" },
     { name = "daytona" },
+    { name = "descope" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
@@ -477,7 +488,7 @@ wheels = [
 
 [[package]]
 name = "descope"
-version = "1.12.2"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "email-validator" },
@@ -485,9 +496,9 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/87/8de56a0d31de3f88cbb12fb9abdbe44d2b9d01709cca8a9b6493158db1b9/descope-1.12.2.tar.gz", hash = "sha256:1b9a109a55a9cc15cbbf047645d1bc453c179b3c3cb160159e7aa2234637ce70", size = 93576, upload-time = "2026-04-12T16:02:23.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/b3/d67f38dfcdca2202455a012f59e988d2348bb49d6878cab88c21eddf193f/descope-1.13.0.tar.gz", hash = "sha256:eafb65d00f415771430acb9c0e7ca4f54e96488bbb3f813147c0d42404683e6b", size = 93621, upload-time = "2026-04-20T06:14:42.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/36/7de59242a68a9e039a6f9dc12d054893ce70695932af1afacbf92b5891de/descope-1.12.2-py3-none-any.whl", hash = "sha256:75a00c41d956eb69e2d0823f77c4c1c4201f16cba8cf4f03ac52813007af70c5", size = 100260, upload-time = "2026-04-12T16:02:22.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/9e/20da15caaf498f5c4bd9d58291a16f052016017e4bb6660e4b855aee9500/descope-1.13.0-py3-none-any.whl", hash = "sha256:ecd021f82e1b60f865a3ef9814c2a757b6a7391538b27ea65be6031d478880d1", size = 100313, upload-time = "2026-04-20T06:14:41.257Z" },
 ]
 
 [[package]]
@@ -673,9 +684,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -1831,7 +1840,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed#a83e56a768134eb855ffa3e9f7052ab6476605ed" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498#64763260a4f6db73229591a311d7e92fde59e498" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1840,7 +1840,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536#dc4e1428dd03a687e1221cc6e3665fba7aec2536" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24#45e6db696fc465c0a621121cf2773606f72c8e24" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1840,7 +1840,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import click
 import yaml
-from tracker.database.models import BenchmarkStatus
+from tracker.database.models import BenchmarkStatus, RetryMode
 from tracker.exceptions import S3Error
 from tracker.types import FinalViewResponse, Order, RetrieveResultsResponse, StartBenchmarkResponse
 
@@ -764,6 +764,12 @@ def stop(run_id: UUID, force: bool):
     default=False,
     help="Refresh the frozen agent copy from the current agents/<name>.zip in S3 before resuming.",
 )
+@click.option(
+    "--from-scratch",
+    is_flag=True,
+    default=False,
+    help="Clear durable eval state and rerun generation.",
+)
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -773,6 +779,7 @@ def resume(
     task_ids: str | None,
     task_ids_file: Path | None,
     update_agent: bool,
+    from_scratch: bool,
 ):
     """
     Resume a run by its run id.
@@ -814,6 +821,7 @@ def resume(
             _ = tracker.retry_or_resume_benchmark(
                 run_id,
                 retry,
+                RetryMode.FROM_SCRATCH if from_scratch else RetryMode.AUTO,
                 concurrency,
                 retry_task_ids,
                 service_headers=service_headers,

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -11,7 +11,7 @@ import httpx
 import yaml
 from dotenv import load_dotenv
 from httpx._models import Response
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, RetryMode
 from tracker.types import (
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
@@ -425,6 +425,7 @@ class TrackerService:
         self,
         benchmark_id: UUID,
         retry: bool,
+        retry_mode: RetryMode,
         concurrency: int | None,
         task_ids: list[str],
         service_headers: dict[str, str] | None = None,
@@ -443,7 +444,7 @@ class TrackerService:
             RetryOrResumeBenchmarkResponse with status and message
         """
         try:
-            params: dict[str, Any] = {"retry": retry}
+            params: dict[str, Any] = {"retry": retry, "retry_mode": retry_mode.value}
 
             # NOTE: 0 is not acceptable
             if concurrency:

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -1,0 +1,53 @@
+from uuid import uuid4
+
+import httpx
+import pytest
+from tracker.database.models import RetryMode
+
+from valkyrie.cli.tracker_service import TrackerService
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.params: dict[str, object] | None = None
+        self.json: dict[str, object] | None = None
+
+    def post(self, _url: str, *, params: dict[str, object], json: dict[str, object]) -> httpx.Response:
+        self.params = params
+        self.json = json
+        return httpx.Response(200, json={"status": "success"})
+
+    def close(self) -> None:
+        pass
+
+
+def empty_config() -> dict[str, object]:
+    return {}
+
+
+def empty_config_keys(_tracker: TrackerService) -> dict[str, str]:
+    return {}
+
+
+def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    result = tracker.retry_or_resume_benchmark(
+        uuid4(),
+        retry=True,
+        retry_mode=RetryMode.FROM_SCRATCH,
+        concurrency=3,
+        task_ids=["task-1"],
+    )
+
+    assert result.status == "success"
+    assert client.params == {"retry": True, "retry_mode": "from_scratch", "concurrency": 3}
+    assert client.json == {"task_ids": ["task-1"], "service_headers": {}}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -320,6 +320,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "7.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -566,10 +575,12 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#0d06ceecd2b0d886cbef8fa8dec0a62543774598" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7#5c1ee06d9584336010e11d3ec440fa9ceae064d7" }
 dependencies = [
+    { name = "cachetools" },
     { name = "click" },
     { name = "daytona" },
+    { name = "descope" },
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
@@ -737,7 +748,7 @@ wheels = [
 
 [[package]]
 name = "descope"
-version = "1.12.2"
+version = "1.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "email-validator" },
@@ -745,9 +756,9 @@ dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/87/8de56a0d31de3f88cbb12fb9abdbe44d2b9d01709cca8a9b6493158db1b9/descope-1.12.2.tar.gz", hash = "sha256:1b9a109a55a9cc15cbbf047645d1bc453c179b3c3cb160159e7aa2234637ce70", size = 93576, upload-time = "2026-04-12T16:02:23.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/b3/d67f38dfcdca2202455a012f59e988d2348bb49d6878cab88c21eddf193f/descope-1.13.0.tar.gz", hash = "sha256:eafb65d00f415771430acb9c0e7ca4f54e96488bbb3f813147c0d42404683e6b", size = 93621, upload-time = "2026-04-20T06:14:42.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/36/7de59242a68a9e039a6f9dc12d054893ce70695932af1afacbf92b5891de/descope-1.12.2-py3-none-any.whl", hash = "sha256:75a00c41d956eb69e2d0823f77c4c1c4201f16cba8cf4f03ac52813007af70c5", size = 100260, upload-time = "2026-04-12T16:02:22.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/9e/20da15caaf498f5c4bd9d58291a16f052016017e4bb6660e4b855aee9500/descope-1.13.0-py3-none-any.whl", hash = "sha256:ecd021f82e1b60f865a3ef9814c2a757b6a7391538b27ea65be6031d478880d1", size = 100313, upload-time = "2026-04-20T06:14:41.257Z" },
 ]
 
 [[package]]
@@ -1045,9 +1056,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -1055,9 +1064,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -1065,9 +1072,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
-    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -1075,9 +1080,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -2640,7 +2643,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7#5c1ee06d9584336010e11d3ec440fa9ceae064d7" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536#dc4e1428dd03a687e1221cc6e3665fba7aec2536" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2643,7 +2643,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=5c1ee06d9584336010e11d3ec440fa9ceae064d7" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed#a83e56a768134eb855ffa3e9f7052ab6476605ed" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498#64763260a4f6db73229591a311d7e92fde59e498" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2643,7 +2643,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536#dc4e1428dd03a687e1221cc6e3665fba7aec2536" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24#45e6db696fc465c0a621121cf2773606f72c8e24" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2643,7 +2643,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=dc4e1428dd03a687e1221cc6e3665fba7aec2536" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498#64763260a4f6db73229591a311d7e92fde59e498" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b#899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2658,7 +2658,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" },
     { name = "daytona", specifier = "==0.172.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24#45e6db696fc465c0a621121cf2773606f72c8e24" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed#a83e56a768134eb855ffa3e9f7052ab6476605ed" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2643,7 +2643,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=45e6db696fc465c0a621121cf2773606f72c8e24" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=a83e56a768134eb855ffa3e9f7052ab6476605ed" },
     { name = "daytona", specifier = ">=0.169.0a2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary

Adds tracker support for eval-only retry when a benchmark service has already saved evaluation progress state:

- stores latest `eval_resume_state` on `Task`
- allows `EVALUATING` tasks with saved state to resume through `BenchmarkServiceClient.resume_evaluation()` without creating a new sandbox
- falls back to normal scratch retry when no eval state exists
- records final eval results with nullable `EvaluationResult.instance_id`
- adds retry mode selection: default `auto`, plus `--from-scratch` to clear stored eval state and rerun from generation

## Dependency

Stacked on vals-ai/create-benchmark-service#38. The current dependency pin references create-benchmark-service commit `899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b` from that PR.