### PR TITLE
docs: add --started-by flag to run list section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,20 @@ valkyrie run list \
   --agent-name claude_code \
   --benchmark-name swebench \
   --status IN_PROGRESS \
-  --order-by DESC
+  --order-by DESC \
+  --started-by alice@vals.ai,bob@vals.ai
 ```
 
-Status options: `IN_PROGRESS`, `STOPPING`, `STOPPED`, `FINISHED`, `ERROR`. Supports paginated navigation ([h] previous, [l] next, [q] quit).
+| Option | Description |
+| --- | --- |
+| `--agent-name` | Filter by agent name |
+| `--benchmark-name` | Filter by benchmark name |
+| `--model` | Filter by model |
+| `--status` | Filter by status: `IN_PROGRESS`, `STOPPING`, `STOPPED`, `FINISHED`, `ERROR` |
+| `--order-by` | Order results (`desc` or `asc`) |
+| `--started-by` | Comma-separated list of starter emails (case-insensitive) |
+
+Supports paginated navigation ([h] previous, [l] next, [q] quit).
 
 ### Download agent outputs
 


### PR DESCRIPTION
## Summary
Documents the new `--started-by` flag for `valkyrie run list`, introduced in 7889dd100b4275bd8bbb31a40fe47d043ac1a94f.

## Changes
- Added `--started-by` to the `run list` CLI example in the README
- Added an options table to the "List runs" section documenting all available flags

## Related Issues
Follows up on #358

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/652350c5f979405fb0ab13bb58e0fb43
Requested by: @BradenBug