### PR TITLE
set daytona sandbox autostop to ten hours

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -65,7 +65,7 @@ logger = get_logger(__name__)
 
 bundle_path = PurePosixPath("/bundle")
 SNAPSHOT_IMAGE_PREFIX = "snapshot:"
-_SANDBOX_AUTOSTOP_INTERVAL_MINUTES = 24 * 60
+_SANDBOX_AUTOSTOP_INTERVAL_MINUTES = 10 * 60
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -65,6 +65,7 @@ logger = get_logger(__name__)
 
 bundle_path = PurePosixPath("/bundle")
 SNAPSHOT_IMAGE_PREFIX = "snapshot:"
+_SANDBOX_AUTOSTOP_INTERVAL_MINUTES = 24 * 60
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
@@ -174,7 +175,7 @@ async def _create_sandbox(
 
         return await daytona.create(
             CreateSandboxFromSnapshotParams(
-                auto_stop_interval=0,
+                auto_stop_interval=_SANDBOX_AUTOSTOP_INTERVAL_MINUTES,
                 auto_delete_interval=0,
                 name=sandbox_name,
                 labels=labels,
@@ -186,10 +187,10 @@ async def _create_sandbox(
             timeout=360,
         )
 
-    # Create a new sandbox from scratch, if it stops we delete it within a minute
+    # Create a new sandbox from scratch.
     return await daytona.create(
         CreateSandboxFromImageParams(
-            auto_stop_interval=0,
+            auto_stop_interval=_SANDBOX_AUTOSTOP_INTERVAL_MINUTES,
             auto_delete_interval=0,
             name=sandbox_name,
             labels=labels,


### PR DESCRIPTION
## Summary
Sets Daytona sandboxes created by the tracker to auto-stop after 10 hours instead of leaving auto-stop disabled. Auto-delete remains enabled on stop, so stopped sandboxes are still cleaned up by Daytona.

## Changes
- Add a private sandbox lifecycle constant for a 10-hour auto-stop interval.
- Use the 10-hour auto-stop interval for both snapshot-based and image-based sandbox creation.
- Leave the existing cleanup fallback unchanged: `delete_sandbox()` still sets a 1-minute auto-stop before calling Daytona delete.
- Remove a stale comment that no longer matched the create-time lifecycle settings.

## Related Issues
<img width="441" height="122" alt="image" src="https://github.com/user-attachments/assets/3fdc3527-93e2-45ad-b155-f8aaecdbdae7" />

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

Commands run:
- `uv run pytest services/tracker/tests/unit/test_sandbox.py`
- `UV_CACHE_DIR=/private/tmp/uv-cache make lint`
- `UV_CACHE_DIR=/private/tmp/uv-cache make format-check`
- `UV_CACHE_DIR=/private/tmp/uv-cache make typecheck`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
