### PR TITLE
Close connection after removing sandboxes

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1265,44 +1265,47 @@ async def force_stop_sandboxes(
     """
     daytona_client: AsyncDaytona = benchmark_row.benchmark_service(daytona_secret_name, aws).daytona_client
 
-    # Update all tasks being processed to stopped
-    session.exec(
-        update(Task)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
-        .values(status=TaskStatus.STOPPED)
-    )
+    try:
+        # Update all tasks being processed to stopped
+        session.exec(
+            update(Task)
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.org_id) == org.id)
+            .where(col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
+            .values(status=TaskStatus.STOPPED)
+        )
 
-    session.commit()
-
-    # Iterate through each running sandbox and stop it, collecting error messages
-    results: dict[str, str | None] = {}
-    async for sandbox in sandbox_generator(benchmark_row, daytona_client):
-        result = await stop_sandbox(sandbox, daytona_client)
-
-        results[sandbox.name] = result
-
-    error_message: str = "\n".join(
-        f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
-    )
-
-    # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
-    finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
-    tasks_still_running: int = session.exec(
-        select(func.count(col(Task.id)))
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).notin_(finished_statuses))
-    ).one()
-
-    if not tasks_still_running:
-        benchmark_row.status = BenchmarkStatus.STOPPED
-        session.add(benchmark_row)
         session.commit()
 
-    if error_message:
-        raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
+        # Iterate through each running sandbox and stop it, collecting error messages
+        results: dict[str, str | None] = {}
+        async for sandbox in sandbox_generator(benchmark_row, daytona_client):
+            result = await stop_sandbox(sandbox, daytona_client)
+
+            results[sandbox.name] = result
+
+        error_message: str = "\n".join(
+            f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
+        )
+
+        # If all tasks are already in a stopped state, we need to update the final status here since the worker has exited
+        finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+        tasks_still_running: int = session.exec(
+            select(func.count(col(Task.id)))
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.org_id) == org.id)
+            .where(col(Task.status).notin_(finished_statuses))
+        ).one()
+
+        if not tasks_still_running:
+            benchmark_row.status = BenchmarkStatus.STOPPED
+            session.add(benchmark_row)
+            session.commit()
+
+        if error_message:
+            raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
+    finally:
+        await daytona_client.close()
 
 
 async def reset_to_in_progress_status(


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Was seeing a unclosed connection log, after tracing it I found out we were not closing the daytona client when force stopping sandboxes.

## Changes
<!-- List the key changes made -->
- Force stopping sandboxes method now is inside of a try final statement which closes the client when its done running

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/406" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->