### PR TITLE
Wrap cli in a keyboard interrupt handle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 ]
 
 [project.scripts]
-valkyrie = "valkyrie.cli.main:cli"
-valk = "valkyrie.cli.main:cli"
+valkyrie = "valkyrie.cli.entry:main"
+valk = "valkyrie.cli.entry:main"
 
 [dependency-groups]
 dev = [

--- a/src/valkyrie/cli/entry.py
+++ b/src/valkyrie/cli/entry.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def main():
+    try:
+        from valkyrie.cli.main import cli
+
+        cli()
+    except KeyboardInterrupt:
+        sys.exit(130)


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
This error is caused by not wrapping the cli in a try except
```bash
jarettforzano@Jaretts-MacBook-Pro agentic-harness % valk run fetch 2de4b084-42ae-4c51-8c1c-8ccaab85360f

^CTraceback (most recent call last):
  File "/Users/jarettforzano/.local/bin/valk", line 4, in <module>
    from valkyrie.cli.main import cli
  File "/Users/jarettforzano/Documents/agentic-harness/src/valkyrie/cli/main.py", line 11, in <module>
    from tracker.database.models import BenchmarkStatus, RetryMode
  File "/Users/jarettforzano/Documents/agentic-harness/services/tracker/src/tracker/__init__.py", line 5, in <module>
    from tracker.aws.s3 import handle_s3_error
  File "/Users/jarettforzano/Documents/agentic-harness/services/tracker/src/tracker/aws/s3.py", line 7, in <module>
    import boto3
  File "/Users/jarettforzano/.local/share/uv/tools/valkyrie/lib/python3.13/site-packages/boto3/__init__.py", line 18, in <module>
    from boto3.session import Session
  File "/Users/jarettforzano/.local/share/uv/tools/valkyrie/lib/python3.13/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/Users/jarettforzano/.local/share/uv/tools/valkyrie/lib/python3.13/site-packages/botocore/session.py", line 45, in <module>
    from botocore.configprovider import (
    ...<7 lines>...
    )
KeyboardInterrupt

jarettforzano@Jaretts-MacB
```
## Changes
<!-- List the key changes made -->
- Move entry and wrap cli

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->