### PR TITLE
fix: docent analyze — credentialed S3 client + thread-safe Session

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -421,8 +421,7 @@ async def analyze_benchmark(
 
     return StreamingResponse(
         analyze_event_stream(
-            benchmark_row=benchmark_row,
-            session=session,
+            benchmark_id=benchmark_row.id,
             lambda_function=body.lambda_function,
             payload=payload,
             aws=harness_config.aws,

--- a/services/tracker/src/tracker/docent_analysis.py
+++ b/services/tracker/src/tracker/docent_analysis.py
@@ -11,12 +11,14 @@ import asyncio
 import json
 from collections.abc import AsyncGenerator
 from typing import Any
+from uuid import UUID
 
 from botocore.config import Config
-from sqlmodel import Session as _Session
+from sqlmodel import Session
 
 from tracker._lambda import invoke_lambda, lambda_client
 from tracker.database.models import Benchmark, DocentReadingStatus
+from tracker.database.session import engine
 from tracker.types import AWSCredentials
 
 # Analyzer Lambdas can run up to 15 min (AWS Lambda's ceiling); retries
@@ -28,40 +30,45 @@ _ANALYZER_CONFIG = Config(read_timeout=905, retries={"max_attempts": 1})
 
 def invoke_analyzer(
     *,
-    benchmark: Benchmark,
-    session: _Session,
+    benchmark_id: UUID,
     lambda_function: str,
     payload: dict[str, Any],
     aws: AWSCredentials,
 ) -> dict[str, Any]:
     """Invoke an analyzer Lambda and persist status/URL onto the Benchmark row.
 
-    try/finally guarantees status is always set before returning, so no row is
-    left at RUNNING on failure.
+    Opens its own SQLAlchemy Session so it can safely run inside
+    ``asyncio.to_thread`` (Sessions are not thread-safe, so we never share one
+    across the event loop / worker thread boundary). try/finally guarantees
+    status is always set before returning, so no row is left at RUNNING.
     """
-    benchmark.docent_reading_status = DocentReadingStatus.RUNNING
-    session.add(benchmark)
-    session.commit()
+    with Session(engine, expire_on_commit=False) as session:
+        benchmark = session.get(Benchmark, benchmark_id)
+        if benchmark is None:
+            raise ValueError(f"benchmark {benchmark_id} not found")
 
-    try:
-        result = invoke_lambda(lambda_client(aws, _ANALYZER_CONFIG), lambda_function, payload)
-        reading_plan_url = result.get("reading_plan_url")
-        if reading_plan_url:
-            benchmark.docent_reading_url = str(reading_plan_url)
-        benchmark.docent_reading_status = DocentReadingStatus.DONE
-        return result
-    except Exception:
-        benchmark.docent_reading_status = DocentReadingStatus.ERROR
-        raise
-    finally:
+        benchmark.docent_reading_status = DocentReadingStatus.RUNNING
         session.add(benchmark)
         session.commit()
+
+        try:
+            result = invoke_lambda(lambda_client(aws, _ANALYZER_CONFIG), lambda_function, payload)
+            reading_plan_url = result.get("reading_plan_url")
+            if reading_plan_url:
+                benchmark.docent_reading_url = str(reading_plan_url)
+            benchmark.docent_reading_status = DocentReadingStatus.DONE
+            return result
+        except Exception:
+            benchmark.docent_reading_status = DocentReadingStatus.ERROR
+            raise
+        finally:
+            session.add(benchmark)
+            session.commit()
 
 
 async def analyze_event_stream(
     *,
-    benchmark_row: Benchmark,
-    session: _Session,
+    benchmark_id: UUID,
     lambda_function: str,
     payload: dict[str, Any],
     aws: AWSCredentials,
@@ -72,8 +79,7 @@ async def analyze_event_stream(
     invoke_task = asyncio.create_task(
         asyncio.to_thread(
             invoke_analyzer,
-            benchmark=benchmark_row,
-            session=session,
+            benchmark_id=benchmark_id,
             lambda_function=lambda_function,
             payload=payload,
             aws=aws,

--- a/services/tracker/tests/unit/test_docent_analysis.py
+++ b/services/tracker/tests/unit/test_docent_analysis.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 from sqlmodel import Session
 
 from tracker.database.models import Benchmark, BenchmarkStatus, DocentReadingStatus
 from tracker.docent_analysis import invoke_analyzer
-from tracker.utils import catch_errors_during_cleanup
 from tracker.types import AWSCredentials
+from tracker.utils import catch_errors_during_cleanup
 
 
 @pytest.fixture
@@ -23,33 +21,47 @@ def aws() -> AWSCredentials:
     )
 
 
-def test_invoke_analyzer_success_sets_done_and_url(monkeypatch: pytest.MonkeyPatch, aws: AWSCredentials) -> None:
-    benchmark = MagicMock(spec=Benchmark)
-    benchmark.docent_reading_status = DocentReadingStatus.IDLE
-    benchmark.docent_reading_url = None
-    session = MagicMock()
+@pytest.fixture(autouse=True)
+def _patch_engine(monkeypatch: pytest.MonkeyPatch, database_session: Session) -> None:
+    """invoke_analyzer opens its own Session via the module-level `engine`; point
+    it at the in-memory test DB so its commits land in the same database the
+    test fixtures use."""
+    monkeypatch.setattr("tracker.docent_analysis.engine", database_session.bind)
+
+
+def test_invoke_analyzer_success_sets_done_and_url(
+    monkeypatch: pytest.MonkeyPatch,
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    aws: AWSCredentials,
+) -> None:
+    database_session.add(example_benchmark_object)
+    database_session.commit()
 
     fake_response = {"reading_plan_url": "https://x.test/r/123", "ingested": 5}
     monkeypatch.setattr("tracker.docent_analysis.invoke_lambda", lambda *a, **kw: fake_response)
 
     result = invoke_analyzer(
-        benchmark=benchmark,
-        session=session,
+        benchmark_id=example_benchmark_object.id,
         lambda_function="analysis-foo",
         payload={"benchmark_id": "x"},
         aws=aws,
     )
 
-    assert benchmark.docent_reading_status == DocentReadingStatus.DONE
-    assert benchmark.docent_reading_url == "https://x.test/r/123"
+    database_session.refresh(example_benchmark_object)
+    assert example_benchmark_object.docent_reading_status == DocentReadingStatus.DONE
+    assert example_benchmark_object.docent_reading_url == "https://x.test/r/123"
     assert result == fake_response
 
 
-def test_invoke_analyzer_failure_sets_error_and_raises(monkeypatch: pytest.MonkeyPatch, aws: AWSCredentials) -> None:
-    benchmark = MagicMock(spec=Benchmark)
-    benchmark.docent_reading_status = DocentReadingStatus.IDLE
-    benchmark.docent_reading_url = None
-    session = MagicMock()
+def test_invoke_analyzer_failure_sets_error_and_raises(
+    monkeypatch: pytest.MonkeyPatch,
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    aws: AWSCredentials,
+) -> None:
+    database_session.add(example_benchmark_object)
+    database_session.commit()
 
     def boom(*a: object, **kw: object) -> None:
         raise RuntimeError("lambda exploded")
@@ -58,39 +70,39 @@ def test_invoke_analyzer_failure_sets_error_and_raises(monkeypatch: pytest.Monke
 
     with pytest.raises(RuntimeError, match="lambda exploded"):
         invoke_analyzer(
-            benchmark=benchmark,
-            session=session,
+            benchmark_id=example_benchmark_object.id,
             lambda_function="analysis-foo",
             payload={"benchmark_id": "x"},
             aws=aws,
         )
 
-    assert benchmark.docent_reading_status == DocentReadingStatus.ERROR
-    assert benchmark.docent_reading_url is None
+    database_session.refresh(example_benchmark_object)
+    assert example_benchmark_object.docent_reading_status == DocentReadingStatus.ERROR
+    assert example_benchmark_object.docent_reading_url is None
 
 
-def test_invoke_analyzer_no_url_still_marks_done(monkeypatch: pytest.MonkeyPatch, aws: AWSCredentials) -> None:
+def test_invoke_analyzer_no_url_still_marks_done(
+    monkeypatch: pytest.MonkeyPatch,
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    aws: AWSCredentials,
+) -> None:
     """Lambda returned successfully but no reading_plan_url — still DONE; URL remains untouched."""
-    benchmark = MagicMock(spec=Benchmark)
-    benchmark.docent_reading_status = DocentReadingStatus.IDLE
-    benchmark.docent_reading_url = None
-    session = MagicMock()
+    database_session.add(example_benchmark_object)
+    database_session.commit()
 
     monkeypatch.setattr("tracker.docent_analysis.invoke_lambda", lambda *a, **kw: {"ingested": 0})
 
     invoke_analyzer(
-        benchmark=benchmark,
-        session=session,
+        benchmark_id=example_benchmark_object.id,
         lambda_function="analysis-foo",
         payload={},
         aws=aws,
     )
 
-    assert benchmark.docent_reading_status == DocentReadingStatus.DONE
-    assert benchmark.docent_reading_url is None
-
-
-"""Integration-flavored test: cleanup sweeps a stuck RUNNING row."""
+    database_session.refresh(example_benchmark_object)
+    assert example_benchmark_object.docent_reading_status == DocentReadingStatus.DONE
+    assert example_benchmark_object.docent_reading_url is None
 
 
 def test_cleanup_sweeps_running_docent_status_to_error(
@@ -99,8 +111,8 @@ def test_cleanup_sweeps_running_docent_status_to_error(
 ) -> None:
     """A benchmark stuck at IN_PROGRESS with docent_reading_status=RUNNING is
     swept to ERROR (both the benchmark itself and the analyzer status)."""
-    from tracker.database.models import Org
     from tests.conftest import TEST_ORG_ID
+    from tracker.database.models import Org
 
     example_benchmark_object.status = BenchmarkStatus.IN_PROGRESS
     example_benchmark_object.docent_reading_status = DocentReadingStatus.RUNNING

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -384,7 +384,7 @@ async def get_ingest_lambda_from_s3(agent_name: str) -> str | None:
     """
     bucket_name = _fetch_bucket_name()
 
-    async with aioboto3.Session().client("s3") as s3_client:
+    async with _s3_client() as s3_client:
         try:
             response = await s3_client.get_object(Bucket=bucket_name, Key=f"agents/{agent_name}.zip")
             zip_bytes: bytes = cast(bytes, await response["Body"].read())


### PR DESCRIPTION
## Summary
Two fixes for issues found in review of merged PR #309 (Docent analyze flow).

### 1. CLI's `get_ingest_lambda_from_s3` used a credential-less S3 client

`src/valkyrie/cli/s3_client.py` was creating a bare `aioboto3.Session().client(\"s3\")` for the contract-lookup. Every other S3 function in the file uses `_s3_client()`, which threads AWS credentials from `~/.config/valkyrie/valkyrie.yaml` (set via `valk config set`). The bare session falls back to env vars / IAM role only.

**Effect:** self-hosted users who configure AWS via `valk config` (not env vars) would see `valk run analyze` fail with credentials errors when looking up the agent's `ingest_lambda`.

**Fix:** swap to the credentialed `_s3_client()` helper.

### 2. Tracker passed a request-scoped SQLAlchemy Session across thread boundaries

`analyze_event_stream` dispatched `invoke_analyzer` via `asyncio.to_thread`, passing the FastAPI-managed `Session` and a `Benchmark` ORM object. The worker thread then called `session.add()` / `session.commit()` on a session that was created on the event-loop thread. SQLAlchemy explicitly documents Sessions as not thread-safe; this is undefined behavior even when access is sequential.

**Fix:** `invoke_analyzer` now takes `benchmark_id: UUID` (not a Benchmark ORM object) and opens its own `Session(engine)` inside the worker, re-fetching the Benchmark by ID. The endpoint only crosses the thread boundary with primitives.

## Files changed

- `src/valkyrie/cli/s3_client.py` — use `_s3_client()` in `get_ingest_lambda_from_s3`.
- `services/tracker/src/tracker/docent_analysis.py` — `invoke_analyzer` takes `benchmark_id` and opens its own Session.
- `services/tracker/main.py` — endpoint passes `benchmark_id` to `analyze_event_stream`.
- `services/tracker/tests/unit/test_docent_analysis.py` — tests seed a real Benchmark row and monkeypatch the module-level engine to the in-memory test DB.

## Verification

- ✅ All 4 unit tests pass against the in-memory test DB
- ✅ Typecheck clean
- ✅ Cached short-circuit and fresh-invoke paths still smoke-test against local tracker

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->