### PR TITLE
fix: pin sentry sdk and add cli smoke test

### DIFF
--- a/.github/workflows/cli-tool-smoke-test.yaml
+++ b/.github/workflows/cli-tool-smoke-test.yaml
@@ -2,12 +2,7 @@ name: CLI tool smoke test
 
 on:
   pull_request:
-    branches: [dev]
-
-  workflow_call:
-    secrets:
-      GH_PAT:
-        required: true
+    branches: [dev, prod]
 
 jobs:
   cli-tool-smoke-test:

--- a/.github/workflows/cli-tool-smoke-test.yaml
+++ b/.github/workflows/cli-tool-smoke-test.yaml
@@ -1,0 +1,46 @@
+name: CLI tool smoke test
+
+on:
+  workflow_call:
+    secrets:
+      GH_PAT:
+        required: true
+
+jobs:
+  cli-tool-smoke-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Configure uv tool path
+        run: |
+          echo "UV_TOOL_BIN_DIR=$RUNNER_TEMP/uv-tool-bin" >> "$GITHUB_ENV"
+          echo "UV_TOOL_DIR=$RUNNER_TEMP/uv-tools" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/uv-tool-bin" "$RUNNER_TEMP/uv-tools"
+          echo "$RUNNER_TEMP/uv-tool-bin" >> "$GITHUB_PATH"
+
+      - name: Install Valkyrie CLI as a uv tool
+        run: uv tool install --force . --prerelease=allow
+
+      - name: Smoke test CLI startup
+        run: |
+          command -v valk
+          valk --help
+          valk agent --help
+          valk agent download --help

--- a/.github/workflows/cli-tool-smoke-test.yaml
+++ b/.github/workflows/cli-tool-smoke-test.yaml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          token: ${{ secrets.GH_PAT }}
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/cli-tool-smoke-test.yaml
+++ b/.github/workflows/cli-tool-smoke-test.yaml
@@ -1,6 +1,9 @@
 name: CLI tool smoke test
 
 on:
+  pull_request:
+    branches: [dev]
+
   workflow_call:
     secrets:
       GH_PAT:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,13 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  cli-tool-smoke-test:
-    uses: ./.github/workflows/cli-tool-smoke-test.yaml
-    secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}
-
   deploy:
-    needs: cli-tool-smoke-test
     runs-on: ubuntu-24.04-arm
 
     steps:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  cli-tool-smoke-test:
+    uses: ./.github/workflows/cli-tool-smoke-test.yaml
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}
+
   deploy:
+    needs: cli-tool-smoke-test
     runs-on: ubuntu-24.04-arm
 
     steps:

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "alembic>=1.18.4",
     "descope>=0.9.0",
     "tenacity>=9.0.0",
-    "sentry-sdk[fastapi]>=2.58.0",
+    "sentry-sdk[fastapi]==2.58.0",
     "python-json-logger>=3.2.1",
     "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@main",
 ]

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1857,7 +1857,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-json-logger", specifier = ">=3.2.1" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.58.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.58.0" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "taskiq", specifier = ">=0.12.1" },
     { name = "taskiq-redis", specifier = ">=1.2.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2666,7 +2666,7 @@ requires-dist = [
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-json-logger", specifier = ">=3.2.1" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.58.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.58.0" },
     { name = "sqlmodel", specifier = ">=0.0.38" },
     { name = "taskiq", specifier = ">=0.12.1" },
     { name = "taskiq-redis", specifier = ">=1.2.2" },


### PR DESCRIPTION
## Summary
Pins `sentry-sdk` to the known-working `2.58.0` release so `uv tool install ... --prerelease=allow` does not resolve the CLI tool environment to an incompatible Sentry 3 prerelease.

Adds a PR-only CLI tool smoke workflow for PRs into `dev` and `prod`. The smoke test installs Valkyrie as a uv tool and checks that the CLI can start and load the affected command groups.

## Changes
- Pin `sentry-sdk[fastapi]` to `==2.58.0` in the tracker service dependency metadata.
- Refresh the root and tracker lockfile metadata for the exact Sentry pin.
- Add `.github/workflows/cli-tool-smoke-test.yaml` to install Valkyrie with `uv tool install --force . --prerelease=allow` on PRs into `dev` and `prod`.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

Manual verification:
- `uv lock --check`
- `cd services/tracker && uv lock --check`
- isolated `uv tool install --force . --prerelease=allow`
- `valk --help`
- `valk agent --help`
- `valk agent download --help`
- YAML parse for `.github/workflows/cli-tool-smoke-test.yaml`
- `make lint`
- `make unit-test`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
