### PR TITLE
feat: add valkyrie config show command

### DIFF
--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -38,6 +38,7 @@ from valkyrie.cli.utils import (
     format_start_benchmark_response,
     format_table,
     infer_mode,
+    mask_secrets,
     paginate_agents,
     paginate_benchmarks,
     paginate_services,
@@ -270,6 +271,61 @@ def config_mode(target_mode: str) -> None:
             fg="green",
         )
     )
+
+
+@config.command(name="show")
+def config_show() -> None:
+    """Print the resolved active configuration with secrets masked."""
+    if not CONFIG_LOCATION.exists():
+        raise click.ClickException("Config not found. Run `valkyrie config init` first.")
+
+    with open(CONFIG_LOCATION) as f:
+        config: dict[str, Any] = yaml.safe_load(f) or {}
+
+    masked = mask_secrets(config)
+
+    env_url = os.environ.get("TRACKER_SERVICE_URL")
+    configured_url = config.get("tracker_service_url")
+    active_mode = config.get("mode") or infer_mode(config)
+
+    if env_url:
+        url_display = f"{env_url}  (from env)"
+    elif configured_url and active_mode == "self-hosted":
+        url_display = f"{configured_url}  (from config)"
+    else:
+        try:
+            url_display = f"{resolve_tracker_url(config)}  (mode default)"
+        except click.ClickException as e:
+            url_display = f"<unresolved: {e.message}>"
+
+    click.echo(f"mode:                  {active_mode}")
+    click.echo(f"tracker_service_url:   {url_display}")
+    if configured_url and active_mode == "hosted" and not env_url:
+        click.echo(
+            f"                       note: config has tracker_service_url={configured_url} — unused in hosted mode"
+        )
+    if config.get("api_key"):
+        suffix = "" if active_mode == "hosted" else "  -- inactive in this mode"
+        click.echo(f"api_key:               (set, masked){suffix}")
+    for key in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"):
+        if config.get(key):
+            click.echo(f"{key.lower():<22} (set, masked)")
+    for k, v in masked.items():
+        if k in {
+            "mode",
+            "tracker_service_url",
+            "api_key",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        }:
+            continue
+        if isinstance(v, dict):
+            click.echo(f"{k}:")
+            for sub_k, sub_v in v.items():
+                click.echo(f"  {sub_k}: {sub_v}")
+        else:
+            click.echo(f"{k}: {v}")
 
 
 @config.group()

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -159,6 +159,13 @@ def load_config() -> dict[str, str]:
 
 HOSTED_TRACKER_URL_DEFAULT = "https://benchmark-tracker.vals.ai"
 
+_SECRET_KEYS: set[str] = {
+    "api_key",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+}
+
 
 def infer_mode(config: dict[str, Any]) -> str:
     """Infer mode from a legacy config that lacks the `mode` field."""
@@ -234,6 +241,19 @@ def validate_mode_requirements(config: dict[str, Any], target_mode: str) -> None
             )
     else:
         raise click.ClickException(f"unknown mode: {target_mode}")
