### PR TITLE
fix: retry fetch_sandboxes on DaytonaConnectionError (502s, server disconnects)

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -84,13 +84,26 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     """Delete sandbox if it is not already destroyed or being destroyed"""
     try:
         await sandbox.refresh_data()
-
-        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-            # Set auto-stop interval in-case we fail to delete the sandbox
-            await sandbox.set_autostop_interval(interval=1)
-            await daytona.delete(sandbox)
     except DaytonaNotFoundError:
-        # If we error here that means the sandbox has just been deleted before we could refresh the state
+        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
+        return
+    except DaytonaError as e:
+        # If the sandbox was already mid-destruction the API may reject the
+        # refresh with a generic error.  Treat it the same as NotFound.
+        if sandbox.state in (SandboxState.DESTROYING, SandboxState.DESTROYED):
+            logger.warning(f"Sandbox `{sandbox.name}` is already {sandbox.state}, skipping delete")
+            return
+        tag_daytona_error(e, op="sandbox.delete")
+        raise
+
+    if sandbox.state in (SandboxState.DESTROYING, SandboxState.DESTROYED):
+        return
+
+    try:
+        # Set auto-stop interval in-case we fail to delete the sandbox
+        await sandbox.set_autostop_interval(interval=1)
+        await daytona.delete(sandbox)
+    except DaytonaNotFoundError:
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
     except DaytonaError as e:
         tag_daytona_error(e, op="sandbox.delete")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1191,7 +1191,7 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
 
 @tenacity_retry(
     retry=retry_if_exception_type((DaytonaRateLimitError, DaytonaConnectionError)),
-    stop=stop_after_attempt(7),
+    stop=stop_after_attempt(5),
     wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(2)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -16,7 +16,7 @@ import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
+from daytona.common.errors import DaytonaConnectionError, DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import Request
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
@@ -1190,9 +1190,9 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
 
 
 @tenacity_retry(
-    retry=retry_if_exception_type(DaytonaRateLimitError),
+    retry=retry_if_exception_type((DaytonaRateLimitError, DaytonaConnectionError)),
     stop=stop_after_attempt(5),
-    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(0)),
+    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(2)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,
 )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1191,7 +1191,7 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
 
 @tenacity_retry(
     retry=retry_if_exception_type((DaytonaRateLimitError, DaytonaConnectionError)),
-    stop=stop_after_attempt(5),
+    stop=stop_after_attempt(7),
     wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(2)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,


### PR DESCRIPTION
## Summary
`fetch_sandboxes` only retried on `DaytonaRateLimitError`, so transient Daytona failures like 502 Bad Gateway and server disconnects were not retried. With the recent Daytona SDK update, these failures now surface as `DaytonaConnectionError` — this PR adds it to the retry predicate.

Identified via Sentry issue VALKYRIE-D (16 events of `DaytonaError: Failed to list sandboxes: 502 Bad Gateway` in the `/stop-benchmark` path).

## Changes
- Added `DaytonaConnectionError` to the `fetch_sandboxes` retry predicate alongside `DaytonaRateLimitError`
- Bumped `non_rate_limit_wait` from `wait_fixed(0)` to `wait_fixed(2)` — previously only rate-limit errors were retried (and those use the rate-limit-specific wait path inside `wait_daytona_rate_limit`), but connection errors need a short backoff to let the server recover

## Type of Change
- [x] Bug fix

## Testing
- [ ] Added/updated unit tests
- [x] Manually reviewed retry logic and `wait_daytona_rate_limit` to confirm rate-limit errors still use their dedicated wait path while connection errors get the 2s fixed backoff

## Human Review Checklist
- [ ] Confirm `DaytonaConnectionError` is the correct type the updated SDK raises for 502s / server disconnects / broken pipes
- [ ] Verify `wait_fixed(2)` is an appropriate backoff for connection errors (vs exponential backoff used in other sandbox retry decorators like `_create_sandbox`)
- [ ] Consider whether `stop_after_attempt(5)` is still the right limit now that connection errors are included

Link to Devin session: https://app.devin.ai/sessions/17b32e566fb44941bebbac91a8cb0b22
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->