### PR TITLE
fix(tracker): respect Daytona rate-limit retry headers

### DIFF
--- a/services/tracker/src/tracker/daytona_retry.py
+++ b/services/tracker/src/tracker/daytona_retry.py
@@ -5,6 +5,7 @@ from collections.abc import Callable, Mapping
 
 from daytona.common.errors import DaytonaRateLimitError
 from tenacity import RetryCallState
+from tenacity import wait_exponential
 from tenacity.wait import wait_base
 
 from tracker.observability.metrics import distribution, incr
@@ -82,18 +83,20 @@ def daytona_retry_after_seconds(exc: DaytonaRateLimitError) -> float | None:
 
 
 class wait_daytona_rate_limit(wait_base):
-    def __init__(self, fallback: wait_base, *, max_retry_after_seconds: float = 60.0) -> None:
-        self._fallback = fallback
-        self._max_retry_after_seconds = max_retry_after_seconds
+    def __init__(self, *, non_rate_limit_wait: wait_base, rate_limit_wait: wait_base | None = None) -> None:
+        self._non_rate_limit_wait = non_rate_limit_wait
+        self._rate_limit_wait = rate_limit_wait or wait_exponential(multiplier=1, min=1, max=30)
 
     def __call__(self, retry_state: RetryCallState) -> float:
         exc = retry_state.outcome.exception() if retry_state.outcome else None
         if isinstance(exc, DaytonaRateLimitError):
             seconds = daytona_retry_after_seconds(exc)
             if seconds is not None:
-                return min(seconds, self._max_retry_after_seconds)
+                return seconds
 
