### PR TITLE
feat(cli,tracker): --extend-to-dataset flag on resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,10 @@ valkyrie run retry <id>
 
 # Override concurrency on resume (works on retry)
 valkyrie run resume <id> --concurrency 20
+
+# Extend a subset run to cover the full current dataset (lazy-spikes any
+# dataset task ids not already on the run; existing finished tasks preserved)
+valkyrie run resume <id> --extend-to-dataset
 ```
 
 | Option | Description |
@@ -299,6 +303,7 @@ valkyrie run resume <id> --concurrency 20
 | `--concurrency` | Override concurrency level |
 | `--task-ids` | Comma-separated task IDs to resume/retry. Any id without an existing row is created as fresh `PENDING` if valid in the current dataset — lets you grow scope without starting a new run. |
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
+| `--extend-to-dataset` | Ask the benchmark service for the full task list in the run's dataset and lazy-spike any ids not already on the run. Already-finished tasks are preserved. |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -13,7 +13,7 @@ from fastapi.responses import StreamingResponse
 from opentelemetry.propagate import inject
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import joinedload
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from tracker.auth import (
     extract_api_key,
@@ -34,7 +34,7 @@ from tracker.aws.s3 import (
     s3_object_exists,
 )
 from tracker.config import AUTH_REQUIRED, ENVIRONMENT
-from tracker.database.models import Benchmark, BenchmarkStatus, FinalEvaluation, Org, RetryMode
+from tracker.database.models import Benchmark, BenchmarkStatus, FinalEvaluation, Org, RetryMode, Task
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
 from tracker.exceptions import TrackerServiceError
@@ -452,6 +452,7 @@ async def retry_or_resume_benchmark(
     retry: bool = Query(default=False),
     retry_mode: RetryMode = Query(default=RetryMode.AUTO),
     concurrency: int | None = Query(default=None),
+    extend_to_dataset: bool = Query(default=False),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
     session: Session = Depends(get_session),
@@ -496,13 +497,31 @@ async def retry_or_resume_benchmark(
         session.add(benchmark_row)
         session.commit()
 
+    benchmark_service = benchmark_row.benchmark_service(
+        harness_config.daytona_secret_name, harness_config.aws, service_headers=effective_service_headers
+    )
+
+    if extend_to_dataset:
+        full = await benchmark_service.verify_task_ids(
+            task_ids=None, slice_str=None, dataset=benchmark_row.arguments.dataset
+        )
+        existing_task_ids = set(
+            session.exec(
+                select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(Task.org_id == org.id)
+            ).all()
+        )
+        missing = [tid for tid in full.task_ids if tid not in existing_task_ids]
+        task_ids = list(dict.fromkeys([*task_ids, *missing]))
+        logger.info(
+            f"extend_to_dataset: dataset has {len(full.task_ids)} tasks, "
+            f"{len(missing)} not yet on run — adding as PENDING"
+        )
+
     # Reset tasks and retry or resume benchmark
     verified_task_ids = await reset_to_in_progress_status(
         benchmark_row=benchmark_row,
         session=session,
-        benchmark_service=benchmark_row.benchmark_service(
-            harness_config.daytona_secret_name, harness_config.aws, service_headers=effective_service_headers
-        ),
+        benchmark_service=benchmark_service,
         retry=retry,
         retry_mode=retry_mode,
         rerun_task_ids=task_ids,

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -309,6 +309,52 @@ class TestBenchmarkUtils:
         assert len(task_rows) == 5
         assert all(task_row.status == TaskStatus.PENDING for task_row in task_rows)
 
+    async def test_resume_with_extend_to_dataset_spikes_missing_tasks(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """`extend_to_dataset=true` pulls the full task list from the benchmark service and
+        lazy-spikes any ids not yet on the run as PENDING. Existing FINISHED tasks are
+        preserved (not reset)."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        # Seed 2 of 5 dataset tasks as FINISHED on the run (a curated-subset run)
+        for i in range(2):
+            database_session.add(
+                Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.FINISHED)
+            )
+        database_session.commit()
+
+        dataset_task_ids = [f"task_{i}" for i in range(5)]
+
+        async def _mock_verify(*_args: Any, task_ids: list[str] | None, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            # task_ids=None means "list the whole dataset"
+            return VerifyTaskIdsResponse(task_ids=task_ids if task_ids else dataset_task_ids)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=false&extend_to_dataset=true",
+            json={"task_ids": []},
+        )
+        assert response.status_code == 200
+
+        rows = {
+            row.task_id: row.status
+            for row in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        }
+        # All 5 dataset tasks present; the 2 already-FINISHED preserved; the 3 missing added as PENDING
+        assert set(rows.keys()) == {f"task_{i}" for i in range(5)}
+        assert rows["task_0"] == TaskStatus.FINISHED
+        assert rows["task_1"] == TaskStatus.FINISHED
+        assert rows["task_2"] == TaskStatus.PENDING
+        assert rows["task_3"] == TaskStatus.PENDING
+        assert rows["task_4"] == TaskStatus.PENDING
+
     def test_create_task_rows(self, example_benchmark_object: Benchmark, database_session: Session):
         """
         Tests different scenarios for creating task rows

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -788,6 +788,12 @@ def stop(run_id: UUID, force: bool):
     default=False,
     help="Clear durable eval state and rerun generation.",
 )
+@click.option(
+    "--extend-to-dataset",
+    is_flag=True,
+    default=False,
+    help="Ask the benchmark service for the full task list in this run's dataset and lazy-spike any ids not already on the run. Useful for extending a curated-subset run to the full dataset without maintaining a parallel task-id list.",
+)
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -798,6 +804,7 @@ def resume(
     task_ids_file: str | None,
     update_agent: bool,
     from_scratch: bool,
+    extend_to_dataset: bool,
 ):
     """
     Resume a run by its run id.
@@ -837,6 +844,7 @@ def resume(
                 concurrency,
                 retry_task_ids,
                 service_headers=service_headers,
+                extend_to_dataset=extend_to_dataset,
             )
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -433,6 +433,7 @@ class TrackerService:
         concurrency: int | None,
         task_ids: list[str],
         service_headers: dict[str, str] | None = None,
+        extend_to_dataset: bool = False,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -444,6 +445,8 @@ class TrackerService:
             task_ids: List of task ids to force retry. Task ids without an existing row
                 are created as fresh PENDING if valid in the current dataset.
             service_headers: Optional headers for benchmark service authentication
+            extend_to_dataset: If True, ask the benchmark service for the full task list in
+                the run's dataset and lazy-spike any ids not already on the run.
 
         Returns:
             RetryOrResumeBenchmarkResponse with status and message
@@ -454,6 +457,9 @@ class TrackerService:
             # NOTE: 0 is not acceptable
             if concurrency:
                 params["concurrency"] = concurrency
+
+            if extend_to_dataset:
+                params["extend_to_dataset"] = True
 
             body: dict[str, Any] = {"task_ids": task_ids, "service_headers": service_headers or {}}
 


### PR DESCRIPTION
## Motivation

The curated-subset workflow (start with a small subset, extend to the full set later) currently requires keeping a parallel task-id list of the full dataset locally. That list can drift from the actual dataset over time (tasks added/removed/renamed in the benchmark suite), creating sync burden and silent mismatches.

The benchmark service already knows the current dataset — the CLI shouldn't need to mirror it.

## What this adds

A new `--extend-to-dataset` flag on `valk run resume` that asks the benchmark service for the full task list in the run's dataset and lazy-spikes any ids not already on the run as fresh `PENDING` rows. Already-finished tasks are preserved (not reset).

```bash
# Phase 1: start a run on a curated subset (existing flow)
valk run start --benchmark <bench> --task-ids-file https://.../subset.txt …

# Phase 2: fill in everything else without enumerating it client-side
valk run resume <id> --extend-to-dataset

# Score both ways from the same run
valk run results <id>                                              # full
valk run results <id> --task-ids-file https://.../subset.txt       # subset
```

## Server-side

New optional `extend_to_dataset` query param on `/retry-or-resume-benchmark/{id}`. When true, the tracker calls `benchmark_service.verify_task_ids(task_ids=None, dataset=…)` to get the dataset's full task list, unions any missing ids into the supplied `task_ids`, and delegates to the existing `reset_to_in_progress_status` lazy-spike path (no new logic). Works alongside `--retry` and explicit `--task-ids`.

No new benchmark-service endpoint required: `verify_task_ids(task_ids=None)` already returns the full dataset via the existing `filter_tasks(TaskFilter())` path in `create-benchmark-service`.

## Test plan
- [x] new tracker test (`test_resume_with_extend_to_dataset_spikes_missing_tasks`) seeds 2 of 5 dataset tasks as FINISHED, posts to the endpoint with `extend_to_dataset=true`, asserts:
  - all 5 dataset tasks present on the run
  - the 2 pre-existing FINISHED rows are preserved (not reset)
  - the 3 missing ids are added as fresh PENDING
- [x] 151 tracker unit tests pass (150 existing + 1 new)
- [x] 40 CLI unit tests pass
- [x] ruff check + format clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/369" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->