### PR TITLE
feat(tracker): lazily add tasks on resume via --task-ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ valkyrie run resume <id> --concurrency 20
 | Option | Description |
 | --- | --- |
 | `--concurrency` | Override concurrency level |
-| `--task-ids` | Comma-separated task IDs to resume/retry |
+| `--task-ids` | Comma-separated task IDs to resume/retry. Any id without an existing row is created as fresh `PENDING` if valid in the current dataset — lets you grow scope without starting a new run. |
 | `--task-ids-file` | Path to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -434,7 +434,8 @@ async def retry_or_resume_benchmark(
         benchmark_id: The benchmark ID to retry/resume
         retry: If true, retry failed tasks. If false, resume from where it left off
         concurrency: Optional new concurrency level (overrides original value)
-        task_ids: Optional list of specific task IDs to run
+        task_ids: Optional list of specific task IDs to run. If a task id is not yet
+            registered but is valid in the current dataset, a fresh PENDING row is created.
 
     Returns:
         RetryOrResumeBenchmarkResponse

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -666,7 +666,7 @@ def create_task_rows(
     task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
 
     for task_id in task_ids_to_create:
-        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING)
+        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id)
         session.add(task_row)
 
     session.commit()

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -757,9 +757,7 @@ async def process_benchmark(
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            task_rows: Sequence[tuple[str, Task]] = create_task_rows(
-                verified_task_ids, benchmark_row, session, org
-            )
+            task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session, org)
 
         task_row_ids: set[str] = {task_id for task_id, _ in task_rows}
         missing_task_ids: list[str] = [task_id for task_id in verified_task_ids if task_id not in task_row_ids]
