### PR TITLE
fix: stop futile PTY reconnect retries and fix stale sandbox state in Sentry (VALKYRIE-4S)

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -546,6 +546,7 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
     try:
         await sandbox.refresh_data()
         _set_sandbox_span_attributes(sandbox)
+        set_sandbox_context(sandbox)
         if sandbox.state in _DEAD_SANDBOX_STATES:
             sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
             incr("valkyrie.sandbox.unhealthy", tags={"state": str(sandbox.state)})
@@ -558,6 +559,16 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
         if isinstance(e, DaytonaError):
             tag_daytona_error(e, op="sandbox.health_check")
         raise SandboxError(f"Failed to check sandbox {sandbox.name} health: {e}") from e
+
+
+async def _refresh_sandbox_state_for_sentry(sandbox: AsyncSandbox) -> None:
+    """Best-effort refresh of the sandbox state so Sentry events capture the actual state at failure time."""
+    try:
+        await sandbox.refresh_data()
+        set_sandbox_context(sandbox)
+        sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
+    except Exception:
+        pass
 
 
 @retry(
@@ -597,9 +608,12 @@ async def _reconnect_and_wait_pty(
         async with _pty_handshake_slot("reconnect", session_id):
             handle = await sandbox.process.connect_pty_session(session_id, on_data)
     except (DaytonaConflictError, DaytonaNotFoundError) as e:
+        # Refresh sandbox state so the Sentry event captures the actual state at failure time
+        await _refresh_sandbox_state_for_sentry(sandbox)
         raise SandboxError(f"PTY session {session_id} no longer exists on sandbox {sandbox.name}") from e
     except DaytonaConnectionError as e:
         if "not found" in str(e).lower():
+            await _refresh_sandbox_state_for_sentry(sandbox)
             raise SandboxError(f"PTY session {session_id} no longer exists on sandbox {sandbox.name}") from e
         raise
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -24,7 +24,7 @@ from daytona import (
     Resources,
     SandboxState,
 )
-from daytona.common.errors import DaytonaConnectionError, DaytonaError
+from daytona.common.errors import DaytonaConflictError, DaytonaConnectionError, DaytonaError
 from daytona.handle.async_pty_handle import AsyncPtyHandle
 from opentelemetry import trace
 from tenacity import (
@@ -593,8 +593,15 @@ async def _reconnect_and_wait_pty(
     _log_pty_event("reconnect_start", sandbox, session_id)
 
     # Reconnect to the PTY. Only the connect handshake is gated; handle.wait() runs ungated below.
-    async with _pty_handshake_slot("reconnect", session_id):
-        handle = await sandbox.process.connect_pty_session(session_id, on_data)
+    try:
+        async with _pty_handshake_slot("reconnect", session_id):
+            handle = await sandbox.process.connect_pty_session(session_id, on_data)
+    except (DaytonaConflictError, DaytonaNotFoundError) as e:
+        raise SandboxError(f"PTY session {session_id} no longer exists on sandbox {sandbox.name}") from e
+    except DaytonaConnectionError as e:
+        if "not found" in str(e).lower():
+            raise SandboxError(f"PTY session {session_id} no longer exists on sandbox {sandbox.name}") from e
+        raise
 
     # Wait until the command has finished running
     await handle.wait()


### PR DESCRIPTION
## Summary

Fixes a hot issue ([VALKYRIE-4S](https://vals-ai.sentry.io/issues/7484323183/), 220+ events, escalating) where PTY reconnection retries 10 times futilely when the underlying sandbox is being deleted concurrently.

**Root cause:** When a sandbox is deleted, its PTY sessions are destroyed *before* the sandbox state transitions. The health check in `_reconnect_and_wait_pty` passes (state still `STARTED`), but `connect_pty_session` fails with `DaytonaConnectionError: PTY session ... not found`. Since this isn't a `SandboxError`, tenacity retries it 10 times — each attempt doomed to fail identically.

**Secondary issue:** The sandbox state shown in Sentry events was stale — `set_sandbox_context` was only called once at sandbox creation, so events always displayed `SandboxState.STARTED` even when the sandbox was being deleted. This made it impossible to see the actual sandbox state at failure time.

## Changes

- Import `DaytonaConflictError` from `daytona.common.errors`
- Wrap the `connect_pty_session` call in `_reconnect_and_wait_pty` with error handling that converts terminal Daytona errors into `SandboxError` (which stops the retry loop):
  - `DaytonaConflictError` / `DaytonaNotFoundError` → immediate `SandboxError`
  - `DaytonaConnectionError` containing "not found" → immediate `SandboxError`
  - Other `DaytonaConnectionError` (transient) → re-raised for normal retry
- `_check_sandbox_health` now calls `set_sandbox_context(sandbox)` after `refresh_data()` so every health check updates the Sentry context with the latest state
- Added `_refresh_sandbox_state_for_sentry` helper — best-effort state refresh before raising terminal PTY errors, so the Sentry event captures the actual sandbox state at failure time

## Related Issues

Fixes VALKYRIE-4S

## Type of Change

- [x] Bug fix

## Testing

- [x] Existing 43 unit tests in `test_sandbox.py` pass
- [x] Lint passes (`make style`)
- [x] `run-ruff-lint` and `run-basedpyright` CI checks pass

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed — N/A

## Human Review Checklist

- [ ] Verify the `"not found"` substring match on `DaytonaConnectionError` messages covers the Daytona SDK's actual error strings
- [ ] Confirm `_refresh_sandbox_state_for_sentry` adding a `refresh_data()` network call in the error path is acceptable latency-wise (it's best-effort / swallows exceptions)
- [ ] Consider whether dedicated unit tests for the new error-handling and state-refresh branches are desired

Link to Devin session: https://app.devin.ai/sessions/d5bfe14b653a41da8e979948e796ce2a
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/383" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->