### PR TITLE
Route tracker sandbox lifecycle through provider

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]==2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@9479df5e7399d08016c6f0c1e32bc1eb3cb4229a",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@797df7665d713abae28b9737e0ca9fb09db42529",
 ]
 
 [dependency-groups]

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,5 @@
 """Sandbox management utilities for the tracker service."""
 
-import base64
 import shlex
 import time
 import uuid
@@ -13,15 +12,22 @@ from typing import Any, AsyncGenerator
 
 import logfire
 import sentry_sdk
-from benchmark_service.schemas import Resources as TrackerResources
+from benchmark_service import (
+    ExecResult,
+    ImageSource,
+    Resources as TrackerResources,
+    Sandbox,
+    SandboxCreateRequest,
+    SandboxNotFoundError,
+    SandboxProvider,
+    SandboxSource,
+    SnapshotSource,
+)
+from benchmark_service.sandbox import DaytonaSandbox
+from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 from daytona import (
-    AsyncDaytona,
     AsyncSandbox,
-    CreateSandboxFromImageParams,
-    CreateSandboxFromSnapshotParams,
     DaytonaNotFoundError,
-    ExecuteResponse,
-    Resources,
     SandboxState,
 )
 from daytona.common.errors import DaytonaConnectionError, DaytonaError
@@ -64,8 +70,6 @@ logger = get_logger(__name__)
 
 
 bundle_path = PurePosixPath("/bundle")
-SNAPSHOT_IMAGE_PREFIX = "snapshot:"
-_SANDBOX_AUTOSTOP_INTERVAL_MINUTES = 10 * 60
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
@@ -74,23 +78,28 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
 
 
 @retry(
-    retry=retry_if_exception_type(DaytonaError),
+    retry=retry_if_exception_type((DaytonaError, ProviderSandboxError)),
     stop=stop_after_attempt(3),
     wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(2)),
     before_sleep=daytona_retry_callback("valkyrie.sandbox.delete", op="sandbox.delete"),
     reraise=True,
 )
-async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
+async def delete_sandbox(sandbox: Sandbox, provider: SandboxProvider) -> None:
     """Delete sandbox if it is not already destroyed or being destroyed"""
     try:
-        await sandbox.refresh_data()
+        daytona_sandbox = _daytona_inner(sandbox)
+        if daytona_sandbox is not None:
+            await daytona_sandbox.refresh_data()
 
-        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+        if daytona_sandbox is None or daytona_sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
             # Set auto-stop interval in-case we fail to delete the sandbox
-            await sandbox.set_autostop_interval(interval=1)
-            await daytona.delete(sandbox)
+            if daytona_sandbox is not None:
+                await daytona_sandbox.set_autostop_interval(interval=1)
+            await provider.delete_sandbox(sandbox.id)
     except DaytonaNotFoundError:
         # If we error here that means the sandbox has just been deleted before we could refresh the state
+        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
+    except SandboxNotFoundError:
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
     except DaytonaError as e:
         tag_daytona_error(e, op="sandbox.delete")
@@ -99,8 +108,17 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
 
 
-def _metric_image_name(image: str) -> str:
-    if image.startswith(SNAPSHOT_IMAGE_PREFIX):
+def _source_name(source: SandboxSource) -> str:
+    match source:
+        case ImageSource(image=image):
+            return image
+        case SnapshotSource():
+            return "snapshot"
+
+
+def _metric_source_name(source: SandboxSource) -> str:
+    image = _source_name(source)
+    if image == "snapshot":
         return "snapshot"
 
     without_digest = image.split("@", maxsplit=1)[0]
@@ -114,18 +132,24 @@ def _metric_image_name(image: str) -> str:
 
 def _set_sandbox_create_span_attributes(
     sandbox_name: str,
-    image: str,
+    source: SandboxSource,
     resources: TrackerResources,
 ) -> None:
     span = trace.get_current_span()
     span.set_attribute("valkyrie.sandbox_name", sandbox_name)
-    span.set_attribute("valkyrie.image", image)
-    span.set_attribute("valkyrie.resources.vcpu", resources.vcpu)
-    span.set_attribute("valkyrie.resources.memory", resources.memory)
-    span.set_attribute("valkyrie.resources.disk", resources.disk)
+    span.set_attribute("valkyrie.image", _source_name(source))
+    span.set_attribute("valkyrie.resources.vcpu", resources.cpu)
+    span.set_attribute("valkyrie.resources.memory", resources.memory_gb)
+    span.set_attribute("valkyrie.resources.disk", resources.disk_gb)
 
 
-def _set_sandbox_span_attributes(sandbox: AsyncSandbox) -> None:
+def _daytona_inner(sandbox: Sandbox) -> AsyncSandbox | None:
+    if isinstance(sandbox, DaytonaSandbox):
+        return sandbox.inner
+    return None
+
+
+def _set_sandbox_span_attributes(sandbox: Sandbox | AsyncSandbox) -> None:
     span = trace.get_current_span()
     span.set_attribute("valkyrie.sandbox_id", sandbox.id)
     span.set_attribute("valkyrie.sandbox_name", sandbox.name)
@@ -143,91 +167,66 @@ def _set_sandbox_span_attributes(sandbox: AsyncSandbox) -> None:
 )
 @logfire.instrument("sandbox.create", extract_args=False)
 async def _create_sandbox(
-    daytona: AsyncDaytona,
+    provider: SandboxProvider,
     sandbox_name: str,
-    image: str,
+    source: SandboxSource,
     resources: TrackerResources,
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
-) -> AsyncSandbox:
+) -> Sandbox:
     """
     Creates a sandbox and takes into account timeouts and retries.
 
     This retry only works in the following case:
     - Client times out while sandbox is being created
     """
-    _set_sandbox_create_span_attributes(sandbox_name, image, resources)
+    _set_sandbox_create_span_attributes(sandbox_name, source, resources)
 
     # If the container already exists and is healthy we reuse it
     try:
-        sandbox = await daytona.get(sandbox_name)
+        sandbox = await provider.get_sandbox(sandbox_name)
+        daytona_sandbox = _daytona_inner(sandbox)
 
         # Restart the sandbox creation process if it cannot be recovered
-        if sandbox.state not in (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED):
-            await sandbox.wait_for_sandbox_start(timeout=0)
+        if daytona_sandbox is None:
             return sandbox
-    except DaytonaNotFoundError:
+        if daytona_sandbox.state not in (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED):
+            await daytona_sandbox.wait_for_sandbox_start(timeout=0)
+            return sandbox
+    except (SandboxNotFoundError, DaytonaNotFoundError):
         pass
     except DaytonaError as e:
         # Transient error (server disconnected, network blip, etc.) — fall through to create.
         logger.warning("Failed to get sandbox %s, will create instead: %s", sandbox_name, e)
 
-    if image.startswith(SNAPSHOT_IMAGE_PREFIX):
-        snapshot_name = image[len(SNAPSHOT_IMAGE_PREFIX) :].strip()
-        if not snapshot_name:
-            raise InvalidSandboxConfigurationError("Snapshot-based sandbox requested without a snapshot name")
-
-        return await daytona.create(
-            CreateSandboxFromSnapshotParams(
-                auto_stop_interval=_SANDBOX_AUTOSTOP_INTERVAL_MINUTES,
-                auto_delete_interval=0,
-                name=sandbox_name,
-                labels=labels,
-                snapshot=snapshot_name,
-                language="python",
-                network_block_all=False,
-                env_vars=env_vars,
-            ),
-            timeout=360,
-        )
-
-    # Create a new sandbox from scratch.
-    return await daytona.create(
-        CreateSandboxFromImageParams(
-            auto_stop_interval=_SANDBOX_AUTOSTOP_INTERVAL_MINUTES,
-            auto_delete_interval=0,
+    return await provider.create_sandbox(
+        SandboxCreateRequest(
+            source=source,
+            resources=resources,
             name=sandbox_name,
-            labels=labels,
-            image=image,
-            network_block_all=False,
-            resources=Resources(
-                cpu=resources.vcpu,
-                memory=resources.memory,
-                disk=resources.disk,
-            ),
-            env_vars=env_vars,
-        ),
-        timeout=360,
+            labels=labels or {},
+            env_vars=env_vars or {},
+        )
     )
 
 
 @asynccontextmanager
 async def create_sandbox(
-    daytona: AsyncDaytona,
+    provider: SandboxProvider,
     sandbox_name: str,
-    image: str,
+    source: SandboxSource,
     resources: TrackerResources,
     creation_semaphore: Semaphore,
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
-) -> AsyncGenerator[AsyncSandbox, Any]:
+) -> AsyncGenerator[Sandbox, Any]:
     """
     Yeild a sandbox to be used within a context manager.
 
     Args:
-        daytona: The daytona client
+        provider: The sandbox provider
         sandbox_name: The name of the sandbox
-        image: The image to use for the sandbox
+        source: The sandbox source image or snapshot
         resources: The resources to use for the sandbox
         labels: The labels to use for the sandbox
         env_vars: The environment variables to use for the sandbox
@@ -236,14 +235,15 @@ async def create_sandbox(
     Returns:
         A context manager that yields the sandbox
     """
-    logger.info(f"Creating sandbox {sandbox_name} with image {image}")
+    source_name = _source_name(source)
+    logger.info(f"Creating sandbox {sandbox_name} with source {source_name}")
 
     # If we run too many at once it can cause hanging issues
     # NOTE does not block how many context managers we can have open, just how many sandboxes we can create at once
     try:
         async with creation_semaphore:
             start = time.monotonic()
-            sandbox = await _create_sandbox(daytona, sandbox_name, image, resources, labels, env_vars)
+            sandbox = await _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars)
     except Exception as e:
         incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
         if isinstance(e, DaytonaError):
@@ -253,9 +253,9 @@ async def create_sandbox(
     distribution(
         "valkyrie.sandbox.create.duration",
         time.monotonic() - start,
-        tags={"image": _metric_image_name(image)},
+        tags={"image": _metric_source_name(source)},
     )
-    set_sandbox_context(sandbox, image=image)
+    set_sandbox_context(sandbox, image=source_name)
 
     try:
         yield sandbox
@@ -263,7 +263,7 @@ async def create_sandbox(
         logger.error(f"Error during sandbox execution {sandbox.name}: {e}")
         raise
     finally:
-        await delete_sandbox(sandbox, daytona)
+        await delete_sandbox(sandbox, provider)
 
 
 @retry(
@@ -273,7 +273,7 @@ async def create_sandbox(
     before_sleep=retry_callback("valkyrie.sandbox.upload"),
 )
 async def upload_agent_artifacts(
-    sandbox: AsyncSandbox,
+    sandbox: Sandbox,
     contract: AgentContractRequest,
     benchmark_id: str,
     aws: AWSCredentials,
@@ -339,7 +339,7 @@ async def upload_agent_artifacts(
 
     error_message: str = (
         f"Failed to upload contract {contract.name} to sandbox {sandbox.name}: "
-        f"Command failed with exit code {result.exit_code}: {result.result}"
+        f"Command failed with exit code {result.exit_code}: {result.stdout}"
     )
     if result.exit_code == 35:
         raise SSLConnectionError(error_message)
@@ -355,7 +355,7 @@ async def upload_agent_artifacts(
     before_sleep=retry_callback("valkyrie.sandbox.deps"),
 )
 async def install_agent_dependencies(
-    sandbox: AsyncSandbox,
+    sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
 ) -> None:
@@ -478,7 +478,7 @@ async def _pty_handshake_slot(operation: str, session_id: str) -> AsyncGenerator
     reraise=True,
 )
 @logfire.instrument("sandbox.exec", extract_args=False)
-async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
+async def _exec(sandbox: Sandbox | AsyncSandbox, command: str) -> ExecResult:
     """
     Execute a command inside the sandbox with retries for transient network failures.
 
@@ -486,8 +486,20 @@ async def _exec(sandbox: AsyncSandbox, command: str) -> ExecuteResponse:
         DaytonaError: If all retry attempts are exhausted
     """
     _set_sandbox_span_attributes(sandbox)
+    if not isinstance(sandbox, AsyncSandbox):
+        daytona_sandbox = _daytona_inner(sandbox)
+        if daytona_sandbox is None:
+            try:
+                return await sandbox.exec(command)
+            except ProviderSandboxError as e:
+                raise SandboxError(str(e)) from e
+    else:
+        daytona_sandbox = sandbox
+
     try:
-        return await sandbox.process.exec(command)
+        result = await daytona_sandbox.process.exec(command)
+        assert result.exit_code is not None
+        return ExecResult(exit_code=result.exit_code, stdout=result.result or "")
     except DaytonaError as e:
         tag_daytona_error(e, op="sandbox.exec")
         raise
@@ -695,11 +707,11 @@ async def _read_exit_code(sandbox: AsyncSandbox, status_path: str) -> int:
 
         # If file does not exist or we have no content the command has not produced an exit code
         # That would suggest the sandbox was killed or something interrupted the program
-        if result.exit_code != 0 or not result.result.strip():
+        if result.exit_code != 0 or not result.stdout.strip():
             raise SandboxError(f"Failed to read exit status from {status_path}")
 
         # Should always be a integer
-        return int(result.result.strip())
+        return int(result.stdout.strip())
 
     except SandboxError:
         raise
@@ -734,7 +746,7 @@ async def _kill_pty_session(sandbox: AsyncSandbox, session_id: str | None) -> No
 
 
 @logfire.instrument("pty.stream_command_output", extract_args=False)
-async def stream_command_output(
+async def _stream_daytona_command_output(
     sandbox: AsyncSandbox,
     command: str,
     on_output: Callable[[str], None],
@@ -800,7 +812,7 @@ async def stream_command_output(
         # Compute process duration
         start_ns_result = await _exec(sandbox, f"cat {start_ns_path}")
         end_ns_result = await _exec(sandbox, f"cat {end_ns_path}")
-        duration = (int(end_ns_result.result.strip()) - int(start_ns_result.result.strip())) / 1e9
+        duration = (int(end_ns_result.stdout.strip()) - int(start_ns_result.stdout.strip())) / 1e9
 
         # Read the exit code of the process running the agent
         exit_code = await _read_exit_code(sandbox, status_path)
@@ -840,12 +852,51 @@ async def stream_command_output(
             pass
 
 
+async def _stream_generic_command_output(
+    sandbox: Sandbox,
+    command: str,
+    on_output: Callable[[str], None],
+) -> tuple[AgentCausedExitReason | None, float]:
+    output: deque[str] = deque(maxlen=50)
+    start = time.perf_counter()
+
+    def collect(data: str) -> None:
+        on_output(data)
+        output.append(data)
+
+    result = await sandbox.exec(command, on_output=collect)
+    duration = time.perf_counter() - start
+
+    if result.exit_code == _SUCCESS_EXIT_CODE:
+        return None, duration
+    if result.exit_code == _TIMEOUT_EXIT_CODE:
+        return AgentCausedExitReason.TIMEOUT, duration
+    if result.exit_code == _OS_KILL_EXIT_CODE:
+        return AgentCausedExitReason.OS_KILLED, duration
+
+    tail = "".join(output).strip().splitlines()
+    recent = "\n".join(tail[-10:]) if tail else "(no output)"
+    sentry_sdk.set_tag("agent_exit_code", str(result.exit_code))
+    raise AgentRunFailedError(f"Failed to run command {command}, exit code: {result.exit_code}\nLast output:\n{recent}")
+
+
+async def stream_command_output(
+    sandbox: Sandbox,
+    command: str,
+    on_output: Callable[[str], None],
+) -> tuple[AgentCausedExitReason | None, float]:
+    daytona_sandbox = _daytona_inner(sandbox)
+    if daytona_sandbox is not None:
+        return await _stream_daytona_command_output(daytona_sandbox, command, on_output)
+    return await _stream_generic_command_output(sandbox, command, on_output)
+
+
 @logfire.instrument(
     "agent_output.archive_and_upload",
     extract_args=("output_path", "agent_output_s3_key", "benchmark_id", "task_id"),
 )
 async def archive_and_upload_output(
-    sandbox: AsyncSandbox,
+    sandbox: Sandbox,
     output_path: str,
     agent_output_s3_key: str,
     aws: AWSCredentials,
@@ -863,11 +914,7 @@ async def archive_and_upload_output(
         raise SandboxError(f"Failed to create archive from {output_path}")
 
     try:
-        b64_result = await _exec(sandbox, f"base64 {shlex.quote(archive_path)}")
-        if b64_result.exit_code != 0:
-            raise SandboxError(f"Failed to read archive from {output_path}")
-
-        file_content = base64.b64decode(b64_result.result)
+        file_content = await sandbox.download_file(archive_path)
         await upload_to_s3(file_content, agent_output_s3_key, aws, s3_bucket)
 
         logger.info(
@@ -892,7 +939,7 @@ async def archive_and_upload_output(
 
 
 async def run_agent(
-    sandbox: AsyncSandbox,
+    sandbox: Sandbox,
     contract: AgentContractRequest,
     problem_path: str,
     task_id: str,

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -5,6 +5,7 @@ import time
 import traceback
 from asyncio import Semaphore, gather
 from collections.abc import AsyncGenerator, Buffer, Coroutine
+from contextlib import suppress
 from datetime import datetime
 from enum import Enum
 from functools import cached_property
@@ -14,9 +15,11 @@ from zoneinfo import ZoneInfo
 
 import logfire
 import sentry_sdk
+from benchmark_service import Sandbox, SandboxNotFoundError, SandboxProvider, SandboxQuery
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
-from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
+from benchmark_service.sandbox import DaytonaSandbox
+from daytona import SandboxState
+from daytona.common.errors import DaytonaNotFoundError
 from fastapi import Request
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
@@ -50,7 +53,6 @@ from tracker.database.models import (
 )
 from tracker.database.scoping import scoped_select
 from tracker.database.session import engine
-from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
 from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
@@ -339,7 +341,7 @@ def _commit_task_status(
     if error_message is not None:
         span_attributes["has_error_message"] = True
 
-    with logfire.span("task.status_transition", **span_attributes):
+    with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
         task.status = to_status
         if error_message is not None:
             task.error_message = error_message
@@ -452,6 +454,7 @@ async def process_task(
                     task_in_session = fetch_task_row(task_row.id, task_session, org)
                     if task_in_session.task_breakdown:
                         existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
+                        assert existing_breakdown is not None
                         existing_breakdown.evaluation_run_duration = resume_eval_duration
                     commit_task_status_transition(task_row.id, task_session, org, TaskStatus.FINISHED)
 
@@ -465,6 +468,7 @@ async def process_task(
                 raise e from e
 
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
+        sandbox_provider = benchmark_service.get_sandbox_provider()
 
         # Labels that show up in the UI we can use to filter sandboxes
         labels = {
@@ -491,9 +495,9 @@ async def process_task(
 
         start_sandbox_build_time = time.perf_counter()
         async with create_sandbox(
-            daytona=benchmark_service.daytona_client,
+            provider=sandbox_provider,
             sandbox_name=task_row.alias,
-            image=task_data.docker_image,
+            source=task_data.source,
             labels=labels,
             env_vars=env_vars,
             resources=task_data.resources,
@@ -601,6 +605,7 @@ async def process_task(
                     task_session.add(evaluation_result_row)
                     task_in_session = fetch_task_row(task_row.id, task_session, org)
                     existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
+                    assert existing_breakdown is not None
                     existing_breakdown.evaluation_run_duration = task_breakdown.evaluation_run_duration
                     existing_breakdown.sandbox_run_duration = task_breakdown.sandbox_run_duration
                     commit_task_status_transition(task_row.id, task_session, org, TaskStatus.FINISHED)
@@ -634,6 +639,8 @@ async def process_task(
         return {task_id: None}
     finally:
         flush_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await flush_task
         buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
 
@@ -1176,60 +1183,32 @@ async def initiate_stop_benchmark(benchmark_row: Benchmark, session: Session, fo
         raise TrackerServiceError(f"Unexpected error stopping run {benchmark_row.id}: {str(e)}") from e
 
 
-async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> str | None:
+async def stop_sandbox(sandbox: Sandbox, provider: SandboxProvider) -> str | None:
     try:
         # Wait for the sandbox to be in a valid deletion state
-        await sandbox.wait_for_sandbox_start(timeout=0)
+        if isinstance(sandbox, DaytonaSandbox):
+            await sandbox.inner.wait_for_sandbox_start(timeout=0)
 
         # Delete the sandbox
-        await delete_sandbox(sandbox, daytona_client)
+        await delete_sandbox(sandbox, provider)
 
         return None
-    except DaytonaNotFoundError:
+    except (DaytonaNotFoundError, SandboxNotFoundError):
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
         return None
     except Exception as e:
         return f"{str(e)}: {traceback.format_exc()}"
 
 
-@tenacity_retry(
-    retry=retry_if_exception_type(DaytonaRateLimitError),
-    stop=stop_after_attempt(5),
-    wait=wait_daytona_rate_limit(non_rate_limit_wait=wait_fixed(0)),
-    before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
-    reraise=True,
-)
-async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona, page: int) -> AsyncPaginatedSandboxes:
-    return await daytona_client.list(
-        labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page
-    )
-
-
-async def sandbox_generator(
-    benchmark_row: Benchmark, daytona_client: AsyncDaytona
-) -> AsyncGenerator[AsyncSandbox, None]:
+async def sandbox_generator(benchmark_row: Benchmark, provider: SandboxProvider) -> AsyncGenerator[Sandbox, None]:
     """
-    Generator that yields all sandboxes for a given benchmark in paginated chunks of 10.
-
-    NOTE: At the time of this implementation there are several things weird with the dayyona api
-        1. If you delete the sandboxes in the list, the next page should be the first page (repopulated)
-        2. Final state is not DESTROYED, but rather DESTROYING
-        3. The total_pages count is not updated as you delete sandboxes
+    Generator that yields all sandboxes for a given benchmark.
     """
-
-    paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(benchmark_row, daytona_client, 1)
-
-    total_pages = paginated_sandboxes.total_pages
-    while (paginated_sandboxes.page <= total_pages) and paginated_sandboxes.items:
-        sandboxes = paginated_sandboxes.items
-        for sandbox in sandboxes:
-            if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-                continue
-
-            yield sandbox
-
-        # NOTE: Since we deleted the first 10 the first page will be populated with the next 10 sandboxes
-        paginated_sandboxes = await fetch_sandboxes(benchmark_row, daytona_client, int(paginated_sandboxes.page))
+    query = SandboxQuery(labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)})
+    async for sandbox in provider.list_sandboxes(query):
+        if sandbox.state in [str(SandboxState.DESTROYING), str(SandboxState.DESTROYED)]:
+            continue
+        yield sandbox
 
 
 async def force_stop_sandboxes(
@@ -1242,7 +1221,8 @@ async def force_stop_sandboxes(
     Raises:
         TrackerServiceError: If there are any errors stopping the sandboxes
     """
-    daytona_client: AsyncDaytona = benchmark_row.benchmark_service(daytona_secret_name, aws).daytona_client
+    benchmark_service = benchmark_row.benchmark_service(daytona_secret_name, aws)
+    provider = benchmark_service.get_sandbox_provider()
 
     # Update all tasks being processed to stopped
     session.exec(
@@ -1257,10 +1237,18 @@ async def force_stop_sandboxes(
 
     # Iterate through each running sandbox and stop it, collecting error messages
     results: dict[str, str | None] = {}
-    async for sandbox in sandbox_generator(benchmark_row, daytona_client):
-        result = await stop_sandbox(sandbox, daytona_client)
+    try:
+        while True:
+            stopped_any = False
+            async for sandbox in sandbox_generator(benchmark_row, provider):
+                stopped_any = True
+                result = await stop_sandbox(sandbox, provider)
 
-        results[sandbox.name] = result
+                results[sandbox.name] = result
+            if not stopped_any:
+                break
+    finally:
+        await benchmark_service.close()
 
     error_message: str = "\n".join(
         f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message

--- a/services/tracker/tests/integration/conftest.py
+++ b/services/tracker/tests/integration/conftest.py
@@ -5,8 +5,8 @@ from collections.abc import AsyncGenerator, Generator
 from typing import Any
 
 import pytest
+from benchmark_service import Resources, SandboxProvider
 from benchmark_service.client import BenchmarkServiceClient
-from daytona import AsyncDaytona
 from dotenv import load_dotenv
 from sqlmodel import Session, SQLModel, create_engine
 from testcontainers.postgres import PostgresContainer
@@ -17,7 +17,6 @@ from tests.conftest import TEST_ORG_ID
 from tracker.database.models import *  # noqa: F403 # type: ignore[attr-defined]
 from tracker.database.models import DEFAULT_ORG_NAME, Org
 from tracker.database.session import get_session
-from tracker.sandbox import TrackerResources
 from tracker.types import AWSCredentials, HarnessConfig
 from tracker.utils import create_benchmark_service_client, fetch_harness_config
 
@@ -154,8 +153,8 @@ async def benchmark_service(
 
 
 @pytest.fixture
-async def daytona_client(benchmark_service: BenchmarkServiceClient) -> AsyncGenerator[AsyncDaytona, None]:
-    yield benchmark_service.daytona_client
+async def sandbox_provider(benchmark_service: BenchmarkServiceClient) -> AsyncGenerator[SandboxProvider, None]:
+    yield benchmark_service.get_sandbox_provider()
 
 
 @pytest.fixture
@@ -170,4 +169,4 @@ def test_image():
 
 @pytest.fixture
 def test_resources():
-    return TrackerResources(vcpu=1, memory=2, disk=5)
+    return Resources(cpu=1, memory_gb=2, disk_gb=5)

--- a/services/tracker/tests/integration/test_database_integration.py
+++ b/services/tracker/tests/integration/test_database_integration.py
@@ -6,9 +6,9 @@ from typing import Any
 from uuid import UUID
 
 import pytest
+from benchmark_service import SandboxProvider
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import FinalScoreResponse, RetrieveTaskResponse
-from daytona import AsyncDaytona
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, col, inspect, select
 
@@ -22,7 +22,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
-from tracker.sandbox import TrackerResources, create_sandbox
+from tracker.sandbox import create_sandbox
 
 logger = logging.getLogger(__name__)
 
@@ -214,21 +214,18 @@ class TestDatabaseIntegration:
         self,
         database_session: Session,
         benchmark_service: BenchmarkServiceClient,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         task_row: Task,
         task_data: RetrieveTaskResponse,
-        test_resources: TrackerResources,
         creation_semaphore: Semaphore,
     ) -> dict[str, str]:
-        docker_image: str = task_data.docker_image
-
         # Change the status of the task to evaluating before we start evaluation
         task_row.status = TaskStatus.EVALUATING
         database_session.add(task_row)
         database_session.flush()
 
         async with create_sandbox(
-            daytona_client, task_row.task_id, docker_image, test_resources, creation_semaphore
+            sandbox_provider, task_row.task_id, task_data.source, task_data.resources, creation_semaphore
         ) as sandbox:
             response = await benchmark_service.setup_task(task_id=task_row.task_id, instance_id=str(sandbox.id))
             assert response.status == "ok"
@@ -242,9 +239,8 @@ class TestDatabaseIntegration:
         self,
         database_session: Session,
         benchmark_service: BenchmarkServiceClient,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         example_benchmark_object: Benchmark,
-        test_resources: TrackerResources,
         creation_semaphore: Semaphore,
     ):
         """
@@ -299,10 +295,9 @@ class TestDatabaseIntegration:
                         evaluation_result = await self._evaluate_instance(
                             database_session,
                             benchmark_service,
-                            daytona_client,
+                            sandbox_provider,
                             task_row,
                             task_data,
-                            test_resources,
                             creation_semaphore,
                         )
                         evaluation_result_row = await self._create_evaluation_result(

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -1,8 +1,9 @@
 import asyncio
 
 import pytest
+from benchmark_service import ImageSource, Resources, SandboxProvider, SandboxQuery
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import Resources as TrackerResources
+from benchmark_service.sandbox import DaytonaSandbox
 from fastapi.testclient import TestClient
 from sqlmodel import Session, col, select
 
@@ -13,9 +14,14 @@ from tracker.database.models import Benchmark, BenchmarkStatus, Org, Task, TaskS
 from tracker.logging import get_logger
 from tracker.sandbox import create_sandbox
 from tracker.types import AWSCredentials, HarnessConfig
-from tracker.utils import fetch_sandboxes, force_stop_sandboxes, process_benchmark
+from tracker.utils import force_stop_sandboxes, process_benchmark
 
 logger = get_logger(__name__)
+
+
+async def _sandboxes_for_benchmark(benchmark: Benchmark, provider: SandboxProvider):
+    query = SandboxQuery(labels={"Benchmark": benchmark.name, "Id": str(benchmark.id)})
+    return [sandbox async for sandbox in provider.list_sandboxes(query)]
 
 
 class TestForceStop:
@@ -24,10 +30,9 @@ class TestForceStop:
         example_benchmark_object: Benchmark,
         database_session: Session,
         benchmark_service: BenchmarkServiceClient,
-        test_resources: TrackerResources,
+        test_resources: Resources,
         daytona_secret_name: str,
         aws_credentials: AWSCredentials,
-        random_sandbox_name: str,
         test_image: str,
         creation_semaphore: asyncio.Semaphore,
     ) -> None:
@@ -51,7 +56,12 @@ class TestForceStop:
         database_session.add(task)
         database_session.commit()
 
-        daytona_client = benchmark_service.daytona_client
+        provider = benchmark_service.get_sandbox_provider()
+        labels = {
+            "Benchmark": example_benchmark_object.name,
+            "Id": str(example_benchmark_object.id),
+            "Task": task.task_id,
+        }
 
         async def force_stop_sandbox() -> None:
             await asyncio.sleep(0.5)
@@ -66,11 +76,12 @@ class TestForceStop:
 
         async def _generator_to_courtine():
             async with create_sandbox(
-                daytona_client,
-                random_sandbox_name,
-                test_image,
+                provider,
+                task.alias,
+                ImageSource(image=test_image),
                 resources=test_resources,
                 creation_semaphore=creation_semaphore,
+                labels=labels,
             ) as _:
                 pass
 
@@ -86,9 +97,7 @@ class TestForceStop:
 
         # Ensure that the sandbox does not exist anymore
         with pytest.raises(Exception):
-            await daytona_client.get(random_sandbox_name)
-
-        await daytona_client.close()
+            await provider.get_sandbox(task.alias)
 
     async def test_force_stop_sandboxes(
         self,
@@ -98,7 +107,7 @@ class TestForceStop:
         daytona_secret_name: str,
         benchmark_service: BenchmarkServiceClient,
         test_image: str,
-        test_resources: TrackerResources,
+        test_resources: Resources,
         creation_semaphore: asyncio.Semaphore,
     ) -> None:
         """
@@ -111,22 +120,23 @@ class TestForceStop:
         database_session.add(example_benchmark_object)
         database_session.commit()
 
-        daytona_client = benchmark_service.daytona_client
+        provider = benchmark_service.get_sandbox_provider()
 
         labels = {"Benchmark": example_benchmark_object.name, "Id": str(example_benchmark_object.id)}
 
         async def create_sandbox_with_delay(sandbox_name: str) -> None:
             """Create sandbox that will not be closed automatically"""
             async with create_sandbox(
-                daytona=daytona_client,
+                provider=provider,
                 sandbox_name=sandbox_name,
-                image=test_image,
+                source=ImageSource(image=test_image),
                 resources=test_resources,
                 creation_semaphore=creation_semaphore,
                 labels=labels,
             ) as sandbox:
                 # NOTE: Must wait until sandboxes have been started
-                await sandbox.wait_for_sandbox_start(timeout=0)
+                assert isinstance(sandbox, DaytonaSandbox)
+                await sandbox.inner.wait_for_sandbox_start(timeout=0)
 
         # Create 12 tasks that are in progress and evaluating
         tasks: list[Task] = []
@@ -161,10 +171,8 @@ class TestForceStop:
         await created_sandboxes
 
         # Ensure that there are no more sandboxes left running
-        sandboxes = await fetch_sandboxes(example_benchmark_object, daytona_client, 1)
-        assert len(sandboxes.items) == 0
-
-        await daytona_client.close()
+        sandboxes = await _sandboxes_for_benchmark(example_benchmark_object, provider)
+        assert len(sandboxes) == 0
 
     @pytest.mark.slow
     async def test_force_stop_end_to_end(
@@ -257,10 +265,10 @@ class TestForceStop:
         assert example_benchmark_object.status == BenchmarkStatus.STOPPED
 
         # Create daytona client from the current benchmark service
-        daytona_client = benchmark_service.daytona_client
+        provider = benchmark_service.get_sandbox_provider()
 
         # Try to fetch the sandboxes and see if any of them are still running
-        sandboxes = await fetch_sandboxes(example_benchmark_object, daytona_client, 1)
-        assert len(sandboxes.items) == 0
+        sandboxes = await _sandboxes_for_benchmark(example_benchmark_object, provider)
+        assert len(sandboxes) == 0
 
-        await daytona_client.close()
+        await benchmark_service.close()

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -7,13 +7,12 @@ from typing import AsyncGenerator
 
 import boto3
 import pytest
-from benchmark_service.schemas import Resources
-from daytona import AsyncDaytona, AsyncSandbox, DaytonaError
+from benchmark_service import ImageSource, Resources, Sandbox, SandboxNotFoundError, SandboxProvider
+from benchmark_service.sandbox import DaytonaSandbox
 
-from tests.utils import random_task_id
+from tracker.aws.s3 import get_benchmark_contract_s3_key, get_contract_s3_key
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SandboxError
-from tracker.aws.s3 import get_benchmark_contract_s3_key, get_contract_s3_key
 from tracker.sandbox import (
     create_sandbox,
     install_agent_dependencies,
@@ -22,20 +21,25 @@ from tracker.sandbox import (
     upload_agent_artifacts,
 )
 from tracker.types import AWSCredentials, HarnessConfig
+from tests.utils import random_task_id
 
 
 @pytest.fixture
 async def test_sandbox(
-    daytona_client: AsyncDaytona,
+    sandbox_provider: SandboxProvider,
     test_resources: Resources,
     test_image: str,
     random_sandbox_name: str,
     creation_semaphore: asyncio.Semaphore,
-) -> AsyncGenerator[AsyncSandbox, None]:
+) -> AsyncGenerator[Sandbox, None]:
     """Create a test sandbox with Python."""
 
     async with create_sandbox(
-        daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+        sandbox_provider,
+        random_sandbox_name,
+        ImageSource(image=test_image),
+        test_resources,
+        creation_semaphore,
     ) as sandbox:
         yield sandbox
 
@@ -45,7 +49,7 @@ class TestSandboxOperations:
 
     async def test_create_and_cleanup_sandbox(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -54,17 +58,21 @@ class TestSandboxOperations:
         """Test that sandbox is created and cleaned up properly."""
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
             assert sandbox.name == random_sandbox_name
-            result = await sandbox.process.exec("echo 'test'")
+            result = await sandbox.exec("echo 'test'")
             assert result.exit_code == 0
 
-        with pytest.raises(DaytonaError):
-            await daytona_client.get(random_sandbox_name)
+        with pytest.raises(SandboxNotFoundError):
+            await sandbox_provider.get_sandbox(random_sandbox_name)
 
     async def test_upload_agent_artifacts(
-        self, test_sandbox: AsyncSandbox, aws_credentials: AWSCredentials, harness_config: HarnessConfig
+        self, test_sandbox: Sandbox, aws_credentials: AWSCredentials, harness_config: HarnessConfig
     ) -> None:
         """Test that agent artifacts are uploaded to the sandbox."""
         contract_name = "test_contract"
@@ -113,18 +121,18 @@ class TestSandboxOperations:
             )
 
             # Verify files exist in sandbox
-            result = await test_sandbox.process.exec(f"cat /bundle/{setup_file}")
+            result = await test_sandbox.exec(f"cat /bundle/{setup_file}")
             assert result.exit_code == 0
-            assert "echo 'setup'" in result.result
+            assert "echo 'setup'" in result.stdout
 
-            result = await test_sandbox.process.exec(f"cat /bundle/{agent_file}")
+            result = await test_sandbox.exec(f"cat /bundle/{agent_file}")
             assert result.exit_code == 0
-            assert "hello world" in result.result
+            assert "hello world" in result.stdout
         finally:
             s3.delete_object(Bucket=harness_config.s3_bucket, Key=agent_key)
             s3.delete_object(Bucket=harness_config.s3_bucket, Key=frozen_key)
 
-    async def test_install_agent_dependencies(self, test_sandbox: AsyncSandbox) -> None:
+    async def test_install_agent_dependencies(self, test_sandbox: Sandbox) -> None:
         """Test that install command is correctly executed in the sandbox."""
         logged_messages: list[str] = []
 
@@ -139,8 +147,8 @@ class TestSandboxOperations:
         )
 
         # Create the contract directory and setup.sh directly in sandbox
-        await test_sandbox.process.exec(f"mkdir -p /bundle/{contract_name}")
-        await test_sandbox.process.exec(f"echo '#!/bin/bash\necho hello world' > /bundle/{contract_name}/setup.sh")
+        await test_sandbox.exec(f"mkdir -p /bundle/{contract_name}")
+        await test_sandbox.exec(f"echo '#!/bin/bash\necho hello world' > /bundle/{contract_name}/setup.sh")
 
         await install_agent_dependencies(test_sandbox, contract, log_callback)
 
@@ -151,7 +159,7 @@ class TestSandboxOperations:
 
     async def test_run_agent(
         self,
-        test_sandbox: AsyncSandbox,
+        test_sandbox: Sandbox,
         aws_credentials: AWSCredentials,
         harness_config: HarnessConfig,
     ) -> None:
@@ -171,7 +179,7 @@ class TestSandboxOperations:
         )
 
         # Expecting bundle directory to exist
-        await test_sandbox.process.exec("mkdir -p /bundle/test_agent")
+        await test_sandbox.exec("mkdir -p /bundle/test_agent")
 
         await run_agent(
             test_sandbox,
@@ -191,7 +199,7 @@ class TestSandboxOperations:
 
     async def test_create_sandbox_reuse(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -200,20 +208,28 @@ class TestSandboxOperations:
         """Test that create_sandbox reuses existing sandbox instead of creating new one."""
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox1:
-            result = await sandbox1.process.exec("echo 'test'")
+            result = await sandbox1.exec("echo 'test'")
             assert result.exit_code == 0
             first_id = sandbox1.id
 
             async with create_sandbox(
-                daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+                sandbox_provider,
+                random_sandbox_name,
+                ImageSource(image=test_image),
+                test_resources,
+                creation_semaphore,
             ) as sandbox2:
                 assert sandbox2.id == first_id
 
     async def test_deterministic_timeout_behavior(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -228,7 +244,11 @@ class TestSandboxOperations:
         """
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
             command = "timeout 15 sleep 70"
 
@@ -237,7 +257,11 @@ class TestSandboxOperations:
             assert command_timeout
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
             command = "timeout 15 sleep 10"
 
@@ -247,7 +271,7 @@ class TestSandboxOperations:
 
     async def test_pty_streaming_captures_all_output(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -260,7 +284,11 @@ class TestSandboxOperations:
             logged_messages.append(message)
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
             command = "echo 'STAGE_1' && sleep 1 && echo 'STAGE_2' && sleep 1 && echo 'STAGE_3'"
 
@@ -274,7 +302,7 @@ class TestSandboxOperations:
 
     async def test_pty_reconnect_with_connect_pty_session(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -283,9 +311,15 @@ class TestSandboxOperations:
         """Test that connect_pty_session can reconnect to a running PTY and receive output."""
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
-            session_id = f"{sandbox.id}:pty-reconnect-test"
+            assert isinstance(sandbox, DaytonaSandbox)
+            daytona_sandbox = sandbox.inner
+            session_id = f"{daytona_sandbox.id}:pty-reconnect-test"
             before_messages: list[str] = []
             after_messages: list[str] = []
 
@@ -296,7 +330,7 @@ class TestSandboxOperations:
                 after_messages.append(data.decode("utf-8", errors="replace"))
 
             # Create PTY session and start a long-running command
-            handle = await sandbox.process.create_pty_session(
+            handle = await daytona_sandbox.process.create_pty_session(
                 id=session_id,
                 on_data=before_callback,
                 envs={"TERM": "dumb"},
@@ -309,7 +343,7 @@ class TestSandboxOperations:
             await handle.disconnect()
 
             # Reconnect to the same PTY session with a new callback
-            handle2 = await sandbox.process.connect_pty_session(session_id, after_callback)
+            handle2 = await daytona_sandbox.process.connect_pty_session(session_id, after_callback)
             await handle2.wait()
             await handle2.disconnect()
 
@@ -319,13 +353,13 @@ class TestSandboxOperations:
             assert any("AFTER_RECONNECT" in msg for msg in after_messages)
 
             try:
-                await sandbox.process.kill_pty_session(session_id)
+                await daytona_sandbox.process.kill_pty_session(session_id)
             except Exception:
                 pass
 
     async def test_stream_command_raises_on_sandbox_crash(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -334,12 +368,16 @@ class TestSandboxOperations:
         """Test that a sandbox crash during execution is detected and raised."""
 
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
 
             async def destroy_sandbox_after_delay() -> None:
                 await asyncio.sleep(2)
-                await daytona_client.delete(sandbox)
+                await sandbox_provider.delete_sandbox(sandbox.id)
 
             with pytest.raises(SandboxError, match="crashed|health"):
                 await asyncio.gather(
@@ -349,7 +387,7 @@ class TestSandboxOperations:
 
     async def test_stream_command_raises_on_nonzero_exit(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
         random_sandbox_name: str,
@@ -357,7 +395,11 @@ class TestSandboxOperations:
     ) -> None:
         """Test that a command with non-zero exit code raises SandboxError."""
         async with create_sandbox(
-            daytona_client, random_sandbox_name, test_image, test_resources, creation_semaphore
+            sandbox_provider,
+            random_sandbox_name,
+            ImageSource(image=test_image),
+            test_resources,
+            creation_semaphore,
         ) as sandbox:
             # Use `false` (returns 1) instead of `exit 1` — exit kills the writer
             # shell itself, preventing the status file from being written.

--- a/services/tracker/tests/integration/test_sandbox_lifecycle.py
+++ b/services/tracker/tests/integration/test_sandbox_lifecycle.py
@@ -2,9 +2,7 @@ import asyncio
 from asyncio import Semaphore
 
 import pytest
-from benchmark_service.schemas import Resources
-from daytona import AsyncDaytona
-from daytona.common.errors import DaytonaNotFoundError
+from benchmark_service import ImageSource, Resources, SandboxNotFoundError, SandboxProvider
 
 from tests.utils import random_task_id
 from tracker.sandbox import create_sandbox
@@ -13,7 +11,7 @@ from tracker.sandbox import create_sandbox
 class TestSandboxLifecycle:
     async def test_parallel_create_and_immediate_delete(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         test_image: str,
     ) -> None:
@@ -29,11 +27,11 @@ class TestSandboxLifecycle:
         names = [f"test-parallel-delete-{random_task_id()}" for _ in range(TASKS_TO_CREATE)]
 
         async def _create_and_delete(name: str) -> None:
-            async with create_sandbox(daytona_client, name, test_image, test_resources, semaphore):
+            async with create_sandbox(sandbox_provider, name, ImageSource(image=test_image), test_resources, semaphore):
                 await asyncio.sleep(2)
 
         await asyncio.gather(*[_create_and_delete(name) for name in names])
 
         for name in names:
-            with pytest.raises(DaytonaNotFoundError):
-                await daytona_client.get(name)
+            with pytest.raises(SandboxNotFoundError):
+                await sandbox_provider.get_sandbox(name)

--- a/services/tracker/tests/integration/test_upload_artifacts_images.py
+++ b/services/tracker/tests/integration/test_upload_artifacts_images.py
@@ -2,8 +2,7 @@ import asyncio
 from uuid import uuid4
 
 import boto3
-from benchmark_service.schemas import Resources
-from daytona import AsyncDaytona
+from benchmark_service import ImageSource, Resources, SandboxProvider
 
 from tests.utils import random_task_id
 from tracker.database.models import AgentContractRequest
@@ -38,7 +37,7 @@ def _format_failure(exc: BaseException) -> str:
 class TestUploadArtifactsAcrossImages:
     async def test_upload_all_images(
         self,
-        daytona_client: AsyncDaytona,
+        sandbox_provider: SandboxProvider,
         test_resources: Resources,
         contract: AgentContractRequest,
         aws_credentials: AWSCredentials,
@@ -70,17 +69,23 @@ class TestUploadArtifactsAcrossImages:
 
             async with (
                 asyncio.timeout(_PER_IMAGE_TIMEOUT_SECONDS),
-                create_sandbox(daytona_client, sandbox_name, image, test_resources, creation_semaphore) as sandbox,
+                create_sandbox(
+                    sandbox_provider,
+                    sandbox_name,
+                    ImageSource(image=image),
+                    test_resources,
+                    creation_semaphore,
+                ) as sandbox,
             ):
                 await upload_agent_artifacts(sandbox, contract, benchmark_id, aws_credentials, harness_config.s3_bucket)
 
-                dir_check = await sandbox.process.exec(f"test -d /bundle/{contract.name}")
+                dir_check = await sandbox.exec(f"test -d /bundle/{contract.name}")
                 assert dir_check.exit_code == 0, f"[{label}] contract dir /bundle/{contract.name} should exist"
 
-                leftover = await sandbox.process.exec(f"test -f /tmp/{contract.name}.zip")
+                leftover = await sandbox.exec(f"test -f /tmp/{contract.name}.zip")
                 assert leftover.exit_code != 0, f"[{label}] temp zip should be deleted after extraction"
 
-                excluded = await sandbox.process.exec("test -f /bundle/contract.py")
+                excluded = await sandbox.exec("test -f /bundle/contract.py")
                 assert excluded.exit_code != 0, f"[{label}] contract.py should be excluded from extraction"
 
         results = await asyncio.gather(

--- a/services/tracker/tests/integration/test_upload_to_s3.py
+++ b/services/tracker/tests/integration/test_upload_to_s3.py
@@ -1,11 +1,11 @@
 import asyncio
 
-from daytona import AsyncDaytona
+from benchmark_service import ImageSource, Resources, SandboxProvider
 
 from tests.utils import random_task_id
 from tracker.database.models import Benchmark
 from tracker.aws.s3 import delete_from_s3, download_from_s3, get_agent_result_s3_key
-from tracker.sandbox import TrackerResources, archive_and_upload_output, create_sandbox
+from tracker.sandbox import archive_and_upload_output, create_sandbox
 from tracker.types import HarnessConfig
 
 
@@ -15,8 +15,8 @@ class TestUploadToS3:
         example_benchmark_object: Benchmark,
         test_image: str,
         random_sandbox_name: str,
-        test_resources: TrackerResources,
-        daytona_client: AsyncDaytona,
+        test_resources: Resources,
+        sandbox_provider: SandboxProvider,
         harness_config: HarnessConfig,
         creation_semaphore: asyncio.Semaphore,
     ) -> None:
@@ -27,13 +27,13 @@ class TestUploadToS3:
 
         try:
             async with create_sandbox(
-                daytona=daytona_client,
+                provider=sandbox_provider,
                 sandbox_name=random_sandbox_name,
-                image=test_image,
+                source=ImageSource(image=test_image),
                 resources=test_resources,
                 creation_semaphore=creation_semaphore,
             ) as sandbox:
-                await sandbox.process.exec(f"echo '{file_content}' > {file_path}")
+                await sandbox.exec(f"echo '{file_content}' > {file_path}")
 
                 await archive_and_upload_output(
                     sandbox, file_path, s3_key, harness_config.aws, harness_config.s3_bucket
@@ -50,11 +50,10 @@ class TestUploadToS3:
         self,
         example_benchmark_object: Benchmark,
         harness_config: HarnessConfig,
-        daytona_secret_name: str,
         test_image: str,
         random_sandbox_name: str,
-        test_resources: TrackerResources,
-        daytona_client: AsyncDaytona,
+        test_resources: Resources,
+        sandbox_provider: SandboxProvider,
         creation_semaphore: asyncio.Semaphore,
     ) -> None:
         """Test creating a tar.gz from a directory in sandbox and uploading to S3."""
@@ -63,17 +62,17 @@ class TestUploadToS3:
 
         try:
             async with create_sandbox(
-                daytona=daytona_client,
+                provider=sandbox_provider,
                 sandbox_name=random_sandbox_name,
-                image=test_image,
+                source=ImageSource(image=test_image),
                 resources=test_resources,
                 creation_semaphore=creation_semaphore,
             ) as sandbox:
-                await sandbox.process.exec(f"mkdir -p {dir_path}")
-                await sandbox.process.exec(f"echo 'file1 content' > {dir_path}/file1.txt")
-                await sandbox.process.exec(f"echo 'file2 content' > {dir_path}/file2.txt")
-                await sandbox.process.exec(f"mkdir -p {dir_path}/nested")
-                await sandbox.process.exec(f"echo 'nested content' > {dir_path}/nested/file3.txt")
+                await sandbox.exec(f"mkdir -p {dir_path}")
+                await sandbox.exec(f"echo 'file1 content' > {dir_path}/file1.txt")
+                await sandbox.exec(f"echo 'file2 content' > {dir_path}/file2.txt")
+                await sandbox.exec(f"mkdir -p {dir_path}/nested")
+                await sandbox.exec(f"echo 'nested content' > {dir_path}/nested/file3.txt")
 
                 await archive_and_upload_output(sandbox, dir_path, s3_key, harness_config.aws, harness_config.s3_bucket)
 

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -5,10 +5,10 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
+from benchmark_service import ImageSource, Resources
 from benchmark_service.schemas import (
     FinalScoreResponse,
     HealthCheckResponse,
-    Resources,
     RetrieveTaskResponse,
     SetupTaskResponse,
     VerifyTaskIdsResponse,
@@ -208,10 +208,10 @@ def process_benchmark_env(monkeypatch: pytest.MonkeyPatch, database_session: Ses
 
     async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
         return RetrieveTaskResponse(
-            docker_image="test-image:latest",
+            source=ImageSource(image="test-image:latest"),
             problem_path="/tmp/problem_statement.txt",
             cwd="/testbed",
-            resources=Resources(vcpu=2, memory=4, disk=5),
+            resources=Resources(cpu=2, memory_gb=4, disk_gb=5),
         )
 
     async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -1,11 +1,12 @@
 from asyncio import Semaphore
 from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import Resources, RetrieveTaskResponse
+from benchmark_service import ImageSource, Resources
+from benchmark_service.schemas import RetrieveTaskResponse
 from sqlmodel import Session
 
 from tests.conftest import TEST_ORG_ID
@@ -100,10 +101,10 @@ class TestPtyRetry:
 
         async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
             return RetrieveTaskResponse(
-                docker_image="test-image:latest",
+                source=ImageSource(image="test-image:latest"),
                 problem_path="/tmp/problem.txt",
                 cwd="/testbed",
-                resources=Resources(vcpu=2, memory=4, disk=5),
+                resources=Resources(cpu=2, memory_gb=4, disk_gb=5),
             )
 
         async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
@@ -111,6 +112,7 @@ class TestPtyRetry:
 
         is_run_agent_target = fail_target == "tracker.utils.run_agent"
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.buffer_logs", Mock())
         monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(fail_target, _fails_first_run_agent if is_run_agent_target else _fails_first_other)
         if not is_run_agent_target:
@@ -169,10 +171,10 @@ class TestPtyRetry:
 
         async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
             return RetrieveTaskResponse(
-                docker_image="test-image:latest",
+                source=ImageSource(image="test-image:latest"),
                 problem_path="/tmp/problem.txt",
                 cwd="/testbed",
-                resources=Resources(vcpu=2, memory=4, disk=5),
+                resources=Resources(cpu=2, memory_gb=4, disk_gb=5),
             )
 
         async def _mock_upload_agent_artifacts(*_args: Any, **_kwargs: Any) -> None:
@@ -215,6 +217,7 @@ class TestPtyRetry:
             return _MockSpan(record)
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.buffer_logs", Mock())
         monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr("tracker.utils.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.run_agent", _mock_run_agent)

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -6,17 +6,17 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from daytona import ExecuteResponse, SandboxState
+from benchmark_service import ExecResult, ImageSource, Resources, SnapshotSource
+from daytona import SandboxState
 from daytona.common.errors import DaytonaConnectionError, DaytonaError, DaytonaNotFoundError, DaytonaRateLimitError
 from tenacity import stop_after_attempt, wait_none
 
 import tracker.daytona_retry as daytona_retry_module
 import tracker.observability.retry as retry_module
-import tracker.utils as utils_module
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
-from tracker.sandbox import create_sandbox, run_agent, stream_command_output, upload_agent_artifacts
+from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import AWSCredentials
 
 _create_sandbox = getattr(sandbox_module, "_create_sandbox")
@@ -28,7 +28,6 @@ _install_agent_dependencies = getattr(sandbox_module, "install_agent_dependencie
 _reconnect_and_wait_pty = getattr(sandbox_module, "_reconnect_and_wait_pty")
 _upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
 _wait_for_pty = getattr(sandbox_module, "_wait_for_pty")
-_fetch_sandboxes = getattr(utils_module, "fetch_sandboxes")
 
 
 def _ignore_pty_data(_data: bytes) -> None:
@@ -238,9 +237,9 @@ class TestAgentOutputTelemetry:
         )
         archive_calls: list[str] = []
 
-        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+        async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
             if command.startswith("mkdir -p") or command.startswith("test -e"):
-                return ExecuteResponse(exit_code=0, result="")
+                return ExecResult(exit_code=0)
             raise AssertionError(f"unexpected command: {command}")
 
         async def fake_stream_command_output(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
@@ -296,8 +295,8 @@ class TestAgentOutputTelemetry:
             "_exec",
             AsyncMock(
                 side_effect=[
-                    ExecuteResponse(exit_code=1, result=""),
-                    ExecuteResponse(exit_code=0, result=""),
+                    ExecResult(exit_code=1),
+                    ExecResult(exit_code=0),
                 ]
             ),
         )
@@ -334,7 +333,7 @@ class TestAgentOutputTelemetry:
         monkeypatch.setattr(
             sandbox_module,
             "_exec",
-            AsyncMock(return_value=ExecuteResponse(exit_code=0, result="")),
+            AsyncMock(return_value=ExecResult(exit_code=0)),
         )
         reconnect = AsyncMock()
         monkeypatch.setattr(sandbox_module, "_reconnect_and_wait_pty", reconnect)
@@ -453,20 +452,6 @@ class TestAgentOutputTelemetry:
         wait_strategy = _reconnect_and_wait_pty.retry.wait
 
         assert wait_strategy(retry_state) == 8
-
-    async def test_fetch_sandboxes_does_not_retry_non_rate_limit_daytona_errors(self) -> None:
-        benchmark = Mock()
-        benchmark.name = "benchmark"
-        benchmark.id = "benchmark-id"
-        daytona_client = AsyncMock()
-        daytona_client.list = AsyncMock(side_effect=DaytonaError("transient"))
-
-        with pytest.raises(DaytonaError):
-            await _fetch_sandboxes.retry_with(stop=stop_after_attempt(3), wait=wait_none())(
-                benchmark, daytona_client, 1
-            )
-
-        assert daytona_client.list.await_count == 1
 
     def test_daytona_retry_callback_emits_rate_limit_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
         increments: list[tuple[str, dict[str, str]]] = []
@@ -661,14 +646,15 @@ class TestAgentOutputTelemetry:
         assert distributions == []
         assert log_records == []
 
-    def test_metric_image_name_drops_high_cardinality_tag_and_digest(self) -> None:
-        metric_image_name = getattr(sandbox_module, "_metric_image_name")
+    def test_metric_source_name_drops_high_cardinality_tag_and_digest(self) -> None:
+        metric_source_name = getattr(sandbox_module, "_metric_source_name")
 
-        assert metric_image_name("ghcr.io/vals/swebench:latest") == "ghcr.io/vals/swebench"
+        assert metric_source_name(ImageSource(image="ghcr.io/vals/swebench:latest")) == "ghcr.io/vals/swebench"
         assert (
-            metric_image_name("registry.local:5000/vals/swebench@sha256:abcdef") == "registry.local:5000/vals/swebench"
+            metric_source_name(ImageSource(image="registry.local:5000/vals/swebench@sha256:abcdef"))
+            == "registry.local:5000/vals/swebench"
         )
-        assert metric_image_name("snapshot:base-python") == "snapshot"
+        assert metric_source_name(SnapshotSource(snapshot="base-python")) == "snapshot"
 
     def test_sandbox_span_helpers_set_safe_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
         span_attributes: dict[str, str | int] = {}
@@ -681,9 +667,9 @@ class TestAgentOutputTelemetry:
 
         create_span_attrs = getattr(sandbox_module, "_set_sandbox_create_span_attributes")
         sandbox_span_attrs = getattr(sandbox_module, "_set_sandbox_span_attributes")
-        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        resources = Resources(cpu=2, memory_gb=4, disk_gb=5)
 
-        create_span_attrs("task-alias", "ghcr.io/vals/swebench:latest", resources)
+        create_span_attrs("task-alias", ImageSource(image="ghcr.io/vals/swebench:latest"), resources)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -708,21 +694,21 @@ class TestAgentOutputTelemetry:
     ) -> None:
         span_calls: list[tuple[str, str, int]] = []
 
-        def fake_create_span_attrs(sandbox_name: str, image: str, resources: Any) -> None:
-            span_calls.append((sandbox_name, image, resources.vcpu))
+        def fake_create_span_attrs(sandbox_name: str, source: Any, resources: Any) -> None:
+            span_calls.append((sandbox_name, source.image, resources.cpu))
 
         monkeypatch.setattr(sandbox_module, "_set_sandbox_create_span_attributes", fake_create_span_attrs)
 
         mock_sandbox = AsyncMock()
         mock_sandbox.wait_for_sandbox_start = AsyncMock()
-        daytona = AsyncMock()
-        daytona.get = AsyncMock(return_value=mock_sandbox)
+        provider = AsyncMock()
+        provider.get_sandbox = AsyncMock(return_value=mock_sandbox)
 
-        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        resources = Resources(cpu=2, memory_gb=4, disk_gb=5)
         sandbox = await _create_sandbox.retry_with(stop=stop_after_attempt(1), wait=wait_none())(
-            daytona,
+            provider,
             "task-alias",
-            "ghcr.io/vals/swebench:latest",
+            ImageSource(image="ghcr.io/vals/swebench:latest"),
             resources,
         )
 
@@ -739,8 +725,11 @@ class TestAgentOutputTelemetry:
         monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
 
         mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
-        mock_sandbox.refresh_data = AsyncMock(side_effect=daytona_error)
+        mock_inner = AsyncMock()
+        mock_inner.refresh_data = AsyncMock(side_effect=daytona_error)
+        monkeypatch.setattr(sandbox_module, "_daytona_inner", lambda _sandbox: mock_inner)
 
         with pytest.raises(DaytonaError):
             await _delete_sandbox.retry_with(stop=stop_after_attempt(1), wait=wait_none())(mock_sandbox, AsyncMock())
@@ -758,7 +747,9 @@ class TestAgentOutputTelemetry:
         monkeypatch.setattr(sandbox_module, "_set_sandbox_span_attributes", Mock(), raising=False)
 
         mock_sandbox = AsyncMock()
-        mock_sandbox.process.exec = AsyncMock(side_effect=daytona_error)
+        mock_inner = AsyncMock()
+        mock_inner.process.exec = AsyncMock(side_effect=daytona_error)
+        monkeypatch.setattr(sandbox_module, "_daytona_inner", lambda _sandbox: mock_inner)
 
         with pytest.raises(DaytonaError):
             await _exec.retry_with(stop=stop_after_attempt(1), wait=wait_none())(mock_sandbox, "echo hi")
@@ -795,11 +786,11 @@ class TestAgentOutputTelemetry:
         monkeypatch.setattr(sandbox_module, "set_sandbox_context", fake_set_sandbox_context, raising=False)
         monkeypatch.setattr(sandbox_module.time, "monotonic", fake_monotonic)
 
-        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        resources = Resources(cpu=2, memory_gb=4, disk_gb=5)
         async with create_sandbox(
-            daytona=AsyncMock(),
+            provider=AsyncMock(),
             sandbox_name="task-alias",
-            image="ghcr.io/vals/swebench:latest",
+            source=ImageSource(image="ghcr.io/vals/swebench:latest"),
             resources=resources,
             creation_semaphore=asyncio.Semaphore(1),
         ) as sandbox:
@@ -832,12 +823,12 @@ class TestAgentOutputTelemetry:
         monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
         monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
 
-        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        resources = Resources(cpu=2, memory_gb=4, disk_gb=5)
         with pytest.raises(DaytonaError):
             async with create_sandbox(
-                daytona=AsyncMock(),
+                provider=AsyncMock(),
                 sandbox_name="task-alias",
-                image="ghcr.io/vals/swebench:latest",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
                 resources=resources,
                 creation_semaphore=asyncio.Semaphore(1),
             ):
@@ -863,12 +854,12 @@ class TestAgentOutputTelemetry:
         monkeypatch.setattr(sandbox_module, "incr", fake_incr, raising=False)
         monkeypatch.setattr(sandbox_module, "tag_daytona_error", fake_tag_daytona_error, raising=False)
 
-        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        resources = Resources(cpu=2, memory_gb=4, disk_gb=5)
         with pytest.raises(ValueError, match="bad config"):
             async with create_sandbox(
-                daytona=AsyncMock(),
+                provider=AsyncMock(),
                 sandbox_name="task-alias",
-                image="ghcr.io/vals/swebench:latest",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
                 resources=resources,
                 creation_semaphore=asyncio.Semaphore(1),
             ):
@@ -1163,7 +1154,7 @@ class TestUploadAgentArtifacts:
         monkeypatch.setattr(
             sandbox_module,
             "_exec",
-            AsyncMock(return_value=ExecuteResponse(exit_code=exit_code, result="error output")),
+            AsyncMock(return_value=ExecResult(exit_code=exit_code, stdout="error output")),
         )
         monkeypatch.setattr(
             "tracker.sandbox.create_presigned_url",
@@ -1210,7 +1201,7 @@ class TestStreamCommandOutputAgentFailure:
         monkeypatch.setattr(
             sandbox_module,
             "_exec",
-            AsyncMock(return_value=ExecuteResponse(exit_code=0, result="1000000000")),
+            AsyncMock(return_value=ExecResult(exit_code=0, stdout="1000000000")),
         )
 
         tagged: dict[str, str] = {}
@@ -1221,7 +1212,7 @@ class TestStreamCommandOutputAgentFailure:
         monkeypatch.setattr(sandbox_module.sentry_sdk, "set_tag", fake_set_tag)
 
         with pytest.raises(AgentRunFailedError) as exc_info:
-            await stream_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)
+            await sandbox_module._stream_daytona_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)
 
         assert isinstance(exc_info.value, SandboxError)
         assert not isinstance(exc_info.value, SandboxSetupError)

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -416,19 +416,24 @@ class TestStopAndResume:
             return {"score": 1.0}
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.buffer_logs", Mock())
         monkeypatch.setattr("tracker.utils.create_sandbox", _unexpected_create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
-        result = await process_task(
-            task_row,
-            request,
-            request.benchmark_service,
-            benchmark_row.id,
-            task_row.task_id,
-            harness_config,
-            self._test_org,
-            creation_semaphore=asyncio.Semaphore(1),
-        )
+        benchmark_service = request.benchmark_service
+        try:
+            result = await process_task(
+                task_row,
+                request,
+                benchmark_service,
+                benchmark_row.id,
+                task_row.task_id,
+                harness_config,
+                self._test_org,
+                creation_semaphore=asyncio.Semaphore(1),
+            )
+        finally:
+            await benchmark_service.close()
 
         database_session.refresh(task_row)
         evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
@@ -482,18 +487,23 @@ class TestStopAndResume:
             raise RuntimeError("evaluation interrupted")
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.buffer_logs", Mock())
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
-        result = await process_task(
-            task_row,
-            request,
-            request.benchmark_service,
-            benchmark_row.id,
-            task_row.task_id,
-            harness_config,
-            self._test_org,
-            creation_semaphore=asyncio.Semaphore(1),
-        )
+        benchmark_service = request.benchmark_service
+        try:
+            result = await process_task(
+                task_row,
+                request,
+                benchmark_service,
+                benchmark_row.id,
+                task_row.task_id,
+                harness_config,
+                self._test_org,
+                creation_semaphore=asyncio.Semaphore(1),
+            )
+        finally:
+            await benchmark_service.close()
 
         database_session.refresh(task_row)
         evaluations = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).all()
@@ -613,13 +623,19 @@ class TestStopAndResume:
         await initiate_stop_benchmark(benchmark_row, database_session, force=True, org=self._test_org)
         assert benchmark_row.status == BenchmarkStatus.STOPPING
 
-        # Mock daytona client since its not required
-        mock_daytona = AsyncMock()
-        mock_daytona.list = AsyncMock(return_value=AsyncMock(items=[], total_pages=0, page=1))
+        async def _empty_list_sandboxes(*_args: Any, **_kwargs: Any):
+            if False:
+                yield None
+
+        mock_provider = Mock()
+        mock_provider.list_sandboxes = _empty_list_sandboxes
+        mock_service = Mock()
+        mock_service.get_sandbox_provider.return_value = mock_provider
+        mock_service.close = AsyncMock()
         monkeypatch.setattr(
             Benchmark,
             "benchmark_service",
-            lambda *_args, **_kwargs: Mock(daytona_client=mock_daytona),  # type: ignore
+            lambda *_args, **_kwargs: mock_service,  # type: ignore
         )
 
         # Force stopping the sandboxes results in the benchmark row being stopped

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -328,8 +328,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a#9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" }
+version = "0.2.1.dev1+g797df7665"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=797df7665d713abae28b9737e0ca9fb09db42529#797df7665d713abae28b9737e0ca9fb09db42529" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1858,7 +1858,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=797df7665d713abae28b9737e0ca9fb09db42529" },
     { name = "daytona", specifier = "==0.176.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a#9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" }
+version = "0.2.1.dev1+g797df7665"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=797df7665d713abae28b9737e0ca9fb09db42529#797df7665d713abae28b9737e0ca9fb09db42529" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2667,7 +2667,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=797df7665d713abae28b9737e0ca9fb09db42529" },
     { name = "daytona", specifier = "==0.176.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary
- route tracker sandbox create/run/archive/delete through the generic CBS sandbox provider interface
- keep Daytona behavior as the default adapter, including existing PTY/retry paths
- update Valkyrie unit and integration test scaffolding to use the provider contract
- pin create-benchmark-service to vals-ai/create-benchmark-service#46 commit 797df766 while this stack is in review

Stacked on vals-ai/create-benchmark-service#46.

## Validation
- uv run ruff check touched tracker files/tests
- uv run basedpyright services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py
- env BROKER_ENVIRONMENT=testing timeout 45 uv run pytest services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_pty_retry.py -q
- env BROKER_ENVIRONMENT=testing timeout 30 uv run pytest selected stop/resume provider tests -q
- timeout 30 uv run pytest --collect-only selected integration tests -q