### PR TITLE
Bump CBS stream schema for eval resume

### DIFF
--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498#64763260a4f6db73229591a311d7e92fde59e498" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b#899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -338,6 +338,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "pyyaml" },
     { name = "tenacity" },
     { name = "websockets" },
 ]
@@ -1855,7 +1856,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=64763260a4f6db73229591a311d7e92fde59e498" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" },
     { name = "daytona", specifier = "==0.172.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -584,6 +584,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "pyyaml" },
     { name = "tenacity" },
     { name = "websockets" },
 ]


### PR DESCRIPTION
## Summary
- refresh Valkyrie root and tracker locks to the current create-benchmark-service main commit
- picks up StreamEvalResumeStateChunk so tracker can consume VCB eval_resume_state stream chunks

## Verification
- cd services/tracker && uv run python - <<'PY'
from pydantic import TypeAdapter
from benchmark_service.schemas import StreamChunk
chunk = TypeAdapter(StreamChunk).validate_json('{"type":"eval_resume_state","data":{"job_id":"job-1"}}')
assert chunk.type == "eval_resume_state"
PY
- cd services/tracker && uv run pytest tests/unit -q
- uv lock --check && cd services/tracker && uv lock --check
- git diff --check

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->