### PR TITLE
feat: Add benchmark task id export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,12 @@ valkyrie run retry <id>
 
 # Override concurrency on resume (works on retry)
 valkyrie run resume <id> --concurrency 20
+
+# Save every task ID in a benchmark dataset to a text file
+valkyrie benchmark tasks swebench --dataset default
+
+# Or choose the output path
+valkyrie benchmark tasks swebench --dataset default --output tasks.txt
 ```
 
 | Option | Description |

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -287,11 +287,14 @@ async def fetch_benchmark_tasks(
             aws=harness_config.aws,
             service_headers=forward_tracker_api_key(request.service_headers, http_request.headers.get("x-api-key")),
         )
-        return await benchmark_service.verify_task_ids(
-            task_ids=None,
-            slice_str=None,
-            dataset=request.dataset,
-        )
+        try:
+            return await benchmark_service.verify_task_ids(
+                task_ids=None,
+                slice_str=None,
+                dataset=request.dataset,
+            )
+        finally:
+            await benchmark_service.close()
     except (BenchmarkServiceError, httpx.HTTPError) as exc:
         raise HTTPException(
             status_code=502,

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -8,6 +8,7 @@ import httpx
 import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceError
+from benchmark_service.schemas import VerifyTaskIdsResponse
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from opentelemetry.propagate import inject
@@ -33,7 +34,7 @@ from tracker.aws.s3 import (
     list_s3_objects,
     s3_object_exists,
 )
-from tracker.config import AUTH_REQUIRED, ENVIRONMENT
+from tracker.config import AUTH_REQUIRED, ENVIRONMENT, create_benchmark_service_url
 from tracker.database.models import Benchmark, BenchmarkStatus, FinalEvaluation, Org, RetryMode
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
@@ -43,6 +44,7 @@ from tracker.middleware import RequestContextMiddleware
 from tracker.observability import configure_observability
 from tracker.types import (
     BenchmarkTableRow,
+    FetchBenchmarkTasksRequest,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
@@ -60,6 +62,7 @@ from tracker.utils import (
     BenchmarkContext,
     YieldingWriter,
     commit_benchmark_error,
+    create_benchmark_service_client,
     create_final_view,
     fetch_filtered_benchmark_rows,
     fetch_harness_config,
@@ -265,6 +268,35 @@ async def start_benchmark(
             str(benchmark_row.id), request.harness_config.aws.aws_default_region, request.harness_config.s3_bucket
         ),
     )
+
+
+@app.post("/fetch-benchmark-tasks")
+async def fetch_benchmark_tasks(
+    http_request: Request,
+    request: FetchBenchmarkTasksRequest,
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+    _org: Org = Depends(get_current_org),
+) -> VerifyTaskIdsResponse:
+    """
+    Fetch all task ids for a benchmark dataset.
+    """
+    try:
+        benchmark_service = create_benchmark_service_client(
+            url=request.custom_benchmark_service or create_benchmark_service_url(request.benchmark_name),
+            daytona_secret_name=harness_config.daytona_secret_name,
+            aws=harness_config.aws,
+            service_headers=forward_tracker_api_key(request.service_headers, http_request.headers.get("x-api-key")),
+        )
+        return await benchmark_service.verify_task_ids(
+            task_ids=None,
+            slice_str=None,
+            dataset=request.dataset,
+        )
+    except (BenchmarkServiceError, httpx.HTTPError) as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to fetch task ids from benchmark service '{request.benchmark_name}': {exc}",
+        ) from exc
 
 
 @app.get("/fetch-benchmark", response_model=None)

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -8,7 +8,7 @@ from typing import Any
 from uuid import UUID
 
 from benchmark_service.client import BenchmarkServiceClient
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from tracker.config import create_benchmark_service_url
 from tracker.database.models import (
@@ -69,6 +69,13 @@ class StartBenchmarkRequest(BaseModel):
             aws=self.harness_config.aws,
             service_headers=self.service_headers,
         )
+
+
+class FetchBenchmarkTasksRequest(BaseModel):
+    benchmark_name: str
+    dataset: str | None = None
+    custom_benchmark_service: str | None = None
+    service_headers: dict[str, str] = Field(default_factory=dict)
 
 
 class StartBenchmarkErrorResponse(BaseModel):

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -55,6 +55,26 @@ class TestFastapiServer:
 
         assert response.json() == {"status": "ok"}
 
+    async def test_fetch_benchmark_tasks(
+        self,
+        monkeypatch: MonkeyPatch,
+    ):
+        async def _mock_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=["task_1", "task_2"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        response = client.post(
+            "/fetch-benchmark-tasks",
+            json={
+                "benchmark_name": "swebench",
+                "dataset": "verified",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"task_ids": ["task_1", "task_2"]}
+
     async def test_start_benchmark(
         self,
         contract: AgentContractRequest,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -66,6 +66,12 @@ def agent():
 
 
 @cli.group()
+def benchmark():
+    """Benchmark command group"""
+    pass
+
+
+@cli.group()
 def config():
     """Config command group"""
     pass
@@ -372,6 +378,76 @@ def auth_list() -> None:
         for name, credential in auth_credentials.items()
     ]
     format_table(rows, ["Benchmark", "Credential"], item_name="credential")
+
+
+@benchmark.command(
+    name="tasks",
+    help="Save task IDs for a benchmark dataset. \n\nExample:\nvalkyrie benchmark tasks swebench --dataset default",
+)
+@click.argument("benchmark_name", type=str)
+@click.option(
+    "--dataset",
+    type=str,
+    required=False,
+    default=None,
+    help="Dataset name to fetch from the benchmark service (defaults to 'default')",
+)
+@click.option(
+    "--header",
+    "-H",
+    "headers",
+    multiple=True,
+    nargs=2,
+    type=(str, str),
+    help="Custom header for benchmark service requests (e.g., -H Authorization my-credential)",
+)
+@click.option(
+    "--ignore-custom-services",
+    "--ics",
+    is_flag=True,
+    help="Ignore custom benchmark services that have been configured. Provides opt-out for custom services.",
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
+    required=False,
+    default=None,
+    help="Path to save task IDs, one per line. Defaults to <benchmark>-<dataset>-tasks.txt.",
+)
+def tasks(
+    benchmark_name: str,
+    dataset: str | None,
+    headers: tuple[tuple[str, str]],
+    ignore_custom_services: bool,
+    output: Path | None,
+):
+    """
+    Save task IDs for a benchmark dataset.
+    """
+    service_headers: dict[str, str] = {}
+    auth_credential = TrackerService.get_benchmark_auth(benchmark_name)
+    if auth_credential:
+        service_headers["Authorization"] = str(auth_credential)
+    for name, value in headers:
+        service_headers[name] = value
+
+    try:
+        with TrackerService() as tracker:
+            if not check_tracker_service_health(tracker):
+                return
+
+            response = tracker.fetch_benchmark_tasks(
+                benchmark_name,
+                dataset=dataset,
+                ignore_custom_services=ignore_custom_services,
+                service_headers=service_headers,
+            )
+            output_path = output or Path(f"{benchmark_name}-{dataset or 'default'}-tasks.txt")
+            output_path.write_text("\n".join(response) + "\n", encoding="utf-8")
+            click.echo(f"Wrote {len(response)} task IDs to {output_path}")
+    except TrackerServiceError as e:
+        raise click.ClickException(str(e))
 
 
 @run.command(

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -9,12 +9,14 @@ from uuid import UUID
 
 import httpx
 import yaml
+from benchmark_service.schemas import VerifyTaskIdsResponse
 from dotenv import load_dotenv
 from httpx._models import Response
 from tracker.database.models import AgentContractRequest, RetryMode
 from tracker.types import (
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
+    FetchBenchmarkTasksRequest,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
     FinalViewResponse,
@@ -39,6 +41,17 @@ _REQUIRED_CONFIG_KEYS = {
     "S3_BUCKET",
     "DAYTONA_SECRET_NAME",
 }
+
+
+def _response_error_detail(response: Response) -> Any:
+    try:
+        body = response.json()
+    except ValueError:
+        return response.text
+
+    if isinstance(body, dict):
+        return body.get("detail", response.text)
+    return response.text
 
 
 class TrackerService:
@@ -228,7 +241,7 @@ class TrackerService:
                 response = client.post(f"{base_url.rstrip('/')}/init")
 
                 if response.status_code != 200:
-                    details = response.json().get("detail", response.text)
+                    details = _response_error_detail(response)
                     raise TrackerServiceError(f"Failed to initialize org: {details}")
 
                 return response.json()
@@ -306,7 +319,7 @@ class TrackerService:
             response = self._client.get(f"{self._base_url}/fetch-benchmark", params={"benchmark_id": str(benchmark_id)})
 
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to fetch run: {details}")
 
             return FetchBenchmarkResponse.model_validate(response.json())
@@ -338,7 +351,7 @@ class TrackerService:
             ) as response:
                 if response.status_code != 200:
                     response.read()
-                    details = response.json().get("detail", response.text)
+                    details = _response_error_detail(response)
                     raise TrackerServiceError(f"Failed to stream run: {details}")
 
                 for line in response.iter_lines():
@@ -367,7 +380,7 @@ class TrackerService:
             response = self._client.get(f"{self._base_url}/retrieve-results", params=params)
 
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to retrieve results: {details}")
 
             response_data = response.json()
@@ -378,6 +391,35 @@ class TrackerService:
 
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to retrieve results: {e}") from e
+
+    def fetch_benchmark_tasks(
+        self,
+        benchmark_name: str,
+        dataset: str | None = None,
+        ignore_custom_services: bool = False,
+        service_headers: dict[str, str] | None = None,
+    ) -> list[str]:
+        """
+        Fetch all task ids for a benchmark dataset.
+        """
+        try:
+            payload = FetchBenchmarkTasksRequest(
+                benchmark_name=benchmark_name,
+                dataset=dataset,
+                custom_benchmark_service=self.get_benchmark_service_url(benchmark_name)
+                if not ignore_custom_services
+                else None,
+                service_headers=service_headers or {},
+            )
+            response = self._client.post(f"{self._base_url}/fetch-benchmark-tasks", json=payload.model_dump())
+
+            if response.status_code != 200:
+                details = _response_error_detail(response)
+                raise TrackerServiceError(f"Failed to fetch task ids: {details}")
+
+            return VerifyTaskIdsResponse.model_validate(response.json()).task_ids
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to fetch task ids: {e}") from e
 
     def check_results_exist_in_s3(self, benchmark_id: UUID) -> bool:
         """
@@ -398,7 +440,7 @@ class TrackerService:
             )
 
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to check S3 results: {details}")
 
             return response.json()["exists"]
@@ -418,7 +460,7 @@ class TrackerService:
         try:
             response = self._client.post(f"{self._base_url}/stop-benchmark/{benchmark_id}", params={"force": force})
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to stop run: {details}")
 
             return StopBenchmarkResponse.model_validate(response.json())
@@ -463,7 +505,7 @@ class TrackerService:
                 json=body,
             )
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to start run: {details}")
 
             return RetryOrResumeBenchmarkResponse.model_validate(response.json())
@@ -485,7 +527,7 @@ class TrackerService:
                 f"{self._base_url}/fetch-benchmarks", params=request.model_dump(exclude_none=True, mode="json")
             )
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to fetch runs: {details}")
 
             return FetchBenchmarksResponse.model_validate(response.json())
@@ -509,7 +551,7 @@ class TrackerService:
                 params["task_ids"] = task_ids
             response = self._client.get(f"{self._base_url}/fetch-agent-outputs/{benchmark_id}", params=params)
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to fetch agent outputs: {details}")
 
             return response
@@ -529,7 +571,7 @@ class TrackerService:
         try:
             response = self._client.get(f"{self._base_url}/fetch-benchmark-metadata/{benchmark_id}")
             if response.status_code != 200:
-                details = response.json().get("detail", response.text)
+                details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to fetch run metadata: {details}")
 
             return FetchBenchmarkMetadataResponse.model_validate(response.json())

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -12,7 +12,13 @@ class FakeClient:
         self.params: dict[str, object] | None = None
         self.json: dict[str, object] | None = None
 
-    def post(self, _url: str, *, params: dict[str, object], json: dict[str, object]) -> httpx.Response:
+    def post(
+        self,
+        _url: str,
+        *,
+        params: dict[str, object] | None = None,
+        json: dict[str, object],
+    ) -> httpx.Response:
         self.params = params
         self.json = json
         return httpx.Response(200, json={"status": "success"})


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Adds a way to get list of task id associated with a benchmark+dataset.
Adds new click `benchmark` subcommand, for benchmark related discovery/metadata operations.
## Changes
<!-- List the key changes made -->
- 

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [x] Added/updated unit tests
- [x] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/372" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->