### PR TITLE
ci: migrate AWS auth from static keys to OIDC federation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     runs-on: ubuntu-24.04-arm
@@ -20,9 +24,8 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy
+          aws-region: us-east-1
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/tracker-integration-tests.yaml
+++ b/.github/workflows/tracker-integration-tests.yaml
@@ -2,6 +2,11 @@ name: Tracker integration tests
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   tracker-integration-tests:
     runs-on: ubuntu-latest
@@ -59,6 +64,12 @@ jobs:
           uv venv --python 3.12
           uv sync --group dev
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-tests
+          aws-region: us-east-1
+
       - name: Run integration tests
         run: |
           cd services/tracker
@@ -67,6 +78,4 @@ jobs:
           TEST_AWS_S3_BUCKET: ${{ secrets.TEST_AWS_S3_BUCKET }}
           TEST_LOG_GROUP: ${{ secrets.TEST_LOG_GROUP }}
           TEST_DAYTONA_SECRET_NAME: ${{ secrets.TEST_DAYTONA_SECRET_NAME }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}
+          AWS_DEFAULT_REGION: us-east-1

--- a/services/tracker/src/tracker/_lambda.py
+++ b/services/tracker/src/tracker/_lambda.py
@@ -16,6 +16,7 @@ def _lambda_client(aws: AWSCredentials) -> Any:
         "lambda",
         aws_access_key_id=aws.aws_access_key_id,
         aws_secret_access_key=aws.aws_secret_access_key,
+        aws_session_token=aws.aws_session_token,
         region_name=aws.aws_default_region,
     )
 

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -22,6 +22,7 @@ def _cloudwatch_client(aws: "AWSCredentials") -> Any:
         "logs",
         aws_access_key_id=aws.aws_access_key_id,
         aws_secret_access_key=aws.aws_secret_access_key,
+        aws_session_token=aws.aws_session_token,
         region_name=aws.aws_default_region,
         config=Config(max_pool_connections=200),
     )

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -26,6 +26,7 @@ def _s3_client(aws: "AWSCredentials") -> Any:
         "s3",
         aws_access_key_id=aws.aws_access_key_id,
         aws_secret_access_key=aws.aws_secret_access_key,
+        aws_session_token=aws.aws_session_token,
         region_name=aws.aws_default_region,
         config=Config(max_pool_connections=200),
     )

--- a/services/tracker/src/tracker/aws/secrets.py
+++ b/services/tracker/src/tracker/aws/secrets.py
@@ -21,6 +21,7 @@ def _secretsmanager_client(aws: AWSCredentials) -> Any:
         "secretsmanager",
         aws_access_key_id=aws.aws_access_key_id,
         aws_secret_access_key=aws.aws_secret_access_key,
+        aws_session_token=aws.aws_session_token,
         region_name=aws.aws_default_region,
     )
 

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -32,6 +32,7 @@ class AWSCredentials(BaseModel, frozen=True):
     aws_access_key_id: str
     aws_secret_access_key: str
     aws_default_region: str
+    aws_session_token: str | None = None
 
 
 class HarnessConfig(BaseModel):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1432,6 +1432,7 @@ def fetch_harness_config(request: Request) -> HarnessConfig:
             aws_access_key_id=flat["aws_access_key_id"],
             aws_secret_access_key=flat["aws_secret_access_key"],
             aws_default_region=flat["aws_default_region"],
+            aws_session_token=flat.get("aws_session_token"),
         ),
         s3_bucket=flat["s3_bucket"],
         log_group=flat["log_group"],

--- a/services/tracker/tests/integration/conftest.py
+++ b/services/tracker/tests/integration/conftest.py
@@ -104,6 +104,7 @@ def aws_credentials():
         aws_access_key_id=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
         aws_default_region=aws_default_region,
+        aws_session_token=os.getenv("AWS_SESSION_TOKEN"),
     )
 
     return aws_credentials

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -91,6 +91,7 @@ class TestSandboxOperations:
             region_name=aws_credentials.aws_default_region,
             aws_access_key_id=aws_credentials.aws_access_key_id,
             aws_secret_access_key=aws_credentials.aws_secret_access_key,
+            aws_session_token=aws_credentials.aws_session_token,
         )
         agent_key = get_contract_s3_key(contract_name)
         frozen_key = get_benchmark_contract_s3_key(benchmark_id, contract_name)

--- a/services/tracker/tests/integration/test_upload_artifacts_images.py
+++ b/services/tracker/tests/integration/test_upload_artifacts_images.py
@@ -55,6 +55,7 @@ class TestUploadArtifactsAcrossImages:
             region_name=aws_credentials.aws_default_region,
             aws_access_key_id=aws_credentials.aws_access_key_id,
             aws_secret_access_key=aws_credentials.aws_secret_access_key,
+            aws_session_token=aws_credentials.aws_session_token,
         )
         agent_key = get_contract_s3_key(contract.name)
         frozen_key = get_benchmark_contract_s3_key(benchmark_id, contract.name)


### PR DESCRIPTION
## Summary
Migrates AWS authentication in CI workflows from static access keys (`AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`) to [GitHub Actions OIDC federation](https://docs.github.com/en/actions/concepts/security/openid-connect).

**Why:** Static long-lived AWS credentials stored as GitHub secrets are a security risk — they don't expire, can be exfiltrated, and are shared across all workflow runs. OIDC federation eliminates stored secrets entirely by letting GitHub mint short-lived tokens that AWS trusts directly via an identity provider. Each workflow run gets unique, scoped, auto-expiring credentials with no secrets to rotate or leak.

## Changes
- `deploy.yaml`: Replace `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` secrets with `role-to-assume` using the `github-actions-valkyrie-deploy` IAM role. Add `permissions: id-token: write` at top level.
- `tracker-integration-tests.yaml`: Add a `configure-aws-credentials` step with `role-to-assume` using the `github-actions-valkyrie-tests` IAM role. Remove explicit `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars (ambient creds from the action are picked up automatically). Add `permissions: id-token: write`.
- `AWSCredentials` model: Add optional `aws_session_token` field and pass it to all boto3 client constructors (Secrets Manager, S3, CloudWatch Logs, Lambda). OIDC temporary credentials include a session token that must be forwarded to AWS API calls.
- Integration test conftest: Read `AWS_SESSION_TOKEN` from environment when constructing test credentials.

## Related Issues
N/A — security hardening initiative

## Type of Change
- [x] Bug fix
- [x] Docs / config

## Testing
- [ ] Manually tested — requires triggering the integration tests manually on the PR
- Required CI checks (ruff-lint, basedpyright) pass
- Integration tests need a manual re-run to validate the session token fix

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/ceeda9d407424da9bcc71893d36edc02
Requested by: @BradenBug