### PR TITLE
Don't retry sandbox creation if the state the sandbox is in cannot be reused

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -36,8 +36,9 @@ from tenacity import (
     wait_fixed,
 )
 
-from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
+from tracker.aws.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.database.models import AgentCausedExitReason, AgentContractRequest
+from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
 from tracker.exceptions import (
     AgentRunFailedError,
     InvalidSandboxConfigurationError,
@@ -57,7 +58,6 @@ from tracker.observability import (
     set_sandbox_context,
     tag_daytona_error,
 )
-from tracker.aws.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.types import AWSCredentials
 
 logger = get_logger(__name__)
@@ -157,13 +157,14 @@ async def _create_sandbox(
     """
     _set_sandbox_create_span_attributes(sandbox_name, image, resources)
 
-    # If the container already exists we reuse it
+    # If the container already exists and is healthy we reuse it
     try:
         sandbox = await daytona.get(sandbox_name)
 
-        await sandbox.wait_for_sandbox_start(timeout=0)
-
-        return sandbox
+        # Restart the sandbox creation process if it cannot be recovered
+        if sandbox.state not in (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED):
+            await sandbox.wait_for_sandbox_start(timeout=0)
+            return sandbox
     except DaytonaNotFoundError:
         pass
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Remove auto reuse sandbox feature, now we retry only when sandbox can be recovered

## Changes
<!-- List the key changes made -->
- Dont always retry the sandbox

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->