### PR TITLE
bug(tracker): outer-join missing tasks so errored/stopped count in final_score

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -716,10 +716,10 @@ async def fetch_missing_tasks(
     session: Session, benchmark_row: Benchmark, evaluation_results: dict[str, dict[str, Any] | None], org: Org
 ):
     remaining_task_results_query = cast(
-        Sequence[tuple[str, dict[str, Any]]],
+        Sequence[tuple[str, dict[str, Any] | None]],
         session.exec(
             select(Task.task_id, EvaluationResult.result)  # pyright: ignore[reportUnknownArgumentType]
-            .join(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
+            .outerjoin(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
             .where(col(Task.benchmark) == benchmark_row.id)
             .where(col(Task.org_id) == org.id)
             .where(col(Task.task_id).notin_(list(evaluation_results.keys())))

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -369,7 +369,10 @@ class TestBenchmarkUtils:
             org_id=TEST_ORG_ID, task_id="task_finished", benchmark=benchmark_row.id, status=TaskStatus.FINISHED
         )
         errored_task = Task(
-            org_id=TEST_ORG_ID, task_id="task_errored", benchmark=benchmark_row.id, status=TaskStatus.ERROR,
+            org_id=TEST_ORG_ID,
+            task_id="task_errored",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.ERROR,
             error_message="boom",
         )
         stopped_task = Task(
@@ -378,9 +381,7 @@ class TestBenchmarkUtils:
         database_session.add_all([finished_task, errored_task, stopped_task])
         database_session.commit()
 
-        database_session.add(
-            EvaluationResult(org_id=TEST_ORG_ID, task=finished_task.id, result={"resolved": True})
-        )
+        database_session.add(EvaluationResult(org_id=TEST_ORG_ID, task=finished_task.id, result={"resolved": True}))
         database_session.commit()
 
         remaining = await fetch_missing_tasks(database_session, benchmark_row, {}, self._test_org)

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -10,13 +10,22 @@ from sqlmodel import Session, col, func, select, update
 
 from tests.unit.test_fastapi_server import client
 from tests.conftest import TEST_ORG_ID
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkStatus,
+    EvaluationResult,
+    Org,
+    Task,
+    TaskStatus,
+)
 from tracker.exceptions import TrackerServiceError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
+    fetch_missing_tasks,
     set_benchmark_final_status,
     start_benchmark_request_to_benchmark,
 )
@@ -346,6 +355,40 @@ class TestBenchmarkUtils:
         all_tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
+
+    async def test_fetch_missing_tasks_returns_none_for_errored_tasks(
+        self, example_benchmark_object: Benchmark, database_session: Session
+    ):
+        """Errored/stopped tasks have no EvaluationResult row; fetch_missing_tasks must still
+        return them as None so the benchmark service scores them against the denominator."""
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        finished_task = Task(
+            org_id=TEST_ORG_ID, task_id="task_finished", benchmark=benchmark_row.id, status=TaskStatus.FINISHED
+        )
+        errored_task = Task(
+            org_id=TEST_ORG_ID, task_id="task_errored", benchmark=benchmark_row.id, status=TaskStatus.ERROR,
+            error_message="boom",
+        )
+        stopped_task = Task(
+            org_id=TEST_ORG_ID, task_id="task_stopped", benchmark=benchmark_row.id, status=TaskStatus.STOPPED
+        )
+        database_session.add_all([finished_task, errored_task, stopped_task])
+        database_session.commit()
+
+        database_session.add(
+            EvaluationResult(org_id=TEST_ORG_ID, task=finished_task.id, result={"resolved": True})
+        )
+        database_session.commit()
+
+        remaining = await fetch_missing_tasks(database_session, benchmark_row, {}, self._test_org)
+
+        assert set(remaining.keys()) == {"task_finished", "task_errored", "task_stopped"}
+        assert remaining["task_finished"] == {"resolved": True}
+        assert remaining["task_errored"] is None
+        assert remaining["task_stopped"] is None
 
     def test_commit_task_error_spans_status_transition(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary
`fetch_missing_tasks` inner-joined `Task ↔ EvaluationResult`, so tasks with no EvaluationResult row (errored/stopped) were dropped from the run-end `final_score` call. On resume — bare `resume` or `resume --task-ids` not covering previously-errored IDs — the recomputed FinalEvaluation silently overwrote the prior correctly computed score which included the Errored/Stopped tasks.

## Changes
- `services/tracker/src/tracker/utils.py`: `.join` → `.outerjoin` in `fetch_missing_tasks` so errored/stopped tasks surface as `None` and the benchmark service can score them against the full denominator.
- `services/tracker/tests/unit/test_benchmark_utils.py`: unit test covering a benchmark with finished + errored + stopped tasks.

## Type of Change
- [x] Bug fix

## Testing
- [x] Unit test (fails on `.join`, passes on `.outerjoin`)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/388" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->