@@ -1292,9 +1290,7 @@ async def reset_to_in_progress_status(
             session.add(task)
 
         for task_id in new_task_ids:
-            session.add(
-                Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING)
-            )
+            session.add(Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING))
 
         # Delete all evaluation results for reset tasks (unlikely they exist)
         if existing_rows:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -657,6 +657,7 @@ def create_task_rows(
 
     NOTE: Only return runnable tasks to support resuming the benchmark.
     """
+    # Find task ids that already exist so that we can filter them out
     existing_task_ids: Sequence[str] = session.exec(
         select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(verified_task_ids))
     ).all()
@@ -1006,7 +1007,7 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
     if benchmark_row.status in terminal_statuses:
         return
 
-    # Force non-terminal tasks to ERROR.
+    # Force non exited tasks to be ERROR
     task_terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
     session.exec(
         update(Task)
@@ -1200,7 +1201,7 @@ async def force_stop_sandboxes(
         f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
     )
 
-    # Worker has exited, so flip the benchmark here if no tasks remain in a non-terminal state.
+    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
     finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
     tasks_still_running: int = session.exec(
         select(func.count(col(Task.id)))
@@ -1231,9 +1232,8 @@ async def reset_to_in_progress_status(
     Resets valid tasks to in progress and to allow for retrying or resuming the benchmark.
 
     Retry: we reset objects with an error status ontop of the stopped status
-    Rerun Task IDs: rerun a task even if finished; if the task has no row yet but is
-        valid in the current dataset, a fresh PENDING row is created (supports running
-        tasks added to the dataset after the benchmark started).
+    Rerun Task IDs: even if task has been finished we restart it. If the task has no
+        row yet, a fresh PENDING row is created when valid in the current dataset.
 
     Benchmark - In progress status
     Tasks - Pending status, or Evaluating status when retrying durable eval state
@@ -1256,16 +1256,14 @@ async def reset_to_in_progress_status(
 
         existing_rows = session.exec(select(Task).where(*filter_query)).all()
         existing_by_task_id: dict[str, Task] = {task.task_id: task for task in existing_rows}
-
-        # rerun_task_ids that don't have a row yet — created lazily if valid in the dataset.
         new_task_ids = [tid for tid in rerun_task_ids if tid not in existing_by_task_id]
 
         # Allow re-running the end of the benchmark without running any tasks
         if not existing_rows and not new_task_ids:
             return []
 
-        # Verify all requested task ids are still valid in the current dataset.
-        # Raises if any are invalid.
+        # Verify the task ids are still valid before priming to resume
+        # Raises if any task ids are invalid
         all_requested_task_ids = list(existing_by_task_id.keys()) + new_task_ids
         verify_response = await benchmark_service.verify_task_ids(
             task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
@@ -1292,7 +1290,7 @@ async def reset_to_in_progress_status(
         for task_id in new_task_ids:
             session.add(Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING))
 
-        # Delete all evaluation results for reset tasks (unlikely they exist)
+        # Delete all evaluation results for the tasks (unlikely they exist)
         if existing_rows:
             session.exec(
                 delete(EvaluationResult)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -647,15 +647,16 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: 
 
 
 def create_task_rows(
-    verified_task_ids: list[str], benchmark_row: Benchmark, session: Session, org: Org
+    verified_task_ids: list[str],
+    benchmark_row: Benchmark,
+    session: Session,
+    org: Org,
 ) -> Sequence[tuple[str, Task]]:
     """
     Create task_rows that do not already exist in the database for the benchmark row.
 
     NOTE: Only return runnable tasks to support resuming the benchmark.
     """
-
-    # Find task ids that already exist so that we can filter them out
     existing_task_ids: Sequence[str] = session.exec(
         select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(verified_task_ids))
     ).all()
@@ -664,7 +665,7 @@ def create_task_rows(
     task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
 
     for task_id in task_ids_to_create:
-        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id)
+        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING)
         session.add(task_row)
 
     session.commit()
@@ -756,7 +757,9 @@ async def process_benchmark(
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session, org)
+            task_rows: Sequence[tuple[str, Task]] = create_task_rows(
+                verified_task_ids, benchmark_row, session, org
+            )
 
         task_row_ids: set[str] = {task_id for task_id, _ in task_rows}
         missing_task_ids: list[str] = [task_id for task_id in verified_task_ids if task_id not in task_row_ids]
@@ -1005,7 +1008,7 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
     if benchmark_row.status in terminal_statuses:
         return
 
-    # Force non exited tasks to be ERROR
+    # Force non-terminal tasks to ERROR.
     task_terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
     session.exec(
         update(Task)
@@ -1199,7 +1202,7 @@ async def force_stop_sandboxes(
         f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
     )
 
-    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
+    # Worker has exited, so flip the benchmark here if no tasks remain in a non-terminal state.
     finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
     tasks_still_running: int = session.exec(
         select(func.count(col(Task.id)))
@@ -1230,7 +1233,9 @@ async def reset_to_in_progress_status(
     Resets valid tasks to in progress and to allow for retrying or resuming the benchmark.
 
     Retry: we reset objects with an error status ontop of the stopped status
-    Rerun Task IDs: even if task has been finished we restart it
+    Rerun Task IDs: rerun a task even if finished; if the task has no row yet but is
+        valid in the current dataset, a fresh PENDING row is created (supports running
+        tasks added to the dataset after the benchmark started).
 
     Benchmark - In progress status
     Tasks - Pending status, or Evaluating status when retrying durable eval state
@@ -1251,24 +1256,21 @@ async def reset_to_in_progress_status(
             ),
         ]
 
-        task_rows = session.exec(select(Task).where(*filter_query)).all()
-        task_mapping: dict[UUID, str] = {task.id: task.task_id for task in task_rows}
+        existing_rows = session.exec(select(Task).where(*filter_query)).all()
+        existing_by_task_id: dict[str, Task] = {task.task_id: task for task in existing_rows}
 
-        # Ensure we are not missing any tasks that were requested (skips if force is empty)
-        missing_task_ids = [task_id for task_id in rerun_task_ids if task_id not in task_mapping.values()]
-        if missing_task_ids:
-            raise TrackerServiceError(
-                f"{', '.join(missing_task_ids)} was requested to be force resumed but does not exist in the dataset"
-            )
+        # rerun_task_ids that don't have a row yet — created lazily if valid in the dataset.
+        new_task_ids = [tid for tid in rerun_task_ids if tid not in existing_by_task_id]
 
         # Allow re-running the end of the benchmark without running any tasks
-        if not task_rows:
+        if not existing_rows and not new_task_ids:
             return []
 
-        # Verify the task ids are still valid before priming to resume
-        # Raises if any task ids are invalid
+        # Verify all requested task ids are still valid in the current dataset.
+        # Raises if any are invalid.
+        all_requested_task_ids = list(existing_by_task_id.keys()) + new_task_ids
         verify_response = await benchmark_service.verify_task_ids(
-            task_ids=list(task_mapping.values()), slice_str=None, dataset=benchmark_row.arguments.dataset
+            task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
         )
 
         # Set the benchmark status to in progress to flag resuming the benchmark
@@ -1276,7 +1278,7 @@ async def reset_to_in_progress_status(
         session.add(benchmark_row)
         session.commit()
 
-        for task in task_rows:
+        for task in existing_rows:
             task.status = (
                 TaskStatus.EVALUATING
                 if retry_mode == RetryMode.AUTO and task.eval_resume_state is not None
@@ -1289,12 +1291,18 @@ async def reset_to_in_progress_status(
                 task.eval_resume_state = None
             session.add(task)
 
-        # Delete all evaluation results for the tasks (unlikely they exist)
-        session.exec(
-            delete(EvaluationResult)
-            .where(col(EvaluationResult.task).in_(list(task_mapping.keys())))
-            .where(col(EvaluationResult.org_id) == org.id)
-        )
+        for task_id in new_task_ids:
+            session.add(
+                Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING)
+            )
+
+        # Delete all evaluation results for reset tasks (unlikely they exist)
+        if existing_rows:
+            session.exec(
+                delete(EvaluationResult)
+                .where(col(EvaluationResult.task).in_([task.id for task in existing_rows]))
+                .where(col(EvaluationResult.org_id) == org.id)
+            )
 
         session.commit()
 

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -1,10 +1,18 @@
 import os
+from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import HealthCheckResponse, SetupTaskResponse, VerifyTaskIdsResponse
+from benchmark_service.schemas import (
+    FinalScoreResponse,
+    HealthCheckResponse,
+    Resources,
+    RetrieveTaskResponse,
+    SetupTaskResponse,
+    VerifyTaskIdsResponse,
+)
 from sqlmodel import Session
 
 from tests.conftest import TEST_ORG_ID
@@ -165,3 +173,45 @@ def mock_broker(monkeypatch: pytest.MonkeyPatch) -> None:
     mock_kicker.return_value.with_labels.return_value.kiq = _mock_kiq
 
     monkeypatch.setattr("main.process_benchmark.kicker", mock_kicker)
+
+
+@pytest.fixture
+def process_benchmark_env(monkeypatch: pytest.MonkeyPatch, database_session: Session) -> None:
+    """Common process_benchmark deps: test DB engine, no-op sandbox, echo verify, static
+    retrieve/evaluate/final_score. Tests requesting this fixture can override any one method
+    with their own monkeypatch.setattr call."""
+
+    @asynccontextmanager
+    async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "mock-sandbox-id"
+        yield mock_sandbox
+
+    async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            docker_image="test-image:latest",
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        return {"status": "success", "score": 1.0}
+
+    async def _mock_final_score(*_args: Any, evaluation_results: dict[str, Any], **_kwargs: Any) -> FinalScoreResponse:
+        tasks_evaluated = list(evaluation_results.keys())
+        return FinalScoreResponse(
+            tasks_evaluated=tasks_evaluated,
+            final_score=50.0,
+            metadata={"resolved_tasks": [], "unresolved_tasks": tasks_evaluated},
+        )
+
+    async def _mock_verify_task_ids(*_args: Any, task_ids: list[str], **_kwargs: Any) -> VerifyTaskIdsResponse:
+        return VerifyTaskIdsResponse(task_ids=task_ids)
+
+    monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+    monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+    monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
+    monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -13,6 +13,7 @@ from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkSt
 from tracker.exceptions import TrackerServiceError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
+    BenchmarkContext,
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
@@ -205,6 +206,7 @@ class TestBenchmarkUtils:
         example_benchmark_object: Benchmark,
         database_session: Session,
         harness_config: HarnessConfig,
+        monkeypatch: pytest.MonkeyPatch,
     ):
         """
         Tests edge cases for resuming a benchmark
@@ -268,7 +270,17 @@ class TestBenchmarkUtils:
         )
         database_session.commit()
 
