### PR TITLE
feat: add DEFERRED task status for staged runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ valkyrie run start \
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
 | `-i` / `--interval` | Progress percentage threshold for Slack notification. Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
 | `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
+| `--defer-rest` | Register every task in the dataset on the run, but only execute the ones in `--task-ids` / `--slice`. The remaining tasks are created in `DEFERRED` status and can be promoted later via `valkyrie run resume`. See [Deferred tasks](#deferred-tasks). |
 
 ### Monitor a run
 
@@ -285,10 +286,44 @@ valkyrie run resume <id> --concurrency 20
 | Option | Description |
 | --- | --- |
 | `--concurrency` | Override concurrency level |
-| `--task-ids` | Comma-separated task IDs to resume/retry |
+| `--task-ids` | Comma-separated task IDs to resume/retry. Also used to promote specific `DEFERRED` tasks. |
 | `--task-ids-file` | Path to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
+| `--run-deferred` | Promote every remaining `DEFERRED` task in the run to `PENDING` so it gets executed. See [Deferred tasks](#deferred-tasks). |
+
+### Deferred tasks
+
+`--defer-rest` lets you start a run that *registers* the full dataset on a single
+`benchmark_id` but only *executes* a subset of tasks up front. The unrun tasks live on
+the run in the `DEFERRED` status until you choose to promote them. This avoids the
+"run a subset now, run the full set later from scratch and waste compute on the subset
+tasks you already ran" pattern — a single run accumulates tasks over time.
+
+```bash
+# 1. Start a run that only executes a small subset; the rest are registered as DEFERRED.
+valkyrie run start \
+  --agent my_agent --benchmark my_bench --model my_model \
+  --task-ids "task_1,task_2,task_3" --defer-rest
+
+# 2. Retry/resume the executed subset as usual — DEFERRED tasks are untouched.
+valkyrie run resume <id> --retry
+
+# 3. Promote a single deferred task (handy for iterative testing).
+valkyrie run resume <id> --task-ids "task_4"
+
+# 4. Promote every remaining DEFERRED task at once to reach full coverage.
+valkyrie run resume <id> --run-deferred
+```
+
+Behavior:
+
+- A run with `DEFERRED` tasks still transitions to `FINISHED` once every non-deferred task
+  completes — `DEFERRED` is treated the same way as `ERROR` for the benchmark-level status.
+- Default `resume` / `retry` does **not** sweep `DEFERRED` tasks. They are only promoted
+  when explicitly named via `--task-ids` or when `--run-deferred` is passed.
+- Once promoted (`DEFERRED → PENDING → FINISHED`), a task is indistinguishable from one
+  that ran originally. Subsequent retry/resume treats it like any other task.
 
 ### List runs
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -219,10 +219,20 @@ async def start_benchmark(
     benchmark_id_var.set(str(benchmark_row.id))
 
     # Verify task ids passed in (they exist within dataset and all dependencies are met to run them)
+    all_dataset_task_ids: list[str] | None = None
     try:
         verify_response = await benchmark_service.verify_task_ids(
             task_ids=request.task_ids, slice_str=request.slice_str, dataset=request.dataset
         )
+
+        # If --defer-rest, fetch the full dataset task list so the benchmark also stages
+        # the unselected tasks as DEFERRED rows. They sit dormant until promoted via
+        # retry-or-resume (or named explicitly in --task-ids).
+        if request.defer_rest:
+            full_response = await benchmark_service.verify_task_ids(
+                task_ids=None, slice_str=None, dataset=request.dataset
+            )
+            all_dataset_task_ids = full_response.task_ids
 
         # Copy agent so edits to agents/<name>.zip during the run doesn't affect it
         await copy_agent_to_benchmark(
@@ -248,6 +258,7 @@ async def start_benchmark(
             start_benchmark_request_json=request.model_dump(),
             benchmark_id_str=str(benchmark_row.id),
             verified_task_ids=verify_response.task_ids,
+            all_dataset_task_ids=all_dataset_task_ids,
         )
     )
 
@@ -417,6 +428,7 @@ async def retry_or_resume_benchmark(
     retry: bool = Query(default=False),
     retry_mode: RetryMode = Query(default=RetryMode.AUTO),
     concurrency: int | None = Query(default=None),
+    run_deferred: bool = Query(default=False),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
     session: Session = Depends(get_session),
@@ -434,6 +446,8 @@ async def retry_or_resume_benchmark(
         benchmark_id: The benchmark ID to retry/resume
         retry: If true, retry failed tasks. If false, resume from where it left off
         concurrency: Optional new concurrency level (overrides original value)
+        run_deferred: If true, promote all DEFERRED tasks in this benchmark to PENDING
+            so they get executed. DEFERRED tasks are otherwise untouched by retry/resume.
         task_ids: Optional list of specific task IDs to run
 
     Returns:
@@ -471,6 +485,7 @@ async def retry_or_resume_benchmark(
         retry_mode=retry_mode,
         rerun_task_ids=task_ids,
         org=org,
+        run_deferred=run_deferred,
     )
 
     # Ensure that credentials are included with the model dump

--- a/services/tracker/src/tracker/database/migrations/versions/e1a2b3c4d5f6_add_deferred_task_status.py
+++ b/services/tracker/src/tracker/database/migrations/versions/e1a2b3c4d5f6_add_deferred_task_status.py
@@ -1,0 +1,28 @@
+"""Add DEFERRED task status
+
+Revision ID: e1a2b3c4d5f6
+Revises: d4e5f6a7b8c9
+Create Date: 2026-05-11 13:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e1a2b3c4d5f6"
+down_revision: Union[str, Sequence[str], None] = "35f2d4a8c9b1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("ALTER TYPE taskstatus ADD VALUE IF NOT EXISTS 'DEFERRED' AFTER 'ERROR'")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # PostgreSQL does not support removing values from an enum type
+    pass

--- a/services/tracker/src/tracker/database/migrations/versions/e1a2b3c4d5f6_add_deferred_task_status.py
+++ b/services/tracker/src/tracker/database/migrations/versions/e1a2b3c4d5f6_add_deferred_task_status.py
@@ -1,7 +1,7 @@
 """Add DEFERRED task status
 
 Revision ID: e1a2b3c4d5f6
-Revises: d4e5f6a7b8c9
+Revises: 35f2d4a8c9b1
 Create Date: 2026-05-11 13:00:00.000000
 
 """

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -242,10 +242,13 @@ class Benchmark(SQLModel, table=True):
         """
         from tracker.types import BenchmarkTableRow
 
+        # Exclude DEFERRED tasks from totals — they were intentionally not queued
+        # and shouldn't drag down progress (subset run shows 100% with deferred parked).
         total_tasks: int = session.exec(
             select(func.count(col(Task.task_id)))
             .where(col(Task.benchmark) == self.id)
             .where(col(Task.org_id) == self.org_id)
+            .where(Task.status != TaskStatus.DEFERRED)
         ).one()
 
         finished_tasks: int = session.exec(

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -52,6 +52,9 @@ class TaskStatus(str, Enum):
     STOPPED = "STOPPED"
     FINISHED = "FINISHED"
     ERROR = "ERROR"
+    # Task was registered with the benchmark but intentionally not queued for execution.
+    # Promoted to PENDING via retry-or-resume with --run-deferred or explicit --task-ids.
+    DEFERRED = "DEFERRED"
 
 
 class BenchmarkStatus(str, Enum):

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -55,6 +55,11 @@ class StartBenchmarkRequest(BaseModel):
     service_headers: dict[str, str] = {}
     webhook_secret_name: str | None = None
     webhook_intervals: list[int] | None = None
+    # When True, register every task in the dataset on the benchmark, but only mark the
+    # ones in `task_ids` (or selected by `slice_str`) as PENDING. The rest are created
+    # in DEFERRED status and can be promoted later via
+    # `retry-or-resume --run-deferred` (or by naming them in --task-ids).
+    defer_rest: bool = False
 
     @property
     def benchmark_service(self) -> BenchmarkServiceClient:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -931,6 +931,9 @@ class BenchmarkContext:
     def _task_counts(self) -> TaskCounts:
         finished_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
 
+        # Exclude DEFERRED from both totals — those tasks were intentionally not queued
+        # and shouldn't drag down progress (e.g. a subset-only run with 180/180 done
+        # should show 100%, not 180/450). They'll re-enter the counts when promoted.
         statement = (
             select(
                 func.count().label("total_tasks"),
@@ -940,6 +943,7 @@ class BenchmarkContext:
             .select_from(Task)
             .where(Task.benchmark == self._benchmark_row.id)
             .where(Task.org_id == self._org.id)
+            .where(Task.status != TaskStatus.DEFERRED)
         )
 
         result = self._session.exec(statement).one()
@@ -1025,8 +1029,9 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
     if benchmark_row.status in terminal_statuses:
         return
 
-    # Force non exited tasks to be ERROR
-    task_terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+    # Force non exited tasks to be ERROR. DEFERRED tasks were intentionally
+    # not queued, so leave them alone — they should still be promotable later.
+    task_terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED, TaskStatus.DEFERRED]
     session.exec(
         update(Task)
         .where(col(Task.benchmark) == benchmark_id)
@@ -1219,8 +1224,15 @@ async def force_stop_sandboxes(
         f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
     )
 
-    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
-    finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited.
+    # DEFERRED counts as terminal here too — those tasks were never queued, so they don't block the benchmark from
+    # transitioning out of STOPPING.
+    finished_statuses: list[TaskStatus] = [
+        TaskStatus.FINISHED,
+        TaskStatus.ERROR,
+        TaskStatus.STOPPED,
+        TaskStatus.DEFERRED,
+    ]
     tasks_still_running: int = session.exec(
         select(func.count(col(Task.id)))
         .where(col(Task.benchmark) == benchmark_row.id)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -647,24 +647,41 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: 
 
 
 def create_task_rows(
-    verified_task_ids: list[str], benchmark_row: Benchmark, session: Session, org: Org
+    verified_task_ids: list[str],
+    benchmark_row: Benchmark,
+    session: Session,
+    org: Org,
+    all_dataset_task_ids: list[str] | None = None,
 ) -> Sequence[tuple[str, Task]]:
     """
     Create task_rows that do not already exist in the database for the benchmark row.
 
+    Args:
+        verified_task_ids: Task ids to register as PENDING and run now.
+        all_dataset_task_ids: When provided, also register the remaining tasks in the
+            dataset (those not in verified_task_ids) as DEFERRED so they can be promoted
+            later via retry-or-resume. When None, only verified_task_ids are registered.
+
     NOTE: Only return runnable tasks to support resuming the benchmark.
     """
+    verified_set: set[str] = set(verified_task_ids)
+    # Preserve dataset order for any deferred tasks; verified ones are emitted first
+    # so runnable-task ordering matches the caller-supplied order.
+    all_task_ids = list(verified_task_ids)
+    if all_dataset_task_ids is not None:
+        all_task_ids += [tid for tid in all_dataset_task_ids if tid not in verified_set]
 
     # Find task ids that already exist so that we can filter them out
     existing_task_ids: Sequence[str] = session.exec(
-        select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(verified_task_ids))
+        select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(all_task_ids))
     ).all()
 
     # NOTE: Must maintain same order that was passed in
-    task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
+    task_ids_to_create = [task_id for task_id in all_task_ids if task_id not in existing_task_ids]
 
     for task_id in task_ids_to_create:
-        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id)
+        status = TaskStatus.PENDING if task_id in verified_set else TaskStatus.DEFERRED
+        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=status)
         session.add(task_row)
 
     session.commit()
@@ -706,6 +723,7 @@ async def process_benchmark(
     start_benchmark_request_json: dict[str, Any],
     benchmark_id_str: str,
     verified_task_ids: list[str],
+    all_dataset_task_ids: list[str] | None = None,
 ) -> None:
     # Was serialized to make it compatible with the broker
     start_benchmark_request: StartBenchmarkRequest = StartBenchmarkRequest(**start_benchmark_request_json)
@@ -756,7 +774,9 @@ async def process_benchmark(
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session, org)
+            task_rows: Sequence[tuple[str, Task]] = create_task_rows(
+                verified_task_ids, benchmark_row, session, org, all_dataset_task_ids=all_dataset_task_ids
+            )
 
         task_row_ids: set[str] = {task_id for task_id, _ in task_rows}
         missing_task_ids: list[str] = [task_id for task_id in verified_task_ids if task_id not in task_row_ids]
@@ -1225,12 +1245,14 @@ async def reset_to_in_progress_status(
     retry_mode: RetryMode,
     rerun_task_ids: list[str],
     org: Org,
+    run_deferred: bool = False,
 ) -> list[str]:
     """
     Resets valid tasks to in progress and to allow for retrying or resuming the benchmark.
 
     Retry: we reset objects with an error status ontop of the stopped status
     Rerun Task IDs: even if task has been finished we restart it
+    Run Deferred: promote tasks in DEFERRED status (intentionally-not-run) to PENDING
 
     Benchmark - In progress status
     Tasks - Pending status, or Evaluating status when retrying durable eval state
@@ -1241,6 +1263,8 @@ async def reset_to_in_progress_status(
         retry_statuses = [TaskStatus.STOPPED]
         if retry:
             retry_statuses.append(TaskStatus.ERROR)
+        if run_deferred:
+            retry_statuses.append(TaskStatus.DEFERRED)
 
         filter_query = [
             col(Task.benchmark) == benchmark_row.id,

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -339,9 +339,7 @@ class TestBenchmarkUtils:
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
 
-    def test_create_task_rows_with_deferred_tasks(
-        self, example_benchmark_object: Benchmark, database_session: Session
-    ):
+    def test_create_task_rows_with_deferred_tasks(self, example_benchmark_object: Benchmark, database_session: Session):
         benchmark_row = example_benchmark_object
         database_session.add(benchmark_row)
         database_session.commit()

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -13,6 +13,7 @@ from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkSt
 from tracker.exceptions import TrackerServiceError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
+    BenchmarkContext,
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
@@ -337,6 +338,53 @@ class TestBenchmarkUtils:
         all_tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
+
+    def test_create_task_rows_with_deferred_tasks(
+        self, example_benchmark_object: Benchmark, database_session: Session
+    ):
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        verified_task_ids = ["task_0", "task_2"]
+        all_dataset_task_ids = ["task_0", "task_1", "task_2", "task_3"]
+
+        task_rows = create_task_rows(
+            verified_task_ids,
+            benchmark_row,
+            database_session,
+            self._test_org,
+            all_dataset_task_ids=all_dataset_task_ids,
+        )
+
+        assert [task_id for task_id, _task in task_rows] == verified_task_ids
+
+        all_tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        statuses_by_task_id = {task.task_id: task.status for task in all_tasks}
+        assert statuses_by_task_id == {
+            "task_0": TaskStatus.PENDING,
+            "task_1": TaskStatus.DEFERRED,
+            "task_2": TaskStatus.PENDING,
+            "task_3": TaskStatus.DEFERRED,
+        }
+
+        benchmark_details = BenchmarkContext(benchmark_row, database_session, self._test_org).benchmark_details
+        assert benchmark_details.total_tasks == len(verified_task_ids)
+        assert benchmark_details.task_breakdown[TaskStatus.DEFERRED] == 2
+        assert benchmark_row.create_benchmark_table_row(database_session).total_tasks == len(verified_task_ids)
+
+        # Calling again should be idempotent and still only return runnable tasks.
+        task_rows = create_task_rows(
+            verified_task_ids,
+            benchmark_row,
+            database_session,
+            self._test_org,
+            all_dataset_task_ids=all_dataset_task_ids,
+        )
+        assert [task_id for task_id, _task in task_rows] == verified_task_ids
+        assert len(database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()) == len(
+            all_dataset_task_ids
+        )
 
     def test_commit_task_error_spans_status_transition(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: pytest.MonkeyPatch

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -194,6 +194,56 @@ class TestFastapiServer:
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
         assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
 
+    async def test_start_benchmark_with_defer_rest_enqueues_full_dataset(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=10,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+            defer_rest=True,
+        )
+        verify_calls: list[tuple[list[str] | None, str | None, str | None]] = []
+        captured_kiq_kwargs: dict[str, Any] = {}
+
+        async def _mock_verify_task_ids(
+            *_args: Any,
+            task_ids: list[str] | None,
+            slice_str: str | None,
+            dataset: str | None = None,
+            **_kwargs: Any,
+        ) -> VerifyTaskIdsResponse:
+            verify_calls.append((task_ids, slice_str, dataset))
+            if task_ids is None and slice_str is None:
+                return VerifyTaskIdsResponse(task_ids=["task_0", "task_1", "task_2"])
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        class _MockKicker:
+            def with_labels(self, **_kwargs: Any) -> "_MockKicker":
+                return self
+
+            async def kiq(self, **kwargs: Any) -> None:
+                captured_kiq_kwargs.update(kwargs)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+        monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+
+        response = client.post("/start-benchmark", json=request.model_dump())
+
+        assert response.status_code == 200
+        assert response.json()["task_count"] == 1
+        assert verify_calls == [
+            (["task_0"], None, None),
+            (None, None, None),
+        ]
+        assert captured_kiq_kwargs["verified_task_ids"] == ["task_0"]
+        assert captured_kiq_kwargs["all_dataset_task_ids"] == ["task_0", "task_1", "task_2"]
+
     async def test_fetch_benchmark(self, database_session: Session, example_benchmark_object: Benchmark):
         """
         Test fetch benchmark of the fastapi server.

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -279,6 +279,71 @@ class TestStopAndResume:
         assert task_row.status == expected_status
         assert task_row.eval_resume_state == expected_state
 
+    @pytest.mark.parametrize(
+        ("run_deferred", "rerun_task_ids", "expected_pending", "expected_deferred"),
+        [
+            (False, [], {"task_0"}, {"task_1", "task_2"}),
+            (True, [], {"task_0", "task_1", "task_2"}, set()),
+            (False, ["task_1"], {"task_0", "task_1"}, {"task_2"}),
+        ],
+    )
+    async def test_reset_handles_deferred_tasks(
+        self,
+        run_deferred: bool,
+        rerun_task_ids: list[str],
+        expected_pending: set[str],
+        expected_deferred: set[str],
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        tasks = [
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.STOPPED),
+            Task(org_id=TEST_ORG_ID, task_id="task_1", benchmark=benchmark_row.id, status=TaskStatus.DEFERRED),
+            Task(org_id=TEST_ORG_ID, task_id="task_2", benchmark=benchmark_row.id, status=TaskStatus.DEFERRED),
+        ]
+        database_session.add(benchmark_row)
+        database_session.add_all(tasks)
+        database_session.commit()
+
+        verified_requests: list[set[str]] = []
+
+        async def _mock_request_verify_task_ids(
+            *_args: Any, task_ids: list[str], **_kwargs: Any
+        ) -> VerifyTaskIdsResponse:
+            verified_requests.append(set(task_ids))
+            return VerifyTaskIdsResponse(task_ids=task_ids)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
+            retry=False,
+            retry_mode=RetryMode.AUTO,
+            rerun_task_ids=rerun_task_ids,
+            org=self._test_org,
+            run_deferred=run_deferred,
+        )
+
+        task_statuses = {
+            task.task_id: task.status
+            for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        }
+
+        assert set(verified_task_ids) == expected_pending
+        assert verified_requests == [expected_pending]
+        assert {
+            task_id for task_id, status in task_statuses.items() if status == TaskStatus.PENDING
+        } == expected_pending
+        assert {
+            task_id for task_id, status in task_statuses.items() if status == TaskStatus.DEFERRED
+        } == expected_deferred
+
     async def test_process_task_resumes_evaluation_without_sandbox(
         self,
         contract: AgentContractRequest,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -479,6 +479,13 @@ def auth_list() -> None:
     is_flag=True,
     help="Ignore custom benchmark services that have been configured. Provides opt-out for custom services.",
 )
+@click.option(
+    "--defer-rest",
+    is_flag=True,
+    help="Register every task in the dataset on the benchmark, but only run the ones in "
+    "--task-ids / --slice. The rest are marked DEFERRED and can be promoted later via "
+    "`valkyrie run resume --run-deferred` (or by naming them in --task-ids).",
+)
 def start(
     agent: str,
     model: str | None,
@@ -494,6 +501,7 @@ def start(
     headers: tuple[tuple[str, str]],
     intervals: tuple[int, ...],
     ignore_custom_services: bool,
+    defer_rest: bool,
 ):
     """
     Run an agent on a benchmark.
@@ -576,6 +584,7 @@ def start(
                 service_headers=service_headers or None,
                 webhook_secret_name=webhook_secret if webhook_intervals else None,
                 webhook_intervals=webhook_intervals,
+                defer_rest=defer_rest,
             )
 
             click.echo("\r\033[K", nl=False)
@@ -771,6 +780,14 @@ def stop(run_id: UUID, force: bool):
     default=False,
     help="Clear durable eval state and rerun generation.",
 )
+@click.option(
+    "--run-deferred",
+    is_flag=True,
+    default=False,
+    help="Promote all DEFERRED tasks in this run to PENDING so they get executed. Use "
+    "this to upgrade a `--defer-rest` run to full coverage. Specific deferred tasks can "
+    "also be promoted individually by naming them in --task-ids.",
+)
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -781,6 +798,7 @@ def resume(
     task_ids_file: Path | None,
     update_agent: bool,
     from_scratch: bool,
+    run_deferred: bool,
 ):
     """
     Resume a run by its run id.
@@ -826,6 +844,7 @@ def resume(
                 concurrency,
                 retry_task_ids,
                 service_headers=service_headers,
+                run_deferred=run_deferred,
             )
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -248,6 +248,7 @@ class TrackerService:
         service_headers: dict[str, str] | None = None,
         webhook_secret_name: str | None = None,
         webhook_intervals: list[int] | None = None,
+        defer_rest: bool = False,
     ) -> Response:
         """
         Start a benchmark run on the tracker service.
@@ -282,6 +283,7 @@ class TrackerService:
                 service_headers=service_headers or {},
                 webhook_secret_name=webhook_secret_name,
                 webhook_intervals=webhook_intervals,
+                defer_rest=defer_rest,
             )
 
             body = payload.model_dump()
@@ -429,6 +431,7 @@ class TrackerService:
         concurrency: int | None,
         task_ids: list[str],
         service_headers: dict[str, str] | None = None,
+        run_deferred: bool = False,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -439,12 +442,15 @@ class TrackerService:
             concurrency: Optional new concurrency level to override original value
             task_ids: List of task ids to force retry
             service_headers: Optional headers for benchmark service authentication
+            run_deferred: Whether to promote all DEFERRED tasks in the run to PENDING
 
         Returns:
             RetryOrResumeBenchmarkResponse with status and message
         """
         try:
             params: dict[str, Any] = {"retry": retry, "retry_mode": retry_mode.value}
+            if run_deferred:
+                params["run_deferred"] = True
 
             # NOTE: 0 is not acceptable
             if concurrency:

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -129,6 +129,7 @@ class BenchmarkFormatter:
         "STOPPING": "magenta",
         "FINISHED": "green",
         "ERROR": "red",
+        "DEFERRED": "white",
     }
 
     @staticmethod
@@ -161,6 +162,7 @@ class BenchmarkFormatter:
             TaskStatus.EVALUATING,
             TaskStatus.ERROR,
             TaskStatus.STOPPED,
+            TaskStatus.DEFERRED,
             TaskStatus.FINISHED,
         ]
 


### PR DESCRIPTION
## Summary

Adds a new `TaskStatus.DEFERRED` so a single `benchmark_id` can register the full dataset up front but only execute a subset of tasks. The remaining tasks sit in `DEFERRED` until explicitly promoted — avoiding the "subset run, then full run from scratch" pattern that re-runs tasks already completed.

## Usage

```bash
# Initial cheap subset run; the rest are registered as DEFERRED
valkyrie run start --benchmark X --task-ids \"t1,t2,t3\" --defer-rest

