### PR TITLE
Better handling for auth errors

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import httpx
 import logfire
 import sentry_sdk
-from benchmark_service.client import BenchmarkServiceError
+from benchmark_service.client import BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from benchmark_service.schemas import VerifyTaskIdsResponse
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
@@ -40,21 +40,21 @@ from tracker.config import AUTH_REQUIRED, ENVIRONMENT, create_benchmark_service_
 from tracker.database.models import Benchmark, BenchmarkStatus, DocentReadingStatus, FinalEvaluation, Org, RetryMode
 from tracker.database.scoping import assert_org, get_scoped
 from tracker.database.session import check_database_connection, get_session
+from tracker.docent_analysis import (
+    analyze_event_stream,
+)
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
 from tracker.middleware import RequestContextMiddleware
 from tracker.observability import configure_observability
-from tracker.docent_analysis import (
-    analyze_event_stream,
-)
 from tracker.types import (
     AnalyzeBenchmarkRequest,
     BenchmarkTableRow,
-    FetchBenchmarkTasksRequest,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
     FetchBenchmarksResponse,
+    FetchBenchmarkTasksRequest,
     HarnessConfig,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
@@ -123,6 +123,11 @@ async def tracker_service_error_handler(_request: Request, exc: TrackerServiceEr
     logger.error(exc, exc_info=True)
     sentry_sdk.capture_exception(exc)
     raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.exception_handler(BenchmarkServiceUnauthenticatedError)
+async def benchmark_service_unauth_error_handler(_request: Request, exc: BenchmarkServiceUnauthenticatedError):
+    raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
 @app.exception_handler(BenchmarkServiceError)

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -252,6 +252,8 @@ async def start_benchmark(
             request.harness_config.aws,
             request.harness_config.s3_bucket,
         )
+    except BenchmarkServiceUnauthenticatedError:
+        raise
     except Exception as e:
         error_message = f"{str(e)}\n{traceback.format_exc()}"
         commit_benchmark_error(benchmark_row, session, error_message)

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]==2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@9479df5e7399d08016c6f0c1e32bc1eb3cb4229a",
+    "create-benchmark-service @ git+https://github.com/vals-ai/create-benchmark-service.git@v0.2.0",
 ]
 
 [dependency-groups]

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -14,7 +14,7 @@ from zoneinfo import ZoneInfo
 
 import logfire
 import sentry_sdk
