### PR TITLE
feat(cli,tracker): http URL task-ids files + subset rescore on results

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ valkyrie run start \
 | `-k` / `--kwarg` | Key-value pair passed to the agent run command. Repeatable |
 | `--lambda` | AWS Lambda function to invoke after the run completes |
 | `--task-ids` | Comma-separated task IDs to run |
-| `--task-ids-file` | Path to a text file with one task ID per line |
+| `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--slice` | Slice the benchmark dataset (`start:stop:step`) |
 | `--dataset` | Dataset variant to run from the benchmark service. A single benchmark can expose multiple datasets (e.g. `default`, `test`, `validation`, `train`, `lite`) representing different task splits or difficulty levels. Defaults to `default` |
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
@@ -258,7 +258,19 @@ valkyrie run results <id> --path ./results.json
 
 # Upload to S3
 valkyrie run results <id> --s3
+
+# Score over a task-id subset (recomputed via the benchmark service;
+# stored full results are unchanged)
+valkyrie run results <id> --task-ids task_1,task_2
+valkyrie run results <id> --task-ids-file https://example.com/subset.txt
 ```
+
+| Option | Description |
+| --- | --- |
+| `--path` | Local path to save results (default: `./<benchmark>.json`) |
+| `--s3` | Upload to S3 instead of downloading. With `--task-ids` / `--task-ids-file` the subset view overwrites the canonical S3 key — re-run without filters to restore |
+| `--task-ids` | Comma-separated task IDs to score the subset over (recomputes `final_score` over the filtered set) |
+| `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 
 ### Stop a run
 
@@ -286,7 +298,7 @@ valkyrie run resume <id> --concurrency 20
 | --- | --- |
 | `--concurrency` | Override concurrency level |
 | `--task-ids` | Comma-separated task IDs to resume/retry. Any id without an existing row is created as fresh `PENDING` if valid in the current dataset — lets you grow scope without starting a new run. |
-| `--task-ids-file` | Path to a text file with one task ID per line |
+| `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -34,7 +34,7 @@ from tracker.aws.s3 import (
     s3_object_exists,
 )
 from tracker.config import AUTH_REQUIRED, ENVIRONMENT
-from tracker.database.models import Benchmark, BenchmarkStatus, Org, RetryMode
+from tracker.database.models import Benchmark, BenchmarkStatus, FinalEvaluation, Org, RetryMode
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
@@ -318,24 +318,59 @@ async def fetch_benchmark(
 @app.get("/retrieve-results")
 async def retrieve_results(
     benchmark_id: TrackedBenchmarkId,
+    http_request: Request,
     s3: bool = Query(default=False),
+    task_ids: list[str] | None = Query(default=None),
     session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
 ) -> RetrieveResultsResponse:
     """
-    Retrieve the results of a benchmark by its id.
+    Retrieve the results of a benchmark by its id. When task_ids is non-empty, the final view is
+    filtered to that subset and the final score is recomputed over the subset; the persisted
+    FinalEvaluation / per-task rows are left untouched.
+
+    Note: with `s3=True` the S3 final view at the canonical key is overwritten with whatever was
+    just computed (full or subset). The DB remains source of truth, so re-running without
+    task_ids re-uploads the canonical full view.
 
     Usage:
-    curl -X GET http://<endpoint>/retrieve-results/<benchmark_id>?s3=false
-
-    Returns:
-        RetrieveResultsResponse
+    curl -X GET http://<endpoint>/retrieve-results?benchmark_id=<uuid>&s3=false
+    curl -X GET 'http://<endpoint>/retrieve-results?benchmark_id=<uuid>&task_ids=task_1&task_ids=task_2'
     """
     benchmark_row = session.get(Benchmark, benchmark_id, options=[joinedload(Benchmark.final_evaluation)])
     assert_org(benchmark_row, org)
 
     final_view = create_final_view(benchmark_row, session, org)
+
+    if task_ids:
+        task_ids_set = set(task_ids)
+
+        def _filter_task_map(task_map):
+            return {task_id: value for task_id, value in (task_map or {}).items() if task_id in task_ids_set} or None
+
+        final_view.evaluation_results = _filter_task_map(final_view.evaluation_results)
+        final_view.task_errors = _filter_task_map(final_view.task_errors)
+
+        effective_service_headers = forward_tracker_api_key(None, http_request.headers.get("x-api-key"))
+        benchmark_service = benchmark_row.benchmark_service(
+            harness_config.daytona_secret_name,
+            harness_config.aws,
+            service_headers=effective_service_headers,
+        )
+        try:
+            resp = await benchmark_service.final_score(
+                evaluation_results=final_view.evaluation_results or {},
+                dataset=benchmark_row.arguments.dataset,
+            )
+        finally:
+            await benchmark_service.close()
+        final_view.final_evaluation = FinalEvaluation(
+            org_id=org.id,
+            benchmark=benchmark_row.id,
+            final_score=resp.final_score,
+            properties=resp.metadata,
+        )
 
     if s3:
         s3_key = await upload_final_view(benchmark_row, final_view, harness_config)

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 
 import httpx
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import VerifyTaskIdsResponse
+from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
 from dateutil.parser import isoparse
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
@@ -272,7 +272,9 @@ class TestFastapiServer:
         assert details.get("total_tasks") and details["total_tasks"] == 10
         assert details.get("finished_tasks") and details["finished_tasks"] == 6
 
-    async def test_retrieve_results(self, database_session: Session, example_benchmark_object: Benchmark):
+    async def test_retrieve_results(
+        self, monkeypatch: MonkeyPatch, database_session: Session, example_benchmark_object: Benchmark
+    ):
         """
         Test the retrieve results endpoint of the fastapi server.
 
@@ -418,6 +420,26 @@ class TestFastapiServer:
 
         # If we did not get an error message, we return a default message
         assert response_json.get("task_errors").get("task_23") == "No error message was provided"
+
+        # Test case 9. task_ids subset filters evaluation_results and recomputes final_score
+        observed_headers: dict[str, str] = {}
+
+        async def _mock_final_score(client: BenchmarkServiceClient, **kwargs: Any) -> FinalScoreResponse:
+            observed_headers.update(client._headers)
+            ids = list(kwargs["evaluation_results"].keys())
+            return FinalScoreResponse(tasks_evaluated=ids, final_score=float(len(ids)), metadata={})
+
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
+        response = client.get(
+            "/retrieve-results",
+            params=[("benchmark_id", str(benchmark_row.id)), ("task_ids", "task_1"), ("task_ids", "task_3")],
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body["evaluation_results"]) == {"task_1", "task_3"}
+        assert body["final_evaluation"]["final_score"] == 2.0
+        assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
 
     async def test_benchmark_error_handling(
         self,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -40,6 +40,7 @@ from valkyrie.cli.utils import (
     paginate_agents,
     paginate_benchmarks,
     paginate_services,
+    resolve_task_ids,
     resolve_webhook_config,
     stream_benchmark_status,
 )
@@ -418,10 +419,10 @@ def auth_list() -> None:
 )
 @click.option(
     "--task-ids-file",
-    type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
+    type=str,
     required=False,
     default=None,
-    help="Path to a text file with one task ID per line",
+    help="Path or http(s) URL to a text file with one task ID per line",
 )
 @click.option(
     "--slice",
@@ -486,7 +487,7 @@ def start(
     concurrency: int,
     lambda_function: str | None,
     task_ids: str | None,
-    task_ids_file: Path | None,
+    task_ids_file: str | None,
     slice_str: str | None,
     dataset: str | None,
     kwargs: tuple[tuple[str, str]],
@@ -501,12 +502,7 @@ def start(
     Example:
         valkyrie run start --agent agents/claude_code --benchmark swebench
     """
-    if task_ids and task_ids_file:
-        raise click.UsageError("--task-ids and --task-ids-file are mutually exclusive")
-
-    if task_ids_file:
-        lines = task_ids_file.read_text().splitlines()
-        task_ids = ",".join(line.strip() for line in lines if line.strip())
+    formatted_task_ids = resolve_task_ids(task_ids, task_ids_file)
 
     service_headers: dict[str, str] = {}
     auth_credential = TrackerService.get_benchmark_auth(benchmark)
@@ -518,13 +514,10 @@ def start(
     # Webhook notification setup (may print a warning before the boxes)
     webhook_secret, webhook_intervals = resolve_webhook_config(intervals, TrackerService.get_webhook_secret())
 
-    format_run_start_details(benchmark, dataset, concurrency, slice_str, task_ids)
+    task_ids_display = ",".join(formatted_task_ids) if formatted_task_ids else None
+    format_run_start_details(benchmark, dataset, concurrency, slice_str, task_ids_display)
 
     format_agent_start_details(agent, model, secrets, kwargs, service_headers, webhook_secret, webhook_intervals)
-
-    formatted_task_ids: list[str] | None = None
-    if task_ids:
-        formatted_task_ids = task_ids.split(",")
 
     try:
         # Build agent config
@@ -640,13 +633,29 @@ def fetch(run_id: UUID, connect: bool):
     required=False,
     help="Saves results to s3 instead of downloading them locally. Can be found at bucket://benchmarks/run_id/<benchmark>.json",
 )
-def results(run_id: UUID, path: Path | None, s3: bool):
+@click.option(
+    "--task-ids",
+    type=str,
+    required=False,
+    default=None,
+    help="Comma-separated task IDs to score the subset over. Final score is recomputed over the subset.",
+)
+@click.option(
+    "--task-ids-file",
+    type=str,
+    required=False,
+    default=None,
+    help="Path or http(s) URL to a text file with one task ID per line",
+)
+def results(run_id: UUID, path: Path | None, s3: bool, task_ids: str | None, task_ids_file: str | None):
     """
     Retrieve the results of a run by its run id.
 
     Example:
         valkyrie run results e532551e-d51b-4912-983d-47695bd24174 --path ./results.json
     """
+    subset_task_ids = resolve_task_ids(task_ids, task_ids_file)
+
     click.echo(f"Retrieving results for run: {run_id}")
 
     try:
@@ -659,9 +668,17 @@ def results(run_id: UUID, path: Path | None, s3: bool):
                     if not click.confirm("Results already exist in S3. Overwrite?"):
                         raise click.Abort()
 
-            results_response: RetrieveResultsResponse = tracker.retrieve_results(run_id, s3)
+            results_response: RetrieveResultsResponse = tracker.retrieve_results(run_id, s3, task_ids=subset_task_ids)
 
             if isinstance(results_response, FinalViewResponse):
+                if subset_task_ids:
+                    scored = len(results_response.evaluation_results or {})
+                    click.echo(
+                        click.style(
+                            f"Scored over {scored} of {len(subset_task_ids)} subset task ids.",
+                            fg="yellow" if scored < len(subset_task_ids) else "green",
+                        )
+                    )
                 default_path: Path = Path(f"./{results_response.benchmark_name}.json")
 
                 download_final_view(path or default_path, results_response)
@@ -753,10 +770,10 @@ def stop(run_id: UUID, force: bool):
 )
 @click.option(
     "--task-ids-file",
-    type=click.Path(exists=True, path_type=Path, file_okay=True, dir_okay=False),
+    type=str,
     required=False,
     default=None,
-    help="Path to a text file with one task ID per line",
+    help="Path or http(s) URL to a text file with one task ID per line",
 )
 @click.option(
     "--update-agent",
@@ -778,7 +795,7 @@ def resume(
     retry: bool,
     concurrency: int | None,
     task_ids: str | None,
-    task_ids_file: Path | None,
+    task_ids_file: str | None,
     update_agent: bool,
     from_scratch: bool,
 ):
@@ -788,12 +805,7 @@ def resume(
     Example:
         valkyrie run resume 123e4567-e89b-12d3-a456-426614174000 --retry --concurrency 20
     """
-    if task_ids and task_ids_file:
-        raise click.UsageError("--task-ids and --task-ids-file are mutually exclusive")
-
-    if task_ids_file:
-        lines = task_ids_file.read_text().splitlines()
-        task_ids = ",".join(line.strip() for line in lines if line.strip())
+    retry_task_ids = resolve_task_ids(task_ids, task_ids_file) or []
 
     # NOTE: workaround for auto retrying tasks when using the retry command
     if ctx.info_name == "retry":
@@ -818,7 +830,6 @@ def resume(
                 asyncio.run(update_benchmark_agent_version(agent_name, str(run_id)))
                 click.echo(click.style("\r\033[K✓ Agent updated", fg="green"))
 
-            retry_task_ids = task_ids.split(",") if task_ids else []
             _ = tracker.retry_or_resume_benchmark(
                 run_id,
                 retry,
@@ -954,7 +965,8 @@ def outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
             click.echo(f"\r\033[KFetching agent outputs for run {run_id}...", nl=False)
 
             response = tracker.fetch_agent_outputs(
-                run_id, task_ids=[task.strip() for task in task_ids.split(",")] if task_ids else None
+                run_id,
+                task_ids=resolve_task_ids(task_ids),
             )
 
             download_agent_outputs(response, output_dir)

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -347,20 +347,24 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stream run: {e}") from e
 
-    def retrieve_results(self, benchmark_id: UUID, s3: bool) -> RetrieveResultsResponse:
+    def retrieve_results(
+        self,
+        benchmark_id: UUID,
+        s3: bool,
+        task_ids: list[str] | None = None,
+    ) -> RetrieveResultsResponse:
         """
         Retrieve the results of a benchmark by its benchmark id.
 
-        Args:
-            benchmark_id: Benchmark id
-
-        Returns:
-            RetrieveResultsResponse with benchmark results
+        If task_ids is provided, results are filtered to that subset and the final score is
+        recomputed over those tasks (does not mutate the stored FinalEvaluation).
         """
         try:
-            response = self._client.get(
-                f"{self._base_url}/retrieve-results", params={"benchmark_id": str(benchmark_id), "s3": s3}
-            )
+            params: dict[str, Any] = {"benchmark_id": str(benchmark_id), "s3": s3}
+            if task_ids:
+                params["task_ids"] = task_ids
+
+            response = self._client.get(f"{self._base_url}/retrieve-results", params=params)
 
             if response.status_code != 200:
                 details = response.json().get("detail", response.text)

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -5,10 +5,13 @@ import json
 import shutil
 import tarfile
 import tempfile
+import urllib.request
+from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, Coroutine, TypeVar
+from urllib.parse import urlparse
 from uuid import UUID
 
 import click
@@ -95,6 +98,38 @@ async def run_with_spinner(coro: Coroutine[Any, Any, T], message: str) -> T:
             click.echo("\r\033[K", nl=False)
 
     return result
+
+
+def _clean_task_ids(task_ids: Iterable[str]) -> list[str]:
+    cleaned = [task_id.strip() for task_id in task_ids]
+    return list(dict.fromkeys(task_id for task_id in cleaned if task_id))
+
+
+def read_task_ids_source(source: str) -> list[str]:
+    """Read task IDs (one per line) from a local path or an http(s) URL."""
+    try:
+        if urlparse(source).scheme in {"http", "https"}:
+            with urllib.request.urlopen(source) as response:
+                content = response.read().decode("utf-8")
+        else:
+            content = Path(source).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise click.ClickException(f"Failed to read task ids from {source}: {exc}") from exc
+
+    task_ids = _clean_task_ids(content.splitlines())
+    if not task_ids:
+        raise click.ClickException(f"No task ids found in {source}")
+    return task_ids
+
+
+def resolve_task_ids(task_ids: str | None = None, task_ids_file: str | None = None) -> list[str] | None:
+    if task_ids and task_ids_file:
+        raise click.UsageError("--task-ids and --task-ids-file are mutually exclusive")
+    if task_ids_file:
+        return read_task_ids_source(task_ids_file)
+    if task_ids:
+        return _clean_task_ids(task_ids.split(",")) or None
+    return None
 
 
 def local_time(dt: datetime) -> str:


### PR DESCRIPTION
## Motivation

Teams often maintain a **curated subset** of a benchmark — a smaller, representative slice of task IDs that they care about reporting on (e.g., a published headline number) — separately from the full task suite the agent is actually run against. The canonical subset definition typically lives in a shared, version-pinnable place: a `.txt` of task IDs in a GitHub repo, an S3 object, a published URL.

Today, scoring an agent on both the full suite and the curated subset from the *same* run isn't supported:
- The tracker computes one `FinalEvaluation` over whatever tasks the run included, and the S3 final view reflects that.
- To get a subset score you'd either start a second run scoped to the subset (duplicating compute) or compute the subset score yourself off-line (no benchmark-service scoring guarantees, no consistent artifact).

This PR closes that gap with the smallest possible surface change: a subset filter on `run results`, plus URL support for the `--task-ids-file` flag so the subset definition can live anywhere reachable.

## What this enables

```bash
# Subset definition lives in a versioned remote location:
#   https://raw.githubusercontent.com/<org>/<repo>/<sha>/subsets/<bench>.txt

# Start a run on the full benchmark (your existing flow, unchanged)
valk run start --agent ... --benchmark <bench> --dataset <full-set>

# Once it finishes, get the full-set score and the curated-subset score from the same run
valk run results <id>                                                            # full
valk run results <id> --task-ids-file https://.../subsets/<bench>.txt            # subset
```

Pairs naturally with the lazy-spike pattern landed in #363: start small with the curated subset, extend the same run to the full suite by passing the full task list to `run resume`, and afterwards query both scores from a single run.

## Changes

- `--task-ids-file` on `run start` / `run resume` / `run results` accepts an `http(s)` URL in addition to a local path (uses `urllib.request` — no new deps). Lets users share a curated task-id list without local setup.
- `run results --task-ids` / `--task-ids-file` filters the FinalView to that subset and re-calls `benchmark_service.final_score` over the filtered `evaluation_results`; the persisted `FinalEvaluation` and per-task rows are left untouched (DB is source of truth).
- CLI prints `Scored over <K> of <N> subset task ids` so stale / partially-overlapping subsets surface visibly (e.g. a versioned subset file that names tasks added after the run started).

## Subset-score semantics

The recompute calls `benchmark_service.final_score` with only the filtered `evaluation_results`. Whether the resulting score is subset-relative or dataset-relative depends on the benchmark service's `calculate_final_score` implementation (some normalize against the full dataset, others against what was passed). Benchmark-service maintainers can update on their side if subset-relative semantics matter for their score.

## Test plan

- [x] 150 tracker unit tests pass; new test (case 9 in `test_retrieve_results`) exercises the subset path with a mocked `final_score` and asserts the `X-Descope-Api-Key` forwarding header
- [x] 40 CLI unit tests pass
- [x] ruff format + check clean
- [x] live end-to-end against a local tracker + benchmark service + python http server
  - `run start --task-ids-file <URL>` → run created with tasks fetched from URL
  - `run resume --task-ids-file <URL>` → lazy spike adds new PENDING rows; all complete
  - `run results` (no flags) → full set scored
  - `run results --task-ids a,b` → "Scored over 2 of 2"
  - `run results --task-ids-file <URL>` → "Scored over N of N"
  - `run results --task-ids a,missing-id` → "Scored over 1 of 2" warning fires
  - `run results --task-ids X --task-ids-file Y` → `--task-ids and --task-ids-file are mutually exclusive`