# Default retry/resume does NOT touch DEFERRED (same protection as ERROR)
valkyrie run resume <id> --retry

# Promote specific deferred tasks individually
valkyrie run resume <id> --task-ids \"t4\"

# Or promote all remaining deferred tasks at once
valkyrie run resume <id> --run-deferred
```

## Design

- DEFERRED is excluded from the worker's runnable filter and from the default \`retry_statuses\`, so it stays inert unless the caller explicitly names tasks (\`--task-ids\`) or passes \`--run-deferred\`.
- A benchmark with DEFERRED tasks still transitions to \`FINISHED\` once every non-deferred task completes — DEFERRED behaves analogously to ERROR at the benchmark-status level. **No \`BenchmarkStatus\` changes required.**
- Migration adds the enum value to Postgres via \`ALTER TYPE ... ADD VALUE\`.

## Why a new status (vs reusing STOPPED)

We considered repurposing STOPPED for parked tasks, but STOPPED is in the default \`retry_statuses\` list — so any retry-or-resume call would accidentally sweep up parked tasks. A dedicated DEFERRED status keeps the opt-in semantics clean.

## Test plan

Tested end-to-end against a real benchmark service + agent + LLM (\`openai/gpt-5.4-nano-2026-03-17\` on a 3-task dev set):

- [x] \`run start --task-ids X --defer-rest\` → 1 PENDING + 2 DEFERRED rows; benchmark transitions to FINISHED with deferred tasks present
- [x] \`run resume --retry\` → ERROR task picked up, DEFERRED tasks untouched
- [x] \`run resume --task-ids Y\` → only Y promoted from DEFERRED → PENDING
- [x] \`run resume --run-deferred\` → all remaining DEFERRED tasks promoted
- [x] Normal path (no \`--defer-rest\`, no \`--task-ids\`) → unchanged: all dataset tasks PENDING, zero DEFERRED rows
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/361" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->