### PR TITLE
fix: correct migration down_revision to avoid forked Alembic history

### DIFF
--- a/services/tracker/src/tracker/database/migrations/versions/d4e5f6a7b8c9_add_run_attribution_columns.py
+++ b/services/tracker/src/tracker/database/migrations/versions/d4e5f6a7b8c9_add_run_attribution_columns.py
@@ -1,7 +1,7 @@
 """add run attribution columns
 
 Revision ID: d4e5f6a7b8c9
-Revises: 35f2d4a8c9b1
+Revises: a92e64afa650
 Create Date: 2026-05-05 00:00:00.000000
 
 """
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "d4e5f6a7b8c9"
-down_revision: Union[str, Sequence[str], None] = "35f2d4a8c9b1"
+down_revision: Union[str, Sequence[str], None] = "a92e64afa650"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
Fixes the `down_revision` in migration `d4e5f6a7b8c9` (add_run_attribution_columns) from `35f2d4a8c9b1` to `a92e64afa650` to prevent a forked Alembic migration chain. Both `a92e64afa650` and `d4e5f6a7b8c9` previously pointed to `35f2d4a8c9b1`, which would cause "Multiple heads detected" errors on `alembic upgrade head`.

## Changes
- Updated `down_revision` in `d4e5f6a7b8c9_add_run_attribution_columns.py` from `35f2d4a8c9b1` to `a92e64afa650`

## Type of Change
- [x] Bug fix

Link to Devin session: https://app.devin.ai/sessions/c61332883f444e35b44e651ef69adc2b
Requested by: @BradenBug