-        return self._fallback(retry_state)
+            return self._rate_limit_wait(retry_state)
+
+        return self._non_rate_limit_wait(retry_state)
 
 
 def daytona_retry_callback(

--- a/services/tracker/src/tracker/daytona_retry.py
+++ b/services/tracker/src/tracker/daytona_retry.py
@@ -1,0 +1,130 @@
+"""Daytona retry helpers."""
+
+import logging
+from collections.abc import Callable, Mapping
+
+from daytona.common.errors import DaytonaRateLimitError
+from tenacity import RetryCallState
+from tenacity.wait import wait_base
+
+from tracker.observability.metrics import distribution, incr
+from tracker.observability.retry import retry_callback
+
+logger = logging.getLogger(__name__)
+
+_RETRY_AFTER_PREFIX = "retry-after-"
+_RATE_LIMIT_REMAINING_PREFIX = "x-ratelimit-remaining-"
+_KNOWN_THROTTLERS = ("sandbox-create", "sandbox-lifecycle", "authenticated", "anonymous")
+
+
+def _parse_retry_after_seconds(value: object) -> float | None:
+    try:
+        seconds = float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+    if seconds < 0:
+        return None
+
+    return seconds
+
+
+def _get_header(headers: Mapping[str, object], header_name: str) -> object | None:
+    header_name_lower = header_name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == header_name_lower:
+            return value
+
+    return None
+
+
+def daytona_rate_limit_throttler(exc: DaytonaRateLimitError) -> str:
+    for key in exc.headers:
+        lower_key = str(key).lower()
+        if lower_key.startswith(_RETRY_AFTER_PREFIX):
+            return lower_key.removeprefix(_RETRY_AFTER_PREFIX)
+        if lower_key.startswith(_RATE_LIMIT_REMAINING_PREFIX):
+            return lower_key.removeprefix(_RATE_LIMIT_REMAINING_PREFIX)
+
+    return "unknown"
+
+
+def _daytona_rate_limit_header(exc: DaytonaRateLimitError, prefix: str, throttler: str) -> object | None:
+    if throttler == "unknown":
+        return None
+
+    return _get_header(exc.headers, f"{prefix}{throttler}")
+
+
+def daytona_retry_after_seconds(exc: DaytonaRateLimitError) -> float | None:
+    headers: Mapping[str, object] = exc.headers
+
+    for throttler in _KNOWN_THROTTLERS:
+        value = _get_header(headers, f"retry-after-{throttler}")
+        seconds = _parse_retry_after_seconds(value)
+        if seconds is not None:
+            return seconds
+
+    value = _get_header(headers, "retry-after")
+    seconds = _parse_retry_after_seconds(value)
+    if seconds is not None:
+        return seconds
+
+    for key, value in headers.items():
+        if str(key).lower().startswith(_RETRY_AFTER_PREFIX):
+            seconds = _parse_retry_after_seconds(value)
+            if seconds is not None:
+                return seconds
+
+    return None
+
+
+class wait_daytona_rate_limit(wait_base):
+    def __init__(self, fallback: wait_base, *, max_retry_after_seconds: float = 60.0) -> None:
+        self._fallback = fallback
+        self._max_retry_after_seconds = max_retry_after_seconds
+
+    def __call__(self, retry_state: RetryCallState) -> float:
+        exc = retry_state.outcome.exception() if retry_state.outcome else None
+        if isinstance(exc, DaytonaRateLimitError):
+            seconds = daytona_retry_after_seconds(exc)
+            if seconds is not None:
+                return min(seconds, self._max_retry_after_seconds)
+
+        return self._fallback(retry_state)
+
+
+def daytona_retry_callback(
+    metric_name: str,
+    *,
+    op: str,
+    log_level: int = logging.WARNING,
+) -> Callable[[RetryCallState], None]:
+    base_callback = retry_callback(metric_name, log_level=log_level)
+
+    def _hook(state: RetryCallState) -> None:
+        base_callback(state)
+
+        exc = state.outcome.exception() if state.outcome else None
+        if not isinstance(exc, DaytonaRateLimitError):
+            return
+
+        throttler = daytona_rate_limit_throttler(exc)
+        sleep_seconds = state.next_action.sleep if state.next_action else None
+        logger.warning(
+            "daytona.rate_limit_retry",
+            extra={
+                "op": op,
+                "throttler": throttler,
+                "attempt": state.attempt_number,
+                "sleep_seconds": sleep_seconds,
+                "rate_limit_remaining": _daytona_rate_limit_header(exc, "x-ratelimit-remaining-", throttler),
+                "rate_limit_reset": _daytona_rate_limit_header(exc, "x-ratelimit-reset-", throttler),
+            },
+        )
+        tags = {"op": op, "throttler": throttler}
+        incr("valkyrie.daytona.rate_limit.retry", tags=tags)
+        if sleep_seconds is not None:
+            distribution("valkyrie.daytona.rate_limit.retry_sleep", sleep_seconds, tags=tags)
+
+    return _hook

--- a/services/tracker/src/tracker/daytona_retry.py
+++ b/services/tracker/src/tracker/daytona_retry.py
@@ -42,9 +42,11 @@ def daytona_rate_limit_throttler(exc: DaytonaRateLimitError) -> str:
     for key in exc.headers:
         lower_key = str(key).lower()
         if lower_key.startswith(_RETRY_AFTER_PREFIX):
-            return lower_key.removeprefix(_RETRY_AFTER_PREFIX)
+            throttler = lower_key.removeprefix(_RETRY_AFTER_PREFIX)
+            return throttler if throttler in _KNOWN_THROTTLERS else "unknown"
         if lower_key.startswith(_RATE_LIMIT_REMAINING_PREFIX):
-            return lower_key.removeprefix(_RATE_LIMIT_REMAINING_PREFIX)
+            throttler = lower_key.removeprefix(_RATE_LIMIT_REMAINING_PREFIX)
+            return throttler if throttler in _KNOWN_THROTTLERS else "unknown"
 
     return "unknown"
 

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import daytona
 import sentry_sdk
+from daytona.common.errors import DaytonaRateLimitError
 from opentelemetry.trace import get_current_span
 from sentry_sdk.consts import INSTRUMENTER
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -144,3 +145,5 @@ def tag_daytona_error(exc: Exception, *, op: str) -> None:
         logger.warning("tag_daytona_error failed: %s: %s", type(e).__name__, e)
 
     incr("valkyrie.daytona.error", tags={"op": op, "error_class": error_class})
+    if isinstance(exc, DaytonaRateLimitError):
+        incr("valkyrie.daytona.rate_limit.error", tags={"op": op})

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -75,7 +75,7 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
 @retry(
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(3),
-    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(2)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.delete", op="sandbox.delete"),
     reraise=True,
 )
@@ -136,7 +136,7 @@ def _set_sandbox_span_attributes(sandbox: AsyncSandbox) -> None:
 @retry(
     retry=retry_if_not_exception_type(InvalidSandboxConfigurationError),
     stop=stop_after_attempt(3),
-    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_exponential(multiplier=1, min=5, max=30)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.create", op="sandbox.create"),
     reraise=True,
 )
@@ -375,6 +375,7 @@ _SUCCESS_EXIT_CODE: int = 0
 
 # Process exec retry settings
 _EXEC_MAX_ATTEMPTS: int = 3
+_EXEC_DELAY_SECONDS: float = 2.0
 
 # Reconnect to the PTY retry settings
 _PTY_RECONNECT_MAX_ATTEMPTS: int = 10
@@ -382,6 +383,7 @@ _PTY_RECONNECT_DELAY_SECONDS: float = 1.0
 
 # Creating a PTY retry settings
 _PTY_CREATE_MAX_ATTEMPTS: int = 5
+_PTY_CREATE_DELAY_SECONDS: float = 2.0
 
 # Process-global cap on concurrent PTY WebSocket handshakes.
 # Daytona starts failing above ~500 concurrent handshakes; 100 held 800 PTYs cleanly in testing.
@@ -466,7 +468,7 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
 @retry(
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(_EXEC_MAX_ATTEMPTS),
-    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(_EXEC_DELAY_SECONDS)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.exec", op="sandbox.exec"),
     reraise=True,
 )
@@ -489,7 +491,7 @@ async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
 @retry(
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(_PTY_CREATE_MAX_ATTEMPTS),
-    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(_PTY_CREATE_DELAY_SECONDS)),
     before_sleep=daytona_retry_callback("valkyrie.pty.create", op="pty.create"),
     reraise=True,
 )
@@ -550,7 +552,7 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
 @retry(
     retry=retry_if_not_exception_type(SandboxError),
     stop=stop_after_attempt(_PTY_RECONNECT_MAX_ATTEMPTS),
-    wait=wait_daytona_rate_limit(wait_fixed(_PTY_RECONNECT_DELAY_SECONDS)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(_PTY_RECONNECT_DELAY_SECONDS)),
     before_sleep=daytona_retry_callback("valkyrie.pty.reconnect", op="pty.reconnect"),
     reraise=True,
 )

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -33,6 +33,7 @@ from tenacity import (
     retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential,
+    wait_fixed,
 )
 
 from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
@@ -377,6 +378,7 @@ _EXEC_MAX_ATTEMPTS: int = 3
 
 # Reconnect to the PTY retry settings
 _PTY_RECONNECT_MAX_ATTEMPTS: int = 10
+_PTY_RECONNECT_DELAY_SECONDS: float = 1.0
 
 # Creating a PTY retry settings
 _PTY_CREATE_MAX_ATTEMPTS: int = 5
@@ -548,7 +550,7 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
 @retry(
     retry=retry_if_not_exception_type(SandboxError),
     stop=stop_after_attempt(_PTY_RECONNECT_MAX_ATTEMPTS),
-    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    wait=wait_daytona_rate_limit(wait_fixed(_PTY_RECONNECT_DELAY_SECONDS)),
     before_sleep=daytona_retry_callback("valkyrie.pty.reconnect", op="pty.reconnect"),
     reraise=True,
 )

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -33,9 +33,9 @@ from tenacity import (
     retry_if_not_exception_type,
     stop_after_attempt,
     wait_exponential,
-    wait_fixed,
 )
 
+from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
 from tracker.database.models import AgentCausedExitReason, AgentContractRequest
 from tracker.exceptions import (
     AgentRunFailedError,
@@ -74,8 +74,8 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
 @retry(
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(3),
-    wait=wait_fixed(2),
-    before_sleep=retry_callback("valkyrie.sandbox.delete"),
+    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    before_sleep=daytona_retry_callback("valkyrie.sandbox.delete", op="sandbox.delete"),
     reraise=True,
 )
 async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
@@ -135,8 +135,8 @@ def _set_sandbox_span_attributes(sandbox: AsyncSandbox) -> None:
 @retry(
     retry=retry_if_not_exception_type(InvalidSandboxConfigurationError),
     stop=stop_after_attempt(3),
-    wait=wait_exponential(multiplier=1, min=5, max=30),
-    before_sleep=retry_callback("valkyrie.sandbox.create"),
+    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    before_sleep=daytona_retry_callback("valkyrie.sandbox.create", op="sandbox.create"),
     reraise=True,
 )
 @logfire.instrument("sandbox.create", extract_args=False)
@@ -374,15 +374,12 @@ _SUCCESS_EXIT_CODE: int = 0
 
 # Process exec retry settings
 _EXEC_MAX_ATTEMPTS: int = 3
-_EXEC_DELAY_SECONDS: float = 2.0
 
 # Reconnect to the PTY retry settings
 _PTY_RECONNECT_MAX_ATTEMPTS: int = 10
-_PTY_RECONNECT_DELAY_SECONDS: float = 1.0
 
 # Creating a PTY retry settings
 _PTY_CREATE_MAX_ATTEMPTS: int = 5
-_PTY_CREATE_DELAY_SECONDS: float = 2.0
 
 # Process-global cap on concurrent PTY WebSocket handshakes.
 # Daytona starts failing above ~500 concurrent handshakes; 100 held 800 PTYs cleanly in testing.
@@ -467,8 +464,8 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
 @retry(
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(_EXEC_MAX_ATTEMPTS),
-    wait=wait_fixed(_EXEC_DELAY_SECONDS),
-    before_sleep=retry_callback("valkyrie.sandbox.exec"),
+    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    before_sleep=daytona_retry_callback("valkyrie.sandbox.exec", op="sandbox.exec"),
     reraise=True,
 )
 @logfire.instrument("sandbox.exec", extract_args=False)
@@ -490,8 +487,8 @@ async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
 @retry(
     retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(_PTY_CREATE_MAX_ATTEMPTS),
-    wait=wait_fixed(_PTY_CREATE_DELAY_SECONDS),
-    before_sleep=retry_callback("valkyrie.pty.create"),
+    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    before_sleep=daytona_retry_callback("valkyrie.pty.create", op="pty.create"),
     reraise=True,
 )
 @logfire.instrument("pty.create", extract_args=False)
@@ -551,8 +548,8 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
 @retry(
     retry=retry_if_not_exception_type(SandboxError),
     stop=stop_after_attempt(_PTY_RECONNECT_MAX_ATTEMPTS),
-    wait=wait_fixed(_PTY_RECONNECT_DELAY_SECONDS),
-    before_sleep=retry_callback("valkyrie.pty.reconnect"),
+    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    before_sleep=daytona_retry_callback("valkyrie.pty.reconnect", op="pty.reconnect"),
     reraise=True,
 )
 @logfire.instrument("pty.reconnect", extract_args=False)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -16,12 +16,12 @@ import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from daytona.common.errors import DaytonaError, DaytonaNotFoundError
+from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import Request
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
-from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
+from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
 from tenacity import retry as tenacity_retry
 
 from tracker._lambda import invoke_lambda
@@ -1126,9 +1126,9 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
 
 
 @tenacity_retry(
-    retry=retry_if_exception_type(DaytonaError),
+    retry=retry_if_exception_type(DaytonaRateLimitError),
     stop=stop_after_attempt(5),
-    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(0)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,
 )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -16,12 +16,12 @@ import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from daytona.common.errors import DaytonaNotFoundError
+from daytona.common.errors import DaytonaError, DaytonaNotFoundError
 from fastapi import Request
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
-from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
+from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential, wait_fixed
 from tenacity import retry as tenacity_retry
 
 from tracker._lambda import invoke_lambda
@@ -48,6 +48,7 @@ from tracker.database.models import (
 )
 from tracker.database.scoping import scoped_select
 from tracker.database.session import engine
+from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
 from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
@@ -1124,6 +1125,13 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
         return f"{str(e)}: {traceback.format_exc()}"
 
 
+@tenacity_retry(
+    retry=retry_if_exception_type(DaytonaError),
+    stop=stop_after_attempt(5),
+    wait=wait_daytona_rate_limit(wait_exponential(multiplier=1, min=1, max=30)),
+    before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
+    reraise=True,
+)
 async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona, page: int) -> AsyncPaginatedSandboxes:
     return await daytona_client.list(
         labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page

--- a/services/tracker/tests/unit/test_observability.py
+++ b/services/tracker/tests/unit/test_observability.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from daytona.common.errors import DaytonaRateLimitError
 
 
 def _observability() -> Any:
@@ -344,6 +345,30 @@ def test_tag_daytona_error_sets_tags_and_metric(monkeypatch: pytest.MonkeyPatch)
                 "error_class": "TimeoutError",
             },
         )
