### PR TITLE
fix: return 502 for unreachable benchmark service

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -4,6 +4,7 @@ import traceback
 from typing import Annotated
 from uuid import UUID
 
+import httpx
 import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceError
@@ -205,7 +206,13 @@ async def start_benchmark(
     benchmark_service = request.benchmark_service
 
     # Check service is running
-    _ = await benchmark_service.health_check()
+    try:
+        _ = await benchmark_service.health_check()
+    except httpx.ConnectError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Benchmark service '{request.benchmark_name}' is not reachable",
+        ) from exc
 
     # Create benchmark row inside of database to mark start of the benchmark
     benchmark_row = start_benchmark_request_to_benchmark(request, org)

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -3,6 +3,7 @@ from datetime import timezone
 from typing import Any
 from uuid import UUID, uuid4
 
+import httpx
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import VerifyTaskIdsResponse
 from dateutil.parser import isoparse
@@ -121,6 +122,31 @@ class TestFastapiServer:
         assert json_response["benchmark_name"] == request.benchmark_name
         assert json_response["agent_name"] == request.contract.name
         assert json_response["concurrency"] == request.concurrency
+
+    async def test_start_benchmark_returns_502_when_benchmark_service_is_unreachable(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=10,
+            task_ids=None,
+            harness_config=harness_config,
+        )
+
+        async def _mock_health_check(*_args: Any, **_kwargs: Any):
+            raise httpx.ConnectError("Name or service not known")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "health_check", _mock_health_check)
+
+        no_raise_client = TestClient(app, raise_server_exceptions=False)
+        response = no_raise_client.post("/start-benchmark", json=request.model_dump())
+
+        assert response.status_code == 502
+        assert response.json() == {"detail": "Benchmark service 'swebench' is not reachable"}
 
     async def test_start_benchmark_forwards_tracker_api_key_to_benchmark_service(
         self,


### PR DESCRIPTION
## Summary
Handle unreachable benchmark-service health checks in tracker start-benchmark requests so callers receive an actionable 502 instead of a generic 500.

## Changes
- Catch httpx.ConnectError around the benchmark service health check in start_benchmark
- Return a 502 response naming the unreachable benchmark service
- Add a regression test for the unreachable service path

## Related Issues
Closes vals-ai/valkyrie-ticket-library#15

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed