### PR TITLE
Speed up S3 downloads

### DIFF
--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -17,6 +17,8 @@ from valkyrie.cli.bundler import get_agent_zip_stream, get_contract_from_zip_byt
 from valkyrie.cli.utils import run_with_spinner
 from valkyrie.schemas import AgentConfig
 
+_S3_DOWNLOAD_CONCURRENCY = 8
+
 
 def _fetch_bucket_name() -> str:
     from valkyrie.cli.utils import load_config
@@ -342,13 +344,17 @@ async def download_s3_path(s3_path: str, output_dir: Path) -> int:
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        for key in keys:
+        async def download_object(key: str) -> None:
             relative = key.removeprefix(prefix).lstrip("/")
             dest = output_dir / relative if relative else output_dir / Path(key).name
             dest.parent.mkdir(parents=True, exist_ok=True)
 
             response = await s3_client.get_object(Bucket=bucket_name, Key=key)
             dest.write_bytes(cast(bytes, await response["Body"].read()))
+
+        for start in range(0, len(keys), _S3_DOWNLOAD_CONCURRENCY):
+            batch = keys[start : start + _S3_DOWNLOAD_CONCURRENCY]
+            await asyncio.gather(*(download_object(key) for key in batch))
 
         return len(keys)
 

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -1,0 +1,110 @@
+import asyncio
+from pathlib import Path
+from types import TracebackType
+
+import pytest
+
+from valkyrie.cli.s3_client import download_s3_path
+
+
+class FakeBody:
+    def __init__(self, payload: bytes, tracker: "ConcurrencyTracker") -> None:
+        self._payload = payload
+        self._tracker = tracker
+
+    async def read(self) -> bytes:
+        self._tracker.active += 1
+        self._tracker.max_active = max(self._tracker.max_active, self._tracker.active)
+        await asyncio.sleep(0)
+        self._tracker.active -= 1
+        return self._payload
+
+
+class ConcurrencyTracker:
+    def __init__(self) -> None:
+        self.active = 0
+        self.max_active = 0
+
+
+class FakePaginator:
+    def __init__(self, keys: list[str]) -> None:
+        self._keys = keys
+
+    async def paginate(self, **_kwargs: object):
+        yield {"Contents": [{"Key": key} for key in self._keys]}
+
+
+class FakeS3Client:
+    def __init__(self, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
+        self._payloads = payloads
+        self._tracker = tracker
+
+    def get_paginator(self, _name: str) -> FakePaginator:
+        return FakePaginator(list(self._payloads))
+
+    async def get_object(self, *, Bucket: str, Key: str) -> dict[str, FakeBody]:
+        assert Bucket == "test-bucket"
+        return {"Body": FakeBody(self._payloads[Key], self._tracker)}
+
+
+class FakeS3ClientContext:
+    def __init__(self, client: FakeS3Client) -> None:
+        self._client = client
+
+    async def __aenter__(self) -> FakeS3Client:
+        return self._client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+
+class FakeSession:
+    def __init__(self, client: FakeS3Client) -> None:
+        self._client = client
+
+    def client(self, _name: str) -> FakeS3ClientContext:
+        return FakeS3ClientContext(self._client)
+
+
+@pytest.mark.asyncio
+async def test_download_s3_path_downloads_files_in_parallel(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    tracker = ConcurrencyTracker()
+    payloads = {
+        "benchmarks/run-1/task-a/output.json": b"a",
+        "benchmarks/run-1/task-b/output.json": b"b",
+        "benchmarks/run-1/summary.json": b"summary",
+    }
+
+    monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
+    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeSession(FakeS3Client(payloads, tracker)))
+
+    count = await download_s3_path("benchmarks/run-1", tmp_path)
+
+    assert count == 3
+    assert (tmp_path / "task-a" / "output.json").read_bytes() == b"a"
+    assert (tmp_path / "task-b" / "output.json").read_bytes() == b"b"
+    assert (tmp_path / "summary.json").read_bytes() == b"summary"
+    assert tracker.max_active > 1
+
+
+@pytest.mark.asyncio
+async def test_download_s3_path_handles_exact_file_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    tracker = ConcurrencyTracker()
+    payloads = {"benchmarks/run-1/results.json": b"results"}
+
+    monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
+    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeSession(FakeS3Client(payloads, tracker)))
+
+    count = await download_s3_path("benchmarks/run-1/results.json", tmp_path)
+
+    assert count == 1
+    assert (tmp_path / "results.json").read_bytes() == b"results"

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -1,6 +1,7 @@
 import asyncio
 from pathlib import Path
 from types import TracebackType
+from typing import Any
 
 import pytest
 
@@ -26,33 +27,16 @@ class ConcurrencyTracker:
         self.max_active = 0
 
 
-class FakePaginator:
-    def __init__(self, keys: list[str]) -> None:
-        self._keys = keys
-
-    async def paginate(self, **_kwargs: object):
-        yield {"Contents": [{"Key": key} for key in self._keys]}
-
-
 class FakeS3Client:
     def __init__(self, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
         self._payloads = payloads
         self._tracker = tracker
 
-    def get_paginator(self, _name: str) -> FakePaginator:
-        return FakePaginator(list(self._payloads))
+    def client(self, _name: str) -> "FakeS3Client":
+        return self
 
-    async def get_object(self, *, Bucket: str, Key: str) -> dict[str, FakeBody]:
-        assert Bucket == "test-bucket"
-        return {"Body": FakeBody(self._payloads[Key], self._tracker)}
-
-
-class FakeS3ClientContext:
-    def __init__(self, client: FakeS3Client) -> None:
-        self._client = client
-
-    async def __aenter__(self) -> FakeS3Client:
-        return self._client
+    async def __aenter__(self) -> "FakeS3Client":
+        return self
 
     async def __aexit__(
         self,
@@ -62,13 +46,20 @@ class FakeS3ClientContext:
     ) -> None:
         return None
 
+    def get_paginator(self, _name: str) -> "FakeS3Client":
+        return self
 
-class FakeSession:
-    def __init__(self, client: FakeS3Client) -> None:
-        self._client = client
+    async def paginate(self, **_kwargs: object) -> Any:
+        yield {"Contents": [{"Key": key} for key in self._payloads]}
 
-    def client(self, _name: str) -> FakeS3ClientContext:
-        return FakeS3ClientContext(self._client)
+    async def get_object(self, *, Bucket: str, Key: str) -> dict[str, FakeBody]:
+        assert Bucket == "test-bucket"
+        return {"Body": FakeBody(self._payloads[Key], self._tracker)}
+
+
+def patch_s3(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
+    monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
+    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeS3Client(payloads, tracker))
 
 
 @pytest.mark.asyncio
@@ -82,8 +73,7 @@ async def test_download_s3_path_downloads_files_in_parallel(
         "benchmarks/run-1/summary.json": b"summary",
     }
 
-    monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
-    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeSession(FakeS3Client(payloads, tracker)))
+    patch_s3(monkeypatch, payloads, tracker)
 
     count = await download_s3_path("benchmarks/run-1", tmp_path)
 
@@ -101,8 +91,7 @@ async def test_download_s3_path_handles_exact_file_path(
     tracker = ConcurrencyTracker()
     payloads = {"benchmarks/run-1/results.json": b"results"}
 
-    monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
-    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeSession(FakeS3Client(payloads, tracker)))
+    patch_s3(monkeypatch, payloads, tracker)
 
     count = await download_s3_path("benchmarks/run-1/results.json", tmp_path)
 

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -63,9 +63,7 @@ def patch_s3(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, bytes], tracke
 
 
 @pytest.mark.asyncio
-async def test_download_s3_path_downloads_files_in_parallel(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_download_s3_path_downloads_files_in_parallel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     tracker = ConcurrencyTracker()
     payloads = {
         "benchmarks/run-1/task-a/output.json": b"a",
@@ -85,9 +83,7 @@ async def test_download_s3_path_downloads_files_in_parallel(
 
 
 @pytest.mark.asyncio
-async def test_download_s3_path_handles_exact_file_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+async def test_download_s3_path_handles_exact_file_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     tracker = ConcurrencyTracker()
     payloads = {"benchmarks/run-1/results.json": b"results"}
 


### PR DESCRIPTION
I ran the following test: `valk agent output` (for run dfbcd3c4-d688-463a-b2b1-6344ca6f2f60) improved from 1:06.84 on dev to 20.08s on this branch when downloading the same 502 files for SWE-bench Verified.