### PR TITLE
More visibility on pty disconnect issues

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -605,9 +605,7 @@ async def _reconnect_and_wait_pty(
         if sandbox.state in _DEAD_SANDBOX_STATES:
             sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
             sentry_sdk.set_tag("pty.disconnect_reason", "sandbox_killed")
-            raise SandboxError(
-                f"Sandbox {sandbox.name} destroyed during PTY reconnect (state={sandbox.state})"
-            )
+            raise SandboxError(f"Sandbox {sandbox.name} destroyed during PTY reconnect (state={sandbox.state})")
         raise
 
     # Log so the user can see we have seen a disconnection from the websocket (easier to pickup in logs)

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -600,7 +600,7 @@ async def _reconnect_and_wait_pty(
         raise SandboxError(f"PTY session {session_id} no longer exists (sandbox_state={sandbox.state})")
     except DaytonaError:
         # Toolbox unreachable — the sandbox may be destroying but the state API hasn't caught up yet.
-        # Do one fresh refresh to check; fail fast if dead, otherwise let the outer retry handle it.
+        # Do one fresh refresh to check
         await sandbox.refresh_data()
         if sandbox.state in _DEAD_SANDBOX_STATES:
             sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
@@ -619,7 +619,7 @@ async def _reconnect_and_wait_pty(
         except DaytonaConnectionError as e:
             if "not found" in str(e).lower():
                 # TOCTOU fallback: session existed at get_pty_session_info time but was
-                # deleted before connect. Refresh state and fail fast.
+                # deleted before connect.
                 await sandbox.refresh_data()
                 sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
                 sentry_sdk.set_tag("pty.disconnect_reason", "pty_session_killed")

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -598,6 +598,17 @@ async def _reconnect_and_wait_pty(
         sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
         _log_pty_event("pty_session_killed", sandbox, session_id)
         raise SandboxError(f"PTY session {session_id} no longer exists (sandbox_state={sandbox.state})")
+    except DaytonaError:
+        # Toolbox unreachable — the sandbox may be destroying but the state API hasn't caught up yet.
+        # Do one fresh refresh to check; fail fast if dead, otherwise let the outer retry handle it.
+        await sandbox.refresh_data()
+        if sandbox.state in _DEAD_SANDBOX_STATES:
+            sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
+            sentry_sdk.set_tag("pty.disconnect_reason", "sandbox_killed")
+            raise SandboxError(
+                f"Sandbox {sandbox.name} destroyed during PTY reconnect (state={sandbox.state})"
+            )
+        raise
 
     # Log so the user can see we have seen a disconnection from the websocket (easier to pickup in logs)
     on_output("[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n")

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -168,6 +168,9 @@ async def _create_sandbox(
             return sandbox
     except DaytonaNotFoundError:
         pass
+    except DaytonaError as e:
+        # Transient error (server disconnected, network blip, etc.) — fall through to create.
+        logger.warning("Failed to get sandbox %s, will create instead: %s", sandbox_name, e)
 
     if image.startswith(SNAPSHOT_IMAGE_PREFIX):
         snapshot_name = image[len(SNAPSHOT_IMAGE_PREFIX) :].strip()
@@ -529,7 +532,7 @@ async def _create_pty_session(
 
 
 @retry(
-    retry=retry_if_exception_type(DaytonaConnectionError),
+    retry=retry_if_exception_type(DaytonaError),
     stop=stop_after_attempt(3),
     wait=wait_fixed(2),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.health_check", op="sandbox.health_check"),
@@ -552,11 +555,10 @@ async def _check_sandbox_health(sandbox: AsyncSandbox) -> None:
             raise SandboxError(f"Sandbox {sandbox.name} crashed during command execution (state: {sandbox.state})")
     except SandboxError:
         raise
-    except DaytonaConnectionError:
+    except DaytonaError as e:
+        tag_daytona_error(e, op="sandbox.health_check")
         raise
     except Exception as e:
-        if isinstance(e, DaytonaError):
-            tag_daytona_error(e, op="sandbox.health_check")
         raise SandboxError(f"Failed to check sandbox {sandbox.name} health: {e}") from e
 
 
@@ -588,16 +590,38 @@ async def _reconnect_and_wait_pty(
     # Check if the sandbox has been closed
     await _check_sandbox_health(sandbox)
 
+    # Check if the PTY session still exists before attempting the WebSocket handshake.
+    try:
+        await sandbox.process.get_pty_session_info(session_id)
+    except DaytonaNotFoundError:
+        sentry_sdk.set_tag("pty.disconnect_reason", "pty_session_killed")
+        sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
+        _log_pty_event("pty_session_killed", sandbox, session_id)
+        raise SandboxError(f"PTY session {session_id} no longer exists (sandbox_state={sandbox.state})")
+
     # Log so the user can see we have seen a disconnection from the websocket (easier to pickup in logs)
     on_output("[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n")
     _log_pty_event("reconnect_start", sandbox, session_id)
 
     # Reconnect to the PTY. Only the connect handshake is gated; handle.wait() runs ungated below.
     async with _pty_handshake_slot("reconnect", session_id):
-        handle = await sandbox.process.connect_pty_session(session_id, on_data)
+        try:
+            handle = await sandbox.process.connect_pty_session(session_id, on_data)
+        except DaytonaConnectionError as e:
+            if "not found" in str(e).lower():
+                # TOCTOU fallback: session existed at get_pty_session_info time but was
+                # deleted before connect. Refresh state and fail fast.
+                await sandbox.refresh_data()
+                sentry_sdk.set_tag("sandbox_state", str(sandbox.state))
+                sentry_sdk.set_tag("pty.disconnect_reason", "pty_session_killed")
+                raise SandboxError(f"PTY session not found (sandbox_state={sandbox.state}): {e}") from e
+            raise
 
     # Wait until the command has finished running
     await handle.wait()
+
+    incr("valkyrie.pty.reconnect.success")
+    _log_pty_event("reconnect_success", sandbox, session_id)
 
 
 @logfire.instrument("pty.wait", extract_args=False)

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -400,7 +400,7 @@ _pty_handshake_semaphore: Semaphore = Semaphore(_PTY_HANDSHAKE_CAP)
 _pty_handshake_in_flight_count: int = 0
 
 # States that determine if the sandbox has been killed
-_DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED)
+_DEAD_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED, SandboxState.ERROR)
 
 
 def _set_pty_span_attributes(sandbox: AsyncSandbox, session_id: str) -> None:

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from daytona import ExecuteResponse, SandboxState
-from daytona.common.errors import DaytonaError, DaytonaRateLimitError
+from daytona.common.errors import DaytonaConnectionError, DaytonaError, DaytonaNotFoundError, DaytonaRateLimitError
 from tenacity import stop_after_attempt, wait_none
 
 import tracker.daytona_retry as daytona_retry_module
@@ -145,12 +145,16 @@ class TestPtyHandshakeSemaphore:
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.process.get_pty_session_info = AsyncMock()
         mock_sandbox.process.connect_pty_session = AsyncMock(return_value=mock_handle)
         outputs: list[str] = []
 
         await _reconnect_and_wait_pty(mock_sandbox, "session-1", _ignore_pty_data, outputs.append)
 
-        assert increments == [("valkyrie.pty.reconnect.count", {"operation": "reconnect"})]
+        assert increments == [
+            ("valkyrie.pty.reconnect.count", {"operation": "reconnect"}),
+            ("valkyrie.pty.reconnect.success", {}),
+        ]
         assert outputs == ["[Debug]: Disconnected from websocket, creating a new reader and reconnecting\n"]
         assert log_records == [
             {
@@ -158,7 +162,13 @@ class TestPtyHandshakeSemaphore:
                 "pty_event": "reconnect_start",
                 "session_id": "session-1",
                 "sandbox_id": "sandbox-123",
-            }
+            },
+            {
+                "message": "pty.reconnect_success",
+                "pty_event": "reconnect_success",
+                "session_id": "session-1",
+                "sandbox_id": "sandbox-123",
+            },
         ]
         handshake_duration_call = next(call for call in distributions if call[0] == "valkyrie.pty.handshake.duration")
         assert 0 <= handshake_duration_call[1] < 1
@@ -884,7 +894,10 @@ class TestAgentOutputTelemetry:
 
         assert increments == []
 
-    async def test_check_sandbox_health_emits_unhealthy_state_telemetry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    @pytest.mark.parametrize("dead_state", [SandboxState.DESTROYED, SandboxState.ERROR])
+    async def test_check_sandbox_health_emits_unhealthy_state_telemetry(
+        self, monkeypatch: pytest.MonkeyPatch, dead_state: SandboxState
+    ) -> None:
         tags: dict[str, str] = {}
         increments: list[tuple[str, dict[str, str]]] = []
 
@@ -900,18 +913,13 @@ class TestAgentOutputTelemetry:
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
-        mock_sandbox.state = SandboxState.DESTROYED
+        mock_sandbox.state = dead_state
 
         with pytest.raises(SandboxError, match="crashed during command execution"):
             await _check_sandbox_health(mock_sandbox)
 
-        assert tags == {"sandbox_state": str(SandboxState.DESTROYED)}
-        assert increments == [
-            (
-                "valkyrie.sandbox.unhealthy",
-                {"state": str(SandboxState.DESTROYED)},
-            )
-        ]
+        assert tags == {"sandbox_state": str(dead_state)}
+        assert increments == [("valkyrie.sandbox.unhealthy", {"state": str(dead_state)})]
 
     async def test_check_sandbox_health_tags_daytona_refresh_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
         daytona_error = DaytonaError("refresh failed")
@@ -926,10 +934,11 @@ class TestAgentOutputTelemetry:
         mock_sandbox.name = "task-alias"
         mock_sandbox.refresh_data = AsyncMock(side_effect=daytona_error)
 
-        with pytest.raises(SandboxError, match="Failed to check sandbox"):
+        with pytest.raises(DaytonaError):
             await _check_sandbox_health(mock_sandbox)
 
-        assert daytona_errors == [(daytona_error, "sandbox.health_check")]
+        assert all(exc is daytona_error and op == "sandbox.health_check" for exc, op in daytona_errors)
+        assert len(daytona_errors) >= 1
 
     async def test_check_sandbox_health_does_not_tag_non_daytona_refresh_errors(
         self, monkeypatch: pytest.MonkeyPatch
@@ -988,6 +997,97 @@ class TestAgentOutputTelemetry:
         assert max_concurrent <= cap
         # Sanity: without the cap we'd see total concurrency; confirm contention actually happened
         assert max_concurrent > 1
+
+    @pytest.mark.parametrize(
+        "pty_info_side_effect, sandbox_state, connect_side_effect, stop_after_one, expected_exc_type, expected_match, expected_tags",
+        [
+            pytest.param(
+                DaytonaNotFoundError("gone"),
+                SandboxState.STARTED,
+                None,
+                False,
+                SandboxError,
+                "no longer exists",
+                {"pty.disconnect_reason": "pty_session_killed", "sandbox_state": str(SandboxState.STARTED)},
+                id="pty_not_found",
+            ),
+            pytest.param(
+                DaytonaError("toolbox unreachable"),
+                SandboxState.DESTROYING,
+                None,
+                False,
+                SandboxError,
+                "destroyed during PTY reconnect",
+                {"pty.disconnect_reason": "sandbox_killed", "sandbox_state": str(SandboxState.DESTROYING)},
+                id="sandbox_dead_after_toolbox_error",
+            ),
+            pytest.param(
+                DaytonaError("502 bad gateway"),
+                SandboxState.STARTED,
+                None,
+                True,
+                DaytonaError,
+                "502 bad gateway",
+                {},
+                id="transient_error_alive_sandbox",
+            ),
+            pytest.param(
+                None,
+                SandboxState.STARTED,
+                DaytonaConnectionError("PTY session not found"),
+                False,
+                SandboxError,
+                "PTY session not found",
+                {"pty.disconnect_reason": "pty_session_killed"},
+                id="toctou_connect_not_found",
+            ),
+        ],
+    )
+    async def test_reconnect_fast_fail_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        pty_info_side_effect: Exception | None,
+        sandbox_state: SandboxState,
+        connect_side_effect: Exception | None,
+        stop_after_one: bool,
+        expected_exc_type: type[Exception],
+        expected_match: str,
+        expected_tags: dict[str, str],
+    ) -> None:
+        tags: dict[str, str] = {}
+        monkeypatch.setattr(
+            sandbox_module, "sentry_sdk", SimpleNamespace(set_tag=lambda k, v: tags.update({k: v})), raising=False
+        )
+        monkeypatch.setattr(sandbox_module, "_check_sandbox_health", AsyncMock())
+        monkeypatch.setattr(sandbox_module, "incr", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module.logger, "info", Mock())
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_semaphore", asyncio.Semaphore(5))
+        monkeypatch.setattr(sandbox_module, "_pty_handshake_in_flight_count", 0, raising=False)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module, "gauge", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module, "_set_pty_span_attributes", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module, "set_pty_context", Mock(), raising=False)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.state = sandbox_state
+        mock_sandbox.refresh_data = AsyncMock()
+        mock_sandbox.process.get_pty_session_info = AsyncMock(side_effect=pty_info_side_effect)
+        if connect_side_effect is not None:
+            mock_sandbox.process.connect_pty_session = AsyncMock(side_effect=connect_side_effect)
+
+        fn = (
+            _reconnect_and_wait_pty.retry_with(stop=stop_after_attempt(1), wait=wait_none())
+            if stop_after_one
+            else _reconnect_and_wait_pty
+        )
+
+        with pytest.raises(expected_exc_type, match=expected_match):
+            await fn(mock_sandbox, "session-1", _ignore_pty_data, lambda _: None)
+
+        for key, value in expected_tags.items():
+            assert tags[key] == value
 
     async def test_semaphore_released_after_handshake_returns(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """


### PR DESCRIPTION
## Summary

PTY disconnections were burning through all 10 reconnect retries (~74 seconds) without knowing why — sandbox killed vs. transient network blip looked identical. This PR adds fast-fail detection before the WebSocket handshake and improves retry coverage for transient Daytona errors.

## Changes

- **PTY existence pre-check** — before each reconnect attempt, call `get_pty_session_info` (REST API) to determine disconnect cause:
  - `DaytonaNotFoundError` → PTY session was deleted; raise `SandboxError` immediately with `pty.disconnect_reason=pty_session_killed` Sentry tag
  - `DaytonaError` (toolbox unreachable) + sandbox in dead state → raise `SandboxError` with `pty.disconnect_reason=sandbox_killed`
  - `DaytonaError` + sandbox still alive → re-raise so the outer retry handles it as a transient error
- **TOCTOU fallback** — if PTY existed at pre-check time but `connect_pty_session` raises "not found", fast-fail with `pty.disconnect_reason=pty_session_killed` instead of retrying
- **Reconnect success tracking** — emit `valkyrie.pty.reconnect.success` counter and `pty.reconnect_success` structured log on successful reconnect
- **Health check retry widened** — `_check_sandbox_health` now retries on all `DaytonaError` (was `DaytonaConnectionError` only), so 502/server-disconnected responses are retried instead of failing immediately; re-raises `DaytonaError` directly with `tag_daytona_error` for Sentry visibility
- **Transient `get sandbox` fallback** — `_create_sandbox` now catches `DaytonaError` (not just `DaytonaNotFoundError`) when looking up an existing sandbox, falling through to creation on transient errors
- **`SandboxState.ERROR` added to `_DEAD_SANDBOX_STATES`** — sandboxes in error state are now treated as dead

## Type of Change

- [x] Bug fix
- [x] New feature

## Testing

- [x] Added/updated unit tests
  - Parametrized `test_reconnect_fast_fail_paths` covering all 4 fast-fail paths (PTY not found, sandbox dead after toolbox error, transient error with alive sandbox, TOCTOU connect not-found)
  - Extended `test_check_sandbox_health_emits_unhealthy_state_telemetry` to cover `SandboxState.ERROR`
  - Updated `test_reconnect_emits_counter_metrics_structured_log_and_span_attrs` to assert success counter/log
  - Updated `test_check_sandbox_health_tags_daytona_refresh_errors` to reflect direct `DaytonaError` re-raise

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/384" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->