-from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import Request
@@ -894,6 +894,13 @@ async def process_benchmark(
 
                 invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
 
+    except BenchmarkServiceUnauthenticatedError as e:
+        logfire.warn("process_benchmark failed due to benchmark service auth error")
+        with Session(bind=engine) as session:
+            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            error_message = f"{str(e)}\n{traceback.format_exc()}"
+            logger.warning(error_message)
+            commit_benchmark_error(benchmark_row, session, error_message)
     except Exception as e:
         logfire.exception("process_benchmark failed")
         sentry_sdk.capture_exception(e)

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -5,10 +5,9 @@ from typing import Any
 from unittest.mock import MagicMock
 from uuid import UUID, uuid4
 
-import pytest
-
 import httpx
-from benchmark_service.client import BenchmarkServiceClient
+import pytest
+from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceUnauthenticatedError
 from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
 from dateutil.parser import isoparse
 from descope import DescopeClient
@@ -889,3 +888,71 @@ class TestFastapiServer:
         response = client.get(f"/fetch-benchmark-metadata/{bench.id}")
         assert response.status_code == 200
         assert response.json()["started_by_email"] == "alice@vals.ai"
+
+    async def test_benchmark_service_unauthenticated_error_returns(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        harness_config: HarnessConfig,
+    ):
+        """
+        Test that BenchmarkServiceUnauthenticatedError returns 502 without capturing to Sentry.
+
+        Test Cases:
+            - /start-benchmark returns 502 when benchmark service returns 401
+            - /fetch-benchmark-tasks returns 502 when benchmark service returns 401
+            - /retry-or-resume-benchmark returns 502 when benchmark service returns 401
+            - None of the above cases capture the exception to Sentry
+        """
+        captured: list[Exception] = []
+        monkeypatch.setattr("sentry_sdk.capture_exception", lambda exc: captured.append(exc))  # type: ignore
+
+        async def _raise_unauth(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            raise BenchmarkServiceUnauthenticatedError("401 Unauthorized")
+
+        no_raise_client = TestClient(app, raise_server_exceptions=False)
+
+        # Case 1: /start-benchmark
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _raise_unauth)
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=1,
+            task_ids=None,
+            harness_config=harness_config,
+        )
+
+        response = no_raise_client.post("/start-benchmark", json=request.model_dump())
+        assert response.status_code == 502
+
+        # Case 2: /fetch-benchmark-tasks
+        response = no_raise_client.post(
+            "/fetch-benchmark-tasks",
+            json={"benchmark_name": "swebench"},
+        )
+        assert response.status_code == 502
+
+        # Case 3: /retry-or-resume-benchmark — needs at least one task so verify_task_ids is reached
+        benchmark = Benchmark(
+            org_id=TEST_ORG_ID,
+            name="swebench",
+            status=BenchmarkStatus.ERROR,
+            arguments=BenchmarkArguments(contract=contract, concurrency=1),
+        )
+        database_session.add(benchmark)
+        database_session.commit()
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark.id, status=TaskStatus.ERROR)
+        )
+        database_session.commit()
+
+        response = no_raise_client.post(
+            f"/retry-or-resume-benchmark/{benchmark.id}",
+            json={"task_ids": [], "service_headers": {}},
+            params={"retry": "true"},
+        )
+        assert response.status_code == 502
+
+        # None of the three cases should have reached Sentry
+        assert captured == []

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -328,8 +328,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a#9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" }
+version = "0.2.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.2.0#d4b4e7aedaeff7839b4310462f4646bbe98fc054" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1858,7 +1858,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.2.0" },
     { name = "daytona", specifier = "==0.176.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -663,7 +663,7 @@ def start(
             click.echo("\r\033[K", nl=False)
             if response.status_code != 200:
                 click.echo(click.style("Run failed to start!", fg="red", bold=True))
-                detail = response.json()["detail"]
+                detail = str(response.json().get("detail", response.text))
                 match response.status_code:
                     case 401 | 403:
                         click.echo(click.style("Authentication error: ", fg="yellow", bold=True) + detail)

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -663,7 +663,14 @@ def start(
             click.echo("\r\033[K", nl=False)
             if response.status_code != 200:
                 click.echo(click.style("Run failed to start!", fg="red", bold=True))
-                click.echo(response.text)
+                detail = response.json()["detail"]
+                match response.status_code:
+                    case 401 | 403:
+                        click.echo(click.style("Authentication error: ", fg="yellow", bold=True) + detail)
+                    case 502:
+                        click.echo(click.style("Benchmark service error: ", fg="yellow", bold=True) + detail)
+                    case _:
+                        click.echo(detail)
                 return
 
             format_start_benchmark_response(StartBenchmarkResponse.model_validate(response.json()))

--- a/uv.lock
+++ b/uv.lock
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.1.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a#9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" }
+version = "0.2.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.2.0#d4b4e7aedaeff7839b4310462f4646bbe98fc054" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2665,9 +2665,9 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
-    { name = "boto3", specifier = ">=1.40" },
+    { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=9479df5e7399d08016c6f0c1e32bc1eb3cb4229a" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.2.0" },
     { name = "daytona", specifier = "==0.176.1a1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Uses the typed exception from the benchmark service client to avoid hitting sentry. Also catch auth errors in the CLI to avoid echoing a json.

<img width="315" height="199" alt="image" src="https://github.com/user-attachments/assets/ebc9e129-9807-4ac8-9bd0-9ee686eb674f" />

<img width="482" height="165" alt="image" src="https://github.com/user-attachments/assets/0be7dac9-512e-4fa8-932b-56645d5c8ed4" />

## Changes
<!-- List the key changes made -->
- Added new auth exception type to the tracker service
- Added client side handling for auth errors
- Unit test to confirm we are properly handling auth related exceptions

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- x ] Added/updated unit tests
- [x] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->