### PR TITLE
Bump CBS pin for eval resume websocket payloads

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]>=2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@9479df5e7399d08016c6f0c1e32bc1eb3cb4229a",
 ]
 
 [dependency-groups]

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b#899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a#9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1856,7 +1856,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
     { name = "daytona", specifier = "==0.172.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -575,7 +575,7 @@ wheels = [
 [[package]]
 name = "create-benchmark-service"
 version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b#899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" }
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a#9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2659,7 +2659,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=899b34aa39921e47e2a4cb5b1f0dbdb5ac89606b" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
     { name = "daytona", specifier = "==0.172.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary
- Bumps `create-benchmark-service` from `899b34a` to `9479df5`
- Picks up `Preserve null fields in websocket requests (#42)` for eval resume websocket payload compatibility
- Regenerates root and tracker lockfiles

## Verification
- `uv run python -m pytest tests/unit/test_tracker_service.py -q`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->