-        # Task id is provided as a force parameter but does not exist in dataset
+        # Task id is provided but is not in the current dataset — benchmark service rejects it
+        from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+        from benchmark_service.schemas import VerifyTaskIdsResponse
+
+        async def _verify_rejecting_task_5(*_args: Any, task_ids: list[str] | None, **_kwargs: Any) -> Any:
+            if task_ids and "task_5" in task_ids:
+                raise BenchmarkServiceError("task_5 does not exist in the dataset")
+            return VerifyTaskIdsResponse(task_ids=task_ids or [])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_rejecting_task_5)
+
         response = client.post(
             f"/retry-or-resume-benchmark/{example_benchmark_object.id}?retry=false",
             json={"task_ids": ["task_5"]},

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -3,7 +3,8 @@ from typing import Any, Sequence
 from zoneinfo import ZoneInfo
 
 import pytest
-from benchmark_service.schemas import FinalScoreResponse
+from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
 from httpx._models import Response
 from sqlmodel import Session, col, func, select, update
 
@@ -269,10 +270,7 @@ class TestBenchmarkUtils:
         )
         database_session.commit()
 
-        # Task id is provided but is not in the current dataset — benchmark service rejects it
-        from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-        from benchmark_service.schemas import VerifyTaskIdsResponse
-
+        # Task id is provided as a force parameter but does not exist in dataset
         async def _verify_rejecting_task_5(*_args: Any, task_ids: list[str] | None, **_kwargs: Any) -> Any:
             if task_ids and "task_5" in task_ids:
                 raise BenchmarkServiceError("task_5 does not exist in the dataset")

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -13,7 +13,6 @@ from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkSt
 from tracker.exceptions import TrackerServiceError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
