### PR TITLE
infra: add deployment stage tag to infrastructure resources

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -6,9 +6,12 @@ import aws_cdk as cdk
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
 from tracker_stack import TrackerStack
+from stage_tags import tag_with_deployment_stage
 from worker_stack import WorkerStack
 
 app = cdk.App()
+
+stage_name = app.node.try_get_context("stage") or "prod"
 
 env = cdk.Environment(
     account=os.getenv("CDK_DEFAULT_ACCOUNT"),
@@ -17,6 +20,7 @@ env = cdk.Environment(
 
 # Shared infrastructure (VPC, cluster, service discovery, Route53)
 shared = SharedStack(app, "SharedStack", env=env)
+tag_with_deployment_stage(shared, stage_name)
 
 # Tracker service (public-facing with ALB) + RDS database
 tracker = TrackerStack(
@@ -30,6 +34,7 @@ tracker = TrackerStack(
     redis_url=shared.redis_url,
     env=env,
 )
+tag_with_deployment_stage(tracker, stage_name)
 
 # Worker service (Taskiq worker) - deployed independently
 worker = WorkerStack(
@@ -44,6 +49,7 @@ worker = WorkerStack(
     tracker_service=tracker.tracker_fargate_service,
     env=env,
 )
+tag_with_deployment_stage(worker, stage_name)
 
 monitoring = MonitoringStack(
     app,
@@ -57,6 +63,7 @@ monitoring = MonitoringStack(
     redis_cluster=shared.redis_cluster,
     env=env,
 )
+tag_with_deployment_stage(monitoring, stage_name)
 
 # Deployment order
 tracker.add_dependency(shared)

--- a/infra/stage_tags.py
+++ b/infra/stage_tags.py
@@ -1,0 +1,8 @@
+from aws_cdk import Tags
+from constructs import Construct
+
+DEPLOYMENT_STAGE_TAG_KEY = "stage"
+
+
+def tag_with_deployment_stage(scope: Construct, stage_name: str) -> None:
+    Tags.of(scope).add(DEPLOYMENT_STAGE_TAG_KEY, stage_name)


### PR DESCRIPTION
## Summary
Adds a `stage` tag to all CDK stacks (SharedStack, TrackerStack, WorkerStack, MonitoringStack) so AWS resources can be filtered by environment. Mirrors the pattern from [vals-ai/platform#2372](https://github.com/vals-ai/platform/pull/2372).

The stage value is configurable via CDK context (`-c stage=<value>`) and defaults to `prod`.

## Changes
- Added a shared `stage_tags.py` helper with `tag_with_deployment_stage(scope, stage_name)`
- Applied the helper to all four stacks in `app.py`
- Added CDK context variable `stage` (defaults to `"prod"`)

## Related Issues
https://github.com/vals-ai/platform/issues/2368

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Self-reviewed the diff

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/a016fa9b069e435d988a7e73348d5271
Requested by: @BradenBug