### PR TITLE
#minor: Prod deploy 05/18/2026

### DIFF
--- a/.github/workflows/tracker-integration-tests.yaml
+++ b/.github/workflows/tracker-integration-tests.yaml
@@ -2,6 +2,8 @@ name: Tracker integration tests
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    paths:
+      - "services/tracker/**"
 
 permissions:
   contents: read

--- a/.github/workflows/tracker-unit-tests.yaml
+++ b/.github/workflows/tracker-unit-tests.yaml
@@ -2,8 +2,12 @@ name: Tracker unit tests
 on:
   push:
     branches: [dev]
+    paths:
+      - "services/tracker/**"
   pull_request:
     branches: [dev]
+    paths:
+      - "services/tracker/**"
 
 jobs:
   tracker-unit-tests:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 ]
 
 [project.scripts]
-valkyrie = "valkyrie.cli.main:cli"
-valk = "valkyrie.cli.main:cli"
+valkyrie = "valkyrie.cli.entry:main"
+valk = "valkyrie.cli.entry:main"
 
 [dependency-groups]
 dev = [

--- a/services/tracker/docker-compose.yml
+++ b/services/tracker/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION
+      - BENCHMARK_SERVICE_BASE_URL=${BENCHMARK_SERVICE_BASE_URL:-benchmarks.vals.ai}
       - DAYTONA_HAPPY_EYEBALLS_DELAY=none
     depends_on:
       postgres:
@@ -82,6 +83,7 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_REGION
+      - BENCHMARK_SERVICE_BASE_URL=${BENCHMARK_SERVICE_BASE_URL:-benchmarks.vals.ai}
       - DAYTONA_HAPPY_EYEBALLS_DELAY=none
     depends_on:
       postgres:

--- a/services/tracker/src/tracker/auth.py
+++ b/services/tracker/src/tracker/auth.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import Any
 
 from descope import AuthException, DescopeClient
 from fastapi import Depends, HTTPException, Request
+from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import ReadTimeout
 from sqlmodel import Session, select
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from tracker.config import AUTH_REQUIRED, DESCOPE_PROJECT_ID
 from tracker.database.models import DEFAULT_ORG_NAME, Org
@@ -43,14 +47,27 @@ def extract_api_key(request: Request) -> str:
     return api_key
 
 
+@retry(
+    retry=retry_if_exception_type((ReadTimeout, RequestsConnectionError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
+    reraise=True,
+)
+def _exchange_access_key(api_key: str, descope_client: DescopeClient) -> dict[str, Any]:
+    """Call Descope with retries on transient network errors."""
+    return descope_client.exchange_access_key(api_key)
+
+
 def resolve_descope_tenant(api_key: str) -> str:
     """Validate an API key against Descope and return the tenant name (no DB lookup)."""
     if not _descope_client:
         raise RuntimeError("Descope client not initialized — check DESCOPE_PROJECT_ID and AUTH_REQUIRED")
     try:
-        jwt_response = _descope_client.exchange_access_key(api_key)
+        jwt_response = _exchange_access_key(api_key, _descope_client)
     except AuthException as e:
         raise HTTPException(status_code=401, detail=f"Invalid API key: {e.error_message}") from e
+    except Exception as e:
+        raise HTTPException(status_code=503, detail="Auth service unavailable") from e
 
     tenants = list(jwt_response.get("tenants", {}).keys())
     if len(tenants) != 1:

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -16,18 +16,22 @@ load_dotenv()
 configure_logging()
 
 
-_BENCHMARK_SERVICE_NAMESPACE: str = "local"
-_BENCHMARK_SERVICE_PORT = 8001
+_CLOUDMAP_NAMESPACE: str = "local"
+_CLOUDMAP_PORT = 8001
+_BENCHMARK_SERVICE_BASE_URL: str | None = os.environ.get("BENCHMARK_SERVICE_BASE_URL")
 
 
 def create_benchmark_service_url(benchmark_name: str) -> str:
     """
-    Derive the benchmark service URL from the benchmark name and namespace
+    Derive the benchmark service URL from the benchmark name.
 
-    NOTE: If we are running this locally the namespace is blank
+    NOTE: If BENCHMARK_SERVICE_BASE_URL is set (e.g. benchmarks.vals.ai), use HTTPS subdomains.
+    Otherwise fall back to CloudMap internal DNS (only works inside the VPC).
     """
-    host = f"{benchmark_name}.{_BENCHMARK_SERVICE_NAMESPACE}"
-    return f"http://{host}:{_BENCHMARK_SERVICE_PORT}"
+    if _BENCHMARK_SERVICE_BASE_URL:
+        return f"https://{benchmark_name}.{_BENCHMARK_SERVICE_BASE_URL}"
+
+    return f"http://{benchmark_name}.{_CLOUDMAP_NAMESPACE}:{_CLOUDMAP_PORT}"
 
 
 AWS_S3_BUCKET = os.environ.get("AWS_S3_BUCKET", "agentic-harness")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -262,6 +262,7 @@ class Benchmark(SQLModel, table=True):
             status=self.status,
             total_tasks=total_tasks,
             finished_tasks=finished_tasks,
+            final_score=self.final_evaluation.final_score if self.final_evaluation else None,
         )
 
 

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -171,6 +171,7 @@ class BenchmarkTableRow(BaseModel):
     status: BenchmarkStatus
     total_tasks: int
     finished_tasks: int
+    final_score: float | None = None
 
 
 class FetchBenchmarksResponse(BaseModel):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -716,10 +716,10 @@ async def fetch_missing_tasks(
     session: Session, benchmark_row: Benchmark, evaluation_results: dict[str, dict[str, Any] | None], org: Org
 ):
     remaining_task_results_query = cast(
-        Sequence[tuple[str, dict[str, Any]]],
+        Sequence[tuple[str, dict[str, Any] | None]],
         session.exec(
             select(Task.task_id, EvaluationResult.result)  # pyright: ignore[reportUnknownArgumentType]
-            .join(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
+            .outerjoin(EvaluationResult, col(Task.id) == col(EvaluationResult.task))
             .where(col(Task.benchmark) == benchmark_row.id)
             .where(col(Task.org_id) == org.id)
             .where(col(Task.task_id).notin_(list(evaluation_results.keys())))

--- a/services/tracker/tests/unit/test_auth_descope.py
+++ b/services/tracker/tests/unit/test_auth_descope.py
@@ -2,9 +2,12 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from descope import AuthException
 from fastapi import HTTPException
+from requests.exceptions import ReadTimeout
 from sqlmodel import Session, SQLModel, create_engine
 
+from tracker.auth import find_org_by_tenant, resolve_descope_tenant
 from tracker.database.models import Org
 
 
@@ -32,8 +35,6 @@ def mock_descope():
 
 
 def test_valid_api_key_resolves_tenant(mock_descope):
-    from tracker.auth import resolve_descope_tenant
-
     mock_descope.exchange_access_key.return_value = {"tenants": {"test-tenant": {}}}
 
     tenant = resolve_descope_tenant("valid-key")
@@ -41,8 +42,6 @@ def test_valid_api_key_resolves_tenant(mock_descope):
 
 
 def test_valid_api_key_finds_org(mock_descope, session, test_org):
-    from tracker.auth import find_org_by_tenant, resolve_descope_tenant
-
     mock_descope.exchange_access_key.return_value = {"tenants": {"test-tenant": {}}}
 
     tenant = resolve_descope_tenant("valid-key")
@@ -52,9 +51,6 @@ def test_valid_api_key_finds_org(mock_descope, session, test_org):
 
 
 def test_invalid_api_key_raises_401(mock_descope):
-    from descope import AuthException
-    from tracker.auth import resolve_descope_tenant
-
     mock_descope.exchange_access_key.side_effect = AuthException(status_code=401, error_message="Invalid key")
 
     with pytest.raises(HTTPException) as exc_info:
@@ -63,8 +59,6 @@ def test_invalid_api_key_raises_401(mock_descope):
 
 
 def test_multiple_tenants_raises_400(mock_descope):
-    from tracker.auth import resolve_descope_tenant
-
     mock_descope.exchange_access_key.return_value = {"tenants": {"tenant-a": {}, "tenant-b": {}}}
 
     with pytest.raises(HTTPException) as exc_info:
@@ -73,7 +67,26 @@ def test_multiple_tenants_raises_400(mock_descope):
 
 
 def test_org_not_in_db_returns_none(mock_descope, session):
-    from tracker.auth import find_org_by_tenant
-
     org = find_org_by_tenant("nonexistent-org", session)
     assert org is None
+
+
+def test_read_timeout_retry_behavior(mock_descope):
+    # Succeeds on second attempt
+    mock_descope.exchange_access_key.side_effect = [
+        ReadTimeout("HTTPSConnectionPool(host='api.descope.com', port=443): Read timed out. (read timeout=60)"),
+        {"tenants": {"test-tenant": {}}},
+    ]
+    tenant = resolve_descope_tenant("some-key")
+    assert tenant == "test-tenant"
+    assert mock_descope.exchange_access_key.call_count == 2
+
+    # Exhausts all 3 attempts → 503
+    mock_descope.exchange_access_key.reset_mock()
+    mock_descope.exchange_access_key.side_effect = ReadTimeout(
+        "HTTPSConnectionPool(host='api.descope.com', port=443): Read timed out. (read timeout=60)"
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_descope_tenant("some-key")
+    assert exc_info.value.status_code == 503
+    assert mock_descope.exchange_access_key.call_count == 3

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -10,13 +10,22 @@ from sqlmodel import Session, col, func, select, update
 
 from tests.unit.test_fastapi_server import client
 from tests.conftest import TEST_ORG_ID
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkStatus,
+    EvaluationResult,
+    Org,
+    Task,
+    TaskStatus,
+)
 from tracker.exceptions import TrackerServiceError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
+    fetch_missing_tasks,
     set_benchmark_final_status,
     start_benchmark_request_to_benchmark,
 )
@@ -346,6 +355,41 @@ class TestBenchmarkUtils:
         all_tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
+
+    async def test_fetch_missing_tasks_returns_none_for_errored_tasks(
+        self, example_benchmark_object: Benchmark, database_session: Session
+    ):
+        """Errored/stopped tasks have no EvaluationResult row; fetch_missing_tasks must still
+        return them as None so the benchmark service scores them against the denominator."""
+        benchmark_row = example_benchmark_object
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        finished_task = Task(
+            org_id=TEST_ORG_ID, task_id="task_finished", benchmark=benchmark_row.id, status=TaskStatus.FINISHED
+        )
+        errored_task = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_errored",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.ERROR,
+            error_message="boom",
+        )
+        stopped_task = Task(
+            org_id=TEST_ORG_ID, task_id="task_stopped", benchmark=benchmark_row.id, status=TaskStatus.STOPPED
+        )
+        database_session.add_all([finished_task, errored_task, stopped_task])
+        database_session.commit()
+
+        database_session.add(EvaluationResult(org_id=TEST_ORG_ID, task=finished_task.id, result={"resolved": True}))
+        database_session.commit()
+
+        remaining = await fetch_missing_tasks(database_session, benchmark_row, {}, self._test_org)
+
+        assert set(remaining.keys()) == {"task_finished", "task_errored", "task_stopped"}
+        assert remaining["task_finished"] == {"resolved": True}
+        assert remaining["task_errored"] is None
+        assert remaining["task_stopped"] is None
 
     def test_commit_task_error_spans_status_transition(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: pytest.MonkeyPatch

--- a/src/valkyrie/cli/entry.py
+++ b/src/valkyrie/cli/entry.py
@@ -1,0 +1,10 @@
+import sys
+
+
+def main():
+    try:
+        from valkyrie.cli.main import cli
+
+        cli()
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -17,6 +17,8 @@ from valkyrie.cli.bundler import get_agent_zip_stream, get_contract_from_zip_byt
 from valkyrie.cli.utils import run_with_spinner
 from valkyrie.schemas import AgentConfig
 
+_S3_DOWNLOAD_CONCURRENCY = 8
+
 
 def _fetch_bucket_name() -> str:
     from valkyrie.cli.utils import load_config
@@ -342,13 +344,17 @@ async def download_s3_path(s3_path: str, output_dir: Path) -> int:
 
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        for key in keys:
+        async def download_object(key: str) -> None:
             relative = key.removeprefix(prefix).lstrip("/")
             dest = output_dir / relative if relative else output_dir / Path(key).name
             dest.parent.mkdir(parents=True, exist_ok=True)
 
             response = await s3_client.get_object(Bucket=bucket_name, Key=key)
             dest.write_bytes(cast(bytes, await response["Body"].read()))
+
+        for start in range(0, len(keys), _S3_DOWNLOAD_CONCURRENCY):
+            batch = keys[start : start + _S3_DOWNLOAD_CONCURRENCY]
+            await asyncio.gather(*(download_object(key) for key in batch))
 
         return len(keys)
 

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -14,21 +14,30 @@ from tracker.database.models import AgentContractRequest
 from tracker.exceptions import S3Error
 
 from valkyrie.cli.bundler import get_agent_zip_stream, get_contract_from_zip_bytes
-from valkyrie.cli.utils import run_with_spinner
+from valkyrie.cli.utils import load_config, run_with_spinner
 from valkyrie.schemas import AgentConfig
 
 _S3_DOWNLOAD_CONCURRENCY = 8
 
 
 def _fetch_bucket_name() -> str:
-    from valkyrie.cli.utils import load_config
-
     config = load_config()
     bucket_name = config.get("S3_BUCKET")
     if not bucket_name:
         raise click.ClickException("S3_BUCKET key not found. Add it using 'valkyrie config set' first.")
 
     return bucket_name
+
+
+def _s3_client():
+    """Create an aioboto3 S3 client using credentials from the valkyrie config."""
+    config = load_config()
+    session = aioboto3.Session(
+        aws_access_key_id=config.get("AWS_ACCESS_KEY_ID"),
+        aws_secret_access_key=config.get("AWS_SECRET_ACCESS_KEY"),
+        region_name=config.get("AWS_DEFAULT_REGION"),
+    )
+    return session.client("s3")
 
 
 async def _run_git_command(repo_path: Path | None, *args: str) -> None:
@@ -149,7 +158,7 @@ async def push_agent(agent_name: str | None, agent_path: Path):
         file_size = file_stream.tell()
         file_stream.seek(0)  # Seek back to start
 
-        async with aioboto3.Session().client("s3") as s3_client:
+        async with _s3_client() as s3_client:
             # Initiate multipart upload
             key = f"agents/{agent_name}.zip"
             now = datetime.now(timezone.utc).isoformat()
@@ -217,7 +226,7 @@ async def update_benchmark_agent_version(agent_name: str, benchmark_id: str) -> 
     source_key = f"agents/{agent_name}.zip"
     dest_key = f"benchmarks/{benchmark_id}/{agent_name}.zip"
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             await s3_client.copy_object(
                 Bucket=bucket_name,
@@ -237,7 +246,7 @@ async def remove_agent(agent_name: str):
     # fetch bucket name from config
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         key = f"agents/{agent_name}.zip"
 
         try:
@@ -260,7 +269,7 @@ async def list_agents():
 
     click.echo(f"\r\033[KListing agents from bucket '{bucket_name}'...", nl=False)
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         response = await s3_client.list_objects_v2(
             Bucket=bucket_name,
             Prefix="agents/",
@@ -287,7 +296,7 @@ async def download_agent(agent_name: str, output_dir: Path | None) -> None:
     """Download an agent zip from S3, extract it, and show progress"""
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             response = await s3_client.get_object(Bucket=bucket_name, Key=f"agents/{agent_name}.zip")
             zip_bytes: bytes = cast(bytes, await response["Body"].read())
@@ -332,7 +341,7 @@ async def download_s3_path(s3_path: str, output_dir: Path) -> int:
     bucket_name = _fetch_bucket_name()
     prefix = s3_path.rstrip("/") + "/" if not Path(s3_path).suffix else s3_path
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         paginator = s3_client.get_paginator("list_objects_v2")
         keys: list[str] = []
         async for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
@@ -363,7 +372,7 @@ async def get_contract_from_s3(agent_name: str, agent_config: AgentConfig) -> Ag
     """Download agent zip from S3 and extract contract.py into a temp dir, returning the contract request"""
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             response = await s3_client.get_object(Bucket=bucket_name, Key=f"agents/{agent_name}.zip")
             zip_bytes: bytes = await response["Body"].read()

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -472,6 +472,9 @@ def format_fetch_benchmarks_response(
         click.echo(click.style("No runs found.", fg="yellow"))
         return
 
+    def format_score(score: float | None) -> str:
+        return f"{score:.1%}" if score is not None else "-"
+
     rows: list[dict[str, str]] = []
     for benchmark in benchmarks:
         _, progress_percentage = BenchmarkFormatter.create_progress_bar(benchmark.finished_tasks, benchmark.total_tasks)
@@ -486,6 +489,7 @@ def format_fetch_benchmarks_response(
                     benchmark.status.value.replace("_", " ").title(),
                     fg=BenchmarkFormatter.STATUS_COLORS[benchmark.status.value],
                 ),
+                "Score": format_score(benchmark.final_score),
                 "Started / Finished": f"{short_local_time(benchmark.started_at)} / {short_local_time(benchmark.finished_at, include_date=False) if benchmark.finished_at else '-'}",
                 "Progress": f"{progress_percentage:.1f}%",
             }
@@ -493,7 +497,7 @@ def format_fetch_benchmarks_response(
 
     format_table(
         rows,
-        ["ID", "Benchmark", "Agent", "Model", "Status", "Started / Finished", "Progress"],
+        ["ID", "Benchmark", "Agent", "Model", "Status", "Score", "Started / Finished", "Progress"],
         current_page,
         total_pages,
         fetch_benchmarks_response.total_count,

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -1,0 +1,95 @@
+import asyncio
+from pathlib import Path
+from types import TracebackType
+from typing import Any
+
+import pytest
+
+from valkyrie.cli.s3_client import download_s3_path
+
+
+class FakeBody:
+    def __init__(self, payload: bytes, tracker: "ConcurrencyTracker") -> None:
+        self._payload = payload
+        self._tracker = tracker
+
+    async def read(self) -> bytes:
+        self._tracker.active += 1
+        self._tracker.max_active = max(self._tracker.max_active, self._tracker.active)
+        await asyncio.sleep(0)
+        self._tracker.active -= 1
+        return self._payload
+
+
+class ConcurrencyTracker:
+    def __init__(self) -> None:
+        self.active = 0
+        self.max_active = 0
+
+
+class FakeS3Client:
+    def __init__(self, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
+        self._payloads = payloads
+        self._tracker = tracker
+
+    def client(self, _name: str) -> "FakeS3Client":
+        return self
+
+    async def __aenter__(self) -> "FakeS3Client":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        return None
+
+    def get_paginator(self, _name: str) -> "FakeS3Client":
+        return self
+
+    async def paginate(self, **_kwargs: object) -> Any:
+        yield {"Contents": [{"Key": key} for key in self._payloads]}
+
+    async def get_object(self, *, Bucket: str, Key: str) -> dict[str, FakeBody]:
+        assert Bucket == "test-bucket"
+        return {"Body": FakeBody(self._payloads[Key], self._tracker)}
+
+
+def patch_s3(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
+    monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
+    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeS3Client(payloads, tracker))
+
+
+@pytest.mark.asyncio
+async def test_download_s3_path_downloads_files_in_parallel(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tracker = ConcurrencyTracker()
+    payloads = {
+        "benchmarks/run-1/task-a/output.json": b"a",
+        "benchmarks/run-1/task-b/output.json": b"b",
+        "benchmarks/run-1/summary.json": b"summary",
+    }
+
+    patch_s3(monkeypatch, payloads, tracker)
+
+    count = await download_s3_path("benchmarks/run-1", tmp_path)
+
+    assert count == 3
+    assert (tmp_path / "task-a" / "output.json").read_bytes() == b"a"
+    assert (tmp_path / "task-b" / "output.json").read_bytes() == b"b"
+    assert (tmp_path / "summary.json").read_bytes() == b"summary"
+    assert tracker.max_active > 1
+
+
+@pytest.mark.asyncio
+async def test_download_s3_path_handles_exact_file_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    tracker = ConcurrencyTracker()
+    payloads = {"benchmarks/run-1/results.json": b"results"}
+
+    patch_s3(monkeypatch, payloads, tracker)
+
+    count = await download_s3_path("benchmarks/run-1/results.json", tmp_path)
+
+    assert count == 1
+    assert (tmp_path / "results.json").read_bytes() == b"results"

--- a/tests/unit/test_s3_client.py
+++ b/tests/unit/test_s3_client.py
@@ -59,7 +59,7 @@ class FakeS3Client:
 
 def patch_s3(monkeypatch: pytest.MonkeyPatch, payloads: dict[str, bytes], tracker: ConcurrencyTracker) -> None:
     monkeypatch.setattr("valkyrie.cli.s3_client._fetch_bucket_name", lambda: "test-bucket")
-    monkeypatch.setattr("valkyrie.cli.s3_client.aioboto3.Session", lambda: FakeS3Client(payloads, tracker))
+    monkeypatch.setattr("valkyrie.cli.s3_client._s3_client", lambda: FakeS3Client(payloads, tracker))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Descope network retry, sub-domain fallback, AWS credential passthrough, CLI keyboard interrupt handling, integration test scoping, final score bug fix, S3 download speed-up, run scores in list view

## Commits
- Retry descope network errors (#391) (e848549) by Jarett
- Default to sub-domains when cloudmap is not available (#381) (8f1174d) by Jarett
- fix(cli): pass AWS credentials from config into boto3 S3 client (#389) (782b543) by Jarett
- Wrap cli in a keyboard interrupt handle (#390) (4377166) by Jarett
- Only run integration tests when the tracker has been updated (#393) (97b17f8) by Jarett
- bug(tracker): outer-join missing tasks so errored/stopped count in final_score (#388) (d382b3c) by Oliver Chen
- Speed up S3 downloads (#387) (263ef0c) by Nikil Ravi
- Show run scores in run list (#386) (3f0c23a) by Nikil Ravi

Link to Devin session: https://app.devin.ai/sessions/f017a63c150742b29d7647d295726594
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/395" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->