### PR TITLE
feat: add tracker lifecycle telemetry

### DIFF
--- a/services/tracker/src/tracker/observability/__init__.py
+++ b/services/tracker/src/tracker/observability/__init__.py
@@ -1,5 +1,7 @@
 """Observability setup and runtime helpers for the tracker service."""
 
+import time
+
 from tracker.observability.metrics import distribution, gauge, incr
 from tracker.observability.retry import retry_callback
 from tracker.observability.sentry import init_sentry, set_pty_context, set_sandbox_context, tag_daytona_error
@@ -12,10 +14,16 @@ def configure_observability(service_name: str, environment: str) -> None:
     configure_tracing(service_name, environment=environment)
 
 
+def elapsed_ms(start: float) -> float:
+    """Milliseconds since `start` (a `time.monotonic()` reading), rounded to 2dp for log-friendly output."""
+    return round((time.monotonic() - start) * 1000, 2)
+
+
 __all__ = [
     "configure_observability",
     "configure_tracing",
     "distribution",
+    "elapsed_ms",
     "gauge",
     "incr",
     "init_sentry",

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -48,6 +48,7 @@ from tracker.exceptions import (
 from tracker.logging import get_logger
 from tracker.observability import (
     distribution,
+    elapsed_ms,
     gauge,
     incr,
     retry_callback,
@@ -779,22 +780,85 @@ async def stream_command_output(
             pass
 
 
+def _log_agent_output_event(
+    event: str,
+    sandbox: AsyncSandbox,
+    output_path: str,
+    s3_key: str,
+    start: float | None = None,
+    **extra: Any,
+) -> None:
+    context: dict[str, Any] = {
+        "sandbox_id": sandbox.id,
+        "sandbox_name": sandbox.name,
+        "output_path": output_path,
+        "s3_key": s3_key,
+        **extra,
+    }
+    if start is not None:
+        context["duration_ms"] = elapsed_ms(start)
+
+    logger.info(event, extra=context)
+
+
+@logfire.instrument("agent_output.archive_and_upload", extract_args=("output_path", "agent_output_s3_key"))
 async def archive_and_upload_output(
     sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str, aws: AWSCredentials, s3_bucket: str
 ) -> None:
     """Compress a file in the sandbox into a tar.gz and upload it to S3"""
     archive_path = f"/tmp/{uuid.uuid4().hex}.tar.gz"
 
+    _log_agent_output_event("agent_output.archive.start", sandbox, output_path, agent_output_s3_key)
+    archive_start = time.monotonic()
     tar_result = await _exec(sandbox, f"tar -czf {shlex.quote(archive_path)} {shlex.quote(output_path)}")
     if tar_result.exit_code != 0:
         raise SandboxError(f"Failed to create archive from {output_path}")
+    _log_agent_output_event("agent_output.archive.complete", sandbox, output_path, agent_output_s3_key, archive_start)
 
     try:
+        _log_agent_output_event("agent_output.base64.start", sandbox, output_path, agent_output_s3_key)
+        base64_start = time.monotonic()
         b64_result = await _exec(sandbox, f"base64 {shlex.quote(archive_path)}")
         if b64_result.exit_code != 0:
             raise SandboxError(f"Failed to read archive from {output_path}")
+        _log_agent_output_event(
+            "agent_output.base64.complete",
+            sandbox,
+            output_path,
+            agent_output_s3_key,
+            base64_start,
+            base64_bytes=len(b64_result.result),
+        )
 
-        await upload_to_s3(base64.b64decode(b64_result.result), agent_output_s3_key, aws, s3_bucket)
+        decode_start = time.monotonic()
+        file_content = base64.b64decode(b64_result.result)
+        archive_bytes = len(file_content)
+        _log_agent_output_event(
+            "agent_output.decode.complete",
+            sandbox,
+            output_path,
+            agent_output_s3_key,
+            decode_start,
+            archive_bytes=archive_bytes,
+        )
+
+        _log_agent_output_event(
+            "agent_output.upload.start",
+            sandbox,
+            output_path,
+            agent_output_s3_key,
+            archive_bytes=archive_bytes,
+        )
+        upload_start = time.monotonic()
+        await upload_to_s3(file_content, agent_output_s3_key, aws, s3_bucket)
+        _log_agent_output_event(
+            "agent_output.upload.complete",
+            sandbox,
+            output_path,
+            agent_output_s3_key,
+            upload_start,
+            archive_bytes=archive_bytes,
+        )
     finally:
         # Remove the file if it exists `-f` exits silently if the file does not exist
         try:
@@ -851,6 +915,7 @@ async def run_agent(
     exit_reason = await stream_command_output(
         sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output
     )
+    log_output("Agent command finished; checking final output\n")
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         log_output(
@@ -865,7 +930,14 @@ async def run_agent(
     if contract.final_output:
         result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
         if result.exit_code == _SUCCESS_EXIT_CODE and agent_output_s3_key:
+            log_output("Final output found; archiving and uploading\n")
             await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, aws, s3_bucket)
+            log_output("Final output archive uploaded\n")
+        elif result.exit_code == _SUCCESS_EXIT_CODE:
+            log_output("Final output found but no upload destination was configured\n")
+        else:
+            log_output("Final output not found; skipping upload\n")
 
     # Return why the agent terminated abnormally, or None on clean exit
+    log_output("Agent run complete; proceeding to evaluation\n")
     return exit_reason

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -780,35 +780,10 @@ async def stream_command_output(
             pass
 
 
-def _log_agent_output_event(
-    event: str,
-    sandbox: AsyncSandbox,
-    output_path: str,
-    s3_key: str,
-    start: float | None = None,
-    *,
-    benchmark_id: str | None = None,
-    task_id: str | None = None,
-    **extra: Any,
-) -> None:
-    context: dict[str, Any] = {
-        "sandbox_id": sandbox.id,
-        "sandbox_name": sandbox.name,
-        "output_path": output_path,
-        "s3_key": s3_key,
-        **extra,
-    }
-    if benchmark_id is not None:
-        context["benchmark_id"] = benchmark_id
-    if task_id is not None:
-        context["task_id"] = task_id
-    if start is not None:
-        context["duration_ms"] = elapsed_ms(start)
-
-    logger.info(event, extra=context)
-
-
-@logfire.instrument("agent_output.archive_and_upload", extract_args=("output_path", "agent_output_s3_key"))
+@logfire.instrument(
+    "agent_output.archive_and_upload",
+    extract_args=("output_path", "agent_output_s3_key", "benchmark_id", "task_id"),
+)
 async def archive_and_upload_output(
     sandbox: AsyncSandbox,
     output_path: str,
@@ -821,90 +796,35 @@ async def archive_and_upload_output(
 ) -> None:
     """Compress a file in the sandbox into a tar.gz and upload it to S3"""
     archive_path = f"/tmp/{uuid.uuid4().hex}.tar.gz"
+    start = time.monotonic()
 
-    _log_agent_output_event(
-        "agent_output.archive.start",
-        sandbox,
-        output_path,
-        agent_output_s3_key,
-        benchmark_id=benchmark_id,
-        task_id=task_id,
-    )
-    archive_start = time.monotonic()
     tar_result = await _exec(sandbox, f"tar -czf {shlex.quote(archive_path)} {shlex.quote(output_path)}")
     if tar_result.exit_code != 0:
         raise SandboxError(f"Failed to create archive from {output_path}")
-    _log_agent_output_event(
-        "agent_output.archive.complete",
-        sandbox,
-        output_path,
-        agent_output_s3_key,
-        archive_start,
-        benchmark_id=benchmark_id,
-        task_id=task_id,
-    )
 
     try:
-        _log_agent_output_event(
-            "agent_output.base64.start",
-            sandbox,
-            output_path,
-            agent_output_s3_key,
-            benchmark_id=benchmark_id,
-            task_id=task_id,
-        )
-        base64_start = time.monotonic()
         b64_result = await _exec(sandbox, f"base64 {shlex.quote(archive_path)}")
         if b64_result.exit_code != 0:
             raise SandboxError(f"Failed to read archive from {output_path}")
-        _log_agent_output_event(
-            "agent_output.base64.complete",
-            sandbox,
-            output_path,
-            agent_output_s3_key,
-            base64_start,
-            benchmark_id=benchmark_id,
-            task_id=task_id,
-            base64_bytes=len(b64_result.result),
-        )
 
-        decode_start = time.monotonic()
         file_content = base64.b64decode(b64_result.result)
-        archive_bytes = len(file_content)
-        _log_agent_output_event(
-            "agent_output.decode.complete",
-            sandbox,
-            output_path,
-            agent_output_s3_key,
-            decode_start,
-            benchmark_id=benchmark_id,
-            task_id=task_id,
-            archive_bytes=archive_bytes,
-        )
-
-        _log_agent_output_event(
-            "agent_output.upload.start",
-            sandbox,
-            output_path,
-            agent_output_s3_key,
-            benchmark_id=benchmark_id,
-            task_id=task_id,
-            archive_bytes=archive_bytes,
-        )
-        upload_start = time.monotonic()
         await upload_to_s3(file_content, agent_output_s3_key, aws, s3_bucket)
-        _log_agent_output_event(
-            "agent_output.upload.complete",
-            sandbox,
-            output_path,
-            agent_output_s3_key,
-            upload_start,
-            benchmark_id=benchmark_id,
-            task_id=task_id,
-            archive_bytes=archive_bytes,
+
+        logger.info(
+            "agent_output.archive_and_upload.complete",
+            extra={
+                "sandbox_id": sandbox.id,
+                "sandbox_name": sandbox.name,
+                "output_path": output_path,
+                "s3_key": agent_output_s3_key,
+                "benchmark_id": benchmark_id,
+                "task_id": task_id,
+                "archive_bytes": len(file_content),
+                "duration_ms": elapsed_ms(start),
+            },
         )
     finally:
-        # Remove the file if it exists `-f` exits silently if the file does not exist
+        # `-f` exits silently if the file does not exist
         try:
             await _exec(sandbox, f"rm -f {shlex.quote(archive_path)}")
         except Exception:
@@ -960,7 +880,6 @@ async def run_agent(
     exit_reason = await stream_command_output(
         sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output
     )
-    log_output("Agent command finished; checking final output\n")
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         log_output(
@@ -975,7 +894,6 @@ async def run_agent(
     if contract.final_output:
         result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
         if result.exit_code == _SUCCESS_EXIT_CODE and agent_output_s3_key:
-            log_output("Final output found; archiving and uploading\n")
             await archive_and_upload_output(
                 sandbox,
                 contract.final_output,
@@ -985,12 +903,6 @@ async def run_agent(
                 benchmark_id=benchmark_id,
                 task_id=task_id,
             )
-            log_output("Final output archive uploaded\n")
-        elif result.exit_code == _SUCCESS_EXIT_CODE:
-            log_output("Final output found but no upload destination was configured\n")
-        else:
-            log_output("Final output not found; skipping upload\n")
 
     # Return why the agent terminated abnormally, or None on clean exit
-    log_output("Agent run complete; proceeding to evaluation\n")
     return exit_reason

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -786,6 +786,9 @@ def _log_agent_output_event(
     output_path: str,
     s3_key: str,
     start: float | None = None,
+    *,
+    benchmark_id: str | None = None,
+    task_id: str | None = None,
     **extra: Any,
 ) -> None:
     context: dict[str, Any] = {
@@ -795,6 +798,10 @@ def _log_agent_output_event(
         "s3_key": s3_key,
         **extra,
     }
+    if benchmark_id is not None:
+        context["benchmark_id"] = benchmark_id
+    if task_id is not None:
+        context["task_id"] = task_id
     if start is not None:
         context["duration_ms"] = elapsed_ms(start)
 
@@ -803,20 +810,49 @@ def _log_agent_output_event(
 
 @logfire.instrument("agent_output.archive_and_upload", extract_args=("output_path", "agent_output_s3_key"))
 async def archive_and_upload_output(
-    sandbox: AsyncSandbox, output_path: str, agent_output_s3_key: str, aws: AWSCredentials, s3_bucket: str
+    sandbox: AsyncSandbox,
+    output_path: str,
+    agent_output_s3_key: str,
+    aws: AWSCredentials,
+    s3_bucket: str,
+    *,
+    benchmark_id: str | None = None,
+    task_id: str | None = None,
 ) -> None:
     """Compress a file in the sandbox into a tar.gz and upload it to S3"""
     archive_path = f"/tmp/{uuid.uuid4().hex}.tar.gz"
 
-    _log_agent_output_event("agent_output.archive.start", sandbox, output_path, agent_output_s3_key)
+    _log_agent_output_event(
+        "agent_output.archive.start",
+        sandbox,
+        output_path,
+        agent_output_s3_key,
+        benchmark_id=benchmark_id,
+        task_id=task_id,
+    )
     archive_start = time.monotonic()
     tar_result = await _exec(sandbox, f"tar -czf {shlex.quote(archive_path)} {shlex.quote(output_path)}")
     if tar_result.exit_code != 0:
         raise SandboxError(f"Failed to create archive from {output_path}")
-    _log_agent_output_event("agent_output.archive.complete", sandbox, output_path, agent_output_s3_key, archive_start)
+    _log_agent_output_event(
+        "agent_output.archive.complete",
+        sandbox,
+        output_path,
+        agent_output_s3_key,
+        archive_start,
+        benchmark_id=benchmark_id,
+        task_id=task_id,
+    )
 
     try:
-        _log_agent_output_event("agent_output.base64.start", sandbox, output_path, agent_output_s3_key)
+        _log_agent_output_event(
+            "agent_output.base64.start",
+            sandbox,
+            output_path,
+            agent_output_s3_key,
+            benchmark_id=benchmark_id,
+            task_id=task_id,
+        )
         base64_start = time.monotonic()
         b64_result = await _exec(sandbox, f"base64 {shlex.quote(archive_path)}")
         if b64_result.exit_code != 0:
@@ -827,6 +863,8 @@ async def archive_and_upload_output(
             output_path,
             agent_output_s3_key,
             base64_start,
+            benchmark_id=benchmark_id,
+            task_id=task_id,
             base64_bytes=len(b64_result.result),
         )
 
@@ -839,6 +877,8 @@ async def archive_and_upload_output(
             output_path,
             agent_output_s3_key,
             decode_start,
+            benchmark_id=benchmark_id,
+            task_id=task_id,
             archive_bytes=archive_bytes,
         )
 
@@ -847,6 +887,8 @@ async def archive_and_upload_output(
             sandbox,
             output_path,
             agent_output_s3_key,
+            benchmark_id=benchmark_id,
+            task_id=task_id,
             archive_bytes=archive_bytes,
         )
         upload_start = time.monotonic()
@@ -857,6 +899,8 @@ async def archive_and_upload_output(
             output_path,
             agent_output_s3_key,
             upload_start,
+            benchmark_id=benchmark_id,
+            task_id=task_id,
             archive_bytes=archive_bytes,
         )
     finally:
@@ -878,6 +922,7 @@ async def run_agent(
     s3_bucket: str,
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
+    benchmark_id: str | None = None,
 ) -> AgentCausedExitReason | None:
     """
     Run the agent inside the sandbox for a given task.
@@ -931,7 +976,15 @@ async def run_agent(
         result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
         if result.exit_code == _SUCCESS_EXIT_CODE and agent_output_s3_key:
             log_output("Final output found; archiving and uploading\n")
-            await archive_and_upload_output(sandbox, contract.final_output, agent_output_s3_key, aws, s3_bucket)
+            await archive_and_upload_output(
+                sandbox,
+                contract.final_output,
+                agent_output_s3_key,
+                aws,
+                s3_bucket,
+                benchmark_id=benchmark_id,
+                task_id=task_id,
+            )
             log_output("Final output archive uploaded\n")
         elif result.exit_code == _SUCCESS_EXIT_CODE:
             log_output("Final output found but no upload destination was configured\n")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -51,7 +51,7 @@ from tracker.database.session import engine
 from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
-from tracker.observability import retry_callback
+from tracker.observability import distribution, elapsed_ms, retry_callback
 from tracker.sandbox import create_sandbox, delete_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     AWSCredentials,
@@ -276,9 +276,7 @@ def fetch_benchmark_row(benchmark_id: UUID, session: Session, org: Org) -> Bench
 
 
 def handle_early_exit(task_row: Task, task_session: Session) -> None:
-    task_row.status = TaskStatus.STOPPED
-    task_session.add(task_row)
-    task_session.commit()
+    _commit_task_status(task_row, task_session, TaskStatus.STOPPED)
 
 
 def fetch_task_row(task_id: UUID, session: Session, org: Org) -> Task:
@@ -314,6 +312,56 @@ def save_eval_resume_state(task_row_id: UUID, org: Org, eval_resume_state: dict[
         task = fetch_task_row(task_row_id, session, org)
         task.eval_resume_state = eval_resume_state
         session.commit()
+
+
+def _commit_task_status(
+    task: Task,
+    session: Session,
+    to_status: TaskStatus,
+    *,
+    error_message: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    transition_start = time.monotonic()
+    from_status = task.status
+    log_context = {
+        "benchmark_id": str(task.benchmark),
+        "task_id": task.task_id,
+        "from_status": from_status.value,
+        "to_status": to_status.value,
+        **(extra or {}),
+    }
+
+    logger.info("task.status_transition.start", extra=log_context)
+
+    commit_start = time.monotonic()
+    task.status = to_status
+    if error_message is not None:
+        task.error_message = error_message
+    session.add(task)
+    session.commit()
+    commit_duration_ms = elapsed_ms(commit_start)
+    transition_seconds = time.monotonic() - transition_start
+
+    logger.info(
+        "task.status_transition.complete",
+        extra={
+            **log_context,
+            "commit_duration_ms": commit_duration_ms,
+            "duration_ms": round(transition_seconds * 1000, 2),
+        },
+    )
+    distribution(
+        "valkyrie.task.status_transition.duration",
+        transition_seconds,
+        tags={"from_status": from_status.value, "to_status": to_status.value},
+    )
+
+
+def commit_task_status_transition(task_row_id: UUID, session: Session, org: Org, to_status: TaskStatus) -> None:
+    fetch_start = time.monotonic()
+    task = fetch_task_row(task_row_id, session, org)
+    _commit_task_status(task, session, to_status, extra={"fetch_duration_ms": elapsed_ms(fetch_start)})
 
 
 @logfire.instrument("process_task")
@@ -409,10 +457,8 @@ async def process_task(
                 )
 
                 with Session(bind=engine) as task_session:
-                    task = fetch_task_row(task_row.id, task_session, org)
                     task_session.add(evaluation_result_row)
-                    task.status = TaskStatus.FINISHED
-                    task_session.commit()
+                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.FINISHED)
 
                     return {task_id: evaluation_result_row.result}
             except Exception as e:
@@ -433,9 +479,7 @@ async def process_task(
         }
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
-            task.status = TaskStatus.BUILDING
-            task_session.commit()
+            commit_task_status_transition(task_row.id, task_session, org, TaskStatus.BUILDING)
 
         env_vars = {
             **resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws),
@@ -458,9 +502,7 @@ async def process_task(
         ) as sandbox:
             try:
                 with Session(bind=engine) as task_session:
-                    task = fetch_task_row(task_row.id, task_session, org)
-                    task.status = TaskStatus.IN_PROGRESS
-                    task_session.commit()
+                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.IN_PROGRESS)
 
                 # Upload the contract to the sandbox after creating and install the dependencies
                 await upload_agent_artifacts(
@@ -495,14 +537,31 @@ async def process_task(
                     agent_output_s3_key=agent_output_s3_key,
                     agent_timeout=task_data.agent_timeout,
                 )
+                logger.info(
+                    "agent.run.complete",
+                    extra={
+                        "benchmark_id": str(benchmark_id),
+                        "task_id": task_row.task_id,
+                        "sandbox_id": sandbox.id,
+                        "sandbox_name": sandbox.name,
+                        "exit_reason": exit_reason.value if exit_reason else None,
+                    },
+                )
 
                 with Session(bind=engine) as task_session:
-                    task = fetch_task_row(task_row.id, task_session, org)
-                    task.status = TaskStatus.EVALUATING
-                    task_session.commit()
+                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.EVALUATING)
 
                 # Evaluate the instance
                 # NOTE: only really good for when we need to evaluate the container (for just evaluating a text response we can delegate before this)
+                logger.info(
+                    "task.evaluation.start",
+                    extra={
+                        "benchmark_id": str(benchmark_id),
+                        "task_id": task_row.task_id,
+                        "sandbox_id": sandbox.id,
+                        "sandbox_name": sandbox.name,
+                    },
+                )
                 logger.info(f"Evaluating agent {start_benchmark_request.contract.name} in sandbox {sandbox.name}")
                 evaluation_result = await benchmark_service.evaluate_instance(
                     task_row.task_id,
@@ -526,10 +585,8 @@ async def process_task(
                 )
 
                 with Session(bind=engine) as task_session:
-                    task = fetch_task_row(task_row.id, task_session, org)
                     task_session.add(evaluation_result_row)
-                    task.status = TaskStatus.FINISHED
-                    task_session.commit()
+                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.FINISHED)
 
                     return {task_id: evaluation_result_row.result}
             except Exception as e:
@@ -983,10 +1040,7 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
 
 
 def commit_task_error(task_row: Task, session: Session, error_message: str) -> None:
-    task_row.status = TaskStatus.ERROR
-    task_row.error_message = error_message
-    session.add(task_row)
-    session.commit()
+    _commit_task_status(task_row, session, TaskStatus.ERROR, error_message=error_message)
 
 
 async def stream_benchmark_results(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -536,6 +536,7 @@ async def process_task(
                     s3_bucket=harness_config.s3_bucket,
                     agent_output_s3_key=agent_output_s3_key,
                     agent_timeout=task_data.agent_timeout,
+                    benchmark_id=str(benchmark_id),
                 )
                 logger.info(
                     "agent.run.complete",

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -51,7 +51,7 @@ from tracker.database.session import engine
 from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
-from tracker.observability import distribution, elapsed_ms, retry_callback
+from tracker.observability import elapsed_ms, retry_callback
 from tracker.sandbox import create_sandbox, delete_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     AWSCredentials,
@@ -322,40 +322,23 @@ def _commit_task_status(
     error_message: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> None:
-    transition_start = time.monotonic()
     from_status = task.status
-    log_context = {
+    span_attributes = {
         "benchmark_id": str(task.benchmark),
         "task_id": task.task_id,
         "from_status": from_status.value,
         "to_status": to_status.value,
         **(extra or {}),
     }
-
-    logger.info("task.status_transition.start", extra=log_context)
-
-    commit_start = time.monotonic()
-    task.status = to_status
     if error_message is not None:
-        task.error_message = error_message
-    session.add(task)
-    session.commit()
-    commit_duration_ms = elapsed_ms(commit_start)
-    transition_seconds = time.monotonic() - transition_start
+        span_attributes["has_error_message"] = True
 
-    logger.info(
-        "task.status_transition.complete",
-        extra={
-            **log_context,
-            "commit_duration_ms": commit_duration_ms,
-            "duration_ms": round(transition_seconds * 1000, 2),
-        },
-    )
-    distribution(
-        "valkyrie.task.status_transition.duration",
-        transition_seconds,
-        tags={"from_status": from_status.value, "to_status": to_status.value},
-    )
+    with logfire.span("task.status_transition", **span_attributes):
+        task.status = to_status
+        if error_message is not None:
+            task.error_message = error_message
+        session.add(task)
+        session.commit()
 
 
 def commit_task_status_transition(task_row_id: UUID, session: Session, org: Org, to_status: TaskStatus) -> None:

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -13,6 +13,7 @@ from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkSt
 from tracker.exceptions import TrackerServiceError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
+    commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
     set_benchmark_final_status,
@@ -336,6 +337,38 @@ class TestBenchmarkUtils:
         all_tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
+
+    def test_commit_task_error_logs_timed_status_transition(
+        self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: pytest.MonkeyPatch
+    ):
+        log_records: list[dict[str, Any]] = []
+
+        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr("tracker.utils.logger.info", fake_info)
+
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=example_benchmark_object.id,
+            status=TaskStatus.IN_PROGRESS,
+        )
+        database_session.add(task_row)
+        database_session.commit()
+
+        commit_task_error(task_row, database_session, "agent failed")
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        transition_record = next(
+            record for record in log_records if record["message"] == "task.status_transition.complete"
+        )
+        assert transition_record["from_status"] == TaskStatus.IN_PROGRESS.value
+        assert transition_record["to_status"] == TaskStatus.ERROR.value
+        assert transition_record["task_id"] == "task_0"
+        assert transition_record["benchmark_id"] == str(example_benchmark_object.id)
+        assert "commit_duration_ms" in transition_record
 
     async def test_set_benchmark_final_status(self, example_benchmark_object: Benchmark, database_session: Session):
         """

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -338,15 +338,33 @@ class TestBenchmarkUtils:
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
 
-    def test_commit_task_error_logs_timed_status_transition(
+    def test_commit_task_error_spans_status_transition(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: pytest.MonkeyPatch
     ):
         log_records: list[dict[str, Any]] = []
+        span_records: list[dict[str, Any]] = []
 
         def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
             log_records.append({"message": message, **(extra or {})})
 
+        class MockSpan:
+            def __init__(self, record: dict[str, Any]) -> None:
+                self._record = record
+
+            def __enter__(self) -> "MockSpan":
+                self._record["entered"] = True
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                self._record["exited"] = True
+
+        def fake_span(message: str, **attributes: Any) -> MockSpan:
+            record = {"message": message, **attributes}
+            span_records.append(record)
+            return MockSpan(record)
+
         monkeypatch.setattr("tracker.utils.logger.info", fake_info)
+        monkeypatch.setattr("tracker.utils.logfire.span", fake_span)
 
         task_row = Task(
             org_id=TEST_ORG_ID,
@@ -361,14 +379,14 @@ class TestBenchmarkUtils:
 
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
-        transition_record = next(
-            record for record in log_records if record["message"] == "task.status_transition.complete"
-        )
+        transition_record = next(record for record in span_records if record["message"] == "task.status_transition")
         assert transition_record["from_status"] == TaskStatus.IN_PROGRESS.value
         assert transition_record["to_status"] == TaskStatus.ERROR.value
         assert transition_record["task_id"] == "task_0"
         assert transition_record["benchmark_id"] == str(example_benchmark_object.id)
-        assert "commit_duration_ms" in transition_record
+        assert transition_record["entered"] and transition_record["exited"]
+        assert transition_record["has_error_message"] is True
+        assert not any(record["message"].startswith("task.status_transition") for record in log_records)
 
     async def test_set_benchmark_final_status(self, example_benchmark_object: Benchmark, database_session: Session):
         """

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -163,7 +163,10 @@ class TestPtyRetry:
         async def _mock_upload_agent_artifacts(*_args: Any, **_kwargs: Any) -> None:
             return None
 
-        async def _mock_run_agent(*_args: Any, **_kwargs: Any) -> None:
+        run_agent_kwargs: dict[str, Any] = {}
+
+        async def _mock_run_agent(*_args: Any, **kwargs: Any) -> None:
+            run_agent_kwargs.update(kwargs)
             return None
 
         async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
@@ -212,6 +215,7 @@ class TestPtyRetry:
         assert all(record["benchmark_id"] == str(benchmark_row.id) for record in transition_records)
         assert all("commit_duration_ms" in record for record in transition_records)
         assert all("duration_ms" in record for record in transition_records)
+        assert run_agent_kwargs["benchmark_id"] == str(benchmark_row.id)
 
         event_names = [record["message"] for record in log_records]
         assert "agent.run.complete" in event_names

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -120,3 +120,109 @@ class TestPtyRetry:
 
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.FINISHED
+
+    async def test_process_task_logs_timed_status_transitions(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = "mock-sandbox-id"
+            mock_sandbox.name = "mock-sandbox-name"
+            yield mock_sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse(
+                docker_image="test-image:latest",
+                problem_path="/tmp/problem.txt",
+                cwd="/testbed",
+                resources=Resources(vcpu=2, memory=4, disk=5),
+            )
+
+        async def _mock_upload_agent_artifacts(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        async def _mock_run_agent(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"status": "success", "score": 1.0}
+
+        log_records: list[dict[str, Any]] = []
+
+        def _mock_logger_info(
+            message: str,
+            *args: object,
+            extra: dict[str, Any] | None = None,
+            **kwargs: Any,
+        ) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr("tracker.utils.upload_agent_artifacts", _mock_upload_agent_artifacts)
+        monkeypatch.setattr("tracker.utils.run_agent", _mock_run_agent)
+        monkeypatch.setattr("tracker.utils.logger.info", _mock_logger_info)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        transition_records = [
+            record for record in log_records if record["message"] == "task.status_transition.complete"
+        ]
+
+        assert [(record["from_status"], record["to_status"]) for record in transition_records] == [
+            (TaskStatus.PENDING.value, TaskStatus.BUILDING.value),
+            (TaskStatus.BUILDING.value, TaskStatus.IN_PROGRESS.value),
+            (TaskStatus.IN_PROGRESS.value, TaskStatus.EVALUATING.value),
+            (TaskStatus.EVALUATING.value, TaskStatus.FINISHED.value),
+        ]
+        assert all(record["task_id"] == "task_0" for record in transition_records)
+        assert all(record["benchmark_id"] == str(benchmark_row.id) for record in transition_records)
+        assert all("commit_duration_ms" in record for record in transition_records)
+        assert all("duration_ms" in record for record in transition_records)
+
+        event_names = [record["message"] for record in log_records]
+        assert "agent.run.complete" in event_names
+        assert "task.evaluation.start" in event_names
+
+        agent_run_record = next(record for record in log_records if record["message"] == "agent.run.complete")
+        assert agent_run_record["task_id"] == "task_0"
+        assert agent_run_record["benchmark_id"] == str(benchmark_row.id)
+        assert agent_run_record["exit_reason"] is None
+
+        evaluation_start_record = next(record for record in log_records if record["message"] == "task.evaluation.start")
+        assert evaluation_start_record["task_id"] == "task_0"
+        assert evaluation_start_record["benchmark_id"] == str(benchmark_row.id)
+        assert evaluation_start_record["sandbox_id"] == "mock-sandbox-id"

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -121,7 +121,7 @@ class TestPtyRetry:
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.FINISHED
 
-    async def test_process_task_logs_timed_status_transitions(
+    async def test_process_task_spans_timed_status_transitions(
         self,
         contract: AgentContractRequest,
         database_session: Session,
@@ -173,6 +173,7 @@ class TestPtyRetry:
             return {"status": "success", "score": 1.0}
 
         log_records: list[dict[str, Any]] = []
+        span_records: list[dict[str, Any]] = []
 
         def _mock_logger_info(
             message: str,
@@ -182,11 +183,28 @@ class TestPtyRetry:
         ) -> None:
             log_records.append({"message": message, **(extra or {})})
 
+        class _MockSpan:
+            def __init__(self, record: dict[str, Any]) -> None:
+                self._record = record
+
+            def __enter__(self) -> "_MockSpan":
+                self._record["entered"] = True
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                self._record["exited"] = True
+
+        def _mock_span(message: str, **attributes: Any) -> _MockSpan:
+            record = {"message": message, **attributes}
+            span_records.append(record)
+            return _MockSpan(record)
+
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr("tracker.utils.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.run_agent", _mock_run_agent)
         monkeypatch.setattr("tracker.utils.logger.info", _mock_logger_info)
+        monkeypatch.setattr("tracker.utils.logfire.span", _mock_span)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
 
@@ -201,9 +219,7 @@ class TestPtyRetry:
             creation_semaphore=Semaphore(1),
         )
 
-        transition_records = [
-            record for record in log_records if record["message"] == "task.status_transition.complete"
-        ]
+        transition_records = [record for record in span_records if record["message"] == "task.status_transition"]
 
         assert [(record["from_status"], record["to_status"]) for record in transition_records] == [
             (TaskStatus.PENDING.value, TaskStatus.BUILDING.value),
@@ -213,8 +229,8 @@ class TestPtyRetry:
         ]
         assert all(record["task_id"] == "task_0" for record in transition_records)
         assert all(record["benchmark_id"] == str(benchmark_row.id) for record in transition_records)
-        assert all("commit_duration_ms" in record for record in transition_records)
-        assert all("duration_ms" in record for record in transition_records)
+        assert all(record["entered"] and record["exited"] for record in transition_records)
+        assert not any(record["message"].startswith("task.status_transition") for record in log_records)
         assert run_agent_kwargs["benchmark_id"] == str(benchmark_row.id)
 
         event_names = [record["message"] for record in log_records]

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -13,7 +13,13 @@ from tenacity import stop_after_attempt, wait_none
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
-from tracker.sandbox import create_sandbox, stream_command_output, upload_agent_artifacts
+from tracker.sandbox import (
+    archive_and_upload_output,
+    create_sandbox,
+    run_agent,
+    stream_command_output,
+    upload_agent_artifacts,
+)
 from tracker.types import AWSCredentials
 
 _create_sandbox = getattr(sandbox_module, "_create_sandbox")
@@ -212,6 +218,133 @@ class TestPtyHandshakeSemaphore:
             "valkyrie.sandbox_name": "task-alias",
             "valkyrie.pty_session_id": "session-1",
         }
+
+
+class TestAgentOutputTelemetry:
+    async def test_archive_and_upload_output_logs_each_expensive_step(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        log_records: list[dict[str, Any]] = []
+        uploaded_content: list[bytes] = []
+
+        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command.startswith("tar -czf"):
+                return ExecuteResponse(exit_code=0, result="")
+            if command.startswith("base64 "):
+                return ExecuteResponse(exit_code=0, result="aGVsbG8=")
+            if command.startswith("rm -f"):
+                return ExecuteResponse(exit_code=0, result="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_upload_to_s3(
+            file_content: bytes,
+            s3_key: str,
+            _aws: Any,
+            s3_bucket: str,
+        ) -> None:
+            uploaded_content.append(file_content)
+            assert s3_key == "benchmarks/run/task/agent_output.tar.gz"
+            assert s3_bucket == harness_config.s3_bucket
+
+        monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await archive_and_upload_output(
+            mock_sandbox,
+            "/tmp/agent_output",
+            "benchmarks/run/task/agent_output.tar.gz",
+            harness_config.aws,
+            harness_config.s3_bucket,
+        )
+
+        assert uploaded_content == [b"hello"]
+        assert [record["message"] for record in log_records] == [
+            "agent_output.archive.start",
+            "agent_output.archive.complete",
+            "agent_output.base64.start",
+            "agent_output.base64.complete",
+            "agent_output.decode.complete",
+            "agent_output.upload.start",
+            "agent_output.upload.complete",
+        ]
+        assert all(record["sandbox_id"] == "sandbox-123" for record in log_records)
+        assert all(record["s3_key"] == "benchmarks/run/task/agent_output.tar.gz" for record in log_records)
+        assert all("duration_ms" in record for record in log_records if record["message"].endswith(".complete"))
+        assert next(record for record in log_records if record["message"] == "agent_output.base64.complete")[
+            "base64_bytes"
+        ] == len("aGVsbG8=")
+        assert next(record for record in log_records if record["message"] == "agent_output.decode.complete")[
+            "archive_bytes"
+        ] == len(b"hello")
+
+    async def test_run_agent_logs_boundaries_around_final_output_upload(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="",
+            run_cmd="echo done",
+            final_output="/tmp/agent_output",
+        )
+        outputs: list[str] = []
+        archive_calls: list[str] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command.startswith("mkdir -p"):
+                return ExecuteResponse(exit_code=0, result="")
+            if command.startswith("test -e"):
+                return ExecuteResponse(exit_code=0, result="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_stream_command_output(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        async def fake_archive_and_upload_output(
+            _sandbox: Any,
+            output_path: str,
+            _s3_key: str,
+            _aws: Any,
+            _s3_bucket: str,
+        ) -> None:
+            archive_calls.append(output_path)
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
+        monkeypatch.setattr(sandbox_module, "archive_and_upload_output", fake_archive_and_upload_output)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await run_agent(
+            mock_sandbox,
+            contract,
+            "/tmp/problem.txt",
+            "task_0",
+            outputs.append,
+            "/testbed",
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+            agent_output_s3_key="benchmarks/run/task/agent_output.tar.gz",
+        )
+
+        assert archive_calls == ["/tmp/agent_output"]
+        assert "Agent command finished; checking final output\n" in outputs
+        assert "Final output found; archiving and uploading\n" in outputs
+        assert "Final output archive uploaded\n" in outputs
+        assert "Agent run complete; proceeding to evaluation\n" in outputs
 
     async def test_wait_for_pty_emits_structured_logs_for_clean_disconnect_and_missing_status(
         self, monkeypatch: pytest.MonkeyPatch

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -13,13 +13,7 @@ from tenacity import stop_after_attempt, wait_none
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
-from tracker.sandbox import (
-    archive_and_upload_output,
-    create_sandbox,
-    run_agent,
-    stream_command_output,
-    upload_agent_artifacts,
-)
+from tracker.sandbox import create_sandbox, run_agent, stream_command_output, upload_agent_artifacts
 from tracker.types import AWSCredentials
 
 _create_sandbox = getattr(sandbox_module, "_create_sandbox")
@@ -221,77 +215,7 @@ class TestPtyHandshakeSemaphore:
 
 
 class TestAgentOutputTelemetry:
-    async def test_archive_and_upload_output_logs_each_expensive_step(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        harness_config: Any,
-    ) -> None:
-        log_records: list[dict[str, Any]] = []
-        uploaded_content: list[bytes] = []
-
-        def fake_info(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
-            log_records.append({"message": message, **(extra or {})})
-
-        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            if command.startswith("tar -czf"):
-                return ExecuteResponse(exit_code=0, result="")
-            if command.startswith("base64 "):
-                return ExecuteResponse(exit_code=0, result="aGVsbG8=")
-            if command.startswith("rm -f"):
-                return ExecuteResponse(exit_code=0, result="")
-            raise AssertionError(f"unexpected command: {command}")
-
-        async def fake_upload_to_s3(
-            file_content: bytes,
-            s3_key: str,
-            _aws: Any,
-            s3_bucket: str,
-        ) -> None:
-            uploaded_content.append(file_content)
-            assert s3_key == "benchmarks/run/task/agent_output.tar.gz"
-            assert s3_bucket == harness_config.s3_bucket
-
-        monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
-        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
-
-        mock_sandbox = Mock()
-        mock_sandbox.id = "sandbox-123"
-        mock_sandbox.name = "task-alias"
-
-        await archive_and_upload_output(
-            mock_sandbox,
-            "/tmp/agent_output",
-            "benchmarks/run/task/agent_output.tar.gz",
-            harness_config.aws,
-            harness_config.s3_bucket,
-            benchmark_id="benchmark-123",
-            task_id="task",
-        )
-
-        assert uploaded_content == [b"hello"]
-        assert [record["message"] for record in log_records] == [
-            "agent_output.archive.start",
-            "agent_output.archive.complete",
-            "agent_output.base64.start",
-            "agent_output.base64.complete",
-            "agent_output.decode.complete",
-            "agent_output.upload.start",
-            "agent_output.upload.complete",
-        ]
-        assert all(record["sandbox_id"] == "sandbox-123" for record in log_records)
-        assert all(record["benchmark_id"] == "benchmark-123" for record in log_records)
-        assert all(record["task_id"] == "task" for record in log_records)
-        assert all(record["s3_key"] == "benchmarks/run/task/agent_output.tar.gz" for record in log_records)
-        assert all("duration_ms" in record for record in log_records if record["message"].endswith(".complete"))
-        assert next(record for record in log_records if record["message"] == "agent_output.base64.complete")[
-            "base64_bytes"
-        ] == len("aGVsbG8=")
-        assert next(record for record in log_records if record["message"] == "agent_output.decode.complete")[
-            "archive_bytes"
-        ] == len(b"hello")
-
-    async def test_run_agent_logs_boundaries_around_final_output_upload(
+    async def test_run_agent_threads_benchmark_id_to_archive_and_upload(
         self,
         monkeypatch: pytest.MonkeyPatch,
         harness_config: Any,
@@ -302,13 +226,10 @@ class TestAgentOutputTelemetry:
             run_cmd="echo done",
             final_output="/tmp/agent_output",
         )
-        outputs: list[str] = []
         archive_calls: list[str] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            if command.startswith("mkdir -p"):
-                return ExecuteResponse(exit_code=0, result="")
-            if command.startswith("test -e"):
+            if command.startswith("mkdir -p") or command.startswith("test -e"):
                 return ExecuteResponse(exit_code=0, result="")
             raise AssertionError(f"unexpected command: {command}")
 
@@ -340,7 +261,7 @@ class TestAgentOutputTelemetry:
             contract,
             "/tmp/problem.txt",
             "task_0",
-            outputs.append,
+            lambda _msg: None,
             "/testbed",
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
@@ -349,10 +270,6 @@ class TestAgentOutputTelemetry:
         )
 
         assert archive_calls == ["benchmark-123:task_0:/tmp/agent_output"]
-        assert "Agent command finished; checking final output\n" in outputs
-        assert "Final output found; archiving and uploading\n" in outputs
-        assert "Final output archive uploaded\n" in outputs
-        assert "Agent run complete; proceeding to evaluation\n" in outputs
 
     async def test_wait_for_pty_emits_structured_logs_for_clean_disconnect_and_missing_status(
         self, monkeypatch: pytest.MonkeyPatch

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -265,6 +265,8 @@ class TestAgentOutputTelemetry:
             "benchmarks/run/task/agent_output.tar.gz",
             harness_config.aws,
             harness_config.s3_bucket,
+            benchmark_id="benchmark-123",
+            task_id="task",
         )
 
         assert uploaded_content == [b"hello"]
@@ -278,6 +280,8 @@ class TestAgentOutputTelemetry:
             "agent_output.upload.complete",
         ]
         assert all(record["sandbox_id"] == "sandbox-123" for record in log_records)
+        assert all(record["benchmark_id"] == "benchmark-123" for record in log_records)
+        assert all(record["task_id"] == "task" for record in log_records)
         assert all(record["s3_key"] == "benchmarks/run/task/agent_output.tar.gz" for record in log_records)
         assert all("duration_ms" in record for record in log_records if record["message"].endswith(".complete"))
         assert next(record for record in log_records if record["message"] == "agent_output.base64.complete")[
@@ -317,8 +321,11 @@ class TestAgentOutputTelemetry:
             _s3_key: str,
             _aws: Any,
             _s3_bucket: str,
+            *,
+            benchmark_id: str | None = None,
+            task_id: str | None = None,
         ) -> None:
-            archive_calls.append(output_path)
+            archive_calls.append(f"{benchmark_id}:{task_id}:{output_path}")
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
         monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
@@ -338,9 +345,10 @@ class TestAgentOutputTelemetry:
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
             agent_output_s3_key="benchmarks/run/task/agent_output.tar.gz",
+            benchmark_id="benchmark-123",
         )
 
-        assert archive_calls == ["/tmp/agent_output"]
+        assert archive_calls == ["benchmark-123:task_0:/tmp/agent_output"]
         assert "Agent command finished; checking final output\n" in outputs
         assert "Final output found; archiving and uploading\n" in outputs
         assert "Final output archive uploaded\n" in outputs


### PR DESCRIPTION
## Summary
Adds tracker lifecycle telemetry so slow or stuck task runs can be narrowed to agent execution, DB status commits, evaluation startup, or final-output archive/upload work.

## Changes
- Wrap every task status commit in a `task.status_transition` Logfire span with `benchmark_id`, `task_id`, `from_status`, `to_status` attributes; covers PENDING→BUILDING→IN_PROGRESS→EVALUATING→FINISHED, plus STOPPED (early exit) and ERROR (with `has_error_message`). All call sites now route through a shared `_commit_task_status` helper.
- Add `agent.run.complete` and `task.evaluation.start` structured logs around the `IN_PROGRESS → EVALUATING` boundary in `process_task`.
- Wrap `archive_and_upload_output` in a Logfire instrument span (with `output_path`, `agent_output_s3_key`, `benchmark_id`, `task_id`) and emit a single `agent_output.archive_and_upload.complete` summary log carrying `archive_bytes` and `duration_ms`.
- Thread `benchmark_id` from `process_task` through `run_agent` into the upload span/log so logs and traces tie back to the owning benchmark.
- Add a `tracker.observability.elapsed_ms` helper for log-friendly monotonic durations.
- Add tracker unit coverage for the status-transition span, the `commit_task_error` path, and `benchmark_id` propagation through `run_agent`.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Verified locally:
- `uv run pytest services/tracker/tests/unit` (`130 passed`)
- `uv run ruff format --check .` from `services/tracker`
- `uv run ruff check .` from `services/tracker`
- `git diff --check`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed