### PR TITLE
feat: add missing sandbox retry telemetry

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -46,7 +46,15 @@ from tracker.exceptions import (
     SSLConnectionError,
 )
 from tracker.logging import get_logger
-from tracker.observability import distribution, gauge, incr, retry_callback, set_sandbox_context, tag_daytona_error
+from tracker.observability import (
+    distribution,
+    gauge,
+    incr,
+    retry_callback,
+    set_pty_context,
+    set_sandbox_context,
+    tag_daytona_error,
+)
 from tracker.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.types import AWSCredentials
 
@@ -255,6 +263,7 @@ async def create_sandbox(
     retry=retry_if_exception_type(SandboxError) & retry_if_not_exception_type(SandboxSetupError),
     reraise=True,
     stop=stop_after_attempt(3),
+    before_sleep=retry_callback("valkyrie.sandbox.upload"),
 )
 async def upload_agent_artifacts(
     sandbox: AsyncSandbox,
@@ -332,7 +341,12 @@ async def upload_agent_artifacts(
         raise SandboxError(error_message)
 
 
-@retry(retry=retry_if_exception_type(SandboxError), reraise=True, stop=stop_after_attempt(3))
+@retry(
+    retry=retry_if_exception_type(SandboxError),
+    reraise=True,
+    stop=stop_after_attempt(3),
+    before_sleep=retry_callback("valkyrie.sandbox.deps"),
+)
 async def install_agent_dependencies(
     sandbox: AsyncSandbox,
     contract: AgentContractRequest,
@@ -499,6 +513,7 @@ async def _create_pty_session(
     # Each time we run this we want it to be logged, makes debugging easier
     on_data(f"[Debug]: Creating PTY session with the following id {salted_id}\n".encode())
     _set_pty_span_attributes(sandbox, salted_id)
+    set_pty_context(session_id=salted_id)
     _log_pty_event("create", sandbox, salted_id)
 
     # Attempt to make the PTY session, timeouts occur under load
@@ -555,6 +570,7 @@ async def _reconnect_and_wait_pty(
     """
     incr("valkyrie.pty.reconnect.count", tags={"operation": "reconnect"})
     _set_pty_span_attributes(sandbox, session_id)
+    set_pty_context(session_id=session_id)
 
     # Check if the sandbox has been closed
     await _check_sandbox_health(sandbox)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import io
 import json
-import logging
 import time
 import traceback
 from asyncio import Semaphore, gather
@@ -22,7 +21,7 @@ from fastapi import Request
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
-from tenacity import before_sleep_log, retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
 from tenacity import retry as tenacity_retry
 
 from tracker._lambda import invoke_lambda
@@ -43,6 +42,7 @@ from tracker.database.session import engine
 from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
+from tracker.observability import retry_callback
 from tracker.s3 import (
     S3_BENCHMARKS_PREFIX,
     copy_agent_to_benchmark,
@@ -313,7 +313,7 @@ def buffer_logs(
     retry=retry_if_exception_type(SandboxSetupError),
     stop=stop_after_attempt(_PTY_TASK_RETRY_LIMIT + 1),
     wait=wait_fixed(2),
-    before_sleep=before_sleep_log(logger, logging.WARNING),
+    before_sleep=retry_callback("valkyrie.task"),
     reraise=True,
 )
 async def process_task(

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -18,6 +18,12 @@ from tracker.utils import process_task, start_benchmark_request_to_benchmark
 class TestPtyRetry:
     _test_org = Org(id=TEST_ORG_ID, name="default")
 
+    def test_process_task_retry_decorator_uses_observability_retry_callback(self) -> None:
+        before_sleep = process_task.retry.before_sleep
+
+        assert before_sleep is not None
+        assert before_sleep.__module__ == "tracker.observability"
+
     @pytest.mark.parametrize(
         "fail_target,error",
         [

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -21,7 +21,9 @@ _create_pty_session = getattr(sandbox_module, "_create_pty_session")
 _check_sandbox_health = getattr(sandbox_module, "_check_sandbox_health")
 _delete_sandbox = getattr(sandbox_module, "delete_sandbox")
 _exec = getattr(sandbox_module, "_exec")
+_install_agent_dependencies = getattr(sandbox_module, "install_agent_dependencies")
 _reconnect_and_wait_pty = getattr(sandbox_module, "_reconnect_and_wait_pty")
+_upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
 _wait_for_pty = getattr(sandbox_module, "_wait_for_pty")
 
 
@@ -43,6 +45,7 @@ class TestPtyHandshakeSemaphore:
         gauges: list[tuple[str, float, dict[str, str]]] = []
         log_records: list[dict[str, Any]] = []
         span_calls: list[tuple[str, str, str]] = []
+        pty_context_calls: list[str] = []
 
         def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
             distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
@@ -60,6 +63,12 @@ class TestPtyHandshakeSemaphore:
         monkeypatch.setattr(sandbox_module, "gauge", fake_gauge, raising=False)
         monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
         monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", fake_set_span_attrs, raising=False)
+        monkeypatch.setattr(
+            sandbox_module,
+            "set_pty_context",
+            lambda *, session_id, attempt=None: pty_context_calls.append(session_id),
+            raising=False,
+        )
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -89,6 +98,7 @@ class TestPtyHandshakeSemaphore:
             }
         ]
         assert span_calls == [("sandbox-123", "task-alias", "session-1-abcdef12")]
+        assert pty_context_calls == ["session-1-abcdef12"]
 
     async def test_reconnect_emits_counter_metrics_structured_log_and_span_attrs(
         self, monkeypatch: pytest.MonkeyPatch
@@ -101,6 +111,7 @@ class TestPtyHandshakeSemaphore:
         gauges: list[tuple[str, float, dict[str, str]]] = []
         log_records: list[dict[str, Any]] = []
         span_calls: list[tuple[str, str, str]] = []
+        pty_context_calls: list[str] = []
 
         def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
             increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
@@ -122,6 +133,12 @@ class TestPtyHandshakeSemaphore:
         monkeypatch.setattr(sandbox_module, "gauge", fake_gauge, raising=False)
         monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
         monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", fake_set_span_attrs, raising=False)
+        monkeypatch.setattr(
+            sandbox_module,
+            "set_pty_context",
+            lambda *, session_id, attempt=None: pty_context_calls.append(session_id),
+            raising=False,
+        )
         monkeypatch.setattr(sandbox_module, "_check_sandbox_health", AsyncMock())
 
         mock_handle = AsyncMock()
@@ -151,6 +168,7 @@ class TestPtyHandshakeSemaphore:
             ("valkyrie.pty.handshake.in_flight", 0, {"operation": "reconnect"}),
         ]
         assert span_calls == [("sandbox-123", "task-alias", "session-1")]
+        assert pty_context_calls == ["session-1"]
 
     async def test_handshake_slot_warns_when_handshake_is_slow(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(5))
@@ -278,13 +296,19 @@ class TestPtyHandshakeSemaphore:
         create_before_sleep = _create_sandbox.retry.before_sleep
         exec_before_sleep = _exec.retry.before_sleep
         delete_before_sleep = _delete_sandbox.retry.before_sleep
+        upload_before_sleep = _upload_agent_artifacts.retry.before_sleep
+        deps_before_sleep = _install_agent_dependencies.retry.before_sleep
 
         assert create_before_sleep is not None
         assert exec_before_sleep is not None
         assert delete_before_sleep is not None
+        assert upload_before_sleep is not None
+        assert deps_before_sleep is not None
         assert create_before_sleep.__module__ == "tracker.observability"
         assert exec_before_sleep.__module__ == "tracker.observability"
         assert delete_before_sleep.__module__ == "tracker.observability"
+        assert upload_before_sleep.__module__ == "tracker.observability"
+        assert deps_before_sleep.__module__ == "tracker.observability"
 
     def test_metric_image_name_drops_high_cardinality_tag_and_digest(self) -> None:
         metric_image_name = getattr(sandbox_module, "_metric_image_name")


### PR DESCRIPTION
## Summary
Adds the remaining retry/context telemetry needed for the sandbox Daytona observability slice. This fills the gaps left after the Sentry metrics and PTY lifecycle work by making retried setup paths visible in structured retry metrics and ensuring PTY Sentry events carry session context.

## Changes
- Attach PTY Sentry context during PTY create and reconnect paths.
- Add observability retry callbacks for sandbox upload and dependency installation retries.
- Replace process_task setup retry logging with the shared observability retry callback.
- Extend unit coverage for PTY context propagation and retry decorator telemetry.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Commands run:
- `make test-unit` in `services/tracker`
- `make typecheck`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed