### PR TITLE
chore: use reusable close-stale-prs workflow from vals-ai/.github

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,21 +1,13 @@
 name: Close Stale Pull Requests
+
 on:
   schedule:
     - cron: '0 8 * * *' # Runs daily at 8:00 AM UTC
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v5
-        with:
-          days-before-pr-stale: 6
-          days-before-pr-close: 1
-          stale-pr-message: 'This pull request has had no activity for 6 days. It will be closed automatically in 1 day unless there is new activity.'
-          close-pr-message: 'This pull request was closed automatically due to inactivity.'
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
-          exempt-draft-pr: false
+    uses: vals-ai/.github/.github/workflows/close-stale-prs.yaml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Close Stale Pull Requests
+on:
+  schedule:
+    - cron: '0 8 * * *' # Runs daily at 8:00 AM UTC
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v5
+        with:
+          days-before-pr-stale: 6
+          days-before-pr-close: 1
+          stale-pr-message: 'This pull request has had no activity for 6 days. It will be closed automatically in 1 day unless there is new activity.'
+          close-pr-message: 'This pull request was closed automatically due to inactivity.'
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          exempt-draft-pr: false


### PR DESCRIPTION
## Summary
Replaces the standalone `actions/stale` workflow with a thin caller that delegates to the reusable workflow now defined in `vals-ai/.github`. Behavior is unchanged: daily run at 08:00 UTC, mark PRs stale after 6 days of inactivity with a thread comment, close after 1 more day with another thread comment.

The reusable workflow lives at https://github.com/vals-ai/.github/pull/13 — that PR must merge before this one for the `@main` reference to resolve.

## Changes
- Replaced inline `actions/stale@v5` config in `.github/workflows/stale.yml` with `uses: vals-ai/.github/.github/workflows/close-stale-prs.yaml@main`.
- Added `workflow_dispatch` so the job can be triggered manually for debugging.
- Kept `permissions: pull-requests: write` at the caller level so the reusable workflow inherits write access to comment and close PRs.

## Related Issues
Closes #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ ] Manually tested

Reusable workflow behavior will be confirmed via `workflow_dispatch` once both PRs merge.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/14c12cd1cc8642e6982c6ad0592d1b35
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/368" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->