-    BenchmarkContext,
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -1,7 +1,9 @@
 import asyncio
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, Mock
+from zoneinfo import ZoneInfo
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
@@ -327,6 +329,112 @@ class TestStopAndResume:
             "task_1": TaskStatus.PENDING,
             "task_2": TaskStatus.PENDING,
         }
+
+    async def test_resume_runs_lazily_added_task_and_recomputes_final_score(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        """A FINISHED run + new --task-ids: the new task runs to completion and the final
+        score is recomputed over the merged set (existing + new)."""
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = "mock-sandbox-id"
+            yield mock_sandbox
+
+        existing_task_ids = ["task_0", "task_1"]
+        new_task_id = "task_2"
+
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=existing_task_ids,
+            harness_config=harness_config,
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
+        benchmark_row.status = BenchmarkStatus.FINISHED
+        benchmark_row.finished_at = datetime.now(ZoneInfo("UTC"))
+        database_session.add(benchmark_row)
+
+        # Seed pre-existing FINISHED tasks with stored EvaluationResults
+        for task_id in existing_task_ids:
+            task = Task(
+                org_id=TEST_ORG_ID,
+                task_id=task_id,
+                benchmark=benchmark_row.id,
+                status=TaskStatus.FINISHED,
+                finished_at=datetime.now(ZoneInfo("UTC")),
+            )
+            database_session.add(task)
+            database_session.flush()
+            database_session.add(
+                EvaluationResult(org_id=TEST_ORG_ID, task=task.id, result={"resolved": True, "score": 1.0})
+            )
+        database_session.commit()
+
+        # Capture what final_score sees so we can assert the merge
+        final_score_calls: list[set[str]] = []
+
+        async def _mock_request_final_score(
+            *_args: Any, evaluation_results: dict[str, Any], **_kwargs: Any
+        ) -> FinalScoreResponse:
+            tasks_evaluated = list(evaluation_results.keys())
+            final_score_calls.append(set(tasks_evaluated))
+            return FinalScoreResponse(
+                tasks_evaluated=tasks_evaluated,
+                final_score=float(len(tasks_evaluated)),
+                metadata={"resolved_tasks": tasks_evaluated, "unresolved_tasks": []},
+            )
+
+        async def _mock_request_verify_task_ids(
+            *_args: Any, task_ids: list[str], **_kwargs: Any
+        ) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=task_ids)
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", self._mock_request_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", self._mock_request_evaluate_instance)
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_request_final_score)
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        # Resume with a new task id — should be lazily created as PENDING
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            retry=False,
+            retry_mode=RetryMode.AUTO,
+            rerun_task_ids=[new_task_id],
+            org=self._test_org,
+        )
+        assert verified_task_ids == [new_task_id]
+
+        # Run the worker — the new task should make it through evaluation
+        await process_benchmark(
+            start_benchmark_request_json=benchmark_row.start_benchmark_request(harness_config).model_dump(),
+            benchmark_id_str=str(benchmark_row.id),
+            verified_task_ids=verified_task_ids,
+        )
+
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.FINISHED, benchmark_row.error_message
+
+        task_statuses = {
+            task.task_id: task.status
+            for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        }
+        assert task_statuses[new_task_id] == TaskStatus.FINISHED
+
+        # final_score was called with the merged set: pre-existing + newly run task
+        assert final_score_calls == [{"task_0", "task_1", new_task_id}]
+        assert benchmark_row.final_evaluation is not None
+        assert benchmark_row.final_evaluation.final_score == 3.0
 
     async def test_process_task_resumes_evaluation_without_sandbox(
         self,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import FinalScoreResponse, Resources, RetrieveTaskResponse, VerifyTaskIdsResponse
+from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 from sqlmodel import Session, select
@@ -43,35 +43,11 @@ client = TestClient(app)
 class TestStopAndResume:
     _test_org = Org(id=TEST_ORG_ID, name="default")
 
-    @staticmethod
-    async def _mock_request_retrieve_task(*args: Any, **kwargs: Any) -> RetrieveTaskResponse:
-        return RetrieveTaskResponse(
-            docker_image="test-image:latest",
-            problem_path="/tmp/problem_statement.txt",
-            cwd="/testbed",
-            resources=Resources(vcpu=2, memory=4, disk=5),
-        )
-
-    @staticmethod
-    async def _mock_request_evaluate_instance(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        return {"status": "success", "score": 1.0}
-
-    @staticmethod
-    async def _mock_request_final_score(
-        *args: Any, evaluation_results: dict[str, Any], **kwargs: Any
-    ) -> FinalScoreResponse:
-        tasks_evaluated = list(evaluation_results.keys())
-        return FinalScoreResponse(
-            tasks_evaluated=tasks_evaluated,
-            final_score=50.0,
-            metadata={"resolved_tasks": [], "unresolved_tasks": tasks_evaluated},
-        )
-
     async def test_stop_and_resume(
         self,
         contract: AgentContractRequest,
         database_session: Session,
-        monkeypatch: MonkeyPatch,
+        process_benchmark_env: None,
         harness_config: HarnessConfig,
     ):
         """
@@ -84,13 +60,6 @@ class TestStopAndResume:
             - Resume benchmark - only the 3 tasks that are stopped should be resumed
             - Retry or resume benchmark - all 5 tasks should have evaluation results after completion
         """
-
-        @asynccontextmanager
-        async def _mock_create_sandbox(*args: Any, **kwargs: Any):
-            mock_sandbox = AsyncMock()
-            mock_sandbox.id = "mock-sandbox-id"
-            yield mock_sandbox
-
         task_ids: list[str] = [
             "astropy__astropy-12907",
             "astropy__astropy-13033",
@@ -110,12 +79,6 @@ class TestStopAndResume:
         benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_org)
         database_session.add(benchmark_row)
         database_session.commit()
-
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", self._mock_request_retrieve_task)
-        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", self._mock_request_evaluate_instance)
-        monkeypatch.setattr(BenchmarkServiceClient, "final_score", self._mock_request_final_score)
 
         # Create tasks - 2 tasks are finished, 3 tasks are pending
         finished_task_ids = task_ids[:2]
@@ -152,11 +115,6 @@ class TestStopAndResume:
         benchmark_row.status = BenchmarkStatus.STOPPED
         database_session.add(benchmark_row)
         database_session.commit()
-
-        async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
-            return VerifyTaskIdsResponse(task_ids=pending_task_ids)
-
-        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
@@ -285,7 +243,7 @@ class TestStopAndResume:
         self,
         example_benchmark_object: Benchmark,
         database_session: Session,
-        monkeypatch: MonkeyPatch,
+        process_benchmark_env: None,
         harness_config: HarnessConfig,
     ):
         """rerun_task_ids that don't have a row yet become fresh PENDING rows."""
@@ -296,16 +254,6 @@ class TestStopAndResume:
             Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.STOPPED),
         )
         database_session.commit()
-
-        verified_requests: list[set[str]] = []
-
-        async def _mock_request_verify_task_ids(
-            *_args: Any, task_ids: list[str], **_kwargs: Any
-        ) -> VerifyTaskIdsResponse:
-            verified_requests.append(set(task_ids))
-            return VerifyTaskIdsResponse(task_ids=task_ids)
-
-        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
@@ -323,7 +271,6 @@ class TestStopAndResume:
         }
 
         assert set(verified_task_ids) == {"task_0", "task_1", "task_2"}
-        assert verified_requests == [{"task_0", "task_1", "task_2"}]
         assert task_statuses == {
             "task_0": TaskStatus.PENDING,
             "task_1": TaskStatus.PENDING,
@@ -334,18 +281,12 @@ class TestStopAndResume:
         self,
         contract: AgentContractRequest,
         database_session: Session,
+        process_benchmark_env: None,
         monkeypatch: MonkeyPatch,
         harness_config: HarnessConfig,
     ):
         """A FINISHED run + new --task-ids: the new task runs to completion and the final
         score is recomputed over the merged set (existing + new)."""
-
-        @asynccontextmanager
-        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
-            mock_sandbox = AsyncMock()
-            mock_sandbox.id = "mock-sandbox-id"
-            yield mock_sandbox
-
         existing_task_ids = ["task_0", "task_1"]
         new_task_id = "task_2"
 
