### PR TITLE
chore(tracker): add host.docker.internal for local smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ valkyrie config service set external-service https://endpoint
 
 Creates or updates a benchmark service. This maps the benchmark name to the endpoint we can reach it at. This will override any service that we already provide.
 
+For local-tracker development, prefer `http://host.docker.internal:8001` over an ngrok tunnel. See [DEVELOPMENT.md](docs/DEVELOPMENT.md#smoke-testing-against-a-local-benchmark-service).
+
 ### List custom benchmark services
 
 ```bash

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -68,6 +68,23 @@ valkyrie config init
 
 Without the env vars, the service runs in self-hosted mode (no auth, default org).
 
+### Smoke-testing against a local benchmark service
+
+When iterating on Valkyrie or a benchmark service against a local tracker, no public ngrok tunnel is required — the tracker container reaches the host machine via `host.docker.internal`.
+
+```bash
+# Run the bench service on host port 8001:
+docker run -d -p 8001:8001 <bench-service-image>:latest
+
+# Point Valkyrie at it:
+valkyrie config service set <bench-name> http://host.docker.internal:8001
+
+# Run a small benchmark:
+valkyrie run start --slice :1 ...
+```
+
+The ngrok-based recipe is still required when a *deployed* tracker needs to reach a *local* bench service; see [create-benchmark-service tunnel setup](https://github.com/vals-ai/create-benchmark-service?tab=readme-ov-file#reverse-tunnel-setup).
+
 ## Code Quality
 
 ```bash

--- a/services/tracker/docker-compose.yml
+++ b/services/tracker/docker-compose.yml
@@ -60,6 +60,8 @@ services:
         condition: service_healthy
     networks:
       - tracker-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   tracker:
     image: tracker-service
@@ -97,6 +99,8 @@ services:
       retries: 5
     networks:
       - tracker-network
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Adds `extra_hosts: ["host.docker.internal:host-gateway"]` to the `tracker` and `worker` services in `services/tracker/docker-compose.yml`. Eliminates the need for an ngrok tunnel when smoke-testing a local benchmark service against a local tracker — the tracker container can now reach `localhost:<port>` on the host directly.

The deployed-tracker → local-bench-service flow still needs ngrok; that's documented in the smoke-test recipe.

## Changes

- `services/tracker/docker-compose.yml`: `extra_hosts` on `tracker` and `worker`.
- `docs/DEVELOPMENT.md`: new "Smoke-testing against a local benchmark service" section.
- `README.md`: one-line pointer from the custom-bench-service section to the new docs.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed