### PR TITLE
bug: results fetch on task subset should pass None for missing/errored tasked

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -387,6 +387,11 @@ async def retrieve_results(
         final_view.evaluation_results = _filter_task_map(final_view.evaluation_results)
         final_view.task_errors = _filter_task_map(final_view.task_errors)
 
+        # Missing/errored tasks are passed to the benchmark service as {task_id: None}.
+        scored_results = dict(final_view.evaluation_results or {})
+        for task_id in final_view.task_errors or {}:
+            scored_results.setdefault(task_id, None)
+
         effective_service_headers = forward_tracker_api_key(None, http_request.headers.get("x-api-key"))
         benchmark_service = benchmark_row.benchmark_service(
             harness_config.daytona_secret_name,
@@ -395,7 +400,7 @@ async def retrieve_results(
         )
         try:
             resp = await benchmark_service.final_score(
-                evaluation_results=final_view.evaluation_results or {},
+                evaluation_results=scored_results,
                 dataset=benchmark_row.arguments.dataset,
             )
         finally:

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -748,7 +748,7 @@ def results(run_id: UUID, path: Path | None, s3: bool, task_ids: str | None, tas
 
             if isinstance(results_response, FinalViewResponse):
                 if subset_task_ids:
-                    scored = len(results_response.evaluation_results or {})
+                    scored = len(results_response.evaluation_results or {}) + len(results_response.task_errors or {})
                     click.echo(
                         click.style(
                             f"Scored over {scored} of {len(subset_task_ids)} subset task ids.",


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Subset rescore on valk run results --task-ids dropped errored tasks when sending to benchmark service to score, so the total tasks used in calculating the final score was incorrect.
e.g. with 5 tasks with 4 eval successfully + 1 errored, score should be 4/5 not 4/4 
## Changes
<!-- List the key changes made -->
- 

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->