### PR TITLE
fix: validate required harness headers in fetch_harness_config

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -18,6 +18,7 @@ from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceErr
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import HTTPException, Request
+from pydantic import ValidationError
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
@@ -1546,32 +1547,20 @@ def fetch_harness_config(request: Request) -> HarnessConfig:
         key[len(prefix) :].replace("-", "_"): value for key, value in request.headers.items() if key.startswith(prefix)
     }
 
-    required_keys = [
-        "aws_access_key_id",
-        "aws_secret_access_key",
-        "aws_default_region",
-        "s3_bucket",
-        "log_group",
-        "log_retention_policy",
-        "daytona_secret_name",
-    ]
-    missing = [key for key in required_keys if key not in flat]
-    if missing:
-        missing_headers = [f"X-Harness-{key.replace('_', '-').title()}" for key in missing]
-        raise HTTPException(
-            status_code=400,
-            detail=f"Missing required harness headers: {', '.join(missing_headers)}",
+    try:
+        return HarnessConfig.model_validate(
+            {
+                "aws": {
+                    "aws_access_key_id": flat.get("aws_access_key_id"),
+                    "aws_secret_access_key": flat.get("aws_secret_access_key"),
+                    "aws_default_region": flat.get("aws_default_region"),
+                    "aws_session_token": flat.get("aws_session_token"),
+                },
+                "s3_bucket": flat.get("s3_bucket"),
+                "log_group": flat.get("log_group"),
+                "log_retention_policy": flat.get("log_retention_policy"),
+                "daytona_secret_name": flat.get("daytona_secret_name"),
+            }
         )
-
-    return HarnessConfig(
-        aws=AWSCredentials(
-            aws_access_key_id=flat["aws_access_key_id"],
-            aws_secret_access_key=flat["aws_secret_access_key"],
-            aws_default_region=flat["aws_default_region"],
-            aws_session_token=flat.get("aws_session_token"),
-        ),
-        s3_bucket=flat["s3_bucket"],
-        log_group=flat["log_group"],
-        log_retention_policy=int(flat["log_retention_policy"]),
-        daytona_secret_name=flat["daytona_secret_name"],
-    )
+    except ValidationError as e:
+        raise HTTPException(status_code=400, detail=e.errors()) from e

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1560,8 +1560,11 @@ def fetch_harness_config(request: Request) -> HarnessConfig:
             daytona_secret_name=flat["daytona_secret_name"],
         )
     except KeyError as e:
-        header_name = f"X-Harness-{e.args[0].replace('_', '-').title()}"
+        config_key = e.args[0].upper()
         raise HTTPException(
             status_code=400,
-            detail=f"Missing required harness header: {header_name}",
+            detail=(
+                f"Missing required config value: '{config_key}'. "
+                "Run `valk config init` to initialize or `valk config set` to update your Valkyrie config."
+            ),
         ) from e

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -18,7 +18,6 @@ from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceErr
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import HTTPException, Request
-from pydantic import ValidationError
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
@@ -1548,19 +1547,21 @@ def fetch_harness_config(request: Request) -> HarnessConfig:
     }
 
     try:
-        return HarnessConfig.model_validate(
-            {
-                "aws": {
-                    "aws_access_key_id": flat.get("aws_access_key_id"),
-                    "aws_secret_access_key": flat.get("aws_secret_access_key"),
-                    "aws_default_region": flat.get("aws_default_region"),
-                    "aws_session_token": flat.get("aws_session_token"),
-                },
-                "s3_bucket": flat.get("s3_bucket"),
-                "log_group": flat.get("log_group"),
-                "log_retention_policy": flat.get("log_retention_policy"),
-                "daytona_secret_name": flat.get("daytona_secret_name"),
-            }
+        return HarnessConfig(
+            aws=AWSCredentials(
+                aws_access_key_id=flat["aws_access_key_id"],
+                aws_secret_access_key=flat["aws_secret_access_key"],
+                aws_default_region=flat["aws_default_region"],
+                aws_session_token=flat.get("aws_session_token"),
+            ),
+            s3_bucket=flat["s3_bucket"],
+            log_group=flat["log_group"],
+            log_retention_policy=int(flat["log_retention_policy"]),
+            daytona_secret_name=flat["daytona_secret_name"],
         )
-    except ValidationError as e:
-        raise HTTPException(status_code=400, detail=e.errors()) from e
+    except KeyError as e:
+        header_name = f"X-Harness-{e.args[0].replace('_', '-').title()}"
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required harness header: {header_name}",
+        ) from e

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -17,7 +17,7 @@ import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
-from fastapi import Request
+from fastapi import HTTPException, Request
 from opentelemetry import trace
 from sqlalchemy import JSON, type_coerce
 from sqlmodel import Session, asc, case, col, delete, desc, func, or_, select, update