+    ]
+
+
+def test_tag_daytona_error_emits_rate_limit_metric(monkeypatch: pytest.MonkeyPatch) -> None:
+    observability = _sentry()
+    increments: list[tuple[str, dict[str, str]]] = []
+
+    def fake_incr(name: str, value: float = 1, tags: dict[str, str] | None = None) -> None:
+        increments.append((name, tags or {}))
+
+    monkeypatch.setattr(observability.sentry_sdk, "set_tag", Mock())
+    monkeypatch.setattr(observability, "incr", fake_incr)
+
+    observability.tag_daytona_error(DaytonaRateLimitError("rate limited"), op="sandbox.create")
+
+    assert increments == [
+        (
+            "valkyrie.daytona.error",
+            {
+                "op": "sandbox.create",
+                "error_class": "DaytonaRateLimitError",
+            },
+        ),
+        ("valkyrie.daytona.rate_limit.error", {"op": "sandbox.create"}),
     ]
 
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -12,6 +12,7 @@ from tenacity import stop_after_attempt, wait_none
 
 import tracker.daytona_retry as daytona_retry_module
 import tracker.observability.retry as retry_module
+import tracker.utils as utils_module
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
@@ -27,6 +28,7 @@ _install_agent_dependencies = getattr(sandbox_module, "install_agent_dependencie
 _reconnect_and_wait_pty = getattr(sandbox_module, "_reconnect_and_wait_pty")
 _upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
 _wait_for_pty = getattr(sandbox_module, "_wait_for_pty")
+_fetch_sandboxes = getattr(utils_module, "fetch_sandboxes")
 
 
 def _ignore_pty_data(_data: bytes) -> None:
@@ -396,7 +398,7 @@ class TestAgentOutputTelemetry:
 
         assert wait_strategy(retry_state) == 4
 
-    def test_daytona_retry_wait_caps_retry_after_header(self) -> None:
+    def test_daytona_retry_wait_uses_retry_after_header_without_local_cap(self) -> None:
         retry_state = Mock()
         retry_state.outcome.exception.return_value = DaytonaRateLimitError(
             "rate limited",
@@ -404,7 +406,7 @@ class TestAgentOutputTelemetry:
         )
         wait_strategy = _create_sandbox.retry.wait
 
-        assert wait_strategy(retry_state) == 60
+        assert wait_strategy(retry_state) == 120
 
     @pytest.mark.parametrize(
         "headers", [{}, {"Retry-After-Sandbox-Create": "bad"}, {"Retry-After-Sandbox-Create": "-1"}]
@@ -417,21 +419,44 @@ class TestAgentOutputTelemetry:
 
         assert wait_strategy(retry_state) == 2
 
-    def test_daytona_retry_wait_falls_back_for_non_rate_limit_errors(self) -> None:
-        retry_state = Mock()
-        retry_state.attempt_number = 2
-        retry_state.outcome.exception.return_value = DaytonaError("transient")
-        wait_strategy = _create_sandbox.retry.wait
+    def test_daytona_retry_wait_preserves_non_rate_limit_waits(self) -> None:
+        cases = [
+            (_delete_sandbox.retry.wait, 4, 2),
+            (_create_sandbox.retry.wait, 2, 5),
+            (_exec.retry.wait, 4, 2),
+            (_create_pty_session.retry.wait, 4, 2),
+            (_reconnect_and_wait_pty.retry.wait, 4, 1),
+        ]
 
-        assert wait_strategy(retry_state) == 2
+        for wait_strategy, attempt_number, expected_seconds in cases:
+            retry_state = Mock()
+            retry_state.attempt_number = attempt_number
+            retry_state.outcome.exception.return_value = DaytonaError("transient")
 
-    def test_pty_reconnect_retry_wait_keeps_fast_fallback_for_non_rate_limit_errors(self) -> None:
+            assert wait_strategy(retry_state) == expected_seconds
+
+    @pytest.mark.parametrize("headers", [{}, {"Retry-After-Sandbox-Lifecycle": "bad"}])
+    def test_pty_reconnect_retry_wait_uses_exponential_fallback_for_rate_limits(self, headers: dict[str, str]) -> None:
         retry_state = Mock()
         retry_state.attempt_number = 4
-        retry_state.outcome.exception.return_value = DaytonaError("transient")
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError("rate limited", headers=headers)
         wait_strategy = _reconnect_and_wait_pty.retry.wait
 
-        assert wait_strategy(retry_state) == 1
+        assert wait_strategy(retry_state) == 8
+
+    async def test_fetch_sandboxes_does_not_retry_non_rate_limit_daytona_errors(self) -> None:
+        benchmark = Mock()
+        benchmark.name = "benchmark"
+        benchmark.id = "benchmark-id"
+        daytona_client = AsyncMock()
+        daytona_client.list = AsyncMock(side_effect=DaytonaError("transient"))
+
+        with pytest.raises(DaytonaError):
+            await _fetch_sandboxes.retry_with(stop=stop_after_attempt(3), wait=wait_none())(
+                benchmark, daytona_client, 1
+            )
+
+        assert daytona_client.list.await_count == 1
 
     def test_daytona_retry_callback_emits_rate_limit_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
         increments: list[tuple[str, dict[str, str]]] = []

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from daytona import ExecuteResponse, SandboxState
-from daytona.common.errors import DaytonaError
+from daytona.common.errors import DaytonaError, DaytonaRateLimitError
 from tenacity import stop_after_attempt, wait_none
 
 from tracker import sandbox as sandbox_module
@@ -367,6 +367,101 @@ class TestAgentOutputTelemetry:
         assert callable(delete_before_sleep)
         assert callable(upload_before_sleep)
         assert callable(deps_before_sleep)
+
+    def test_daytona_retry_wait_uses_retry_after_header(self) -> None:
+        retry_state = Mock()
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={"Retry-After-Sandbox-Create": "7"},
+        )
+        wait_strategy = _create_sandbox.retry.wait
+
+        assert wait_strategy(retry_state) == 7
+
+    def test_daytona_retry_wait_caps_retry_after_header(self) -> None:
+        retry_state = Mock()
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={"retry-after-sandbox-create": "120"},
+        )
+        wait_strategy = _create_sandbox.retry.wait
+
+        assert wait_strategy(retry_state) == 60
+
+    def test_daytona_retry_wait_falls_back_to_exponential_backoff(self) -> None:
+        retry_state = Mock()
+        retry_state.attempt_number = 2
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError("rate limited")
+        wait_strategy = _create_sandbox.retry.wait
+
+        assert wait_strategy(retry_state) == 2
+
+    def test_daytona_retry_callback_emits_rate_limit_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        increments: list[tuple[str, dict[str, str]]] = []
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        log_records: list[dict[str, Any]] = []
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_warning(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
+
+        import tracker.daytona_retry as daytona_retry_module
+        import tracker.observability.retry as retry_module
+
+        monkeypatch.setattr(retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(daytona_retry_module.logger, "warning", fake_warning)
+
+        state = Mock()
+        state.attempt_number = 1
+        state.fn.__name__ = "_create_sandbox"
+        state.idle_for = 0
+        state.next_action.sleep = 7
+        state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={
+                "Retry-After-Sandbox-Create": "7",
+                "X-RateLimit-Remaining-Sandbox-Create": "0",
+                "X-RateLimit-Reset-Sandbox-Create": "7",
+            },
+        )
+        callback = _create_sandbox.retry.before_sleep
+        assert callback is not None
+
+        callback(state)
+
+        assert ("valkyrie.sandbox.create.retry", {"error_class": "DaytonaRateLimitError"}) in increments
+        assert (
+            "valkyrie.daytona.rate_limit.retry",
+            {"op": "sandbox.create", "throttler": "sandbox-create"},
+        ) in increments
+        assert distributions == [
+            (
+                "valkyrie.daytona.rate_limit.retry_sleep",
+                7,
+                {"op": "sandbox.create", "throttler": "sandbox-create"},
+            )
+        ]
+        assert log_records == [
+            {
+                "message": "daytona.rate_limit_retry",
+                "op": "sandbox.create",
+                "throttler": "sandbox-create",
+                "attempt": 1,
+                "sleep_seconds": 7,
+                "rate_limit_remaining": "0",
+                "rate_limit_reset": "7",
+            }
+        ]
 
     def test_metric_image_name_drops_high_cardinality_tag_and_digest(self) -> None:
         metric_image_name = getattr(sandbox_module, "_metric_image_name")

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -378,6 +378,26 @@ class TestAgentOutputTelemetry:
 
         assert wait_strategy(retry_state) == 7
 
+    def test_daytona_retry_wait_uses_generic_retry_after_header(self) -> None:
+        retry_state = Mock()
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={"Retry-After": "3"},
+        )
+        wait_strategy = _create_sandbox.retry.wait
+
+        assert wait_strategy(retry_state) == 3
+
+    def test_daytona_retry_wait_uses_unknown_throttler_retry_after_header(self) -> None:
+        retry_state = Mock()
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={"Retry-After-Custom-Throttler": "4"},
+        )
+        wait_strategy = _create_sandbox.retry.wait
+
+        assert wait_strategy(retry_state) == 4
+
     def test_daytona_retry_wait_caps_retry_after_header(self) -> None:
         retry_state = Mock()
         retry_state.outcome.exception.return_value = DaytonaRateLimitError(
@@ -388,10 +408,21 @@ class TestAgentOutputTelemetry:
 
         assert wait_strategy(retry_state) == 60
 
-    def test_daytona_retry_wait_falls_back_to_exponential_backoff(self) -> None:
+    @pytest.mark.parametrize(
+        "headers", [{}, {"Retry-After-Sandbox-Create": "bad"}, {"Retry-After-Sandbox-Create": "-1"}]
+    )
+    def test_daytona_retry_wait_falls_back_to_exponential_backoff(self, headers: dict[str, str]) -> None:
         retry_state = Mock()
         retry_state.attempt_number = 2
-        retry_state.outcome.exception.return_value = DaytonaRateLimitError("rate limited")
+        retry_state.outcome.exception.return_value = DaytonaRateLimitError("rate limited", headers=headers)
+        wait_strategy = _create_sandbox.retry.wait
+
+        assert wait_strategy(retry_state) == 2
+
+    def test_daytona_retry_wait_falls_back_for_non_rate_limit_errors(self) -> None:
+        retry_state = Mock()
+        retry_state.attempt_number = 2
+        retry_state.outcome.exception.return_value = DaytonaError("transient")
         wait_strategy = _create_sandbox.retry.wait
 
         assert wait_strategy(retry_state) == 2
@@ -462,6 +493,88 @@ class TestAgentOutputTelemetry:
                 "rate_limit_reset": "7",
             }
         ]
