### PR TITLE
fix: wrap WS calls in asyncio.wait_for to prevent semaphore deadlock

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -68,6 +68,8 @@ logger = get_logger(__name__)
 
 _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
+_WS_SETUP_TIMEOUT: float = 1800
+_WS_EVAL_TIMEOUT: float = 3600
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -424,13 +426,22 @@ async def process_task(
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
-                evaluation_result = await benchmark_service.resume_evaluation(
-                    task_row.task_id,
-                    eval_resume_state=task_row.eval_resume_state,
-                    on_message=log_output,
-                    on_eval_resume_state=on_eval_resume_state,
-                    dataset=start_benchmark_request.dataset,
-                )
+                try:
+                    evaluation_result = await asyncio.wait_for(
+                        benchmark_service.resume_evaluation(
+                            task_row.task_id,
+                            eval_resume_state=task_row.eval_resume_state,
+                            on_message=log_output,
+                            on_eval_resume_state=on_eval_resume_state,
+                            dataset=start_benchmark_request.dataset,
+                        ),
+                        timeout=_WS_EVAL_TIMEOUT,
+                    )
+                except TimeoutError:
+                    raise BenchmarkServiceError(
+                        f"resume_evaluation timed out after {_WS_EVAL_TIMEOUT}s for task {task_row.task_id} — "
+                        f"possible half-open WebSocket connection"
+                    )
                 evaluation_result_row = EvaluationResult(
                     org_id=org.id,
                     task=task_row.id,
@@ -496,9 +507,18 @@ async def process_task(
                     harness_config.s3_bucket,
                 )
 
-                _ = await benchmark_service.setup_task(
-                    task_row.task_id, sandbox.id, on_message=log_output, dataset=start_benchmark_request.dataset
-                )
+                try:
+                    _ = await asyncio.wait_for(
+                        benchmark_service.setup_task(
+                            task_row.task_id, sandbox.id, on_message=log_output, dataset=start_benchmark_request.dataset
+                        ),
+                        timeout=_WS_SETUP_TIMEOUT,
+                    )
+                except TimeoutError:
+                    raise BenchmarkServiceError(
+                        f"setup_task timed out after {_WS_SETUP_TIMEOUT}s for task {task_row.task_id} — "
+                        f"possible half-open WebSocket connection"
+                    )
 
                 # Force flush the logs if anything has been buffered
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
@@ -547,13 +567,23 @@ async def process_task(
                     },
                 )
                 logger.info(f"Evaluating agent {start_benchmark_request.contract.name} in sandbox {sandbox.name}")
-                evaluation_result = await benchmark_service.evaluate_instance(
-                    task_row.task_id,
-                    sandbox.id,
-                    on_message=log_output,
-                    on_eval_resume_state=on_eval_resume_state,
-                    dataset=start_benchmark_request.dataset,
-                )
+                eval_timeout = task_data.agent_timeout if task_data.agent_timeout else _WS_EVAL_TIMEOUT
+                try:
+                    evaluation_result = await asyncio.wait_for(
+                        benchmark_service.evaluate_instance(
+                            task_row.task_id,
+                            sandbox.id,
+                            on_message=log_output,
+                            on_eval_resume_state=on_eval_resume_state,
+                            dataset=start_benchmark_request.dataset,
+                        ),
+                        timeout=eval_timeout,
+                    )
+                except TimeoutError:
+                    raise BenchmarkServiceError(
+                        f"evaluate_instance timed out after {eval_timeout}s for task {task_row.task_id} — "
+                        f"possible half-open WebSocket connection"
+                    )
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -72,6 +72,12 @@ _WS_SETUP_TIMEOUT: float = 1800
 _WS_EVAL_TIMEOUT: float = 3600
 
 
+def _benchmark_service_ws_timeout_error(operation: str, timeout: float, task_id: str) -> BenchmarkServiceError:
+    return BenchmarkServiceError(
+        f"{operation} timed out waiting for benchmark service websocket result after {timeout}s for task {task_id}"
+    )
+
+
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
     """Fetch Daytona credentials from AWS Secrets Manager and return as headers for BenchmarkServiceClient."""
     daytona_keys: list[str] = ["DAYTONA_API_KEY", "DAYTONA_API_URL", "DAYTONA_TARGET"]
@@ -437,11 +443,10 @@ async def process_task(
                         ),
                         timeout=_WS_EVAL_TIMEOUT,
                     )
-                except TimeoutError:
-                    raise BenchmarkServiceError(
-                        f"resume_evaluation timed out after {_WS_EVAL_TIMEOUT}s for task {task_row.task_id} — "
-                        f"possible half-open WebSocket connection"
-                    )
+                except TimeoutError as e:
+                    raise _benchmark_service_ws_timeout_error(
+                        "resume_evaluation", _WS_EVAL_TIMEOUT, task_row.task_id
+                    ) from e
                 evaluation_result_row = EvaluationResult(
                     org_id=org.id,
                     task=task_row.id,
@@ -514,11 +519,8 @@ async def process_task(
                         ),
                         timeout=_WS_SETUP_TIMEOUT,
                     )
-                except TimeoutError:
-                    raise BenchmarkServiceError(
-                        f"setup_task timed out after {_WS_SETUP_TIMEOUT}s for task {task_row.task_id} — "
-                        f"possible half-open WebSocket connection"
-                    )
+                except TimeoutError as e:
+                    raise _benchmark_service_ws_timeout_error("setup_task", _WS_SETUP_TIMEOUT, task_row.task_id) from e
 
                 # Force flush the logs if anything has been buffered
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
@@ -567,7 +569,6 @@ async def process_task(
                     },
                 )
                 logger.info(f"Evaluating agent {start_benchmark_request.contract.name} in sandbox {sandbox.name}")
