### PR TITLE
fix(cli): pass AWS credentials from config into boto3 S3 client

### DIFF
--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -31,6 +31,19 @@ def _fetch_bucket_name() -> str:
     return bucket_name
 
 
+def _s3_client():
+    """Create an aioboto3 S3 client using credentials from the valkyrie config."""
+    from valkyrie.cli.utils import load_config
+
+    config = load_config()
+    session = aioboto3.Session(
+        aws_access_key_id=config.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=config.get("AWS_SECRET_ACCESS_KEY"),
+        region_name=config.get("AWS_DEFAULT_REGION"),
+    )
+    return session.client("s3")
+
+
 async def _run_git_command(repo_path: Path | None, *args: str) -> None:
     """Execute a git command by building the command using the provided args"""
     cmd = ["git"]
@@ -149,7 +162,7 @@ async def push_agent(agent_name: str | None, agent_path: Path):
         file_size = file_stream.tell()
         file_stream.seek(0)  # Seek back to start
 
-        async with aioboto3.Session().client("s3") as s3_client:
+        async with _s3_client() as s3_client:
             # Initiate multipart upload
             key = f"agents/{agent_name}.zip"
             now = datetime.now(timezone.utc).isoformat()
@@ -217,7 +230,7 @@ async def update_benchmark_agent_version(agent_name: str, benchmark_id: str) -> 
     source_key = f"agents/{agent_name}.zip"
     dest_key = f"benchmarks/{benchmark_id}/{agent_name}.zip"
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             await s3_client.copy_object(
                 Bucket=bucket_name,
@@ -237,7 +250,7 @@ async def remove_agent(agent_name: str):
     # fetch bucket name from config
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         key = f"agents/{agent_name}.zip"
 
         try:
@@ -260,7 +273,7 @@ async def list_agents():
 
     click.echo(f"\r\033[KListing agents from bucket '{bucket_name}'...", nl=False)
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         response = await s3_client.list_objects_v2(
             Bucket=bucket_name,
             Prefix="agents/",
@@ -287,7 +300,7 @@ async def download_agent(agent_name: str, output_dir: Path | None) -> None:
     """Download an agent zip from S3, extract it, and show progress"""
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             response = await s3_client.get_object(Bucket=bucket_name, Key=f"agents/{agent_name}.zip")
             zip_bytes: bytes = cast(bytes, await response["Body"].read())
@@ -332,7 +345,7 @@ async def download_s3_path(s3_path: str, output_dir: Path) -> int:
     bucket_name = _fetch_bucket_name()
     prefix = s3_path.rstrip("/") + "/" if not Path(s3_path).suffix else s3_path
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         paginator = s3_client.get_paginator("list_objects_v2")
         keys: list[str] = []
         async for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
@@ -363,7 +376,7 @@ async def get_contract_from_s3(agent_name: str, agent_config: AgentConfig) -> Ag
     """Download agent zip from S3 and extract contract.py into a temp dir, returning the contract request"""
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             response = await s3_client.get_object(Bucket=bucket_name, Key=f"agents/{agent_name}.zip")
             zip_bytes: bytes = await response["Body"].read()

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -14,15 +14,13 @@ from tracker.database.models import AgentContractRequest
 from tracker.exceptions import S3Error
 
 from valkyrie.cli.bundler import get_agent_zip_stream, get_contract_from_zip_bytes
-from valkyrie.cli.utils import run_with_spinner
+from valkyrie.cli.utils import load_config, run_with_spinner
 from valkyrie.schemas import AgentConfig
 
 _S3_DOWNLOAD_CONCURRENCY = 8
 
 
 def _fetch_bucket_name() -> str:
-    from valkyrie.cli.utils import load_config
-
     config = load_config()
     bucket_name = config.get("S3_BUCKET")
     if not bucket_name:
@@ -33,8 +31,6 @@ def _fetch_bucket_name() -> str:
 
 def _s3_client():
     """Create an aioboto3 S3 client using credentials from the valkyrie config."""
-    from valkyrie.cli.utils import load_config
-
     config = load_config()
     session = aioboto3.Session(
         aws_access_key_id=config.get("AWS_ACCESS_KEY_ID"),

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -59,7 +59,7 @@ class FakeS3Client:
 
 def patch_s3(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
     monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
-    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeS3Client(payloads, tracker))
+    monkeypatch.setattr("valkyrie.cli.s3_client._s3_client", lambda: FakeS3Client(payloads, tracker))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The CLI's local S3 client was creating bare `aioboto3.Session().client("s3")` sessions without passing AWS credentials. This caused boto3 to fall through its default credential chain (env vars → `~/.aws/credentials` → `~/.aws/config` → IMDS) instead of using the credentials stored in `~/.config/valkyrie/valkyrie.yaml`. On EC2 instances this resolves to the instance role rather than the user's configured credentials.

## Changes
- Added `_s3_client()` helper that reads `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION` from the valkyrie config and passes them explicitly into the `aioboto3.Session` constructor.
- Replaced all 7 bare `aioboto3.Session().client("s3")` calls with `_s3_client()` across: `push_agent`, `update_benchmark_agent_version`, `remove_agent`, `list_agents`, `download_agent`, `download_s3_path`, `get_contract_from_s3`.
- Moved `load_config` to a top-level import (previously was a lazy inline import in `_fetch_bucket_name` and `_s3_client`).
- Updated `test_s3_client.py` `patch_s3` helper to monkeypatch `_s3_client` instead of `aioboto3.Session`, aligning tests with the new credential-loading entry point.

## Type of Change
- [x] Bug fix
- [x] Refactor

## Testing
- [x] Added/updated unit tests
- [x] CI passing (cli-unit-tests, tracker-unit-tests, cli-tool-smoke-test, ruff, basedpyright)

## Human Review Checklist
- [ ] Verify that if config keys are somehow missing, `config.get()` returning `None` won't silently cause `aioboto3.Session` to fall back to the default credential chain (defeating the fix). The `config init` and `TrackerService.parse_config_keys()` flows validate these keys are present, but worth confirming the behavior when `None` is passed explicitly.
- [ ] `_s3_client()` has no return type annotation — the return type is an aioboto3 async context manager which is awkward to annotate. Acceptable or should it be typed?
- [ ] Config is read twice per S3 operation (`_fetch_bucket_name()` + `_s3_client()` both call `load_config()`). Negligible for a CLI tool but worth noting if consolidation is desired later.
- [ ] Moving `load_config` to a top-level import (from a lazy inline import) should be safe since `valkyrie.cli.utils` has no circular dependency with `s3_client` — but verify no import-order issues arise.

Link to Devin session: https://app.devin.ai/sessions/d432673c59514ee0a89651308d0c3177
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->