+
+    def test_daytona_retry_callback_uses_remaining_header_for_throttler(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tracker.daytona_retry as daytona_retry_module
+        import tracker.observability.retry as retry_module
+
+        increments: list[tuple[str, dict[str, str]]] = []
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        log_records: list[dict[str, Any]] = []
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_warning(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr(retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(daytona_retry_module.logger, "warning", fake_warning)
+
+        state = Mock()
+        state.attempt_number = 1
+        state.fn.__name__ = "_create_sandbox"
+        state.idle_for = 0
+        state.next_action = None
+        state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={"X-RateLimit-Remaining-Sandbox-Lifecycle": "0"},
+        )
+        callback = _create_sandbox.retry.before_sleep
+        assert callback is not None
+
+        callback(state)
+
+        assert (
+            "valkyrie.daytona.rate_limit.retry",
+            {"op": "sandbox.create", "throttler": "sandbox-lifecycle"},
+        ) in increments
+        assert distributions == []
+        assert log_records[0]["throttler"] == "sandbox-lifecycle"
+        assert log_records[0]["rate_limit_remaining"] == "0"
+        assert log_records[0]["rate_limit_reset"] is None
+
+    def test_daytona_retry_callback_ignores_non_rate_limit_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import tracker.daytona_retry as daytona_retry_module
+        import tracker.observability.retry as retry_module
+
+        increments: list[tuple[str, dict[str, str]]] = []
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        log_records: list[dict[str, Any]] = []
+
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_warning(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr(retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(daytona_retry_module.logger, "warning", fake_warning)
+
+        state = Mock()
+        state.attempt_number = 1
+        state.fn.__name__ = "_create_sandbox"
+        state.idle_for = 0
+        state.next_action.sleep = 2
+        state.outcome.exception.return_value = DaytonaError("transient")
+        callback = _create_sandbox.retry.before_sleep
+        assert callback is not None
+
+        callback(state)
+
+        assert increments == [("valkyrie.sandbox.create.retry", {"error_class": "DaytonaError"})]
+        assert distributions == []
+        assert log_records == []
 
     def test_metric_image_name_drops_high_cardinality_tag_and_digest(self) -> None:
         metric_image_name = getattr(sandbox_module, "_metric_image_name")

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -10,6 +10,8 @@ from daytona import ExecuteResponse, SandboxState
 from daytona.common.errors import DaytonaError, DaytonaRateLimitError
 from tenacity import stop_after_attempt, wait_none
 
+import tracker.daytona_retry as daytona_retry_module
+import tracker.observability.retry as retry_module
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
@@ -59,16 +61,14 @@ class TestPtyHandshakeSemaphore:
         def fake_set_span_attrs(sandbox: Any, session_id: str) -> None:
             span_calls.append((sandbox.id, sandbox.name, session_id))
 
+        def fake_set_pty_context(*, session_id: str, attempt: int | None = None) -> None:
+            pty_context_calls.append(session_id)
+
         monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
         monkeypatch.setattr(sandbox_module, "gauge", fake_gauge, raising=False)
         monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
         monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", fake_set_span_attrs, raising=False)
-        monkeypatch.setattr(
-            sandbox_module,
-            "set_pty_context",
-            lambda *, session_id, attempt=None: pty_context_calls.append(session_id),
-            raising=False,
-        )
+        monkeypatch.setattr(sandbox_module, "set_pty_context", fake_set_pty_context, raising=False)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -128,17 +128,15 @@ class TestPtyHandshakeSemaphore:
         def fake_set_span_attrs(sandbox: Any, session_id: str) -> None:
             span_calls.append((sandbox.id, sandbox.name, session_id))
 
+        def fake_set_pty_context(*, session_id: str, attempt: int | None = None) -> None:
+            pty_context_calls.append(session_id)
+
         monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
         monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
         monkeypatch.setattr(sandbox_module, "gauge", fake_gauge, raising=False)
         monkeypatch.setattr(sandbox_module.logger, "info", fake_info)
         monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", fake_set_span_attrs, raising=False)
-        monkeypatch.setattr(
-            sandbox_module,
-            "set_pty_context",
-            lambda *, session_id, attempt=None: pty_context_calls.append(session_id),
-            raising=False,
-        )
+        monkeypatch.setattr(sandbox_module, "set_pty_context", fake_set_pty_context, raising=False)
         monkeypatch.setattr(sandbox_module, "_check_sandbox_health", AsyncMock())
 
         mock_handle = AsyncMock()
@@ -427,6 +425,14 @@ class TestAgentOutputTelemetry:
 
         assert wait_strategy(retry_state) == 2
 
+    def test_pty_reconnect_retry_wait_keeps_fast_fallback_for_non_rate_limit_errors(self) -> None:
+        retry_state = Mock()
+        retry_state.attempt_number = 4
+        retry_state.outcome.exception.return_value = DaytonaError("transient")
+        wait_strategy = _reconnect_and_wait_pty.retry.wait
+
+        assert wait_strategy(retry_state) == 1
+
     def test_daytona_retry_callback_emits_rate_limit_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
         increments: list[tuple[str, dict[str, str]]] = []
         distributions: list[tuple[str, float, dict[str, str]]] = []
@@ -443,9 +449,6 @@ class TestAgentOutputTelemetry:
 
         monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
         monkeypatch.setattr(sandbox_module, "distribution", fake_distribution, raising=False)
-
-        import tracker.daytona_retry as daytona_retry_module
-        import tracker.observability.retry as retry_module
 
         monkeypatch.setattr(retry_module, "incr", fake_incr, raising=False)
         monkeypatch.setattr(daytona_retry_module, "incr", fake_incr, raising=False)
@@ -495,9 +498,6 @@ class TestAgentOutputTelemetry:
         ]
 
     def test_daytona_retry_callback_uses_remaining_header_for_throttler(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import tracker.daytona_retry as daytona_retry_module
-        import tracker.observability.retry as retry_module
-
         increments: list[tuple[str, dict[str, str]]] = []
         distributions: list[tuple[str, float, dict[str, str]]] = []
         log_records: list[dict[str, Any]] = []
@@ -539,10 +539,60 @@ class TestAgentOutputTelemetry:
         assert log_records[0]["rate_limit_remaining"] == "0"
         assert log_records[0]["rate_limit_reset"] is None
 
-    def test_daytona_retry_callback_ignores_non_rate_limit_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import tracker.daytona_retry as daytona_retry_module
-        import tracker.observability.retry as retry_module
+    def test_daytona_retry_callback_collapses_unknown_throttler_metric_tag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        increments: list[tuple[str, dict[str, str]]] = []
+        distributions: list[tuple[str, float, dict[str, str]]] = []
+        log_records: list[dict[str, Any]] = []
 
+        def fake_incr(name: str, value: float = 1, tags: Mapping[str, Any] | None = None) -> None:
+            increments.append((name, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_distribution(name: str, value: float, tags: Mapping[str, Any] | None = None) -> None:
+            distributions.append((name, value, {str(k): str(v) for k, v in (tags or {}).items()}))
+
+        def fake_warning(message: str, *args: object, extra: dict[str, Any] | None = None, **kwargs: Any) -> None:
+            log_records.append({"message": message, **(extra or {})})
+
+        monkeypatch.setattr(retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "incr", fake_incr, raising=False)
+        monkeypatch.setattr(daytona_retry_module, "distribution", fake_distribution, raising=False)
+        monkeypatch.setattr(daytona_retry_module.logger, "warning", fake_warning)
+
+        state = Mock()
+        state.attempt_number = 1
+        state.fn.__name__ = "_create_sandbox"
+        state.idle_for = 0
+        state.next_action.sleep = 4
+        state.outcome.exception.return_value = DaytonaRateLimitError(
+            "rate limited",
+            headers={
+                "Retry-After-Custom-Tenant": "4",
+                "X-RateLimit-Remaining-Custom-Tenant": "0",
+            },
+        )
+        callback = _create_sandbox.retry.before_sleep
+        assert callback is not None
+
+        callback(state)
+
+        assert (
+            "valkyrie.daytona.rate_limit.retry",
+            {"op": "sandbox.create", "throttler": "unknown"},
+        ) in increments
+        assert distributions == [
+            (
+                "valkyrie.daytona.rate_limit.retry_sleep",
+                4,
+                {"op": "sandbox.create", "throttler": "unknown"},
+            )
+        ]
+        assert log_records[0]["throttler"] == "unknown"
+        assert log_records[0]["rate_limit_remaining"] is None
+        assert log_records[0]["rate_limit_reset"] is None
+
+    def test_daytona_retry_callback_ignores_non_rate_limit_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
         increments: list[tuple[str, dict[str, str]]] = []
         distributions: list[tuple[str, float, dict[str, str]]] = []
         log_records: list[dict[str, Any]] = []
@@ -1034,7 +1084,11 @@ class TestStreamCommandOutputAgentFailure:
         monkeypatch.setattr(sandbox_module, "_read_exit_code", _mock_read_exit_code)
 
         tagged: dict[str, str] = {}
-        monkeypatch.setattr(sandbox_module.sentry_sdk, "set_tag", lambda key, value: tagged.__setitem__(key, value))
+
+        def fake_set_tag(key: str, value: object) -> None:
+            tagged[key] = str(value)
+
+        monkeypatch.setattr(sandbox_module.sentry_sdk, "set_tag", fake_set_tag)
 
         with pytest.raises(AgentRunFailedError) as exc_info:
             await stream_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)


### PR DESCRIPTION
## Summary
Audits the Tracker Daytona integration against Daytona's rate-limit best practices and tightens retry behavior around `DaytonaRateLimitError`. Daytona SDK calls now honor `Retry-After-*` headers when present, while preserving fast PTY reconnect retries for non-rate-limit failures.

https://www.daytona.io/docs/en/limits/#best-practices

## Changes
- Added Daytona retry helpers that use `Retry-After-{throttler}` headers when present, otherwise fall back to the retry site's configured wait strategy.
- Switched sandbox create/delete/exec, PTY create, and sandbox list Daytona retry sites to the shared Daytona-aware wait/callback helper.
- Kept PTY reconnect's non-rate-limit fallback at the prior fixed 1s cadence while still honoring Daytona retry-after headers for rate-limit responses.
- Added retry coverage for Daytona sandbox list calls used by force-stop cleanup.
- Added low-cardinality metrics/log fields for Daytona 429 retries/errors, including throttler, remaining, reset, and sleep duration where available.
- Collapsed unknown Daytona throttler metric tags to `unknown` to avoid unbounded tag cardinality.
- Added unit coverage for retry-after parsing, cap behavior, fallback behavior, throttler detection, non-429 fallback behavior, low-cardinality unknown throttlers, and 429 retry/error telemetry.
- Moved new retry-helper test imports to top level and typed touched test helpers.

## Related Issues
https://github.com/vals-ai/valkyrie-ticket-library/issues/54

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested
- `cd services/tracker && uv run pytest tests/unit/test_sandbox.py -k "pty_reconnect_retry_wait_keeps_fast_fallback or daytona_retry_callback_collapses_unknown_throttler_metric_tag"`
- `cd services/tracker && uv run pytest tests/unit/test_sandbox.py`
- `cd services/tracker && make test-unit`
- `cd services/tracker && uv run ruff format --check .`
- `cd services/tracker && uv run ruff check .`
- `cd services/tracker && uv run basedpyright src/tracker/daytona_retry.py src/tracker/sandbox.py tests/unit/test_sandbox.py`
- `git diff --check`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/c53defea9b1c475eae4e848fff303979
Requested by: @BradenBug