-                eval_timeout = task_data.agent_timeout if task_data.agent_timeout else _WS_EVAL_TIMEOUT
                 try:
                     evaluation_result = await asyncio.wait_for(
                         benchmark_service.evaluate_instance(
@@ -577,13 +578,12 @@ async def process_task(
                             on_eval_resume_state=on_eval_resume_state,
                             dataset=start_benchmark_request.dataset,
                         ),
-                        timeout=eval_timeout,
+                        timeout=_WS_EVAL_TIMEOUT,
                     )
-                except TimeoutError:
-                    raise BenchmarkServiceError(
-                        f"evaluate_instance timed out after {eval_timeout}s for task {task_row.task_id} — "
-                        f"possible half-open WebSocket connection"
-                    )
+                except TimeoutError as e:
+                    raise _benchmark_service_ws_timeout_error(
+                        "evaluate_instance", _WS_EVAL_TIMEOUT, task_row.task_id
+                    ) from e
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -1,4 +1,4 @@
-from asyncio import Semaphore
+from asyncio import Semaphore, sleep
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock
@@ -9,7 +9,7 @@ from benchmark_service.schemas import Resources, RetrieveTaskResponse
 from sqlmodel import Session
 
 from tests.conftest import TEST_ORG_ID
-from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.exceptions import PtyCreationError, SandboxSetupError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import process_task, start_benchmark_request_to_benchmark
@@ -17,6 +17,31 @@ from tracker.utils import process_task, start_benchmark_request_to_benchmark
 
 class TestPtyRetry:
     _test_org = Org(id=TEST_ORG_ID, name="default")
+
+    def _create_process_task_rows(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        harness_config: HarnessConfig,
+    ) -> tuple[StartBenchmarkRequest, Benchmark, Task]:
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        return start_benchmark_request, benchmark_row, task_row
 
     def test_process_task_retry_decorator_uses_observability_retry_callback(self) -> None:
         before_sleep = process_task.retry.before_sleep
@@ -50,22 +75,9 @@ class TestPtyRetry:
             - Task ends in FINISHED state after the retry succeeds
             - The sandbox context manager is entered twice (one per attempt)
         """
-        start_benchmark_request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=1,
-            task_ids=["task_0"],
-            harness_config=harness_config,
+        start_benchmark_request, benchmark_row, task_row = self._create_process_task_rows(
+            contract, database_session, harness_config
         )
-
-        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
-        database_session.add(task_row)
-        database_session.commit()
 
         sandbox_entry_count = 0
 
@@ -128,22 +140,9 @@ class TestPtyRetry:
         monkeypatch: pytest.MonkeyPatch,
         harness_config: HarnessConfig,
     ) -> None:
-        start_benchmark_request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=1,
-            task_ids=["task_0"],
-            harness_config=harness_config,
+        start_benchmark_request, benchmark_row, task_row = self._create_process_task_rows(
+            contract, database_session, harness_config
         )
-
-        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
-        database_session.add(task_row)
-        database_session.commit()
 
         @asynccontextmanager
         async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
@@ -246,3 +245,108 @@ class TestPtyRetry:
         assert evaluation_start_record["task_id"] == "task_0"
         assert evaluation_start_record["benchmark_id"] == str(benchmark_row.id)
         assert evaluation_start_record["sandbox_id"] == "mock-sandbox-id"
+
+    async def test_process_task_eval_websocket_timeout_does_not_use_agent_timeout(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, benchmark_row, task_row = self._create_process_task_rows(
+            contract, database_session, harness_config
+        )
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = "mock-sandbox-id"
+            mock_sandbox.name = "mock-sandbox-name"
+            yield mock_sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse(
+                docker_image="test-image:latest",
+                problem_path="/tmp/problem.txt",
+                cwd="/testbed",
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                agent_timeout=0.001,
+            )
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            await sleep(0.01)
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr("tracker.utils._WS_EVAL_TIMEOUT", 0.2)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        database_session.refresh(task_row)
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert task_row.status == TaskStatus.FINISHED
+
+    async def test_process_task_eval_websocket_timeout_errors_task(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, benchmark_row, task_row = self._create_process_task_rows(
+            contract, database_session, harness_config
+        )
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = "mock-sandbox-id"
+            mock_sandbox.name = "mock-sandbox-name"
+            yield mock_sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse(
+                docker_image="test-image:latest",
+                problem_path="/tmp/problem.txt",
+                cwd="/testbed",
+                resources=Resources(vcpu=2, memory=4, disk=5),
+            )
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            await sleep(1)
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr("tracker.utils._WS_EVAL_TIMEOUT", 0.001)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        database_session.refresh(task_row)
+        assert result == {"task_0": None}
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "evaluate_instance timed out waiting for benchmark service websocket result" in task_row.error_message


### PR DESCRIPTION
## Summary

Prevents benchmark runs from permanently stalling when benchmark-service WebSocket calls stop returning a result.

This is a tracker-side wall-clock guard around the streamed benchmark-service calls. It complements the shared client keepalive fix, but also covers application-level hangs where the WebSocket can remain open while no `result` chunk is ever returned. When this happens to N tasks where N = concurrency, all semaphore slots can stay held and remaining pending tasks never execute.

This was observed in production: a run with `concurrency=40` stalled at 1080/1251 tasks with 170 PENDING, 0 IN_PROGRESS, and 0 EVALUATING after roughly 40 WebSocket calls hung during EVALUATING.

## Related

https://github.com/vals-ai/valkyrie-ticket-library/issues/54

## Changes

- Added `_WS_SETUP_TIMEOUT` (1800s / 30 min) and `_WS_EVAL_TIMEOUT` (3600s / 1 hr) constants.
- Wrapped `setup_task` in `asyncio.wait_for(..., timeout=_WS_SETUP_TIMEOUT)`.
- Wrapped `resume_evaluation` in `asyncio.wait_for(..., timeout=_WS_EVAL_TIMEOUT)`.
- Wrapped `evaluate_instance` in `asyncio.wait_for(..., timeout=_WS_EVAL_TIMEOUT)`.
- Kept `task_data.agent_timeout` scoped to the agent command only; it is not reused as the evaluation WebSocket timeout.
- On timeout, raises `BenchmarkServiceError` with a benchmark-service WebSocket result timeout message. This flows through existing `process_task` exception handling, errors the task cleanly, releases the semaphore slot, and lets remaining tasks proceed.
- Added regression tests covering both the eval timeout path and the `agent_timeout` vs eval timeout boundary.

## Type of Change

- [x] Bug fix

## Testing

- [x] `uv run pytest tests/unit/test_pty_retry.py -k "eval_websocket_timeout"`
- [x] `make test-unit` from `services/tracker` (134 passed)
- [x] `uv run ruff format --check src/tracker/utils.py tests/unit/test_pty_retry.py`
- [x] `uv run ruff check src/tracker/utils.py tests/unit/test_pty_retry.py`

## Reviewer Checklist

- [ ] Are the hardcoded timeout values (30 min setup / 1 hr eval) appropriate?
- [ ] `asyncio.wait_for` cancels the underlying coroutine on timeout. Verify the `websockets` client teardown behavior is acceptable for this path.

Link to Devin session: https://app.devin.ai/sessions/e000da313d0b4dd4951930e08ebf5828
Requested by: @BradenBug