@@ -377,10 +318,10 @@ class TestStopAndResume:
             )
         database_session.commit()
 
-        # Capture what final_score sees so we can assert the merge
+        # Override final_score to capture what it sees and weight by count
         final_score_calls: list[set[str]] = []
 
-        async def _mock_request_final_score(
+        async def _capturing_final_score(
             *_args: Any, evaluation_results: dict[str, Any], **_kwargs: Any
         ) -> FinalScoreResponse:
             tasks_evaluated = list(evaluation_results.keys())
@@ -391,17 +332,7 @@ class TestStopAndResume:
                 metadata={"resolved_tasks": tasks_evaluated, "unresolved_tasks": []},
             )
 
-        async def _mock_request_verify_task_ids(
-            *_args: Any, task_ids: list[str], **_kwargs: Any
-        ) -> VerifyTaskIdsResponse:
-            return VerifyTaskIdsResponse(task_ids=task_ids)
-
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", self._mock_request_retrieve_task)
-        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", self._mock_request_evaluate_instance)
-        monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_request_final_score)
-        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", _capturing_final_score)
 
         # Resume with a new task id — should be lazily created as PENDING
         verified_task_ids = await reset_to_in_progress_status(

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -279,6 +279,55 @@ class TestStopAndResume:
         assert task_row.status == expected_status
         assert task_row.eval_resume_state == expected_state
 
+    async def test_reset_lazily_creates_rows_for_unregistered_task_ids(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ):
+        """rerun_task_ids that don't have a row yet become fresh PENDING rows."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.STOPPED),
+        )
+        database_session.commit()
+
+        verified_requests: list[set[str]] = []
+
+        async def _mock_request_verify_task_ids(
+            *_args: Any, task_ids: list[str], **_kwargs: Any
+        ) -> VerifyTaskIdsResponse:
+            verified_requests.append(set(task_ids))
+            return VerifyTaskIdsResponse(task_ids=task_ids)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
+
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
+            retry=False,
+            retry_mode=RetryMode.AUTO,
+            rerun_task_ids=["task_1", "task_2"],
+            org=self._test_org,
+        )
+
+        task_statuses = {
+            task.task_id: task.status
+            for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        }
+
+        assert set(verified_task_ids) == {"task_0", "task_1", "task_2"}
+        assert verified_requests == [{"task_0", "task_1", "task_2"}]
+        assert task_statuses == {
+            "task_0": TaskStatus.PENDING,
+            "task_1": TaskStatus.PENDING,
+            "task_2": TaskStatus.PENDING,
+        }
+
     async def test_process_task_resumes_evaluation_without_sandbox(
         self,
         contract: AgentContractRequest,

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -437,7 +437,8 @@ class TrackerService:
             benchmark_id: Benchmark id
             retry: Whether to retry tasks with the status error
             concurrency: Optional new concurrency level to override original value
-            task_ids: List of task ids to force retry
+            task_ids: List of task ids to force retry. Task ids without an existing row
+                are created as fresh PENDING if valid in the current dataset.
             service_headers: Optional headers for benchmark service authentication
 
         Returns:


### PR DESCRIPTION
## Summary
- `retry-or-resume` now creates fresh `PENDING` rows for any `--task-ids` that don't already have a row, as long as they're valid in the current dataset (validated via the benchmark service's existing `verify_task_ids` call).
- Lets you add work to a `STOPPED` or `FINISHED` run without starting over — including tasks added to the dataset after the run began.
- Replaces the tracker's "missing task_id" guard with the benchmark service's existing verify response (invalid ids surface as 400 from the service, propagated as 500 by the tracker).

This supersedes #361 (which introduced an explicit `DEFERRED` status + `--defer-rest` / `--run-deferred` flags) — lazy creation covers the same UX with one mechanism instead of three.


## Notes for reviewers
- Close #361 — that branch is superseded by this approach (no DEFERRED status, no extra flags, smaller code surface).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->