### PR TITLE
[codex] Fix resume concurrency persistence

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -639,7 +639,7 @@ async def retry_or_resume_benchmark(
         )
 
     if concurrency is not None:
-        benchmark_row.arguments.concurrency = concurrency
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": concurrency})
         session.add(benchmark_row)
         session.commit()
 

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -542,14 +542,17 @@ class TestStopAndResume:
         monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
 
         response = client.post(
-            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            f"/retry-or-resume-benchmark/{benchmark_row.id}?concurrency=20",
             json={"task_ids": [], "service_headers": {}},
             headers={"X-Api-Key": "tracker-api-key"},
         )
 
         assert response.status_code == 200
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
+        assert captured_request_json["concurrency"] == 20
         assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.arguments.concurrency == 20
 
     async def test_running_retry_noops_without_error_tasks(
         self,


### PR DESCRIPTION
## Summary
- persist resume concurrency overrides by replacing the JSON-backed benchmark arguments object
- add regression coverage that the queued resume request and stored benchmark args both use the override

## Why
ProgramBench stop/resume with --concurrency 20 initially accepted the request, but the tracker row kept the old concurrency because the nested JSON field was mutated in place.

## Validation
- uv run pytest services/tracker/tests/unit/test_stop_and_resume.py -q