### PR TITLE
fix: handle unreadable exceptions with human-readable error messages

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -74,31 +74,9 @@ from tracker.types import (
 
 logger = get_logger(__name__)
 
-_MAX_ERROR_MESSAGE_LENGTH: int = 500
 _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
-
-
-def _sanitize_benchmark_service_error(message: str) -> str:
-    """Strip HTML content and truncate long benchmark service error messages."""
-    lower = message.lower()
-    if "<html" in lower or "<!doctype" in lower:
-        html_start = len(message)
-        for tag in ["<html", "<!doctype", "<!DOCTYPE"]:
-            idx = message.find(tag)
-            if idx != -1 and idx < html_start:
-                html_start = idx
-        prefix = message[:html_start].rstrip()
-        if prefix:
-            message = prefix + " (HTML error page omitted)"
-        else:
-            message = "Benchmark service returned an HTML error page instead of a valid response"
-
-    if len(message) > _MAX_ERROR_MESSAGE_LENGTH:
-        message = message[:_MAX_ERROR_MESSAGE_LENGTH] + "..."
-
-    return message
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -695,7 +673,7 @@ async def process_task(
 
         return {task_id: None}
     except BenchmarkServiceError as e:
-        error_message = _sanitize_benchmark_service_error(str(e))
+        error_message = str(e)
         logfire.exception("process_task failed")
         logger.error(error_message, exc_info=True)
         sentry_sdk.capture_exception(e)
@@ -995,7 +973,7 @@ async def process_benchmark(
         sentry_sdk.capture_exception(e)
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            error_message = _sanitize_benchmark_service_error(str(e))
+            error_message = str(e)
             commit_benchmark_error(benchmark_row, session, error_message)
     except Exception as e:
         logfire.exception("process_benchmark failed")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -52,7 +52,8 @@ from tracker.database.models import (
 from tracker.database.scoping import scoped_select
 from tracker.database.session import engine
 from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
-from websockets.exceptions import ConnectionClosedError
+from pydantic import ValidationError
+from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
 from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
@@ -73,9 +74,31 @@ from tracker.types import (
 
 logger = get_logger(__name__)
 
+_MAX_ERROR_MESSAGE_LENGTH: int = 500
 _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
+
+
+def _sanitize_benchmark_service_error(message: str) -> str:
+    """Strip HTML content and truncate long benchmark service error messages."""
+    lower = message.lower()
+    if "<html" in lower or "<!doctype" in lower:
+        html_start = len(message)
+        for tag in ["<html", "<!doctype", "<!DOCTYPE"]:
+            idx = message.find(tag)
+            if idx != -1 and idx < html_start:
+                html_start = idx
+        prefix = message[:html_start].rstrip()
+        if prefix:
+            message = prefix + " (HTML error page omitted)"
+        else:
+            message = "Benchmark service returned an HTML error page instead of a valid response"
+
+    if len(message) > _MAX_ERROR_MESSAGE_LENGTH:
+        message = message[:_MAX_ERROR_MESSAGE_LENGTH] + "..."
+
+    return message
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -641,6 +664,48 @@ async def process_task(
             commit_task_error(task, task_session, error_message)
 
         return {task_id: None}
+    except ValidationError as e:
+        field_names = ", ".join(".".join(str(loc) for loc in err["loc"]) for err in e.errors())
+        error_message = (
+            f"Benchmark service returned an incompatible task response. Missing or invalid fields: {field_names}"
+        )
+        logfire.exception("process_task failed")
+        logger.error(error_message, exc_info=True)
+        sentry_sdk.capture_exception(e)
+        log_output(f"\n[ERROR] {error_message}")
+
+        with Session(bind=engine) as task_session:
+            task = fetch_task_row(task_row.id, task_session, org)
+            commit_task_error(task, task_session, error_message)
+
+        return {task_id: None}
+    except InvalidStatus as e:
+        error_message = (
+            f"Benchmark service rejected the WebSocket connection (HTTP {e.response.status_code}). "
+            f"The service may be down or the endpoint may not exist."
+        )
+        logfire.exception("process_task failed")
+        logger.error(error_message, exc_info=True)
+        sentry_sdk.capture_exception(e)
+        log_output(f"\n[ERROR] {error_message}")
+
+        with Session(bind=engine) as task_session:
+            task = fetch_task_row(task_row.id, task_session, org)
+            commit_task_error(task, task_session, error_message)
+
+        return {task_id: None}
+    except BenchmarkServiceError as e:
+        error_message = _sanitize_benchmark_service_error(str(e))
+        logfire.exception("process_task failed")
+        logger.error(error_message, exc_info=True)
+        sentry_sdk.capture_exception(e)
+        log_output(f"\n[ERROR] {error_message}")
+
+        with Session(bind=engine) as task_session:
+            task = fetch_task_row(task_row.id, task_session, org)
+            commit_task_error(task, task_session, error_message)
+
+        return {task_id: None}
     except Exception as e:
         logfire.exception("process_task failed")
         error_message = str(e)
@@ -924,6 +989,13 @@ async def process_benchmark(
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"
             logger.warning(error_message)
+            commit_benchmark_error(benchmark_row, session, error_message)
+    except BenchmarkServiceError as e:
+        logfire.exception("process_benchmark failed")
+        sentry_sdk.capture_exception(e)
+        with Session(bind=engine) as session:
+            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            error_message = _sanitize_benchmark_service_error(str(e))
             commit_benchmark_error(benchmark_row, session, error_message)
     except Exception as e:
         logfire.exception("process_benchmark failed")

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -655,10 +655,7 @@ async def process_task(
 
         return {task_id: None}
     except InvalidStatus as e:
-        error_message = (
-            f"Benchmark service rejected the WebSocket connection (HTTP {e.response.status_code}). "
-            f"The service may be down or the endpoint may not exist."
-        )
+        error_message = f"Benchmark service rejected the WebSocket connection (HTTP {e.response.status_code})"
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -647,9 +647,6 @@ async def process_task(
         error_message = (
             f"Benchmark service returned an incompatible task response. Missing or invalid fields: {field_names}"
         )
-        logfire.exception("process_task failed")
-        logger.error(error_message, exc_info=True)
-        sentry_sdk.capture_exception(e)
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
@@ -662,9 +659,6 @@ async def process_task(
             f"Benchmark service rejected the WebSocket connection (HTTP {e.response.status_code}). "
             f"The service may be down or the endpoint may not exist."
         )
-        logfire.exception("process_task failed")
-        logger.error(error_message, exc_info=True)
-        sentry_sdk.capture_exception(e)
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
@@ -674,9 +668,6 @@ async def process_task(
         return {task_id: None}
     except BenchmarkServiceError as e:
         error_message = str(e)
-        logfire.exception("process_task failed")
-        logger.error(error_message, exc_info=True)
-        sentry_sdk.capture_exception(e)
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
@@ -969,8 +960,6 @@ async def process_benchmark(
             logger.warning(error_message)
             commit_benchmark_error(benchmark_row, session, error_message)
     except BenchmarkServiceError as e:
-        logfire.exception("process_benchmark failed")
-        sentry_sdk.capture_exception(e)
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = str(e)

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -15,7 +15,7 @@ from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.types import HarnessConfig, StartBenchmarkRequest
-from tracker.utils import process_benchmark, process_task, start_benchmark_request_to_benchmark
+from tracker.utils import fetch_benchmark_row, process_benchmark, process_task, start_benchmark_request_to_benchmark
 
 
 class TestBenchmarkServiceDisconnect:
@@ -212,8 +212,6 @@ class TestBenchmarkServiceDisconnect:
             benchmark_id_str=str(benchmark_id),
             verified_task_ids=["task_0"],
         )
-
-        from tracker.utils import fetch_benchmark_row
 
         with Session(bind=database_session.bind) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, self._test_org)

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -1,8 +1,10 @@
 import time
 from asyncio import Semaphore
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import UUID
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
@@ -14,22 +16,63 @@ from websockets.http11 import Response
 
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
-from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import process_benchmark, process_task, start_benchmark_request_to_benchmark
+
+
+@dataclass
+class ProcessTaskFixture:
+    start_benchmark_request: StartBenchmarkRequest
+    benchmark_row: Benchmark
+    task_row: Task
+    harness_config: HarnessConfig
+    org: Org
+    benchmark_id: UUID
+
+    async def run(self) -> dict[str, dict[str, Any] | None]:
+        return await process_task(
+            task_row=self.task_row,
+            start_benchmark_request=self.start_benchmark_request,
+            benchmark_service=self.start_benchmark_request.benchmark_service,
+            benchmark_id=self.benchmark_id,
+            task_id="task_0",
+            harness_config=self.harness_config,
+            org=self.org,
+            creation_semaphore=Semaphore(1),
+        )
+
+
+@asynccontextmanager
+async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+    mock_sandbox = AsyncMock()
+    mock_sandbox.id = "mock-sandbox-id"
+    mock_sandbox.name = "mock-sandbox-name"
+    yield mock_sandbox
+
+
+async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+    return RetrieveTaskResponse(
+        docker_image="test-image:latest",
+        problem_path="/tmp/problem.txt",
+        cwd="/testbed",
+        resources=Resources(vcpu=2, memory=4, disk=5),
+    )
 
 
 class TestBenchmarkServiceDisconnect:
     _test_org = Org(id=TEST_ORG_ID, name="default")
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
 
-    async def test_connection_closed_after_messages_produces_elapsed_error(
+    @pytest.fixture
+    def task_env(
         self,
         contract: AgentContractRequest,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
         harness_config: HarnessConfig,
-    ) -> None:
+    ) -> ProcessTaskFixture:
+        """Common setup for process_task exception tests: request, benchmark row, task row, engine patch."""
         start_benchmark_request = StartBenchmarkRequest(
             benchmark_name="swebench",
             contract=contract,
@@ -47,241 +90,122 @@ class TestBenchmarkServiceDisconnect:
         database_session.add(task_row)
         database_session.commit()
 
-        @asynccontextmanager
-        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
-            mock_sandbox = AsyncMock()
-            mock_sandbox.id = "mock-sandbox-id"
-            mock_sandbox.name = "mock-sandbox-name"
-            yield mock_sandbox
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
 
-        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            return RetrieveTaskResponse(
-                docker_image="test-image:latest",
-                problem_path="/tmp/problem.txt",
-                cwd="/testbed",
-                resources=Resources(vcpu=2, memory=4, disk=5),
-            )
+        return ProcessTaskFixture(
+            start_benchmark_request=start_benchmark_request,
+            benchmark_row=benchmark_row,
+            task_row=task_row,
+            harness_config=harness_config,
+            org=self._test_org,
+            benchmark_id=benchmark_row.id,
+        )
 
+    async def test_connection_closed_after_messages_produces_elapsed_error(
+        self,
+        task_env: ProcessTaskFixture,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-            # Simulate the benchmark service disconnecting 10s after last_log_time was reset.
             monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 10)
             raise ConnectionClosedError(None, None)
 
         real_monotonic = time.monotonic
 
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
 
-        result = await process_task(
-            task_row=task_row,
-            start_benchmark_request=start_benchmark_request,
-            benchmark_service=start_benchmark_request.benchmark_service,
-            benchmark_id=benchmark_row.id,
-            task_id="task_0",
-            harness_config=harness_config,
-            org=self._test_org,
-            creation_semaphore=Semaphore(1),
-        )
+        result = await task_env.run()
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_row)
-        assert task_row.status == TaskStatus.ERROR
-        assert task_row.error_message is not None
+        database_session.refresh(task_env.task_row)
+        assert task_env.task_row.status == TaskStatus.ERROR
+        assert task_env.task_row.error_message is not None
         assert (
-            "Benchmark service has not sent a message, causing the connection to disconnect" in task_row.error_message
+            "Benchmark service has not sent a message, causing the connection to disconnect"
+            in task_env.task_row.error_message
         )
-        assert "last message received" in task_row.error_message
-        assert "10s ago" in task_row.error_message
+        assert "last message received" in task_env.task_row.error_message
+        assert "10s ago" in task_env.task_row.error_message
 
     async def test_validation_error_produces_human_readable_message(
         self,
-        contract: AgentContractRequest,
+        task_env: ProcessTaskFixture,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
-        harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-5D: ValidationError from retrieve_task is caught with field names."""
-        start_benchmark_request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=1,
-            task_ids=["task_0"],
-            harness_config=harness_config,
-        )
 
-        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
-        database_session.add(task_row)
-        database_session.commit()
-
-        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        async def _mock_retrieve_task_invalid(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
             return RetrieveTaskResponse.model_validate(
                 {"source": {"type": "image"}, "resources": {"vcpu_gb": 4, "memory_gb": 4, "disk_gb": 10}}
             )
 
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_invalid)
 
-        result = await process_task(
-            task_row=task_row,
-            start_benchmark_request=start_benchmark_request,
-            benchmark_service=start_benchmark_request.benchmark_service,
-            benchmark_id=benchmark_row.id,
-            task_id="task_0",
-            harness_config=harness_config,
-            org=self._test_org,
-            creation_semaphore=Semaphore(1),
-        )
+        result = await task_env.run()
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_row)
-        assert task_row.status == TaskStatus.ERROR
-        assert task_row.error_message is not None
-        assert "Missing or invalid fields" in task_row.error_message
-        assert "docker_image" in task_row.error_message
+        database_session.refresh(task_env.task_row)
+        assert task_env.task_row.status == TaskStatus.ERROR
+        assert task_env.task_row.error_message is not None
+        assert "Missing or invalid fields" in task_env.task_row.error_message
+        assert "docker_image" in task_env.task_row.error_message
 
     async def test_invalid_status_produces_human_readable_message(
         self,
-        contract: AgentContractRequest,
+        task_env: ProcessTaskFixture,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
-        harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-5A: InvalidStatus from WebSocket rejection is caught with HTTP status."""
-        start_benchmark_request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=1,
-            task_ids=["task_0"],
-            harness_config=harness_config,
-        )
-
-        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
-        database_session.add(task_row)
-        database_session.commit()
-
-        @asynccontextmanager
-        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
-            mock_sandbox = AsyncMock()
-            mock_sandbox.id = "mock-sandbox-id"
-            mock_sandbox.name = "mock-sandbox-name"
-            yield mock_sandbox
-
-        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            return RetrieveTaskResponse(
-                docker_image="test-image:latest",
-                problem_path="/tmp/problem.txt",
-                cwd="/testbed",
-                resources=Resources(vcpu=2, memory=4, disk=5),
-            )
 
         async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> Any:
             raise InvalidStatus(Response(404, "Not Found", Headers()))
 
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
 
-        result = await process_task(
-            task_row=task_row,
-            start_benchmark_request=start_benchmark_request,
-            benchmark_service=start_benchmark_request.benchmark_service,
-            benchmark_id=benchmark_row.id,
-            task_id="task_0",
-            harness_config=harness_config,
-            org=self._test_org,
-            creation_semaphore=Semaphore(1),
-        )
+        result = await task_env.run()
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_row)
-        assert task_row.status == TaskStatus.ERROR
-        assert task_row.error_message is not None
-        assert "rejected the WebSocket connection" in task_row.error_message
-        assert "404" in task_row.error_message
+        database_session.refresh(task_env.task_row)
+        assert task_env.task_row.status == TaskStatus.ERROR
+        assert task_env.task_row.error_message is not None
+        assert "rejected the WebSocket connection" in task_env.task_row.error_message
+        assert "404" in task_env.task_row.error_message
 
     async def test_benchmark_service_error_produces_human_readable_message(
         self,
-        contract: AgentContractRequest,
+        task_env: ProcessTaskFixture,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
-        harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-59: BenchmarkServiceError from setup_task is caught and stored."""
-        start_benchmark_request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=1,
-            task_ids=["task_0"],
-            harness_config=harness_config,
-        )
-
-        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
-        database_session.add(task_row)
-        database_session.commit()
-
-        @asynccontextmanager
-        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
-            mock_sandbox = AsyncMock()
-            mock_sandbox.id = "mock-sandbox-id"
-            mock_sandbox.name = "mock-sandbox-name"
-            yield mock_sandbox
-
-        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            return RetrieveTaskResponse(
-                docker_image="test-image:latest",
-                problem_path="/tmp/problem.txt",
-                cwd="/testbed",
-                resources=Resources(vcpu=2, memory=4, disk=5),
-            )
 
         async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> Any:
             raise BenchmarkServiceError(
                 "ProgramBench task container failed to start: task_cleanroom: Pulling from programbench/test"
             )
 
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
 
-        result = await process_task(
-            task_row=task_row,
-            start_benchmark_request=start_benchmark_request,
-            benchmark_service=start_benchmark_request.benchmark_service,
-            benchmark_id=benchmark_row.id,
-            task_id="task_0",
-            harness_config=harness_config,
-            org=self._test_org,
-            creation_semaphore=Semaphore(1),
-        )
+        result = await task_env.run()
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_row)
-        assert task_row.status == TaskStatus.ERROR
-        assert task_row.error_message is not None
-        assert "ProgramBench task container failed to start" in task_row.error_message
+        database_session.refresh(task_env.task_row)
+        assert task_env.task_row.status == TaskStatus.ERROR
+        assert task_env.task_row.error_message is not None
+        assert "ProgramBench task container failed to start" in task_env.task_row.error_message
 
     async def test_benchmark_service_error_in_process_benchmark(
         self,

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -1,14 +1,11 @@
 import time
 from asyncio import Semaphore
-from contextlib import asynccontextmanager
-from dataclasses import dataclass
 from typing import Any
-from unittest.mock import AsyncMock
 from uuid import UUID
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from benchmark_service.schemas import Resources, RetrieveTaskResponse
+from benchmark_service.schemas import RetrieveTaskResponse
 from sqlmodel import Session
 from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
@@ -16,63 +13,22 @@ from websockets.http11 import Response
 
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
-from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import process_benchmark, process_task, start_benchmark_request_to_benchmark
-
-
-@dataclass
-class ProcessTaskFixture:
-    start_benchmark_request: StartBenchmarkRequest
-    benchmark_row: Benchmark
-    task_row: Task
-    harness_config: HarnessConfig
-    org: Org
-    benchmark_id: UUID
-
-    async def run(self) -> dict[str, dict[str, Any] | None]:
-        return await process_task(
-            task_row=self.task_row,
-            start_benchmark_request=self.start_benchmark_request,
-            benchmark_service=self.start_benchmark_request.benchmark_service,
-            benchmark_id=self.benchmark_id,
-            task_id="task_0",
-            harness_config=self.harness_config,
-            org=self.org,
-            creation_semaphore=Semaphore(1),
-        )
-
-
-@asynccontextmanager
-async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
-    mock_sandbox = AsyncMock()
-    mock_sandbox.id = "mock-sandbox-id"
-    mock_sandbox.name = "mock-sandbox-name"
-    yield mock_sandbox
-
-
-async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-    return RetrieveTaskResponse(
-        docker_image="test-image:latest",
-        problem_path="/tmp/problem.txt",
-        cwd="/testbed",
-        resources=Resources(vcpu=2, memory=4, disk=5),
-    )
 
 
 class TestBenchmarkServiceDisconnect:
     _test_org = Org(id=TEST_ORG_ID, name="default")
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
 
-    @pytest.fixture
-    def task_env(
+    def _create_task_env(
         self,
         contract: AgentContractRequest,
         database_session: Session,
-        monkeypatch: pytest.MonkeyPatch,
         harness_config: HarnessConfig,
-    ) -> ProcessTaskFixture:
-        """Common setup for process_task exception tests: request, benchmark row, task row, engine patch."""
+    ) -> tuple[StartBenchmarkRequest, Task, UUID]:
+        """Create a benchmark request, benchmark row, and task row for process_task tests."""
         start_benchmark_request = StartBenchmarkRequest(
             benchmark_name="swebench",
             contract=contract,
@@ -90,54 +46,70 @@ class TestBenchmarkServiceDisconnect:
         database_session.add(task_row)
         database_session.commit()
 
-        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        return start_benchmark_request, task_row, benchmark_row.id
 
-        return ProcessTaskFixture(
-            start_benchmark_request=start_benchmark_request,
-            benchmark_row=benchmark_row,
+    async def _run_process_task(
+        self,
+        start_benchmark_request: StartBenchmarkRequest,
+        task_row: Task,
+        benchmark_id: UUID,
+        harness_config: HarnessConfig,
+    ) -> dict[str, dict[str, Any] | None]:
+        return await process_task(
             task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_id,
+            task_id="task_0",
             harness_config=harness_config,
             org=self._test_org,
-            benchmark_id=benchmark_row.id,
+            creation_semaphore=Semaphore(1),
         )
 
     async def test_connection_closed_after_messages_produces_elapsed_error(
         self,
-        task_env: ProcessTaskFixture,
+        contract: AgentContractRequest,
         database_session: Session,
+        process_benchmark_env: None,
         monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
     ) -> None:
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
+
         async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
             monkeypatch.setattr(time, "monotonic", lambda: real_monotonic() + 10)
             raise ConnectionClosedError(None, None)
 
         real_monotonic = time.monotonic
-
-        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
 
-        result = await task_env.run()
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_env.task_row)
-        assert task_env.task_row.status == TaskStatus.ERROR
-        assert task_env.task_row.error_message is not None
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
         assert (
-            "Benchmark service has not sent a message, causing the connection to disconnect"
-            in task_env.task_row.error_message
+            "Benchmark service has not sent a message, causing the connection to disconnect" in task_row.error_message
         )
-        assert "last message received" in task_env.task_row.error_message
-        assert "10s ago" in task_env.task_row.error_message
+        assert "last message received" in task_row.error_message
+        assert "10s ago" in task_row.error_message
 
     async def test_validation_error_produces_human_readable_message(
         self,
-        task_env: ProcessTaskFixture,
+        contract: AgentContractRequest,
         database_session: Session,
+        process_benchmark_env: None,
         monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-5D: ValidationError from retrieve_task is caught with field names."""
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
 
         async def _mock_retrieve_task_invalid(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
             return RetrieveTaskResponse.model_validate(
@@ -146,66 +118,72 @@ class TestBenchmarkServiceDisconnect:
 
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_invalid)
 
-        result = await task_env.run()
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_env.task_row)
-        assert task_env.task_row.status == TaskStatus.ERROR
-        assert task_env.task_row.error_message is not None
-        assert "Missing or invalid fields" in task_env.task_row.error_message
-        assert "docker_image" in task_env.task_row.error_message
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "Missing or invalid fields" in task_row.error_message
+        assert "docker_image" in task_row.error_message
 
     async def test_invalid_status_produces_human_readable_message(
         self,
-        task_env: ProcessTaskFixture,
+        contract: AgentContractRequest,
         database_session: Session,
+        process_benchmark_env: None,
         monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-5A: InvalidStatus from WebSocket rejection is caught with HTTP status."""
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
 
         async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> Any:
             raise InvalidStatus(Response(404, "Not Found", Headers()))
 
-        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
 
-        result = await task_env.run()
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_env.task_row)
-        assert task_env.task_row.status == TaskStatus.ERROR
-        assert task_env.task_row.error_message is not None
-        assert "rejected the WebSocket connection" in task_env.task_row.error_message
-        assert "404" in task_env.task_row.error_message
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "rejected the WebSocket connection" in task_row.error_message
+        assert "404" in task_row.error_message
 
     async def test_benchmark_service_error_produces_human_readable_message(
         self,
-        task_env: ProcessTaskFixture,
+        contract: AgentContractRequest,
         database_session: Session,
+        process_benchmark_env: None,
         monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-59: BenchmarkServiceError from setup_task is caught and stored."""
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
 
         async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> Any:
             raise BenchmarkServiceError(
                 "ProgramBench task container failed to start: task_cleanroom: Pulling from programbench/test"
             )
 
-        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
 
-        result = await task_env.run()
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": None}
 
-        database_session.refresh(task_env.task_row)
-        assert task_env.task_row.status == TaskStatus.ERROR
-        assert task_env.task_row.error_message is not None
-        assert "ProgramBench task container failed to start" in task_env.task_row.error_message
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "ProgramBench task container failed to start" in task_row.error_message
 
     async def test_benchmark_service_error_in_process_benchmark(
         self,
@@ -216,22 +194,9 @@ class TestBenchmarkServiceDisconnect:
         harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-1Z: BenchmarkServiceError from final_score is caught at the benchmark level."""
-        start_benchmark_request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=1,
-            task_ids=["task_0"],
-            harness_config=harness_config,
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
         )
-
-        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
-        database_session.add(task_row)
-        database_session.commit()
 
         html_error = (
             "Final score failed with status code 404, response: <!DOCTYPE html><html><body>404 Not Found</body></html>"
@@ -244,11 +209,14 @@ class TestBenchmarkServiceDisconnect:
 
         await process_benchmark(
             start_benchmark_request_json=start_benchmark_request.model_dump(),
-            benchmark_id_str=str(benchmark_row.id),
+            benchmark_id_str=str(benchmark_id),
             verified_task_ids=["task_0"],
         )
 
-        database_session.refresh(benchmark_row)
-        assert benchmark_row.status == BenchmarkStatus.ERROR
-        assert benchmark_row.error_message is not None
-        assert "Final score failed with status code 404" in benchmark_row.error_message
+        from tracker.utils import fetch_benchmark_row
+
+        with Session(bind=database_session.bind) as session:
+            benchmark_row = fetch_benchmark_row(benchmark_id, session, self._test_org)
+            assert benchmark_row.status == BenchmarkStatus.ERROR
+            assert benchmark_row.error_message is not None
+            assert "Final score failed with status code 404" in benchmark_row.error_message

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -5,16 +5,18 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from benchmark_service.client import BenchmarkServiceClient
+from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from benchmark_service.schemas import Resources, RetrieveTaskResponse
 from sqlmodel import Session
-from websockets.exceptions import ConnectionClosedError
+from websockets.datastructures import Headers
+from websockets.exceptions import ConnectionClosedError, InvalidStatus
+from websockets.http11 import Response
 
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.types import HarnessConfig, StartBenchmarkRequest
-from tracker.utils import process_task, start_benchmark_request_to_benchmark
+from tracker.utils import process_benchmark, process_task, start_benchmark_request_to_benchmark
 
 
 class TestBenchmarkServiceDisconnect:
@@ -93,3 +95,236 @@ class TestBenchmarkServiceDisconnect:
         )
         assert "last message received" in task_row.error_message
         assert "10s ago" in task_row.error_message
+
+    async def test_validation_error_produces_human_readable_message(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """VALKYRIE-5D: ValidationError from retrieve_task is caught with field names."""
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse.model_validate(
+                {"source": {"type": "image"}, "resources": {"vcpu_gb": 4, "memory_gb": 4, "disk_gb": 10}}
+            )
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        assert result == {"task_0": None}
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "Missing or invalid fields" in task_row.error_message
+        assert "docker_image" in task_row.error_message
+
+    async def test_invalid_status_produces_human_readable_message(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """VALKYRIE-5A: InvalidStatus from WebSocket rejection is caught with HTTP status."""
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = "mock-sandbox-id"
+            mock_sandbox.name = "mock-sandbox-name"
+            yield mock_sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse(
+                docker_image="test-image:latest",
+                problem_path="/tmp/problem.txt",
+                cwd="/testbed",
+                resources=Resources(vcpu=2, memory=4, disk=5),
+            )
+
+        async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> Any:
+            raise InvalidStatus(Response(404, "Not Found", Headers()))
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
+
+        result = await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        assert result == {"task_0": None}
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "rejected the WebSocket connection" in task_row.error_message
+        assert "404" in task_row.error_message
+
+    async def test_benchmark_service_error_produces_human_readable_message(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """VALKYRIE-59: BenchmarkServiceError from setup_task is caught and stored."""
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = "mock-sandbox-id"
+            mock_sandbox.name = "mock-sandbox-name"
+            yield mock_sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return RetrieveTaskResponse(
+                docker_image="test-image:latest",
+                problem_path="/tmp/problem.txt",
+                cwd="/testbed",
+                resources=Resources(vcpu=2, memory=4, disk=5),
+            )
+
+        async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> Any:
+            raise BenchmarkServiceError(
+                "ProgramBench task container failed to start: task_cleanroom: Pulling from programbench/test"
+            )
+
+        monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
+
+        result = await process_task(
+            task_row=task_row,
+            start_benchmark_request=start_benchmark_request,
+            benchmark_service=start_benchmark_request.benchmark_service,
+            benchmark_id=benchmark_row.id,
+            task_id="task_0",
+            harness_config=harness_config,
+            org=self._test_org,
+            creation_semaphore=Semaphore(1),
+        )
+
+        assert result == {"task_0": None}
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "ProgramBench task container failed to start" in task_row.error_message
+
+    async def test_benchmark_service_error_in_process_benchmark(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        process_benchmark_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """VALKYRIE-1Z: BenchmarkServiceError from final_score is caught at the benchmark level."""
+        start_benchmark_request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        task_row = Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id)
+        database_session.add(task_row)
+        database_session.commit()
+
+        html_error = (
+            "Final score failed with status code 404, response: <!DOCTYPE html><html><body>404 Not Found</body></html>"
+        )
+
+        async def _mock_final_score(*_args: Any, **_kwargs: Any) -> Any:
+            raise BenchmarkServiceError(html_error)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
+
+        await process_benchmark(
+            start_benchmark_request_json=start_benchmark_request.model_dump(),
+            benchmark_id_str=str(benchmark_row.id),
+            verified_task_ids=["task_0"],
+        )
+
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.ERROR
+        assert benchmark_row.error_message is not None
+        assert "Final score failed with status code 404" in benchmark_row.error_message


### PR DESCRIPTION
## Summary

Handles 4 Sentry exceptions that were surfacing raw, unreadable error messages to users and logs. Each is now caught explicitly with a clear, human-readable error message.

## Changes

- **VALKYRIE-5D** (`ValidationError`): Catch Pydantic `ValidationError` in `process_task` and report the missing/invalid field names instead of dumping the raw validation error
- **VALKYRIE-5A** (`InvalidStatus`): Catch `websockets.exceptions.InvalidStatus` and describe the HTTP status code when the benchmark service's reverse proxy rejects the WebSocket connection
- **VALKYRIE-59 / VALKYRIE-1Z** (`BenchmarkServiceError`): Catch `BenchmarkServiceError` separately in both `process_task` and `process_benchmark` so these are classified distinctly from generic exceptions

## Related Issues

Fixes VALKYRIE-5D, VALKYRIE-59, VALKYRIE-1Z, VALKYRIE-5A

## Type of Change

- [x] Bug fix

## Testing

- [x] Lint passes (`make style`)

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/36d91744ef6a4e5b862283381e6925c7
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/410" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->