### PR TITLE
Add sentry observability helpers and PTY metrics

### DIFF
--- a/services/tracker/src/tracker/observability.py
+++ b/services/tracker/src/tracker/observability.py
@@ -1,0 +1,128 @@
+"""Shared observability helpers for metrics, retry logs, and Sentry context."""
+
+import logging
+from collections.abc import Callable, Mapping
+from typing import Any
+
+import sentry_sdk
+from sentry_sdk import metrics as _sentry_metrics
+from tenacity import RetryCallState
+
+logger = logging.getLogger(__name__)
+
+_BANNED_TAG_KEYS = {
+    "command",
+    "error_message",
+    "request_id",
+    "sandbox_id",
+    "session_id",
+    "task_id",
+}
+
+
+def _normalize(tags: Mapping[str, Any] | None) -> dict[str, str]:
+    """Convert metric tags to low-cardinality Sentry metric attributes."""
+    if not tags:
+        return {}
+
+    attributes: dict[str, str] = {}
+    for key, value in tags.items():
+        if value is None:
+            continue
+
+        key_str = str(key)
+        if key_str in _BANNED_TAG_KEYS:
+            logger.debug("dropping high-cardinality metric tag %s", key_str)
+            continue
+
+        attributes[key_str] = str(value)
+
+    return attributes
+
+
+def incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+    """Increment a Sentry counter metric without letting metric failures escape."""
+    try:
+        _sentry_metrics.count(name, value, attributes=_normalize(tags))
+    except Exception as e:
+        logger.warning("metric incr(%s) failed: %s: %s", name, type(e).__name__, e)
+
+
+def distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+    """Record a Sentry distribution metric without letting metric failures escape."""
+    try:
+        _sentry_metrics.distribution(name, value, attributes=_normalize(tags))
+    except Exception as e:
+        logger.warning("metric distribution(%s) failed: %s: %s", name, type(e).__name__, e)
+
+
+def gauge(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+    """Record a Sentry gauge metric without letting metric failures escape."""
+    try:
+        _sentry_metrics.gauge(name, value, attributes=_normalize(tags))
+    except Exception as e:
+        logger.warning("metric gauge(%s) failed: %s: %s", name, type(e).__name__, e)
+
+
+def set_sandbox_context(sandbox: Any, *, image: str | None = None) -> None:
+    """Attach sandbox identifiers to Sentry tags/context, not metric attributes."""
+    try:
+        sentry_sdk.set_tag("sandbox_id", sandbox.id)
+        sentry_sdk.set_tag("sandbox_name", sandbox.name)
+
+        state = getattr(sandbox, "state", None)
+        context = {
+            "id": sandbox.id,
+            "name": sandbox.name,
+            "state": str(state) if state is not None else None,
+        }
+        if image is not None:
+            context["image"] = image
+
+        sentry_sdk.set_context("sandbox", context)
+    except Exception as e:
+        logger.warning("set_sandbox_context failed: %s: %s", type(e).__name__, e)
+
+
+def set_pty_context(*, session_id: str, attempt: int | None = None) -> None:
+    """Attach PTY identifiers to Sentry tags, not metric attributes."""
+    try:
+        sentry_sdk.set_tag("pty_session_id", session_id)
+        if attempt is not None:
+            sentry_sdk.set_tag("pty_attempt", str(attempt))
+    except Exception as e:
+        logger.warning("set_pty_context failed: %s: %s", type(e).__name__, e)
+
+
+def retry_callback(metric_name: str, *, log_level: int = logging.WARNING) -> Callable[[RetryCallState], None]:
+    """Create a Tenacity before_sleep hook with structured logging and retry metrics."""
+
+    def _hook(state: RetryCallState) -> None:
+        exc = state.outcome.exception() if state.outcome else None
+        error_class = type(exc).__name__ if exc else "unknown"
+        logger.log(
+            log_level,
+            "retry.before_sleep",
+            extra={
+                "metric": metric_name,
+                "fn": state.fn.__name__ if state.fn else None,
+                "attempt": state.attempt_number,
+                "idle_for": state.idle_for,
+                "error_class": error_class,
+            },
+        )
+        incr(f"{metric_name}.retry", tags={"error_class": error_class})
+
+    return _hook
+
+
+def tag_daytona_error(exc: Exception, *, op: str) -> None:
+    """Tag the active Sentry scope and emit a low-cardinality Daytona error metric."""
+    error_class = type(exc).__name__
+    try:
+        sentry_sdk.set_tag("daytona.op", op)
+        sentry_sdk.set_tag("error_class", error_class)
+    except Exception as e:
+        logger.warning("tag_daytona_error failed: %s: %s", type(e).__name__, e)
+
+    incr("valkyrie.daytona.error", tags={"op": op, "error_class": error_class})

--- a/services/tracker/src/tracker/observability.py
+++ b/services/tracker/src/tracker/observability.py
@@ -10,6 +10,8 @@ from tenacity import RetryCallState
 
 logger = logging.getLogger(__name__)
 
+# High-cardinality diagnostic fields belong in logs, spans, or Sentry context,
+# not metric attributes where they create one time series per task/session/etc.
 _BANNED_TAG_KEYS = {
     "command",
     "error_message",

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -46,6 +46,7 @@ from tracker.exceptions import (
     SSLConnectionError,
 )
 from tracker.logging import get_logger
+from tracker.observability import distribution, gauge, incr, retry_callback
 from tracker.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.types import AWSCredentials
 
@@ -323,9 +324,29 @@ _PTY_HANDSHAKE_CAP: int = 1_000_000
 _PTY_HANDSHAKE_SLOW_LOG_THRESHOLD: float = 2.0
 
 _pty_handshake_semaphore: Semaphore = Semaphore(_PTY_HANDSHAKE_CAP)
+_pty_handshake_in_flight_count: int = 0
 
 # States that determine if the sandbox has been killed
 _DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED)
+
+
+def _set_pty_span_attributes(sandbox: AsyncSandbox, session_id: str) -> None:
+    span = trace.get_current_span()
+    span.set_attribute("valkyrie.sandbox_id", sandbox.id)
+    span.set_attribute("valkyrie.sandbox_name", sandbox.name)
+    span.set_attribute("valkyrie.pty_session_id", session_id)
+
+
+def _log_pty_event(event: str, sandbox: AsyncSandbox, session_id: str, **extra: Any) -> None:
+    logger.info(
+        f"pty.{event}",
+        extra={
+            "pty_event": event,
+            "session_id": session_id,
+            "sandbox_id": sandbox.id,
+            **extra,
+        },
+    )
 
 
 @asynccontextmanager
@@ -340,7 +361,17 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
 
     wait_start = time.monotonic()
     async with _pty_handshake_semaphore:
+        global _pty_handshake_in_flight_count
+
         wait_duration = time.monotonic() - wait_start
+        distribution("valkyrie.pty.handshake.wait_duration", wait_duration, tags={"operation": operation})
+
+        _pty_handshake_in_flight_count += 1
+        gauge(
+            "valkyrie.pty.handshake.in_flight",
+            _pty_handshake_in_flight_count,
+            tags={"operation": operation},
+        )
 
         if gate_full_on_entry:
             logger.info(
@@ -353,6 +384,13 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
             yield
         finally:
             handshake_duration = time.monotonic() - handshake_start
+            distribution("valkyrie.pty.handshake.duration", handshake_duration, tags={"operation": operation})
+            _pty_handshake_in_flight_count = max(0, _pty_handshake_in_flight_count - 1)
+            gauge(
+                "valkyrie.pty.handshake.in_flight",
+                _pty_handshake_in_flight_count,
+                tags={"operation": operation},
+            )
             if handshake_duration > _PTY_HANDSHAKE_SLOW_LOG_THRESHOLD:
                 logger.warning(
                     f"PTY handshake slow: {operation} session={session_id} duration={handshake_duration:.2f}s"
@@ -381,9 +419,10 @@ async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(_PTY_CREATE_MAX_ATTEMPTS),
     wait=wait_fixed(_PTY_CREATE_DELAY_SECONDS),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
+    before_sleep=retry_callback("valkyrie.pty.create"),
     reraise=True,
 )
+@logfire.instrument("pty.create", extract_args=False)
 async def _create_pty_session(
     sandbox: AsyncSandbox,
     session_id: str,
@@ -402,6 +441,8 @@ async def _create_pty_session(
 
     # Each time we run this we want it to be logged, makes debugging easier
     on_data(f"[Debug]: Creating PTY session with the following id {salted_id}\n".encode())
+    _set_pty_span_attributes(sandbox, salted_id)
+    _log_pty_event("create", sandbox, salted_id)
 
     # Attempt to make the PTY session, timeouts occur under load
     async with _pty_handshake_slot("create", salted_id):
@@ -432,8 +473,10 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
     retry=retry_if_not_exception_type(SandboxError),
     stop=stop_after_attempt(_PTY_RECONNECT_MAX_ATTEMPTS),
     wait=wait_fixed(_PTY_RECONNECT_DELAY_SECONDS),
+    before_sleep=retry_callback("valkyrie.pty.reconnect"),
     reraise=True,
 )
+@logfire.instrument("pty.reconnect", extract_args=False)
 async def _reconnect_and_wait_pty(
     sandbox: AsyncSandbox,
     session_id: str,
@@ -447,12 +490,15 @@ async def _reconnect_and_wait_pty(
     Raises:
         SandboxError: If we cannot successfully check the sandbox health status
     """
+    incr("valkyrie.pty.reconnect.count", tags={"operation": "reconnect"})
+    _set_pty_span_attributes(sandbox, session_id)
 
     # Check if the sandbox has been closed
     await _check_sandbox_health(sandbox)
 
     # Log so the user can see we have seen a disconnection from the websocket (easier to pickup in logs)
     on_output("[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n")
+    _log_pty_event("reconnect_start", sandbox, session_id)
 
     # Reconnect to the PTY. Only the connect handshake is gated; handle.wait() runs ungated below.
     async with _pty_handshake_slot("reconnect", session_id):
@@ -462,6 +508,7 @@ async def _reconnect_and_wait_pty(
     await handle.wait()
 
 
+@logfire.instrument("pty.wait", extract_args=False)
 async def _wait_for_pty(
     sandbox: AsyncSandbox,
     session_id: str,
@@ -478,11 +525,14 @@ async def _wait_for_pty(
     Raises:
         SandboxError: Failed to wait until the command has been completed
     """
+    _set_pty_span_attributes(sandbox, session_id)
     try:
         await handle.wait()
         on_output("[Debug]: PTY has been disconnected, handler has stopped polling\n")
+        _log_pty_event("stream_disconnect", sandbox, session_id)
     except Exception as e:
         on_output(f"[Debug]: PTY stream has been disconnected (Attempting reconnection): {e}\n")
+        _log_pty_event("stream_disconnect_with_error", sandbox, session_id, error_class=type(e).__name__)
         try:
             await _reconnect_and_wait_pty(sandbox, session_id, on_data, on_output)
         except SandboxError:
@@ -498,6 +548,7 @@ async def _wait_for_pty(
             break
 
         on_output("[Debug]: PTY closed but status file not written yet, reconnecting\n")
+        _log_pty_event("reconnect_status_missing", sandbox, session_id)
         try:
             await _reconnect_and_wait_pty(sandbox, session_id, on_data, on_output)
         except SandboxError:
@@ -557,6 +608,7 @@ async def _kill_pty_session(sandbox: AsyncSandbox, session_id: str | None) -> No
         logfire.exception(f"Failed to kill PTY session {session_id} on sandbox {sandbox.id}")
 
 
+@logfire.instrument("pty.stream_command_output", extract_args=False)
 async def stream_command_output(
     sandbox: AsyncSandbox,
     command: str,
@@ -578,6 +630,7 @@ async def stream_command_output(
     status_path = f"{status_dir}/{pty_id}.status"
     handle: AsyncPtyHandle | None = None
     last_output: deque[str] = deque(maxlen=50)
+    _set_pty_span_attributes(sandbox, session_id)
 
     def on_data(data: bytes) -> None:
         text = data.decode("utf-8", errors="replace")

--- a/services/tracker/src/tracker/sentry.py
+++ b/services/tracker/src/tracker/sentry.py
@@ -3,11 +3,13 @@
 import logging
 import os
 
+import daytona
 import sentry_sdk
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.types import Event, Hint
 
+from tracker.exceptions import PtyCreationError, SSLConnectionError, SandboxError
 from tracker.logging.context import get_context_tags
 
 
@@ -16,6 +18,16 @@ def _before_send(
     hint: Hint,
 ) -> Event | None:
     """Attach structured logging context vars as Sentry tags on every event."""
+    exc_info = hint.get("exc_info")
+    if exc_info:
+        exc = exc_info[1]
+        if isinstance(exc, PtyCreationError):
+            event["fingerprint"] = ["{{ default }}", "PtyCreationError"]
+        elif isinstance(exc, SandboxError) and "PTY reconnect failed" in str(exc):
+            event["fingerprint"] = ["{{ default }}", "pty_reconnect_failed"]
+        elif isinstance(exc, SSLConnectionError):
+            event["fingerprint"] = ["{{ default }}", "SSLConnectionError"]
+
     tags = event.setdefault("tags", {})
     for key, value in get_context_tags().items():
         if value:
@@ -56,6 +68,7 @@ def init_sentry(service_name: str, environment: str) -> None:
                 ),
             ],
         )
+        sentry_sdk.set_tag("daytona.sdk_version", getattr(daytona, "__version__", "unknown"))
     except Exception as e:
         # A malformed SENTRY_DSN or invalid integration shouldn't crash service startup.
         logging.getLogger(__name__).warning("Failed to initialize Sentry: %s: %s", type(e).__name__, e)

--- a/services/tracker/tests/unit/test_observability.py
+++ b/services/tracker/tests/unit/test_observability.py
@@ -89,6 +89,28 @@ def test_metric_failures_are_logged_without_propagating(monkeypatch: pytest.Monk
     assert str(warnings[0][1][2]) == "boom"
 
 
+def test_distribution_and_gauge_failures_are_logged_without_propagating(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append((message, args))
+
+    monkeypatch.setattr(observability._sentry_metrics, "distribution", Mock(side_effect=RuntimeError("dist boom")))
+    monkeypatch.setattr(observability._sentry_metrics, "gauge", Mock(side_effect=RuntimeError("gauge boom")))
+    monkeypatch.setattr(observability.logger, "warning", fake_warning)
+
+    observability.distribution("valkyrie.test.duration", 1.5)
+    observability.gauge("valkyrie.test.in_flight", 4)
+
+    assert warnings[0][0] == "metric distribution(%s) failed: %s: %s"
+    assert warnings[0][1][:2] == ("valkyrie.test.duration", "RuntimeError")
+    assert str(warnings[0][1][2]) == "dist boom"
+    assert warnings[1][0] == "metric gauge(%s) failed: %s: %s"
+    assert warnings[1][1][:2] == ("valkyrie.test.in_flight", "RuntimeError")
+    assert str(warnings[1][1][2]) == "gauge boom"
+
+
 def test_set_sandbox_context_sets_tags_and_context(monkeypatch: pytest.MonkeyPatch) -> None:
     observability = _observability()
     tags: dict[str, str] = {}
@@ -121,6 +143,46 @@ def test_set_sandbox_context_sets_tags_and_context(monkeypatch: pytest.MonkeyPat
     }
 
 
+def test_set_sandbox_context_omits_optional_image_and_missing_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    contexts: dict[str, dict[str, Any]] = {}
+
+    def fake_set_context(key: str, value: dict[str, Any]) -> None:
+        contexts[key] = value
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", Mock())
+    monkeypatch.setattr(observability.sentry_sdk, "set_context", fake_set_context)
+
+    sandbox = SimpleNamespace(id="sandbox-123", name="bench-task-1")
+
+    observability.set_sandbox_context(sandbox)
+
+    assert contexts == {
+        "sandbox": {
+            "id": "sandbox-123",
+            "name": "bench-task-1",
+            "state": None,
+        }
+    }
+
+
+def test_set_sandbox_context_failures_are_logged_without_propagating(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append((message, args))
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", Mock(side_effect=RuntimeError("scope closed")))
+    monkeypatch.setattr(observability.logger, "warning", fake_warning)
+
+    observability.set_sandbox_context(SimpleNamespace(id="sandbox-123", name="bench-task-1"))
+
+    assert warnings[0][0] == "set_sandbox_context failed: %s: %s"
+    assert warnings[0][1][:1] == ("RuntimeError",)
+    assert str(warnings[0][1][1]) == "scope closed"
+
+
 def test_set_pty_context_sets_session_and_attempt_tags(monkeypatch: pytest.MonkeyPatch) -> None:
     observability = _observability()
     tags: dict[str, str] = {}
@@ -136,6 +198,37 @@ def test_set_pty_context_sets_session_and_attempt_tags(monkeypatch: pytest.Monke
         "pty_session_id": "sandbox:pty-123",
         "pty_attempt": "3",
     }
+
+
+def test_set_pty_context_omits_attempt_when_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    tags: dict[str, str] = {}
+
+    def fake_set_tag(key: str, value: str) -> None:
+        tags[key] = value
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", fake_set_tag)
+
+    observability.set_pty_context(session_id="sandbox:pty-123")
+
+    assert tags == {"pty_session_id": "sandbox:pty-123"}
+
+
+def test_set_pty_context_failures_are_logged_without_propagating(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append((message, args))
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", Mock(side_effect=RuntimeError("scope closed")))
+    monkeypatch.setattr(observability.logger, "warning", fake_warning)
+
+    observability.set_pty_context(session_id="sandbox:pty-123")
+
+    assert warnings[0][0] == "set_pty_context failed: %s: %s"
+    assert warnings[0][1][:1] == ("RuntimeError",)
+    assert str(warnings[0][1][1]) == "scope closed"
 
 
 def test_retry_callback_logs_attempt_and_emits_retry_metric(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -215,6 +308,37 @@ def test_tag_daytona_error_sets_tags_and_metric(monkeypatch: pytest.MonkeyPatch)
         "daytona.op": "sandbox.create",
         "error_class": "TimeoutError",
     }
+    assert increments == [
+        (
+            "valkyrie.daytona.error",
+            {
+                "op": "sandbox.create",
+                "error_class": "TimeoutError",
+            },
+        )
+    ]
+
+
+def test_tag_daytona_error_logs_tag_failures_and_still_emits_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+    increments: list[tuple[str, dict[str, str]]] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append((message, args))
+
+    def fake_incr(name: str, value: float = 1, tags: dict[str, str] | None = None) -> None:
+        increments.append((name, tags or {}))
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", Mock(side_effect=RuntimeError("scope closed")))
+    monkeypatch.setattr(observability.logger, "warning", fake_warning)
+    monkeypatch.setattr(observability, "incr", fake_incr)
+
+    observability.tag_daytona_error(TimeoutError("timed out"), op="sandbox.create")
+
+    assert warnings[0][0] == "tag_daytona_error failed: %s: %s"
+    assert warnings[0][1][:1] == ("RuntimeError",)
+    assert str(warnings[0][1][1]) == "scope closed"
     assert increments == [
         (
             "valkyrie.daytona.error",

--- a/services/tracker/tests/unit/test_observability.py
+++ b/services/tracker/tests/unit/test_observability.py
@@ -1,0 +1,226 @@
+import logging
+import importlib
+from collections.abc import Mapping
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+
+def _observability() -> Any:
+    try:
+        return importlib.import_module("tracker.observability")
+    except ModuleNotFoundError as e:
+        raise AssertionError("tracker.observability module should exist") from e
+
+
+def test_incr_uses_sentry_count_attributes_and_drops_high_cardinality_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observability = _observability()
+    calls: list[tuple[str, float, dict[str, str]]] = []
+
+    def fake_count(name: str, value: float, *, attributes: dict[str, str]) -> None:
+        calls.append((name, value, attributes))
+
+    monkeypatch.setattr(observability._sentry_metrics, "count", fake_count)
+
+    observability.incr(
+        "valkyrie.test.count",
+        value=2,
+        tags={
+            "operation": "create",
+            "attempt": 3,
+            "task_id": "task-123",
+            "session_id": "pty-123",
+            "ignored_none": None,
+        },
+    )
+
+    assert calls == [
+        (
+            "valkyrie.test.count",
+            2,
+            {
+                "operation": "create",
+                "attempt": "3",
+            },
+        )
+    ]
+
+
+def test_distribution_and_gauge_use_sentry_attributes(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    distribution_calls: list[tuple[str, float, dict[str, str]]] = []
+    gauge_calls: list[tuple[str, float, dict[str, str]]] = []
+
+    def fake_distribution(name: str, value: float, *, attributes: dict[str, str]) -> None:
+        distribution_calls.append((name, value, attributes))
+
+    def fake_gauge(name: str, value: float, *, attributes: dict[str, str]) -> None:
+        gauge_calls.append((name, value, attributes))
+
+    monkeypatch.setattr(observability._sentry_metrics, "distribution", fake_distribution)
+    monkeypatch.setattr(observability._sentry_metrics, "gauge", fake_gauge)
+
+    observability.distribution("valkyrie.test.duration", 1.5, tags={"outcome": "success"})
+    observability.gauge("valkyrie.test.in_flight", 4, tags={"worker": "worker-1"})
+
+    assert distribution_calls == [("valkyrie.test.duration", 1.5, {"outcome": "success"})]
+    assert gauge_calls == [("valkyrie.test.in_flight", 4, {"worker": "worker-1"})]
+
+
+def test_metric_failures_are_logged_without_propagating(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append((message, args))
+
+    monkeypatch.setattr(observability._sentry_metrics, "count", Mock(side_effect=RuntimeError("boom")))
+    monkeypatch.setattr(observability.logger, "warning", fake_warning)
+
+    observability.incr("valkyrie.test.count")
+
+    assert len(warnings) == 1
+    assert warnings[0][0] == "metric incr(%s) failed: %s: %s"
+    assert warnings[0][1][:2] == ("valkyrie.test.count", "RuntimeError")
+    assert str(warnings[0][1][2]) == "boom"
+
+
+def test_set_sandbox_context_sets_tags_and_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    tags: dict[str, str] = {}
+    contexts: dict[str, dict[str, Any]] = {}
+
+    def fake_set_tag(key: str, value: str) -> None:
+        tags[key] = value
+
+    def fake_set_context(key: str, value: dict[str, Any]) -> None:
+        contexts[key] = value
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", fake_set_tag)
+    monkeypatch.setattr(observability.sentry_sdk, "set_context", fake_set_context)
+
+    sandbox = SimpleNamespace(id="sandbox-123", name="bench-task-1", state="STARTED")
+
+    observability.set_sandbox_context(sandbox, image="ghcr.io/example/image:latest")
+
+    assert tags == {
+        "sandbox_id": "sandbox-123",
+        "sandbox_name": "bench-task-1",
+    }
+    assert contexts == {
+        "sandbox": {
+            "id": "sandbox-123",
+            "name": "bench-task-1",
+            "state": "STARTED",
+            "image": "ghcr.io/example/image:latest",
+        }
+    }
+
+
+def test_set_pty_context_sets_session_and_attempt_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    tags: dict[str, str] = {}
+
+    def fake_set_tag(key: str, value: str) -> None:
+        tags[key] = value
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", fake_set_tag)
+
+    observability.set_pty_context(session_id="sandbox:pty-123", attempt=3)
+
+    assert tags == {
+        "pty_session_id": "sandbox:pty-123",
+        "pty_attempt": "3",
+    }
+
+
+def test_retry_callback_logs_attempt_and_emits_retry_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    increments: list[tuple[str, dict[str, str]]] = []
+    log_records: list[dict[str, Any]] = []
+
+    def fake_incr(name: str, value: float = 1, tags: dict[str, str] | None = None) -> None:
+        increments.append((name, tags or {}))
+
+    def retried_function() -> None:
+        raise RuntimeError("unused")
+
+    class FakeOutcome:
+        def exception(self) -> Exception:
+            return TimeoutError("timed out")
+
+    state = SimpleNamespace(
+        outcome=FakeOutcome(),
+        fn=retried_function,
+        attempt_number=2,
+        idle_for=1.25,
+    )
+
+    monkeypatch.setattr(observability, "incr", fake_incr)
+
+    def fake_log(
+        level: int,
+        message: str,
+        *_args: object,
+        extra: Mapping[str, Any] | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        log_records.append(
+            {
+                "level": level,
+                "message": message,
+                **(extra or {}),
+            }
+        )
+
+    monkeypatch.setattr(observability.logger, "log", fake_log)
+
+    observability.retry_callback("valkyrie.pty.create")(state)
+
+    assert increments == [("valkyrie.pty.create.retry", {"error_class": "TimeoutError"})]
+    assert log_records == [
+        {
+            "level": logging.WARNING,
+            "message": "retry.before_sleep",
+            "metric": "valkyrie.pty.create",
+            "fn": "retried_function",
+            "attempt": 2,
+            "idle_for": 1.25,
+            "error_class": "TimeoutError",
+        }
+    ]
+
+
+def test_tag_daytona_error_sets_tags_and_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _observability()
+    tags: dict[str, str] = {}
+    increments: list[tuple[str, dict[str, str]]] = []
+
+    def fake_set_tag(key: str, value: str) -> None:
+        tags[key] = value
+
+    def fake_incr(name: str, value: float = 1, tags: dict[str, str] | None = None) -> None:
+        increments.append((name, tags or {}))
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", fake_set_tag)
+    monkeypatch.setattr(observability, "incr", fake_incr)
+
+    observability.tag_daytona_error(TimeoutError("timed out"), op="sandbox.create")
+
+    assert tags == {
+        "daytona.op": "sandbox.create",
+        "error_class": "TimeoutError",
+    }
+    assert increments == [
+        (
+            "valkyrie.daytona.error",
+            {
+                "op": "sandbox.create",
+                "error_class": "TimeoutError",
+            },
+        )
+    ]

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1,4 +1,6 @@
 import asyncio
+from collections.abc import Mapping
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
@@ -8,11 +10,242 @@ from daytona import ExecuteResponse
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SSLConnectionError, SandboxError, SandboxSetupError
-from tracker.sandbox import _create_pty_session, upload_agent_artifacts
+from tracker.sandbox import upload_agent_artifacts
 from tracker.types import AWSCredentials
+
+_create_pty_session = getattr(sandbox_module, "_create_pty_session")
+_reconnect_and_wait_pty = getattr(sandbox_module, "_reconnect_and_wait_pty")
+_wait_for_pty = getattr(sandbox_module, "_wait_for_pty")
+
+
+def _ignore_pty_data(_data: bytes) -> None:
+    pass
 
 
 class TestPtyHandshakeSemaphore:
+    async def test_create_pty_session_emits_handshake_metrics_structured_log_and_span_attrs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cap = 5
+        monkeypatch.setattr(sandbox_module, "_PTY_HANDSHAKE_CAP", cap)
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(cap))
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_in_flight_count", 0, raising=False)
+        monkeypatch.setattr(sandbox_module.uuid, "uuid4", lambda: SimpleNamespace(hex="abcdef123456"))
+
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        gauges: list[tuple[str, float, dict[str, str]]] = []
+        log_records: list[dict[str, Any]] = []
+        span_calls: list[tuple[str, str, str]] = []
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_gauge(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            gauges.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        def fake_set_span_attrs(sandbox: Any, session_id: str) -> None:
+            span_calls.append((sandbox.id, sandbox.name, session_id))
+
+        monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(sandbox_module, "gauge", fake_gauge, raising=False)
+        monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
+        monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", fake_set_span_attrs, raising=False)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_handle = Mock()
+        mock_sandbox.process.create_pty_session = AsyncMock(return_value=mock_handle)
+        debug_output: list[bytes] = []
+
+        handle, salted_id = await _create_pty_session(mock_sandbox, "session-1", debug_output.append)
+
+        assert handle is mock_handle
+        assert salted_id == "session-1-abcdef12"
+        assert debug_output == [b"[Debug]: Creating PTY session with the following id session-1-abcdef12\n"]
+        wait_duration_call = next(call for call in distributions if call[0] == "valkyrie.pty.handshake.wait_duration")
+        assert 0 <= wait_duration_call[1] < 1
+        assert wait_duration_call[2] == {"operation": "create"}
+        assert [call for call in gauges if call[0] == "valkyrie.pty.handshake.in_flight"] == [
+            ("valkyrie.pty.handshake.in_flight", 1, {"operation": "create"}),
+            ("valkyrie.pty.handshake.in_flight", 0, {"operation": "create"}),
+        ]
+        assert log_records == [
+            {
+                "message": "pty.create",
+                "pty_event": "create",
+                "session_id": "session-1-abcdef12",
+                "sandbox_id": "sandbox-123",
+            }
+        ]
+        assert span_calls == [("sandbox-123", "task-alias", "session-1-abcdef12")]
+
+    async def test_reconnect_emits_counter_metrics_structured_log_and_span_attrs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(5))
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_in_flight_count", 0, raising=False)
+
+        increments: list[tuple[str, dict[str, str]]] = []
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        gauges: list[tuple[str, float, dict[str, str]]] = []
+        log_records: list[dict[str, Any]] = []
+        span_calls: list[tuple[str, str, str]] = []
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_gauge(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            gauges.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        def fake_set_span_attrs(sandbox: Any, session_id: str) -> None:
+            span_calls.append((sandbox.id, sandbox.name, session_id))
+
+        monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(sandbox_module, "gauge", fake_gauge, raising=False)
+        monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
+        monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", fake_set_span_attrs, raising=False)
+        monkeypatch.setattr(sandbox_module, "_check_sandbox_health", AsyncMock())
+
+        mock_handle = AsyncMock()
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.process.connect_pty_session = AsyncMock(return_value=mock_handle)
+        outputs: list[str] = []
+
+        await _reconnect_and_wait_pty(mock_sandbox, "session-1", _ignore_pty_data, outputs.append)
+
+        assert increments == [("valkyrie.pty.reconnect.count", {"operation": "reconnect"})]
+        assert outputs == ["[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n"]
+        assert log_records == [
+            {
+                "message": "pty.reconnect_start",
+                "pty_event": "reconnect_start",
+                "session_id": "session-1",
+                "sandbox_id": "sandbox-123",
+            }
+        ]
+        handshake_duration_call = next(call for call in distributions if call[0] == "valkyrie.pty.handshake.duration")
+        assert 0 <= handshake_duration_call[1] < 1
+        assert handshake_duration_call[2] == {"operation": "reconnect"}
+        assert [call for call in gauges if call[0] == "valkyrie.pty.handshake.in_flight"] == [
+            ("valkyrie.pty.handshake.in_flight", 1, {"operation": "reconnect"}),
+            ("valkyrie.pty.handshake.in_flight", 0, {"operation": "reconnect"}),
+        ]
+        assert span_calls == [("sandbox-123", "task-alias", "session-1")]
+
+    def test_set_pty_span_attributes_sets_safe_span_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        span_attributes: dict[str, str] = {}
+
+        class FakeSpan:
+            def set_attribute(self, key: str, value: str) -> None:
+                span_attributes[key] = value
+
+        monkeypatch.setattr(sandbox_module.trace, "get_current_span", lambda: FakeSpan())
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        set_pty_span_attributes = getattr(sandbox_module, "_set_pty_span_attributes")
+        set_pty_span_attributes(mock_sandbox, "session-1")
+
+        assert span_attributes == {
+            "valkyrie.sandbox_id": "sandbox-123",
+            "valkyrie.sandbox_name": "task-alias",
+            "valkyrie.pty_session_id": "session-1",
+        }
+
+    async def test_wait_for_pty_emits_structured_logs_for_clean_disconnect_and_missing_status(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        log_records: list[dict[str, Any]] = []
+
+        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
+        monkeypatch.setattr(sandbox_module, "_check_sandbox_health", AsyncMock())
+        monkeypatch.setattr(
+            sandbox_module,
+            "_exec",
+            AsyncMock(
+                side_effect=[
+                    ExecuteResponse(exit_code=1, result=""),
+                    ExecuteResponse(exit_code=0, result=""),
+                ]
+            ),
+        )
+        reconnect = AsyncMock()
+        monkeypatch.setattr(sandbox_module, "_reconnect_and_wait_pty", reconnect)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        handle = AsyncMock()
+        outputs: list[str] = []
+
+        await _wait_for_pty(mock_sandbox, "session-1", handle, _ignore_pty_data, outputs.append, "/tmp/status")
+
+        assert outputs == [
+            "[Debug]: PTY has been disconnected, handler has stopped polling\n",
+            "[Debug]: PTY closed but status file not written yet, reconnecting\n",
+        ]
+        assert [record["pty_event"] for record in log_records] == [
+            "stream_disconnect",
+            "reconnect_status_missing",
+        ]
+        assert reconnect.await_count == 1
+
+    async def test_wait_for_pty_emits_structured_log_for_disconnect_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        log_records: list[dict[str, Any]] = []
+
+        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
+        monkeypatch.setattr(sandbox_module, "_check_sandbox_health", AsyncMock())
+        monkeypatch.setattr(
+            sandbox_module,
+            "_exec",
+            AsyncMock(return_value=ExecuteResponse(exit_code=0, result="")),
+        )
+        reconnect = AsyncMock()
+        monkeypatch.setattr(sandbox_module, "_reconnect_and_wait_pty", reconnect)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        handle = AsyncMock()
+        handle.wait = AsyncMock(side_effect=RuntimeError("websocket closed"))
+        outputs: list[str] = []
+
+        await _wait_for_pty(mock_sandbox, "session-1", handle, _ignore_pty_data, outputs.append, "/tmp/status")
+
+        assert outputs == ["[Debug]: PTY stream has been disconnected (Attempting reconnection): websocket closed\n"]
+        assert [record["pty_event"] for record in log_records] == ["stream_disconnect_with_error"]
+        assert reconnect.await_count == 1
+
+    def test_pty_retry_decorators_use_observability_retry_callbacks(self) -> None:
+        create_before_sleep = _create_pty_session.retry.before_sleep
+        reconnect_before_sleep = _reconnect_and_wait_pty.retry.before_sleep
+
+        assert create_before_sleep is not None
+        assert reconnect_before_sleep is not None
+        assert create_before_sleep.__module__ == "tracker.observability"
+        assert reconnect_before_sleep.__module__ == "tracker.observability"
+
     async def test_semaphore_caps_concurrent_handshakes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """
         Concurrent _create_pty_session calls never exceed the cap on in-flight
@@ -44,7 +277,7 @@ class TestPtyHandshakeSemaphore:
         mock_sandbox.process.create_pty_session = fake_create_pty_session
 
         results = await asyncio.gather(
-            *[_create_pty_session(mock_sandbox, f"session-{i}", lambda _data: None) for i in range(total)]
+            *[_create_pty_session(mock_sandbox, f"session-{i}", _ignore_pty_data) for i in range(total)]
         )
 
         assert len(results) == total
@@ -75,7 +308,7 @@ class TestPtyHandshakeSemaphore:
         events: list[str] = []
 
         async def task_holding_handle() -> None:
-            await _create_pty_session(mock_sandbox, "s1", lambda _data: None)
+            await _create_pty_session(mock_sandbox, "s1", _ignore_pty_data)
             events.append("a:handshake_done")
 
             # Simulate a long-running handle.wait() AFTER the handshake.
@@ -86,7 +319,7 @@ class TestPtyHandshakeSemaphore:
         async def task_needing_slot() -> None:
             # Tiny delay so task A acquires the slot first
             await asyncio.sleep(0.01)
-            await _create_pty_session(mock_sandbox, "s2", lambda _data: None)
+            await _create_pty_session(mock_sandbox, "s2", _ignore_pty_data)
             events.append("b:handshake_done")
 
         await asyncio.wait_for(asyncio.gather(task_holding_handle(), task_needing_slot()), timeout=1.0)

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -145,6 +145,27 @@ class TestPtyHandshakeSemaphore:
         ]
         assert span_calls == [("sandbox-123", "task-alias", "session-1")]
 
+    async def test_handshake_slot_warns_when_handshake_is_slow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(5))
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_in_flight_count", 0, raising=False)
+        monkeypatch.setattr(sandbox_module, "_PTY_HANDSHAKE_SLOW_LOG_THRESHOLD", -1)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module, "gauge", Mock(), raising=False)
+
+        warnings: list[str] = []
+
+        def fake_warning(message: str) -> None:
+            warnings.append(message)
+
+        monkeypatch.setattr(sandbox_module.logger, "warning", fake_warning)
+
+        pty_handshake_slot = getattr(sandbox_module, "_pty_handshake_slot")
+        async with pty_handshake_slot("create", "session-1"):
+            pass
+
+        assert warnings
+        assert warnings[0].startswith("PTY handshake slow: create session=session-1 duration=")
+
     def test_set_pty_span_attributes_sets_safe_span_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
         span_attributes: dict[str, str] = {}
 

--- a/services/tracker/tests/unit/test_sentry.py
+++ b/services/tracker/tests/unit/test_sentry.py
@@ -1,0 +1,57 @@
+from collections.abc import Callable
+from typing import cast
+from unittest.mock import Mock
+
+import pytest
+import sentry_sdk
+from sentry_sdk.types import Event, Hint
+
+import tracker.sentry as sentry_module
+from tracker.exceptions import PtyCreationError, SSLConnectionError, SandboxError
+
+
+BeforeSend = Callable[[Event, Hint], Event | None]
+
+
+def _before_send() -> BeforeSend:
+    return cast(BeforeSend, getattr(sentry_module, "_before_send"))
+
+
+def test_before_send_fingerprints_pty_creation_errors() -> None:
+    exc = PtyCreationError("Failed to create PTY session after 5 attempts: sandbox abc")
+    event = _before_send()({}, {"exc_info": (type(exc), exc, None)})
+
+    assert event is not None
+    assert event.get("fingerprint") == ["{{ default }}", "PtyCreationError"]
+
+
+def test_before_send_fingerprints_pty_reconnect_sandbox_errors() -> None:
+    exc = SandboxError("PTY reconnect failed after 10 attempts for sandbox abc")
+    event = _before_send()({}, {"exc_info": (type(exc), exc, None)})
+
+    assert event is not None
+    assert event.get("fingerprint") == ["{{ default }}", "pty_reconnect_failed"]
+
+
+def test_before_send_fingerprints_ssl_connection_errors() -> None:
+    exc = SSLConnectionError("curl failed with exit code 35")
+    event = _before_send()({}, {"exc_info": (type(exc), exc, None)})
+
+    assert event is not None
+    assert event.get("fingerprint") == ["{{ default }}", "SSLConnectionError"]
+
+
+def test_init_sentry_sets_daytona_sdk_version_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    tags: dict[str, str] = {}
+
+    def fake_set_tag(key: str, value: str) -> None:
+        tags[key] = value
+
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+    monkeypatch.setattr(sentry_sdk, "init", Mock())
+    monkeypatch.setattr(sentry_sdk, "set_tag", fake_set_tag)
+    monkeypatch.setattr(sentry_module.daytona, "__version__", "0.169.0a2", raising=False)
+
+    sentry_module.init_sentry("valkyrie-worker", environment="test")
+
+    assert tags["daytona.sdk_version"] == "0.169.0a2"

--- a/services/tracker/tests/unit/test_sentry.py
+++ b/services/tracker/tests/unit/test_sentry.py
@@ -41,6 +41,37 @@ def test_before_send_fingerprints_ssl_connection_errors() -> None:
     assert event.get("fingerprint") == ["{{ default }}", "SSLConnectionError"]
 
 
+def test_before_send_preserves_non_grouped_errors_and_filters_empty_context_tags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    exc = SandboxError("ordinary sandbox setup failure")
+
+    def fake_context_tags() -> dict[str, str]:
+        return {
+            "benchmark_id": "benchmark-123",
+            "task_id": "",
+        }
+
+    monkeypatch.setattr(sentry_module, "get_context_tags", fake_context_tags)
+
+    event = _before_send()({}, {"exc_info": (type(exc), exc, None)})
+
+    assert event is not None
+    assert "fingerprint" not in event
+    assert event.get("tags") == {"benchmark_id": "benchmark-123"}
+
+
+def test_before_send_handles_events_without_exception_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_context_tags() -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr(sentry_module, "get_context_tags", fake_context_tags)
+
+    event = _before_send()({"message": "log event"}, {})
+
+    assert event == {"message": "log event", "tags": {}}
+
+
 def test_init_sentry_sets_daytona_sdk_version_tag(monkeypatch: pytest.MonkeyPatch) -> None:
     tags: dict[str, str] = {}
 
@@ -55,3 +86,24 @@ def test_init_sentry_sets_daytona_sdk_version_tag(monkeypatch: pytest.MonkeyPatc
     sentry_module.init_sentry("valkyrie-worker", environment="test")
 
     assert tags["daytona.sdk_version"] == "0.169.0a2"
+
+
+def test_init_sentry_logs_warning_when_initialization_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    warnings: list[tuple[str, tuple[object, ...]]] = []
+    logger = Mock()
+
+    def fake_warning(message: str, *args: object) -> None:
+        warnings.append((message, args))
+
+    logger.warning.side_effect = fake_warning
+
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+    monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
+    monkeypatch.setattr(sentry_module.logging, "getLogger", Mock(return_value=logger))
+
+    sentry_module.init_sentry("valkyrie-worker", environment="test")
+
+    assert len(warnings) == 1
+    assert warnings[0][0] == "Failed to initialize Sentry: %s: %s"
+    assert warnings[0][1][:1] == ("RuntimeError",)
+    assert str(warnings[0][1][1]) == "bad dsn"


### PR DESCRIPTION
## Summary

Adds the first observability slice for tracker/worker Daytona PTY paths. This gives us a shared Sentry metrics/context helper plus deployable signal for PTY creation, reconnects, handshake latency, in-flight handshakes, retry attempts, and Sentry issue grouping.

## Changes

- Added `tracker.observability` helpers for Sentry `count` / `distribution` / `gauge` metrics, with low-cardinality attribute normalization and metric-failure isolation.
- Added Sentry context/tag helpers for sandbox, PTY, retry, and Daytona error metadata.
- Added PTY handshake metrics:
  - `valkyrie.pty.handshake.wait_duration`
  - `valkyrie.pty.handshake.duration`
  - `valkyrie.pty.handshake.in_flight`
  - `valkyrie.pty.reconnect.count`
- Added structured tracker logs for PTY lifecycle events while preserving existing agent-output debug messages.
- Added Logfire span instrumentation and PTY span attributes for create, reconnect, wait, and stream-command-output paths.
- Replaced PTY create/reconnect Tenacity `before_sleep` logging with the shared structured retry callback.
- Added Sentry `daytona.sdk_version` tagging at SDK initialization.
- Added Sentry fingerprinting for PTY creation failures, PTY reconnect failures, and SSL connection errors.
- Added unit coverage for metrics helpers, Sentry context/fingerprints, PTY metrics/log events, and retry callback wiring.

## Related Issues
- https://github.com/vals-ai/valkyrie-ticket-library/issues/54

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] `make test-unit` (`93 passed`)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run basedpyright src/tracker/observability.py src/tracker/sentry.py src/tracker/sandbox.py tests/unit/test_observability.py tests/unit/test_sentry.py tests/unit/test_sandbox.py`

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
