### PR TITLE
Retry descope network errors

### DIFF
--- a/services/tracker/src/tracker/auth.py
+++ b/services/tracker/src/tracker/auth.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any
 
 from descope import AuthException, DescopeClient
 from fastapi import Depends, HTTPException, Request
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ReadTimeout
 from sqlmodel import Session, select
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from tracker.config import AUTH_REQUIRED, DESCOPE_PROJECT_ID
 from tracker.database.models import DEFAULT_ORG_NAME, Org
@@ -43,14 +47,27 @@ def extract_api_key(request: Request) -> str:
     return api_key
 
 
+@retry(
+    retry=retry_if_exception_type((ReadTimeout, RequestsConnectionError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
+    reraise=True,
+)
+def _exchange_access_key(api_key: str, descope_client: DescopeClient) -> dict[str, Any]:
+    """Call Descope with retries on transient network errors."""
+    return descope_client.exchange_access_key(api_key)
+
+
 def resolve_descope_tenant(api_key: str) -> str:
     """Validate an API key against Descope and return the tenant name (no DB lookup)."""
     if not _descope_client:
         raise RuntimeError("Descope client not initialized — check DESCOPE_PROJECT_ID and AUTH_REQUIRED")
     try:
-        jwt_response = _descope_client.exchange_access_key(api_key)
+        jwt_response = _exchange_access_key(api_key, _descope_client)
     except AuthException as e:
         raise HTTPException(status_code=401, detail=f"Invalid API key: {e.error_message}") from e
+    except Exception as e:
+        raise HTTPException(status_code=503, detail="Auth service unavailable") from e
 
     tenants = list(jwt_response.get("tenants", {}).keys())
     if len(tenants) != 1:

--- a/services/tracker/tests/unit/test_auth_descope.py
+++ b/services/tracker/tests/unit/test_auth_descope.py
@@ -2,9 +2,12 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from descope import AuthException
 from fastapi import HTTPException
+from requests.exceptions import ReadTimeout
 from sqlmodel import Session, SQLModel, create_engine
 
+from tracker.auth import find_org_by_tenant, resolve_descope_tenant
 from tracker.database.models import Org
 
 
@@ -32,8 +35,6 @@ def mock_descope():
 
 
 def test_valid_api_key_resolves_tenant(mock_descope):
-    from tracker.auth import resolve_descope_tenant
-
     mock_descope.exchange_access_key.return_value = {"tenants": {"test-tenant": {}}}
 
     tenant = resolve_descope_tenant("valid-key")
@@ -41,8 +42,6 @@ def test_valid_api_key_resolves_tenant(mock_descope):
 
 
 def test_valid_api_key_finds_org(mock_descope, session, test_org):
-    from tracker.auth import find_org_by_tenant, resolve_descope_tenant
-
     mock_descope.exchange_access_key.return_value = {"tenants": {"test-tenant": {}}}
 
     tenant = resolve_descope_tenant("valid-key")
@@ -52,9 +51,6 @@ def test_valid_api_key_finds_org(mock_descope, session, test_org):
 
 
 def test_invalid_api_key_raises_401(mock_descope):
-    from descope import AuthException
-    from tracker.auth import resolve_descope_tenant
-
     mock_descope.exchange_access_key.side_effect = AuthException(status_code=401, error_message="Invalid key")
 
     with pytest.raises(HTTPException) as exc_info:
@@ -63,8 +59,6 @@ def test_invalid_api_key_raises_401(mock_descope):
 
 
 def test_multiple_tenants_raises_400(mock_descope):
-    from tracker.auth import resolve_descope_tenant
-
     mock_descope.exchange_access_key.return_value = {"tenants": {"tenant-a": {}, "tenant-b": {}}}
 
     with pytest.raises(HTTPException) as exc_info:
@@ -73,7 +67,26 @@ def test_multiple_tenants_raises_400(mock_descope):
 
 
 def test_org_not_in_db_returns_none(mock_descope, session):
-    from tracker.auth import find_org_by_tenant
-
     org = find_org_by_tenant("nonexistent-org", session)
     assert org is None
+
+
+def test_read_timeout_retry_behavior(mock_descope):
+    # Succeeds on second attempt
+    mock_descope.exchange_access_key.side_effect = [
+        ReadTimeout("HTTPSConnectionPool(host='api.descope.com', port=443): Read timed out. (read timeout=60)"),
+        {"tenants": {"test-tenant": {}}},
+    ]
+    tenant = resolve_descope_tenant("some-key")
+    assert tenant == "test-tenant"
+    assert mock_descope.exchange_access_key.call_count == 2
+
+    # Exhausts all 3 attempts → 503
+    mock_descope.exchange_access_key.reset_mock()
+    mock_descope.exchange_access_key.side_effect = ReadTimeout(
+        "HTTPSConnectionPool(host='api.descope.com', port=443): Read timed out. (read timeout=60)"
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_descope_tenant("some-key")
+    assert exc_info.value.status_code == 503
+    assert mock_descope.exchange_access_key.call_count == 3


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Fix this error case detected on sentry

```bash
HTTPSConnectionPool(host='api.descope.com', port=443): Read timed out. (read timeout=60)
```

## Changes
<!-- List the key changes made -->
- Add tenacity retry to reconnect on network errors

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [x] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->