@@ -1545,6 +1545,24 @@ def fetch_harness_config(request: Request) -> HarnessConfig:
     flat = {
         key[len(prefix) :].replace("-", "_"): value for key, value in request.headers.items() if key.startswith(prefix)
     }
+
+    required_keys = [
+        "aws_access_key_id",
+        "aws_secret_access_key",
+        "aws_default_region",
+        "s3_bucket",
+        "log_group",
+        "log_retention_policy",
+        "daytona_secret_name",
+    ]
+    missing = [key for key in required_keys if key not in flat]
+    if missing:
+        missing_headers = [f"X-Harness-{key.replace('_', '-').title()}" for key in missing]
+        raise HTTPException(
+            status_code=400,
+            detail=f"Missing required harness headers: {', '.join(missing_headers)}",
+        )
+
     return HarnessConfig(
         aws=AWSCredentials(
             aws_access_key_id=flat["aws_access_key_id"],

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -30,12 +30,14 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.types import (
+    AWSCredentials,
     BenchmarkTableRow,
     FetchBenchmarksRequest,
     FinalViewResponse,
     HarnessConfig,
     StartBenchmarkRequest,
 )
+from tracker.utils import fetch_harness_config
 
 client = TestClient(app)
 
@@ -956,3 +958,23 @@ class TestFastapiServer:
 
         # None of the three cases should have reached Sentry
         assert captured == []
+
+    def test_fetch_benchmark_returns_400_when_harness_headers_missing(self):
+        """Missing X-Harness-* headers should return 400, not 500 KeyError."""
+        app.dependency_overrides.pop(fetch_harness_config)
+        try:
+            response = client.get("/fetch-benchmark", params={"benchmark_id": str(uuid4())})
+            assert response.status_code == 400
+            assert "Missing required harness header" in response.json()["detail"]
+        finally:
+            app.dependency_overrides[fetch_harness_config] = lambda: HarnessConfig(
+                aws=AWSCredentials(
+                    aws_access_key_id="test-aws-access-key-id",
+                    aws_secret_access_key="test-aws-secret-access-key",
+                    aws_default_region="test-aws-default-region",
+                ),
+                s3_bucket="test-bucket",
+                log_group="test-log-group",
+                log_retention_policy=30,
+                daytona_secret_name="test-daytona-secret",
+            )

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -965,7 +965,7 @@ class TestFastapiServer:
         try:
             response = client.get("/fetch-benchmark", params={"benchmark_id": str(uuid4())})
             assert response.status_code == 400
-            assert "Missing required harness header" in response.json()["detail"]
+            assert "Missing required config value" in response.json()["detail"]
         finally:
             app.dependency_overrides[fetch_harness_config] = lambda: HarnessConfig(
                 aws=AWSCredentials(


### PR DESCRIPTION
## Summary
Requests to endpoints that depend on `fetch_harness_config` (e.g. `/fetch-benchmark`, `/retrieve-results`, `/stop-benchmark/{benchmark_id}`) raise an unhandled `KeyError` (500) when the required `X-Harness-*` headers are missing. This has been firing continuously in production since 2026-04-15 (Sentry VALKYRIE-2, 700+ events).

The root cause: `fetch_harness_config` used raw `flat["key"]` dict access to extract header values without handling the case where headers are absent.

## Changes
- Wrapped the `HarnessConfig` / `AWSCredentials` construction in a `try/except KeyError`, converting missing headers into an HTTP 400 with a descriptive error message
- Added `HTTPException` import from `fastapi`
- Added a regression unit test confirming `/fetch-benchmark` returns 400 (not 500) when harness headers are missing

## Related Issues
Resolves [VALKYRIE-2](https://vals-ai.sentry.io/issues/7415324314/)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/bf00b9252fe845c498bbca278f5024ec
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->