+
+
+def mask_secrets(config: dict[str, Any]) -> dict[str, Any]:
+    """Return a shallow copy of ``config`` with secret values replaced by a placeholder."""
+    masked: dict[str, Any] = {}
+    for k, v in config.items():
+        if k in _SECRET_KEYS and v:
+            masked[k] = "(set, masked)"
+        elif k == "benchmark_auth" and isinstance(v, dict):
+            masked[k] = {sub_k: "(set, masked)" if sub_v else sub_v for sub_k, sub_v in v.items()}
+        else:
+            masked[k] = v
+    return masked
 
 
 class BenchmarkFormatter:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -12,6 +12,7 @@ import yaml
 from valkyrie.cli.utils import (
     HOSTED_TRACKER_URL_DEFAULT,
     infer_mode,
+    mask_secrets,
     resolve_tracker_url,
     save_config,
     validate_mode_requirements,
@@ -251,3 +252,102 @@ def test_config_mode_self_hosted_without_url_errors(
     result = CliRunner().invoke(cli, ["config", "mode", "self-hosted"])
     assert result.exit_code != 0
     assert "tracker_service_url" in result.output
+
+
+# ---------- mask_secrets ----------
+
+
+def test_mask_secrets_replaces_known_secret_keys() -> None:
+    config = {
+        "mode": "hosted",
+        "api_key": "secret-1",
+        "AWS_ACCESS_KEY_ID": "AKIA-2",
+        "AWS_SECRET_ACCESS_KEY": "secret-3",
+        "AWS_SESSION_TOKEN": "secret-4",
+        "AWS_DEFAULT_REGION": "us-west-2",
+        "tracker_service_url": "https://example",
+        "benchmark_auth": {"swebench": "token-5"},
+    }
+    masked = mask_secrets(config)
+    assert masked["mode"] == "hosted"
+    assert masked["api_key"] == "(set, masked)"
+    assert masked["AWS_ACCESS_KEY_ID"] == "(set, masked)"
+    assert masked["AWS_SECRET_ACCESS_KEY"] == "(set, masked)"
+    assert masked["AWS_SESSION_TOKEN"] == "(set, masked)"
+    assert masked["AWS_DEFAULT_REGION"] == "us-west-2"
+    assert masked["tracker_service_url"] == "https://example"
+    assert masked["benchmark_auth"]["swebench"] == "(set, masked)"
+
+
+# ---------- config show CLI ----------
+
+
+def test_config_show_masks_secrets_and_labels_env_source(
+    fake_config_location: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from click.testing import CliRunner
+    from valkyrie.cli.main import cli
+
+    _write(
+        fake_config_location,
+        {
+            "mode": "hosted",
+            "api_key": "super-secret-key",
+            "AWS_ACCESS_KEY_ID": "AKIA-secret",
+            "AWS_SECRET_ACCESS_KEY": "shhh",
+            "AWS_DEFAULT_REGION": "us-west-2",
+            "tracker_service_url": "https://from-config",
+            "S3_BUCKET": "test-bucket",
+        },
+    )
+    monkeypatch.setattr("valkyrie.cli.main.CONFIG_LOCATION", fake_config_location)
+    monkeypatch.setenv("TRACKER_SERVICE_URL", "https://from-env")
+
+    result = CliRunner().invoke(cli, ["config", "show"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    # secrets are masked
+    assert "super-secret-key" not in result.output
+    assert "AKIA-secret" not in result.output
+    assert "shhh" not in result.output
+    # non-secrets are shown
+    assert "us-west-2" in result.output
+    assert "test-bucket" in result.output
+    # env-var sourcing is surfaced
+    assert "https://from-env" in result.output
+    assert "from env" in result.output.lower() or "(from env" in result.output.lower()
+
+
+def test_config_show_warns_when_tracker_url_inactive_in_hosted_mode(
+    fake_config_location: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`config show` surfaces a stale tracker_service_url that hosted mode ignores."""
+    from click.testing import CliRunner
+
+    from valkyrie.cli.main import cli
+
+    _write(
+        fake_config_location,
+        {
+            "mode": "hosted",
+            "api_key": "k",
+            "tracker_service_url": "http://localhost:8000",  # stale self-hosted carry-over
+            "AWS_ACCESS_KEY_ID": "x",
+            "AWS_SECRET_ACCESS_KEY": "y",
+            "AWS_DEFAULT_REGION": "us-west-2",
+            "S3_BUCKET": "b",
+        },
+    )
+    monkeypatch.setattr("valkyrie.cli.main.CONFIG_LOCATION", fake_config_location)
+    monkeypatch.delenv("TRACKER_SERVICE_URL", raising=False)
+
+    result = CliRunner().invoke(cli, ["config", "show"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    # Active URL is the hosted default, not the stale localhost.
+    assert HOSTED_TRACKER_URL_DEFAULT in result.output
+    # The hint surfaces the inactive field.
+    assert "unused in hosted mode" in result.output
+    assert "http://localhost:8000" in result.output


### PR DESCRIPTION
## Summary

Adds a `valkyrie config show` command that prints the resolved active configuration with secrets masked. Surfaces which source supplied the active tracker URL (env var / config field / mode default) and flags stale `tracker_service_url` values that the resolver ignores in hosted mode.

Stacked on #373.

## Changes

- New `mask_secrets` helper + `_SECRET_KEYS` set in `cli/utils.py`. Masks `api_key`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, plus every value under `benchmark_auth`.
- New `valkyrie config show` command in `cli/main.py`:
  - Distinguishes `(from env)` / `(from config)` / `(mode default)` for the active tracker URL.
  - Prints an `unused in hosted mode` hint when a stale `tracker_service_url` is present in hosted mode.
  - Annotates `api_key` as `inactive in this mode` when not hosted.
- 3 new tests in `tests/unit/test_config.py`: mask_secrets unit test, show smoke test (masking + env-var sourcing), show inactive-field-hint test.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

## Checklist
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed