### PR TITLE
Default to sub-domains when cloudmap is not available

### DIFF
--- a/services/tracker/docker-compose.yml
+++ b/services/tracker/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION
+      - BENCHMARK_SERVICE_BASE_URL=${BENCHMARK_SERVICE_BASE_URL:-benchmarks.vals.ai}
       - DAYTONA_HAPPY_EYEBALLS_DELAY=none
     depends_on:
       postgres:
@@ -82,6 +83,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION
+      - BENCHMARK_SERVICE_BASE_URL=${BENCHMARK_SERVICE_BASE_URL:-benchmarks.vals.ai}
       - DAYTONA_HAPPY_EYEBALLS_DELAY=none
     depends_on:
       postgres:

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -16,18 +16,22 @@ load_dotenv()
 configure_logging()
 
 
-_BENCHMARK_SERVICE_NAMESPACE: str = "local"
-_BENCHMARK_SERVICE_PORT = 8001
+_CLOUDMAP_NAMESPACE: str = "local"
+_CLOUDMAP_PORT = 8001
+_BENCHMARK_SERVICE_BASE_URL: str | None = os.environ.get("BENCHMARK_SERVICE_BASE_URL")
 
 
 def create_benchmark_service_url(benchmark_name: str) -> str:
     """
-    Derive the benchmark service URL from the benchmark name and namespace
+    Derive the benchmark service URL from the benchmark name.
 
-    NOTE: If we are running this locally the namespace is blank
+    NOTE: If BENCHMARK_SERVICE_BASE_URL is set (e.g. benchmarks.vals.ai), use HTTPS subdomains.
+    Otherwise fall back to CloudMap internal DNS (only works inside the VPC).
     """
-    host = f"{benchmark_name}.{_BENCHMARK_SERVICE_NAMESPACE}"
-    return f"http://{host}:{_BENCHMARK_SERVICE_PORT}"
+    if _BENCHMARK_SERVICE_BASE_URL:
+        return f"https://{benchmark_name}.{_BENCHMARK_SERVICE_BASE_URL}"
+
+    return f"http://{benchmark_name}.{_CLOUDMAP_NAMESPACE}:{_CLOUDMAP_PORT}"
 
 
 AWS_S3_BUCKET = os.environ.get("AWS_S3_BUCKET", "agentic-harness")


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
It was getting bothersome to add my ip to the security group and use the public ip, this change will default to using the exposed benchmark service sub domains that use https. This will also simplify the integration tests since we can remove the need to run the swebench container inside (since the public one is always available)

<img width="1609" height="124" alt="image" src="https://github.com/user-attachments/assets/ae0b1edf-0bb5-418e-a5f8-9757046ae9db" />

## Changes
<!-- List the key changes made -->
- Added `BENCHMARK_SERVICE_BASE_URL` env var that is used to inject subdomain
- Added `BENCHMARK_SERVICE_BASE_URL` by default to docker compose file so it works by default
- Update method docstring

NOTE: No docs needed to be updated since it works by default

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/381" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->