### PR TITLE
Add sandbox Daytona telemetry

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,7 +1,6 @@
 """Sandbox management utilities for the tracker service."""
 
 import base64
-import logging
 import shlex
 import time
 import uuid
@@ -13,6 +12,7 @@ from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
 
 import logfire
+import sentry_sdk
 from benchmark_service.schemas import Resources as TrackerResources
 from daytona import (
     AsyncDaytona,
@@ -28,7 +28,6 @@ from daytona.common.errors import DaytonaError
 from daytona.handle.async_pty_handle import AsyncPtyHandle
 from opentelemetry import trace
 from tenacity import (
-    before_sleep_log,
     retry,
     retry_if_exception_type,
     retry_if_not_exception_type,
@@ -46,7 +45,7 @@ from tracker.exceptions import (
     SSLConnectionError,
 )
 from tracker.logging import get_logger
-from tracker.observability import distribution, gauge, incr, retry_callback
+from tracker.observability import distribution, gauge, incr, retry_callback, set_sandbox_context, tag_daytona_error
 from tracker.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.types import AWSCredentials
 
@@ -66,7 +65,7 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(3),
     wait=wait_fixed(2),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
+    before_sleep=retry_callback("valkyrie.sandbox.delete"),
     reraise=True,
 )
 async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
@@ -81,19 +80,56 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     except DaytonaNotFoundError:
         # If we error here that means the sandbox has just been deleted before we could refresh the state
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
-    except DaytonaError:
+    except DaytonaError as e:
+        tag_daytona_error(e, op="sandbox.delete")
         raise
     except Exception as e:
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
+
+
+def _metric_image_name(image: str) -> str:
+    if image.startswith(SNAPSHOT_IMAGE_PREFIX):
+        return "snapshot"
+
+    without_digest = image.split("@", maxsplit=1)[0]
+    last_slash = without_digest.rfind("/")
+    last_colon = without_digest.rfind(":")
+    if last_colon > last_slash:
+        without_digest = without_digest[:last_colon]
+
+    return without_digest[:80]
+
+
+def _set_sandbox_create_span_attributes(
+    sandbox_name: str,
+    image: str,
+    resources: TrackerResources,
+) -> None:
+    span = trace.get_current_span()
+    span.set_attribute("valkyrie.sandbox_name", sandbox_name)
+    span.set_attribute("valkyrie.image", image)
+    span.set_attribute("valkyrie.resources.vcpu", resources.vcpu)
+    span.set_attribute("valkyrie.resources.memory", resources.memory)
+    span.set_attribute("valkyrie.resources.disk", resources.disk)
+
+
+def _set_sandbox_span_attributes(sandbox: AsyncSandbox) -> None:
+    span = trace.get_current_span()
+    span.set_attribute("valkyrie.sandbox_id", sandbox.id)
+    span.set_attribute("valkyrie.sandbox_name", sandbox.name)
+    state = getattr(sandbox, "state", None)
+    if state is not None:
+        span.set_attribute("valkyrie.sandbox_state", str(state))
 
 
 @retry(
     retry=retry_if_not_exception_type(InvalidSandboxConfigurationError),
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=5, max=30),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
+    before_sleep=retry_callback("valkyrie.sandbox.create"),
     reraise=True,
 )
+@logfire.instrument("sandbox.create", extract_args=False)
 async def _create_sandbox(
     daytona: AsyncDaytona,
     sandbox_name: str,
@@ -108,6 +144,7 @@ async def _create_sandbox(
     This retry only works in the following case:
     - Client times out while sandbox is being created
     """
+    _set_sandbox_create_span_attributes(sandbox_name, image, resources)
 
     # If the container already exists we reuse it
     try:
@@ -187,8 +224,22 @@ async def create_sandbox(
 
     # If we run too many at once it can cause hanging issues
     # NOTE does not block how many context managers we can have open, just how many sandboxes we can create at once
-    async with creation_semaphore:
-        sandbox = await _create_sandbox(daytona, sandbox_name, image, resources, labels, env_vars)
+    try:
+        async with creation_semaphore:
+            start = time.monotonic()
+            sandbox = await _create_sandbox(daytona, sandbox_name, image, resources, labels, env_vars)
+    except Exception as e:
+        incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
+        if isinstance(e, DaytonaError):
+            tag_daytona_error(e, op="sandbox.create")
+        raise
+
+    distribution(
+        "valkyrie.sandbox.create.duration",
+        time.monotonic() - start,
+        tags={"image": _metric_image_name(image)},
+    )
+    set_sandbox_context(sandbox, image=image)
 
     try:
         yield sandbox
@@ -401,9 +452,10 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(_EXEC_MAX_ATTEMPTS),
     wait=wait_fixed(_EXEC_DELAY_SECONDS),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
+    before_sleep=retry_callback("valkyrie.sandbox.exec"),
     reraise=True,
 )
+@logfire.instrument("sandbox.exec", extract_args=False)
 async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
     """
     Execute a command inside the sandbox with retries for transient network failures.
@@ -411,8 +463,12 @@ async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
     Raises:
         DaytonaError: If all retry attempts are exhausted
     """
-
-    return await sandbox.process.exec(command)
+    _set_sandbox_span_attributes(sandbox)
+    try:
+        return await sandbox.process.exec(command)
+    except DaytonaError as e:
+        tag_daytona_error(e, op="sandbox.exec")
+        raise
 
 
 @retry(
@@ -452,6 +508,7 @@ async def _create_pty_session(
     return handle, salted_id
 
 
+@logfire.instrument("sandbox.health_check", extract_args=False)
 async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
     """
     Checks if we can connect to a sandbox
@@ -461,11 +518,16 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
     """
     try:
         await sandbox.refresh_data()
+        _set_sandbox_span_attributes(sandbox)
         if sandbox.state in _DEAD_SANDBOX_STATES:
+            sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
+            incr("valkyrie.sandbox.unhealthy", tags={"state": str(sandbox.state)})
             raise SandboxError(f"Sandbox {sandbox.name} crashed during command execution (state: {sandbox.state})")
     except SandboxError:
         raise
     except Exception as e:
+        if isinstance(e, DaytonaError):
+            tag_daytona_error(e, op="sandbox.health_check")
         raise SandboxError(f"Failed to check sandbox {sandbox.name} health: {e}") from e
 
 
@@ -645,6 +707,7 @@ async def stream_command_output(
                 sandbox, session_id, on_data, envs={"TERM": "dumb", "LANG": "C.UTF-8"}
             )
         except DaytonaError as e:
+            tag_daytona_error(e, op="pty.create")
             raise PtyCreationError(
                 f"Failed to create PTY session after {_PTY_CREATE_MAX_ATTEMPTS} attempts: {e}"
             ) from e

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1,19 +1,26 @@
 import asyncio
+from collections import deque
 from collections.abc import Mapping
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from daytona import ExecuteResponse
+from daytona import ExecuteResponse, SandboxState
+from daytona.common.errors import DaytonaError
+from tenacity import stop_after_attempt, wait_none
 
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SSLConnectionError, SandboxError, SandboxSetupError
-from tracker.sandbox import upload_agent_artifacts
+from tracker.sandbox import create_sandbox, upload_agent_artifacts
 from tracker.types import AWSCredentials
 
+_create_sandbox = getattr(sandbox_module, "_create_sandbox")
 _create_pty_session = getattr(sandbox_module, "_create_pty_session")
+_check_sandbox_health = getattr(sandbox_module, "_check_sandbox_health")
+_delete_sandbox = getattr(sandbox_module, "delete_sandbox")
+_exec = getattr(sandbox_module, "_exec")
 _reconnect_and_wait_pty = getattr(sandbox_module, "_reconnect_and_wait_pty")
 _wait_for_pty = getattr(sandbox_module, "_wait_for_pty")
 
@@ -266,6 +273,317 @@ class TestPtyHandshakeSemaphore:
         assert reconnect_before_sleep is not None
         assert create_before_sleep.__module__ == "tracker.observability"
         assert reconnect_before_sleep.__module__ == "tracker.observability"
+
+    def test_sandbox_retry_decorators_use_observability_retry_callbacks(self) -> None:
+        create_before_sleep = _create_sandbox.retry.before_sleep
+        exec_before_sleep = _exec.retry.before_sleep
+        delete_before_sleep = _delete_sandbox.retry.before_sleep
+
+        assert create_before_sleep is not None
+        assert exec_before_sleep is not None
+        assert delete_before_sleep is not None
+        assert create_before_sleep.__module__ == "tracker.observability"
+        assert exec_before_sleep.__module__ == "tracker.observability"
+        assert delete_before_sleep.__module__ == "tracker.observability"
+
+    def test_metric_image_name_drops_high_cardinality_tag_and_digest(self) -> None:
+        metric_image_name = getattr(sandbox_module, "_metric_image_name")
+
+        assert metric_image_name("ghcr.io/vals/swebench:latest") == "ghcr.io/vals/swebench"
+        assert (
+            metric_image_name("registry.local:5000/vals/swebench@sha256:abcdef") == "registry.local:5000/vals/swebench"
+        )
+        assert metric_image_name("snapshot:base-python") == "snapshot"
+
+    def test_sandbox_span_helpers_set_safe_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        span_attributes: dict[str, str | int] = {}
+
+        class FakeSpan:
+            def set_attribute(self, key: str, value: str | int) -> None:
+                span_attributes[key] = value
+
+        monkeypatch.setattr(sandbox_module.trace, "get_current_span", lambda: FakeSpan())
+
+        create_span_attrs = getattr(sandbox_module, "_set_sandbox_create_span_attributes")
+        sandbox_span_attrs = getattr(sandbox_module, "_set_sandbox_span_attributes")
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+
+        create_span_attrs("task-alias", "ghcr.io/vals/swebench:latest", resources)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        sandbox_span_attrs(mock_sandbox)
+
+        mock_sandbox.state = SandboxState.STARTED
+        sandbox_span_attrs(mock_sandbox)
+
+        assert span_attributes == {
+            "valkyrie.sandbox_name": "task-alias",
+            "valkyrie.image": "ghcr.io/vals/swebench:latest",
+            "valkyrie.resources.vcpu": 2,
+            "valkyrie.resources.memory": 4,
+            "valkyrie.resources.disk": 5,
+            "valkyrie.sandbox_id": "sandbox-123",
+            "valkyrie.sandbox_state": str(SandboxState.STARTED),
+        }
+
+    async def test_create_sandbox_sets_create_span_attributes_for_existing_sandbox(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        span_calls: list[tuple[str, str, int]] = []
+
+        def fake_create_span_attrs(sandbox_name: str, image: str, resources: Any) -> None:
+            span_calls.append((sandbox_name, image, resources.vcpu))
+
+        monkeypatch.setattr(sandbox_module, "_set_sandbox_create_span_attributes", fake_create_span_attrs)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.wait_for_sandbox_start = AsyncMock()
+        daytona = AsyncMock()
+        daytona.get = AsyncMock(return_value=mock_sandbox)
+
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        sandbox = await _create_sandbox.retry_with(stop=stop_after_attempt(1), wait=wait_none())(
+            daytona,
+            "task-alias",
+            "ghcr.io/vals/swebench:latest",
+            resources,
+        )
+
+        assert sandbox is mock_sandbox
+        assert span_calls == [("task-alias", "ghcr.io/vals/swebench:latest", 2)]
+
+    async def test_delete_sandbox_tags_daytona_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        daytona_error = DaytonaError("delete failed")
+        daytona_errors: list[tuple[Exception, str]] = []
+
+        def fake_tag_daytona_error(exc: Exception, *, op: str) -> None:
+            daytona_errors.append((exc, op))
+
+        monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.refresh_data = AsyncMock(side_effect=daytona_error)
+
+        with pytest.raises(DaytonaError):
+            await _delete_sandbox.retry_with(stop=stop_after_attempt(1), wait=wait_none())(mock_sandbox, AsyncMock())
+
+        assert daytona_errors == [(daytona_error, "sandbox.delete")]
+
+    async def test_exec_tags_daytona_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        daytona_error = DaytonaError("exec failed")
+        daytona_errors: list[tuple[Exception, str]] = []
+
+        def fake_tag_daytona_error(exc: Exception, *, op: str) -> None:
+            daytona_errors.append((exc, op))
+
+        monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
+        monkeypatch.setattr(sandbox_module, "_set_sandbox_span_attributes", Mock(), raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.process.exec = AsyncMock(side_effect=daytona_error)
+
+        with pytest.raises(DaytonaError):
+            await _exec.retry_with(stop=stop_after_attempt(1), wait=wait_none())(mock_sandbox, "echo hi")
+
+        assert daytona_errors == [(daytona_error, "sandbox.exec")]
+
+    async def test_create_sandbox_emits_create_duration_and_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        context_calls: list[tuple[str, str]] = []
+
+        async def fake_create_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            return mock_sandbox
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_set_sandbox_context(sandbox: Any, *, image: str | None = None) -> None:
+            context_calls.append((sandbox.id, image or ""))
+
+        monotonic_values: deque[float] = deque([10.0, 13.5])
+
+        def fake_monotonic() -> float:
+            if monotonic_values:
+                return monotonic_values.popleft()
+            return 13.5
+
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", fake_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", AsyncMock())
+        monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", fake_set_sandbox_context, raising=False)
+        monkeypatch.setattr(sandbox_module.time, "monotonic", fake_monotonic)
+
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        async with create_sandbox(
+            daytona=AsyncMock(),
+            sandbox_name="task-alias",
+            image="ghcr.io/vals/swebench:latest",
+            resources=resources,
+            creation_semaphore=asyncio.Semaphore(1),
+        ) as sandbox:
+            assert sandbox is mock_sandbox
+
+        assert distributions == [
+            (
+                "valkyrie.sandbox.create.duration",
+                3.5,
+                {"image": "ghcr.io/vals/swebench"},
+            )
+        ]
+        assert context_calls == [("sandbox-123", "ghcr.io/vals/swebench:latest")]
+
+    async def test_create_sandbox_emits_error_metric_and_daytona_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        daytona_error = DaytonaError("create failed")
+        increments: list[tuple[str, dict[str, str]]] = []
+        daytona_errors: list[tuple[Exception, str]] = []
+
+        async def fake_create_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            raise daytona_error
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_tag_daytona_error(exc: Exception, *, op: str) -> None:
+            daytona_errors.append((exc, op))
+
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", fake_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
+
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        with pytest.raises(DaytonaError):
+            async with create_sandbox(
+                daytona=AsyncMock(),
+                sandbox_name="task-alias",
+                image="ghcr.io/vals/swebench:latest",
+                resources=resources,
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                pass
+
+        assert increments == [("valkyrie.sandbox.create.errors", {"error_class": "DaytonaError"})]
+        assert daytona_errors == [(daytona_error, "sandbox.create")]
+
+    async def test_create_sandbox_does_not_tag_non_daytona_create_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        increments: list[tuple[str, dict[str, str]]] = []
+        daytona_errors: list[tuple[Exception, str]] = []
+
+        async def fake_create_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            raise ValueError("bad config")
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_tag_daytona_error(exc: Exception, *, op: str) -> None:
+            daytona_errors.append((exc, op))
+
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", fake_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
+
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        with pytest.raises(ValueError, match="bad config"):
+            async with create_sandbox(
+                daytona=AsyncMock(),
+                sandbox_name="task-alias",
+                image="ghcr.io/vals/swebench:latest",
+                resources=resources,
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                pass
+
+        assert increments == [("valkyrie.sandbox.create.errors", {"error_class": "ValueError"})]
+        assert daytona_errors == []
+
+    async def test_check_sandbox_health_allows_running_sandboxes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        increments: list[tuple[str, dict[str, str]]] = []
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.state = SandboxState.STARTED
+
+        await _check_sandbox_health(mock_sandbox)
+
+        assert increments == []
+
+    async def test_check_sandbox_health_emits_unhealthy_state_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        tags: dict[str, str] = {}
+        increments: list[tuple[str, dict[str, str]]] = []
+
+        def fake_set_tag(key: str, value: str) -> None:
+            tags[key] = value
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        monkeypatch.setattr(sandbox_module, "sentry_sdk", SimpleNamespace(set_tag=fake_set_tag), raising=False)
+        monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.state = SandboxState.DESTROYED
+
+        with pytest.raises(SandboxError, match="crashed during command execution"):
+            await _check_sandbox_health(mock_sandbox)
+
+        assert tags == {"sandbox_state": str(SandboxState.DESTROYED)}
+        assert increments == [
+            (
+                "valkyrie.sandbox.unhealthy",
+                {"state": str(SandboxState.DESTROYED)},
+            )
+        ]
+
+    async def test_check_sandbox_health_tags_daytona_refresh_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        daytona_error = DaytonaError("refresh failed")
+        daytona_errors: list[tuple[Exception, str]] = []
+
+        def fake_tag_daytona_error(exc: Exception, *, op: str) -> None:
+            daytona_errors.append((exc, op))
+
+        monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.refresh_data = AsyncMock(side_effect=daytona_error)
+
+        with pytest.raises(SandboxError, match="Failed to check sandbox"):
+            await _check_sandbox_health(mock_sandbox)
+
+        assert daytona_errors == [(daytona_error, "sandbox.health_check")]
+
+    async def test_check_sandbox_health_does_not_tag_non_daytona_refresh_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        daytona_errors: list[tuple[Exception, str]] = []
+
+        def fake_tag_daytona_error(exc: Exception, *, op: str) -> None:
+            daytona_errors.append((exc, op))
+
+        monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.refresh_data = AsyncMock(side_effect=RuntimeError("refresh failed"))
+
+        with pytest.raises(SandboxError, match="Failed to check sandbox"):
+            await _check_sandbox_health(mock_sandbox)
+
+        assert daytona_errors == []
 
     async def test_semaphore_caps_concurrent_handshakes(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """


### PR DESCRIPTION
## Summary
Adds Daytona sandbox telemetry on top of #337 so provider-side sandbox and PTY failures are easier to find after deploy. This keeps the PR stacked on `bw/observability-foundation` and focuses this layer on sandbox create/delete/exec/health-check paths plus PTY create failure tagging.

## Changes
- Adds retry metrics and Logfire/Sentry context around Daytona sandbox create, delete, exec, and health-check calls.
- Emits Daytona error tags/metrics for surfaced provider failures, including `daytona.op=pty.create` and `valkyrie.daytona.error` when PTY creation exhausts SDK retries.
- Adds low-cardinality sandbox create duration metrics keyed by normalized image name.
- Expands tracker unit coverage for sandbox telemetry, Daytona tagging, unhealthy sandbox handling, and PTY create failure instrumentation.
- Stack: base PR #337 (`bw/observability-foundation`), this PR `bw/sandbox-daytona-telemetry`.

## Related Issues
None.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested
- [x] `cd services/tracker && make test-unit` (`117 passed`)

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed