### PR TITLE
chore: bump daytona SDK to 0.176.1a1 with connection fixes

### DIFF
--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -84,6 +84,7 @@ class TrackerStack(Stack):
             "BROKER_ENVIRONMENT": "production",
             "AWS_S3_BUCKET": bucket.bucket_name,
             "ENVIRONMENT": "production",
+            "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
         }
 
         # ── RDS ──────────────────────────────────────────────────────────

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -79,6 +79,7 @@ class WorkerStack(Stack):
             "BROKER_ENVIRONMENT": "production",
             "AWS_S3_BUCKET": bucket.bucket_name,
             "ENVIRONMENT": "production",
+            "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
         }
 
         db_env = {

--- a/services/tracker/docker-compose.yml
+++ b/services/tracker/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION
+      - DAYTONA_HAPPY_EYEBALLS_DELAY=none
     depends_on:
       postgres:
         condition: service_healthy
@@ -81,6 +82,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION
+      - DAYTONA_HAPPY_EYEBALLS_DELAY=none
     depends_on:
       postgres:
         condition: service_healthy

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "boto3-stubs[s3]",
     "moto[s3]",
     "fastapi[standard]>=0.135.3",
-    "daytona==0.172.1a1",
+    "daytona==0.176.1a1",
     "sqlmodel>=0.0.38",
     "psycopg2-binary>=2.9.11",
     "httpx>=0.28.1",

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -24,7 +24,7 @@ from daytona import (
     Resources,
     SandboxState,
 )
-from daytona.common.errors import DaytonaError
+from daytona.common.errors import DaytonaConnectionError, DaytonaError
 from daytona.handle.async_pty_handle import AsyncPtyHandle
 from opentelemetry import trace
 from tenacity import (
@@ -526,6 +526,13 @@ async def _create_pty_session(
     return handle, salted_id
 
 
+@retry(
+    retry=retry_if_exception_type(DaytonaConnectionError),
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(2),
+    before_sleep=daytona_retry_callback("valkyrie.sandbox.health_check", op="sandbox.health_check"),
+    reraise=True,
+)
 @logfire.instrument("sandbox.health_check", extract_args=False)
 async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
     """
@@ -542,6 +549,8 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
             incr("valkyrie.sandbox.unhealthy", tags={"state": str(sandbox.state)})
             raise SandboxError(f"Sandbox {sandbox.name} crashed during command execution (state: {sandbox.state})")
     except SandboxError:
+        raise
+    except DaytonaConnectionError:
         raise
     except Exception as e:
         if isinstance(e, DaytonaError):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, DaytonaConfig, SandboxState
+from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import Request
 from opentelemetry import trace
@@ -102,18 +102,7 @@ def create_benchmark_service_client(
     headers = fetch_daytona_headers(daytona_secret_name, aws)
     if service_headers:
         headers.update(service_headers)
-    client = BenchmarkServiceClient(url=url, headers=headers)
-
-    client._daytona_client = AsyncDaytona(  # pyright: ignore[reportPrivateUsage]
-        config=DaytonaConfig(
-            api_key=headers["x-api-key"],
-            api_url=headers["x-api-url"],
-            target=headers["x-target"],
-            connection_pool_maxsize=None,
-        )
-    )
-
-    return client
+    return BenchmarkServiceClient(url=url, headers=headers)
 
 
 def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest, org: Org) -> Benchmark:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
+from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, DaytonaConfig, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import Request
 from opentelemetry import trace
@@ -102,7 +102,18 @@ def create_benchmark_service_client(
     headers = fetch_daytona_headers(daytona_secret_name, aws)
     if service_headers:
         headers.update(service_headers)
-    return BenchmarkServiceClient(url=url, headers=headers)
+    client = BenchmarkServiceClient(url=url, headers=headers)
+
+    client._daytona_client = AsyncDaytona(  # pyright: ignore[reportPrivateUsage]
+        config=DaytonaConfig(
+            api_key=headers["x-api-key"],
+            api_url=headers["x-api-url"],
+            target=headers["x-target"],
+            connection_pool_maxsize=None,
+        )
+    )
+
+    return client
 
 
 def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest, org: Org) -> Benchmark:

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -408,14 +408,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/c2/09b9b3021f896097740df16e9412a1c8feedcb774875080f05781179a2c8/daytona-0.172.1a1.tar.gz", hash = "sha256:bee76be4371c6315036841b6483fb0a2083f79d814b3a2cb5b21796914684ca2", size = 130973, upload-time = "2026-05-06T12:11:34.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/53/9d137853216e7bd15eea00e5742922c41f3ebe07ab3485d1fbcfed22c512/daytona-0.176.1a1.tar.gz", hash = "sha256:8f4c83c7f350937edb8426538c8dfd0d2a968546af492684a01ef46ac0d06960", size = 138578, upload-time = "2026-05-14T14:39:41.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/e0/f011d003523c916e3e72cfc1012e2cdb4352d2990b5a3f9061bb66ce783a/daytona-0.172.1a1-py3-none-any.whl", hash = "sha256:76b72112cc7684f0db41fe12b2984f22a87f8d5ca9e47c42eb5c82ab69f98141", size = 161680, upload-time = "2026-05-06T12:11:32.895Z" },
+    { url = "https://files.pythonhosted.org/packages/97/94/61917c7852f0da926c916dabfb7b5badc8d795393a3bf5442e9bcd92caf1/daytona-0.176.1a1-py3-none-any.whl", hash = "sha256:2b2d2e9b6e550928c3202c15e0e9f8d639ebd0eded4a61f0cc337af72c7f85b4", size = 169581, upload-time = "2026-05-14T14:39:40.002Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -423,14 +423,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/6a/6be656b9066873f1451503630e11feffbe1d6db97470454825aa16302065/daytona_api_client-0.172.1a1.tar.gz", hash = "sha256:41f9df2ffb8b3c86d8ab2912415b897d25d858bba86b28ab233b324a567b7a92", size = 147719, upload-time = "2026-05-06T12:05:47.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/61/db7f3f7dd03caf4d40ce4180fe44e1b94b97a9b07d4db5c7ccac5a039c0a/daytona_api_client-0.176.1a1.tar.gz", hash = "sha256:805cf1395c1e99e4a94a53a62fdd869986715d8d60365f579751740d3311ddb1", size = 148425, upload-time = "2026-05-14T14:38:44.752Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/9d/49c06a6afaa5c2ed14bb1be9b25a4b63042dbe1b526b1d3b4e31635726de/daytona_api_client-0.172.1a1-py3-none-any.whl", hash = "sha256:5269f9b35ac664b502aa2d7edc908b6197a2b186fdd1cdfa2dd4a2e72e62b448", size = 459747, upload-time = "2026-05-06T12:05:46.12Z" },
+    { url = "https://files.pythonhosted.org/packages/61/bd/21da5fd6529d543fc9002150fcf80894a8e2eb9974192fd3c4d06cf2604d/daytona_api_client-0.176.1a1-py3-none-any.whl", hash = "sha256:3ad26b919d2c5b090bbc358b08fd19593a1c641edac253c7c56c18693f41f76c", size = 459976, upload-time = "2026-05-14T14:38:40.414Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -439,14 +439,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/3c/0998a36ed47db8ae44658b8883a790b0f02dad06dfbe4ad3f5196c3e950c/daytona_api_client_async-0.172.1a1.tar.gz", hash = "sha256:5359ab37d8f0ca0ce72f187e2bbed4ecdedd180413ab9fe581355ae63e1ee9c5", size = 148237, upload-time = "2026-05-06T12:05:28.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/3d/d93acaf3548190199d87e91ad015edae945ae53a87822128082bf47dd267/daytona_api_client_async-0.176.1a1.tar.gz", hash = "sha256:f62bc09001948597422aa6f871db7023d2a4baf8725ab8f2163267833bd683c3", size = 148973, upload-time = "2026-05-14T14:38:42.575Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/34/899212f8b4a106185bb6980ae6f3dec32a6beea272a78d9254dcd65fc0b1/daytona_api_client_async-0.172.1a1-py3-none-any.whl", hash = "sha256:de084888e51de7d094483e49ac776b944f48209d1dfb07c7e2d74a867e03b198", size = 465647, upload-time = "2026-05-06T12:05:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/2c637924ad67cac15eee31d820d04610f117aa268057ccb4cc3b86343018/daytona_api_client_async-0.176.1a1-py3-none-any.whl", hash = "sha256:b3e96fc35cbc280cdb2e44d4acb6aa25007c2621cabfe3e9c95f038b75045b3a", size = 465879, upload-time = "2026-05-14T14:38:40.774Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -454,14 +454,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/3d/30a0719102ea7dc098e94050f9272c5a59eb1cbf100a5184017d9f19964f/daytona_toolbox_api_client-0.172.1a1.tar.gz", hash = "sha256:c8e32c457f7e348005922de1afdebc2f1cd55924ade87749baeb7b8f40baa1e0", size = 73891, upload-time = "2026-05-06T12:05:32.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/a6/19ce458b619b1635659af4aa13a08fed1246c64b6bee6829e12bdae878c0/daytona_toolbox_api_client-0.176.1a1.tar.gz", hash = "sha256:247eb5dfed5ac338ac95c77ffcde0eccd0ce4bedf478a1a3c2c37aba5629b86b", size = 73860, upload-time = "2026-05-14T14:39:08.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/b9/90bca114612060dd3ed5efefbe89ad4b5c266501fde9ff1660486802391d/daytona_toolbox_api_client-0.172.1a1-py3-none-any.whl", hash = "sha256:2b475724c61a21798c2acb553d117b59b6bf4352a7e8e8ddaf805db4f9220919", size = 192854, upload-time = "2026-05-06T12:05:30.741Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e5/738a89090f02445c0314cda3c2878714a8187025d7e52232d40d180c0f28/daytona_toolbox_api_client-0.176.1a1-py3-none-any.whl", hash = "sha256:a444e1145e4c6144eb3b59a71e3878a0b2351ba2566276f8f3f0ce0e60833bda", size = 192855, upload-time = "2026-05-14T14:39:07.415Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -470,9 +470,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/71/2f4c93e3df95558937ac365cd4485b85154cde286d7fafdbbe8615a2c9c8/daytona_toolbox_api_client_async-0.172.1a1.tar.gz", hash = "sha256:df3400154a43e90ef9e858d6c2fe5ced85b0657c8ca260c3d5e1ca843723a281", size = 67437, upload-time = "2026-05-06T12:05:31.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/20/7edcd949a1e1c3cb606fca253f1f0c8cbfb7e7b6add8673608c434a06cec/daytona_toolbox_api_client_async-0.176.1a1.tar.gz", hash = "sha256:498ced48b6987fcadd19500bae3f26b123378915164c4d61afa2b5d23b28093c", size = 67434, upload-time = "2026-05-14T14:38:41.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/09/13e3246907d9fa7416531f79dc1fb3bd8ce170ba4d691fd08660ce3698bf/daytona_toolbox_api_client_async-0.172.1a1-py3-none-any.whl", hash = "sha256:355cbcdd757106cc9a63d7d9734ceffcf7d4df0724d900c30f589e33bc1b94c1", size = 190996, upload-time = "2026-05-06T12:05:29.385Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/75/aefe52745478916b88cb0b54ffd95c82a398c609c80512da7d6492609186/daytona_toolbox_api_client_async-0.176.1a1-py3-none-any.whl", hash = "sha256:966662e6a1b02e52b5dc0ed7fa57a70f80bf734fc7597f91916002fc2162b6ab", size = 190994, upload-time = "2026-05-14T14:38:40.084Z" },
 ]
 
 [[package]]
@@ -685,7 +685,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -1857,7 +1859,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
-    { name = "daytona", specifier = "==0.172.1a1" },
+    { name = "daytona", specifier = "==0.176.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -644,7 +644,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -668,14 +668,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/c2/09b9b3021f896097740df16e9412a1c8feedcb774875080f05781179a2c8/daytona-0.172.1a1.tar.gz", hash = "sha256:bee76be4371c6315036841b6483fb0a2083f79d814b3a2cb5b21796914684ca2", size = 130973, upload-time = "2026-05-06T12:11:34.658Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/53/9d137853216e7bd15eea00e5742922c41f3ebe07ab3485d1fbcfed22c512/daytona-0.176.1a1.tar.gz", hash = "sha256:8f4c83c7f350937edb8426538c8dfd0d2a968546af492684a01ef46ac0d06960", size = 138578, upload-time = "2026-05-14T14:39:41.883Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/e0/f011d003523c916e3e72cfc1012e2cdb4352d2990b5a3f9061bb66ce783a/daytona-0.172.1a1-py3-none-any.whl", hash = "sha256:76b72112cc7684f0db41fe12b2984f22a87f8d5ca9e47c42eb5c82ab69f98141", size = 161680, upload-time = "2026-05-06T12:11:32.895Z" },
+    { url = "https://files.pythonhosted.org/packages/97/94/61917c7852f0da926c916dabfb7b5badc8d795393a3bf5442e9bcd92caf1/daytona-0.176.1a1-py3-none-any.whl", hash = "sha256:2b2d2e9b6e550928c3202c15e0e9f8d639ebd0eded4a61f0cc337af72c7f85b4", size = 169581, upload-time = "2026-05-14T14:39:40.002Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -683,14 +683,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/6a/6be656b9066873f1451503630e11feffbe1d6db97470454825aa16302065/daytona_api_client-0.172.1a1.tar.gz", hash = "sha256:41f9df2ffb8b3c86d8ab2912415b897d25d858bba86b28ab233b324a567b7a92", size = 147719, upload-time = "2026-05-06T12:05:47.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/61/db7f3f7dd03caf4d40ce4180fe44e1b94b97a9b07d4db5c7ccac5a039c0a/daytona_api_client-0.176.1a1.tar.gz", hash = "sha256:805cf1395c1e99e4a94a53a62fdd869986715d8d60365f579751740d3311ddb1", size = 148425, upload-time = "2026-05-14T14:38:44.752Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/9d/49c06a6afaa5c2ed14bb1be9b25a4b63042dbe1b526b1d3b4e31635726de/daytona_api_client-0.172.1a1-py3-none-any.whl", hash = "sha256:5269f9b35ac664b502aa2d7edc908b6197a2b186fdd1cdfa2dd4a2e72e62b448", size = 459747, upload-time = "2026-05-06T12:05:46.12Z" },
+    { url = "https://files.pythonhosted.org/packages/61/bd/21da5fd6529d543fc9002150fcf80894a8e2eb9974192fd3c4d06cf2604d/daytona_api_client-0.176.1a1-py3-none-any.whl", hash = "sha256:3ad26b919d2c5b090bbc358b08fd19593a1c641edac253c7c56c18693f41f76c", size = 459976, upload-time = "2026-05-14T14:38:40.414Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -699,14 +699,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/3c/0998a36ed47db8ae44658b8883a790b0f02dad06dfbe4ad3f5196c3e950c/daytona_api_client_async-0.172.1a1.tar.gz", hash = "sha256:5359ab37d8f0ca0ce72f187e2bbed4ecdedd180413ab9fe581355ae63e1ee9c5", size = 148237, upload-time = "2026-05-06T12:05:28.905Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/3d/d93acaf3548190199d87e91ad015edae945ae53a87822128082bf47dd267/daytona_api_client_async-0.176.1a1.tar.gz", hash = "sha256:f62bc09001948597422aa6f871db7023d2a4baf8725ab8f2163267833bd683c3", size = 148973, upload-time = "2026-05-14T14:38:42.575Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/34/899212f8b4a106185bb6980ae6f3dec32a6beea272a78d9254dcd65fc0b1/daytona_api_client_async-0.172.1a1-py3-none-any.whl", hash = "sha256:de084888e51de7d094483e49ac776b944f48209d1dfb07c7e2d74a867e03b198", size = 465647, upload-time = "2026-05-06T12:05:26.76Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ca/2c637924ad67cac15eee31d820d04610f117aa268057ccb4cc3b86343018/daytona_api_client_async-0.176.1a1-py3-none-any.whl", hash = "sha256:b3e96fc35cbc280cdb2e44d4acb6aa25007c2621cabfe3e9c95f038b75045b3a", size = 465879, upload-time = "2026-05-14T14:38:40.774Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -714,14 +714,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/3d/30a0719102ea7dc098e94050f9272c5a59eb1cbf100a5184017d9f19964f/daytona_toolbox_api_client-0.172.1a1.tar.gz", hash = "sha256:c8e32c457f7e348005922de1afdebc2f1cd55924ade87749baeb7b8f40baa1e0", size = 73891, upload-time = "2026-05-06T12:05:32.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/a6/19ce458b619b1635659af4aa13a08fed1246c64b6bee6829e12bdae878c0/daytona_toolbox_api_client-0.176.1a1.tar.gz", hash = "sha256:247eb5dfed5ac338ac95c77ffcde0eccd0ce4bedf478a1a3c2c37aba5629b86b", size = 73860, upload-time = "2026-05-14T14:39:08.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/b9/90bca114612060dd3ed5efefbe89ad4b5c266501fde9ff1660486802391d/daytona_toolbox_api_client-0.172.1a1-py3-none-any.whl", hash = "sha256:2b475724c61a21798c2acb553d117b59b6bf4352a7e8e8ddaf805db4f9220919", size = 192854, upload-time = "2026-05-06T12:05:30.741Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/e5/738a89090f02445c0314cda3c2878714a8187025d7e52232d40d180c0f28/daytona_toolbox_api_client-0.176.1a1-py3-none-any.whl", hash = "sha256:a444e1145e4c6144eb3b59a71e3878a0b2351ba2566276f8f3f0ce0e60833bda", size = 192855, upload-time = "2026-05-14T14:39:07.415Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.172.1a1"
+version = "0.176.1a1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -730,9 +730,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/71/2f4c93e3df95558937ac365cd4485b85154cde286d7fafdbbe8615a2c9c8/daytona_toolbox_api_client_async-0.172.1a1.tar.gz", hash = "sha256:df3400154a43e90ef9e858d6c2fe5ced85b0657c8ca260c3d5e1ca843723a281", size = 67437, upload-time = "2026-05-06T12:05:31.384Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/20/7edcd949a1e1c3cb606fca253f1f0c8cbfb7e7b6add8673608c434a06cec/daytona_toolbox_api_client_async-0.176.1a1.tar.gz", hash = "sha256:498ced48b6987fcadd19500bae3f26b123378915164c4d61afa2b5d23b28093c", size = 67434, upload-time = "2026-05-14T14:38:41.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/09/13e3246907d9fa7416531f79dc1fb3bd8ce170ba4d691fd08660ce3698bf/daytona_toolbox_api_client_async-0.172.1a1-py3-none-any.whl", hash = "sha256:355cbcdd757106cc9a63d7d9734ceffcf7d4df0724d900c30f589e33bc1b94c1", size = 190996, upload-time = "2026-05-06T12:05:29.385Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/75/aefe52745478916b88cb0b54ffd95c82a398c609c80512da7d6492609186/daytona_toolbox_api_client_async-0.176.1a1-py3-none-any.whl", hash = "sha256:966662e6a1b02e52b5dc0ed7fa57a70f80bf734fc7597f91916002fc2162b6ab", size = 190994, upload-time = "2026-05-14T14:38:40.084Z" },
 ]
 
 [[package]]
@@ -1057,7 +1057,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -1065,7 +1067,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/75/7e9cd1126a1e1f0cd67b0eda02e5221b28488d352684704a78ed505bd719/greenlet-3.4.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43748988b097f9c6f09364f260741aa73c80747f63389824435c7a50bfdfd5c1", size = 285856, upload-time = "2026-04-08T15:52:45.82Z" },
     { url = "https://files.pythonhosted.org/packages/9d/c4/3e2df392e5cb199527c4d9dbcaa75c14edcc394b45040f0189f649631e3c/greenlet-3.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5566e4e2cd7a880e8c27618e3eab20f3494452d12fd5129edef7b2f7aa9a36d1", size = 610208, upload-time = "2026-04-08T16:24:39.674Z" },
     { url = "https://files.pythonhosted.org/packages/da/af/750cdfda1d1bd30a6c28080245be8d0346e669a98fdbae7f4102aa95fff3/greenlet-3.4.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1054c5a3c78e2ab599d452f23f7adafef55062a783a8e241d24f3b633ba6ff82", size = 621269, upload-time = "2026-04-08T16:30:59.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/93/c8c508d68ba93232784bbc1b5474d92371f2897dfc6bc281b419f2e0d492/greenlet-3.4.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:98eedd1803353daf1cd9ef23eef23eda5a4d22f99b1f998d273a8b78b70dd47f", size = 628455, upload-time = "2026-04-08T16:40:40.698Z" },
     { url = "https://files.pythonhosted.org/packages/54/78/0cbc693622cd54ebe25207efbb3a0eb07c2639cb8594f6e3aaaa0bb077a8/greenlet-3.4.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f82cb6cddc27dd81c96b1506f4aa7def15070c3b2a67d4e46fd19016aacce6cf", size = 617549, upload-time = "2026-04-08T15:56:34.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/46/cfaaa0ade435a60550fd83d07dfd5c41f873a01da17ede5c4cade0b9bab8/greenlet-3.4.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:b7857e2202aae67bc5725e0c1f6403c20a8ff46094ece015e7d474f5f7020b55", size = 426238, upload-time = "2026-04-08T16:43:06.865Z" },
     { url = "https://files.pythonhosted.org/packages/ba/c0/8966767de01343c1ff47e8b855dc78e7d1a8ed2b7b9c83576a57e289f81d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:227a46251ecba4ff46ae742bc5ce95c91d5aceb4b02f885487aff269c127a729", size = 1575310, upload-time = "2026-04-08T16:26:21.671Z" },
     { url = "https://files.pythonhosted.org/packages/b8/38/bcdc71ba05e9a5fda87f63ffc2abcd1f15693b659346df994a48c968003d/greenlet-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5b99e87be7eba788dd5b75ba1cde5639edffdec5f91fe0d734a249535ec3408c", size = 1640435, upload-time = "2026-04-08T15:57:32.572Z" },
     { url = "https://files.pythonhosted.org/packages/a1/c2/19b664b7173b9e4ef5f77e8cef9f14c20ec7fce7920dc1ccd7afd955d093/greenlet-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:849f8bc17acd6295fcb5de8e46d55cc0e52381c56eaf50a2afd258e97bc65940", size = 238760, upload-time = "2026-04-08T17:04:03.878Z" },
@@ -1073,7 +1077,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -1081,7 +1087,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },
@@ -2660,7 +2668,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
-    { name = "daytona", specifier = "==0.172.1a1" },
+    { name = "daytona", specifier = "==0.176.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

Bumps the Daytona SDK from `0.172.1a1` to `0.176.1a1` to pick up connection error retry. Also applies the recommended env var config and adds retry logic for the new `DaytonaConnectionError` on sandbox health checks.

## Changes

- Bump `daytona==0.172.1a1` → `daytona==0.176.1a1` in `services/tracker/pyproject.toml`
- Add `DAYTONA_HAPPY_EYEBALLS_DELAY=none` to `shared_env` in both `infra/tracker_stack.py` and `infra/worker_stack.py` CDK stacks (also added to `docker-compose.yml` for local dev)
- Add retry decorator to `_check_sandbox_health` for `DaytonaConnectionError` (3 attempts, 2s backoff). Previously, connection errors during `refresh_data()` were wrapped as `SandboxError` and not retried, causing transient network issues to fail the entire task
- Update `uv.lock` files

### What changed in `daytona==0.176.1a1`:
- `Server disconnected` / `Broken pipe` / `Cannot connect to host` are now retried internally (2 retries, short backoff) and persistent failures surface as `DaytonaConnectionError` instead of generic `DaytonaError`
- `DAYTONA_HAPPY_EYEBALLS_DELAY` env var support added to opt out of aiohttp's RFC 8305 race
- `connection_pool_maxsize` config option added (defaults to 250, set to `None` in `create-benchmark-service` to remove cap)

## Related Issues

N/A — addresses Sentry connection errors from Daytona SDK

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing

- [x] `make style` passes
- [x] Type checker shows no new errors
- [x] All 43 unit tests in `test_sandbox.py` pass

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/036214f5c1ff46b9b6b662d683d8509b
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->