### PR TITLE
fix: correct score display in valk CLI

### DIFF
--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -473,7 +473,7 @@ def format_fetch_benchmarks_response(
         return
 
     def format_score(score: float | None) -> str:
-        return f"{score:.1%}" if score is not None else "-"
+        return f"{score:.1f}%" if score is not None else "-"
 
     rows: list[dict[str, str]] = []
     for benchmark in benchmarks:


### PR DESCRIPTION
## Summary
The score column in `valk run list` displayed `10000.0%` instead of `100.0%`. The `format_score` helper used Python's `:.1%` format specifier, which multiplies the value by 100 and appends `%` — but `final_score` is already stored as a percentage (e.g. `100.0` means 100%). This double-multiplication caused the inflated display.

## Changes
- Changed `f"{score:.1%}"` → `f"{score:.1f}%"` in `src/valkyrie/cli/utils.py`

## Type of Change
- [x] Bug fix

## Testing
- [x] Self-reviewed the diff

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in

Link to Devin session: https://app.devin.ai/sessions/6b206da1abc3438092d71c64ad059ddc
Requested by: @Chen-Oliver
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/398" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->