### PR TITLE
fix(cli): suppress library logs by default

### DIFF
--- a/src/valkyrie/cli/logging.py
+++ b/src/valkyrie/cli/logging.py
@@ -1,0 +1,15 @@
+"""Logging controls for the Valkyrie CLI."""
+
+import logging
+import os
+
+CLI_LOGS_ENV_VAR = "VALKYRIE_CLI_LOGS"
+
+
+def configure_cli_logging() -> None:
+    """Disable library logs in CLI output unless explicitly enabled."""
+    if os.environ.get(CLI_LOGS_ENV_VAR) == "true":
+        logging.disable(logging.NOTSET)
+        return
+
+    logging.disable(logging.CRITICAL)

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -14,6 +14,7 @@ from tracker.types import FinalViewResponse, Order, RetrieveResultsResponse, Sta
 
 from valkyrie.cli.bundler import get_contract
 from valkyrie.cli.exceptions import BundlerError, ContractValidationError, TrackerServiceError
+from valkyrie.cli.logging import configure_cli_logging
 from valkyrie.cli.s3_client import (
     download_agent,
     download_s3_path,
@@ -48,7 +49,7 @@ from valkyrie.schemas import AgentConfig
 @click.group()
 def cli():
     """Valkyrie CLI."""
-    pass
+    configure_cli_logging()
 
 
 @cli.group()

--- a/tests/unit/test_cli_logging.py
+++ b/tests/unit/test_cli_logging.py
@@ -1,0 +1,56 @@
+import io
+import logging
+
+import pytest
+
+from valkyrie.cli.logging import configure_cli_logging
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_disable() -> None:
+    previous_disable_level = logging.root.manager.disable
+    logging.disable(logging.NOTSET)
+    yield
+    logging.disable(previous_disable_level)
+
+
+def _emit_info_log() -> str:
+    stream = io.StringIO()
+    logger = logging.getLogger("httpx")
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+    try:
+        logger.info("HTTP Request: GET https://benchmark-tracker.vals.ai/health")
+    finally:
+        logger.removeHandler(handler)
+
+    return stream.getvalue()
+
+
+def test_configure_cli_logging_suppresses_logs_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("VALKYRIE_CLI_LOGS", raising=False)
+
+    configure_cli_logging()
+
+    assert _emit_info_log() == ""
+
+
+def test_configure_cli_logging_allows_logs_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALKYRIE_CLI_LOGS", "true")
+
+    configure_cli_logging()
+
+    assert "HTTP Request" in _emit_info_log()
+
+
+@pytest.mark.parametrize("value", ["1", "TRUE", "yes", "on", "false"])
+def test_configure_cli_logging_suppresses_logs_for_non_true_values(value: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VALKYRIE_CLI_LOGS", value)
+
+    configure_cli_logging()
+
+    assert _emit_info_log() == ""


### PR DESCRIPTION
## Summary
Suppress Python logging output in the Valkyrie CLI by default so `valkyrie run start` output stays focused on CLI-rendered status and errors. Logs can still be enabled explicitly with `VALKYRIE_CLI_LOGS=true` when debugging is needed.

<img width="1871" height="1189" alt="Screenshot 2026-05-05 at 2 34 28 PM" src="https://github.com/user-attachments/assets/766d81e7-c82c-4a6b-a952-cc6145392a24" />

## Changes
- Add `configure_cli_logging()` for CLI-specific log suppression.
- Wire the logging configuration into the top-level Click group.
- Add unit coverage for default suppression, the exact `VALKYRIE_CLI_LOGS=true` opt-in, and non-true env values.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Verified locally:
- `uv run pytest tests/unit` -> 39 passed
- `uv run ruff check src/valkyrie/cli/main.py src/valkyrie/cli/logging.py tests/unit/test_cli_logging.py`
- `uv run ruff format --check src/valkyrie/cli/main.py src/valkyrie/cli/logging.py tests/unit/test_cli_logging.py`
- `uv run basedpyright`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed