### PR TITLE
feat: output artifacts

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -22,6 +22,10 @@ run_cmd: >-
 
 final_output: /logs/my_agent
 
+output_artifacts:
+  - full_result/run_config.json
+  - full_result/turns.jsonl
+
 secrets:
   ANTHROPIC_API_KEY: devEvalInfraAnthropicKey
 
@@ -102,10 +106,10 @@ install_cmd: "bash setup.sh"
 
 Shell command to run the agent on a task. Must contain the `{problem_statement_path}` placeholder. Placeholders are substituted at runtime:
 
-| Placeholder | Substituted with |
-|-------------|------------------|
+| Placeholder                | Substituted with                                                 |
+| -------------------------- | ---------------------------------------------------------------- |
 | `{problem_statement_path}` | Path to the problem statement file in the sandbox **(required)** |
-| `{task_id}` | The task identifier (e.g. `astropy__astropy-12907`) |
+| `{task_id}`                | The task identifier (e.g. `astropy__astropy-12907`)              |
 
 ```yaml
 run_cmd: "my_agent --task {problem_statement_path} --id {task_id}"
@@ -119,6 +123,44 @@ Absolute path to the final output to collect. The artifact found here will be co
 
 ```yaml
 final_output: /logs/my_agent
+```
+
+### `output_artifacts: list`
+
+Small files to upload directly from the sandbox into the task's S3 folder so they can be read without downloading `agent_output.tar.gz`. Files may still remain inside `final_output`; direct sidecars intentionally duplicate selected files for cheap Lambda/parser reads while preserving the full debug archive.
+
+Canonical producers can write files under `/tmp/valkyrie`:
+
+```yaml
+output_artifacts:
+  - full_result/run_config.json
+  - full_result/turns.jsonl
+```
+
+Model-library agents can instead declare their existing files; if they are not present under `/tmp/valkyrie`, the tracker resolves them from `final_output`:
+
+```yaml
+output_artifacts:
+  - full_result/config.json # resolved from <final_output>/*/turns/init/config.json
+  - full_result/result.json # resolved from <final_output>/*/result.json, excluding turns/*
+```
+
+Guardrails:
+
+- Artifact paths are relative to `/tmp/valkyrie` in the sandbox unless they are one of the supported model-library sidecars resolved from `final_output`.
+- Artifact paths must be under `full_result/`.
+- Each declared artifact is required. Missing files or unresolved model-library sources fail the task clearly.
+- Individual files cannot exceed 50 MiB.
+- At most 10 output artifacts can be declared.
+- The total uploaded sidecar bytes per task cannot exceed 50 MiB.
+
+For the examples above, task `task_0` in run `run_id` uploads to matching task-scoped keys such as:
+
+```text
+benchmarks/run_id/task_0/full_result/run_config.json
+benchmarks/run_id/task_0/full_result/turns.jsonl
+benchmarks/run_id/task_0/full_result/config.json
+benchmarks/run_id/task_0/full_result/result.json
 ```
 
 ### `secrets: dict`
@@ -159,15 +201,16 @@ kwargs:
 
 Each kwarg supports these fields:
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `type` | yes | One of: `str`, `int`, `float`, `bool`, `dict` |
-| `required` | yes | Whether the user must provide this value |
-| `default` | no | Default value when the user doesn't provide one |
-| `description` | no | Human-readable description |
-| `choices` | no | List of valid values (enforced at validation time) |
+| Field         | Required | Description                                        |
+| ------------- | -------- | -------------------------------------------------- |
+| `type`        | yes      | One of: `str`, `int`, `float`, `bool`, `dict`      |
+| `required`    | yes      | Whether the user must provide this value           |
+| `default`     | no       | Default value when the user doesn't provide one    |
+| `description` | no       | Human-readable description                         |
+| `choices`     | no       | List of valid values (enforced at validation time) |
 
 Kwargs are resolved at parse time:
+
 - **Defaults** are applied for any kwarg the user doesn't provide
 - **CLI overrides** (`-k`) replace defaults when provided
 - **Required kwargs** without a value raise a validation error

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -127,11 +127,11 @@ final_output: /logs/my_agent
 
 ### `output_artifacts: list`
 
-Small files to upload directly from the sandbox into the task's S3 folder so they can be read without downloading `agent_output.tar.gz`. Files may still remain inside `final_output`; direct sidecars intentionally duplicate selected files for cheap Lambda/parser reads while preserving the full debug archive.
+Small files to upload directly from the sandbox into the task's S3 folder without adding them to `agent_output.tar.gz`. Use this for parser/evaluation inputs that need cheap direct reads.
 
 String entries are shorthand: tracker reads `/tmp/valkyrie/<path>` and uploads to `<path>`.
 
-Canonical producers can write files under `/tmp/valkyrie`:
+Producers can write files under `/tmp/valkyrie`:
 
 ```yaml
 output_artifacts:
@@ -151,9 +151,8 @@ output_artifacts:
 
 Guardrails:
 
-- Artifact destination paths are relative task S3 paths. String entries use the same path under `/tmp/valkyrie`; object entries use their explicit `source`.
+- Artifact destination paths are relative to the task's S3 prefix. String entries use the same path under `/tmp/valkyrie`; object entries use their explicit `source`.
 - Object `source` paths must be absolute sandbox paths. Glob sources must include a non-root directory prefix such as `/logs` or `/app/results/...`.
-- Artifact paths must be under `full_result/`.
 - Each declared artifact is required. Missing files or unresolved glob sources fail the task clearly.
 - Individual files cannot exceed 50 MiB.
 - At most 10 output artifacts can be declared.

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -23,8 +23,8 @@ run_cmd: >-
 final_output: /logs/my_agent
 
 output_artifacts:
-  - full_result/run_config.json
-  - full_result/turns.jsonl
+  - artifacts/summary.json
+  - artifacts/turns.jsonl
 
 secrets:
   ANTHROPIC_API_KEY: devEvalInfraAnthropicKey
@@ -135,19 +135,21 @@ Producers can write files under `/tmp/valkyrie`:
 
 ```yaml
 output_artifacts:
-  - full_result/run_config.json
-  - full_result/turns.jsonl
+  - artifacts/summary.json
+  - artifacts/turns.jsonl
 ```
 
 Object entries specify an explicit sandbox source and upload destination. Sources may include `{task_id}` and shell-style glob patterns resolved inside the sandbox:
 
 ```yaml
 output_artifacts:
-  - path: full_result/config.json
+  - path: artifacts/config.json
     source: /logs/{task_id}/turns/init/config.json
-  - path: full_result/result.json
+  - path: artifacts/result.json
     source: /logs/{task_id}/result.json
 ```
+
+Valkyrie does not require a specific destination prefix. For Vals benchmark result ingestion, use the project convention `vals_format/config.json` and `vals_format/result.json`.
 
 Guardrails:
 
@@ -161,10 +163,10 @@ Guardrails:
 For the examples above, task `task_0` in run `run_id` uploads to matching task-scoped keys such as:
 
 ```text
-benchmarks/run_id/task_0/full_result/run_config.json
-benchmarks/run_id/task_0/full_result/turns.jsonl
-benchmarks/run_id/task_0/full_result/config.json
-benchmarks/run_id/task_0/full_result/result.json
+benchmarks/run_id/task_0/artifacts/summary.json
+benchmarks/run_id/task_0/artifacts/turns.jsonl
+benchmarks/run_id/task_0/artifacts/config.json
+benchmarks/run_id/task_0/artifacts/result.json
 ```
 
 ### `secrets: dict`

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -129,6 +129,8 @@ final_output: /logs/my_agent
 
 Small files to upload directly from the sandbox into the task's S3 folder so they can be read without downloading `agent_output.tar.gz`. Files may still remain inside `final_output`; direct sidecars intentionally duplicate selected files for cheap Lambda/parser reads while preserving the full debug archive.
 
+String entries are shorthand: tracker reads `/tmp/valkyrie/<path>` and uploads to `<path>`.
+
 Canonical producers can write files under `/tmp/valkyrie`:
 
 ```yaml
@@ -137,19 +139,22 @@ output_artifacts:
   - full_result/turns.jsonl
 ```
 
-Model-library agents can instead declare their existing files; if they are not present under `/tmp/valkyrie`, the tracker resolves them from `final_output`:
+Object entries specify an explicit sandbox source and upload destination. Sources may include `{task_id}` and shell-style glob patterns resolved inside the sandbox:
 
 ```yaml
 output_artifacts:
-  - full_result/config.json # resolved from <final_output>/*/turns/init/config.json
-  - full_result/result.json # resolved from <final_output>/*/result.json, excluding turns/*
+  - path: full_result/config.json
+    source: /logs/{task_id}/turns/init/config.json
+  - path: full_result/result.json
+    source: /logs/{task_id}/result.json
 ```
 
 Guardrails:
 
-- Artifact paths are relative to `/tmp/valkyrie` in the sandbox unless they are one of the supported model-library sidecars resolved from `final_output`.
+- Artifact destination paths are relative task S3 paths. String entries use the same path under `/tmp/valkyrie`; object entries use their explicit `source`.
+- Object `source` paths must be absolute sandbox paths. Glob sources must include a non-root directory prefix such as `/logs` or `/app/results/...`.
 - Artifact paths must be under `full_result/`.
-- Each declared artifact is required. Missing files or unresolved model-library sources fail the task clearly.
+- Each declared artifact is required. Missing files or unresolved glob sources fail the task clearly.
 - Individual files cannot exceed 50 MiB.
 - At most 10 output artifacts can be declared.
 - The total uploaded sidecar bytes per task cannot exceed 50 MiB.

--- a/infra/uv.lock
+++ b/infra/uv.lock
@@ -1,6 +1,9 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
+
+[options]
+prerelease-mode = "allow"
 
 [[package]]
 name = "agentic-harness-infra"

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -86,31 +86,70 @@ MAX_OUTPUT_ARTIFACT_BYTES = 50 * 1024 * 1024
 MAX_OUTPUT_ARTIFACT_COUNT = 10
 
 
+def _source_has_glob(source: str) -> bool:
+    return any(char in source for char in "*?[")
+
+
+def _source_glob_root(source: str) -> str:
+    glob_indices = [source.find(char) for char in "*?[" if source.find(char) != -1]
+    first_glob_index = min(glob_indices)
+    root = source[:first_glob_index].rsplit("/", 1)[0]
+    return root or "/"
+
+
+class OutputArtifact(BaseModel):
+    path: str
+    source: str | None = None
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not value.startswith("/"):
+            raise ValueError("output_artifacts source paths must be absolute sandbox paths")
+
+        path = PurePosixPath(value)
+        if not path.parts or ".." in path.parts or "." in path.parts:
+            raise ValueError("output_artifacts source paths cannot contain empty, '.', or '..' path parts")
+        if _source_has_glob(value) and _source_glob_root(value) == "/":
+            raise ValueError("output_artifacts glob sources must include a non-root directory prefix")
+
+        return value
+
+
+OutputArtifactSpec = str | OutputArtifact
+
+
 class AgentContractRequest(BaseModel):
     name: str
     model: str | None = None
     install_cmd: str
     run_cmd: str
     final_output: str | None = None
-    output_artifacts: list[str] = []
+    output_artifacts: list[OutputArtifactSpec] = []
     secrets: dict[str, str] = {}
 
     @field_validator("output_artifacts")
     @classmethod
-    def validate_output_artifacts(cls, value: list[str]) -> list[str]:
+    def validate_output_artifacts(cls, value: list[OutputArtifactSpec]) -> list[OutputArtifactSpec]:
         if len(value) > MAX_OUTPUT_ARTIFACT_COUNT:
             raise ValueError(f"output_artifacts cannot contain more than {MAX_OUTPUT_ARTIFACT_COUNT} entries")
 
-        normalized_artifacts: list[str] = []
-        for artifact_path in value:
+        normalized_artifacts: list[OutputArtifactSpec] = []
+        for artifact in value:
+            artifact_path = artifact if isinstance(artifact, str) else artifact.path
             path = PurePosixPath(artifact_path)
             if path.is_absolute():
-                raise ValueError("output_artifacts must be relative paths")
+                raise ValueError("output_artifacts paths must be relative paths")
             if not path.parts or ".." in path.parts or "." in path.parts:
-                raise ValueError("output_artifacts cannot contain empty, '.', or '..' path parts")
+                raise ValueError("output_artifacts paths cannot contain empty, '.', or '..' path parts")
             if len(path.parts) < 2 or path.parts[0] != "full_result":
-                raise ValueError("output_artifacts must be under the full_result/ prefix")
-            normalized_artifacts.append(str(path))
+                raise ValueError("output_artifacts paths must be under the full_result/ prefix")
+            if isinstance(artifact, str):
+                normalized_artifacts.append(str(path))
+            else:
+                normalized_artifacts.append(artifact.model_copy(update={"path": str(path)}))
 
         return normalized_artifacts
 

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 from enum import Enum
+from pathlib import PurePosixPath
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, computed_field, field_serializer
+from pydantic import BaseModel, computed_field, field_serializer, field_validator
 from sqlalchemy import Connection, Dialect, event
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -81,13 +82,37 @@ class RetryMode(str, Enum):
     FROM_SCRATCH = "from_scratch"
 
 
+MAX_OUTPUT_ARTIFACT_BYTES = 50 * 1024 * 1024
+MAX_OUTPUT_ARTIFACT_COUNT = 10
+
+
 class AgentContractRequest(BaseModel):
     name: str
     model: str | None = None
     install_cmd: str
     run_cmd: str
     final_output: str | None = None
+    output_artifacts: list[str] = []
     secrets: dict[str, str] = {}
+
+    @field_validator("output_artifacts")
+    @classmethod
+    def validate_output_artifacts(cls, value: list[str]) -> list[str]:
+        if len(value) > MAX_OUTPUT_ARTIFACT_COUNT:
+            raise ValueError(f"output_artifacts cannot contain more than {MAX_OUTPUT_ARTIFACT_COUNT} entries")
+
+        normalized_artifacts: list[str] = []
+        for artifact_path in value:
+            path = PurePosixPath(artifact_path)
+            if path.is_absolute():
+                raise ValueError("output_artifacts must be relative paths")
+            if not path.parts or ".." in path.parts or "." in path.parts:
+                raise ValueError("output_artifacts cannot contain empty, '.', or '..' path parts")
+            if len(path.parts) < 2 or path.parts[0] != "full_result":
+                raise ValueError("output_artifacts must be under the full_result/ prefix")
+            normalized_artifacts.append(str(path))
+
+        return normalized_artifacts
 
 
 class BenchmarkArguments(BaseModel):

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -104,7 +104,7 @@ class OutputArtifact(BaseModel):
     @field_validator("source")
     @classmethod
     def validate_source(cls, value: str | None) -> str | None:
-        if value is None:
+        if not value:
             return None
         if not value.startswith("/"):
             raise ValueError("output_artifacts source paths must be absolute sandbox paths")
@@ -144,8 +144,6 @@ class AgentContractRequest(BaseModel):
                 raise ValueError("output_artifacts paths must be relative paths")
             if not path.parts or ".." in path.parts or "." in path.parts:
                 raise ValueError("output_artifacts paths cannot contain empty, '.', or '..' path parts")
-            if len(path.parts) < 2 or path.parts[0] != "full_result":
-                raise ValueError("output_artifacts paths must be under the full_result/ prefix")
             if isinstance(artifact, str):
                 normalized_artifacts.append(str(path))
             else:

--- a/services/tracker/src/tracker/exceptions.py
+++ b/services/tracker/src/tracker/exceptions.py
@@ -18,6 +18,13 @@ class InvalidSandboxConfigurationError(SandboxError):
     """Exception raised for deterministic sandbox configuration errors."""
 
 
+class OutputArtifactError(TrackerServiceError):
+    """Exception raised when a declared output artifact is missing or invalid."""
+
+    def __str__(self) -> str:
+        return "Output artifact error: " + super().__str__()
+
+
 class AgentRunFailedError(SandboxError):
     """Exception raised when the agent process inside a healthy sandbox exits non-zero.
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -37,7 +37,12 @@ from tenacity import (
 )
 
 from tracker.aws.s3 import create_presigned_url, get_agent_result_s3_key, get_benchmark_contract_s3_key, upload_to_s3
-from tracker.database.models import AgentCausedExitReason, AgentContractRequest, MAX_OUTPUT_ARTIFACT_BYTES
+from tracker.database.models import (
+    AgentCausedExitReason,
+    AgentContractRequest,
+    MAX_OUTPUT_ARTIFACT_BYTES,
+    OutputArtifactSpec,
+)
 from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
 from tracker.exceptions import (
     AgentRunFailedError,
@@ -893,58 +898,57 @@ async def archive_and_upload_output(
 
 OUTPUT_ARTIFACTS_SANDBOX_ROOT = PurePosixPath("/tmp/valkyrie")
 OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES = 50 * 1024 * 1024
-MODEL_LIBRARY_CONFIG_ARTIFACT = "full_result/config.json"
-MODEL_LIBRARY_RESULT_ARTIFACT = "full_result/result.json"
-MODEL_LIBRARY_OUTPUT_ARTIFACTS = {
-    MODEL_LIBRARY_CONFIG_ARTIFACT,
-    MODEL_LIBRARY_RESULT_ARTIFACT,
-}
 
 
-async def _model_library_artifact_paths(sandbox: AsyncSandbox, final_output: str) -> dict[str, str]:
-    find_command = f"find {shlex.quote(final_output)} -type f -path '*/turns/init/config.json' | sort | head -n 1"
-    config_result = await _exec(sandbox, find_command)
-    config_path = config_result.result.strip()
-    if config_result.exit_code != _SUCCESS_EXIT_CODE or not config_path:
-        raise SandboxError(f"Required model-library config artifact missing under {final_output}")
+def _output_artifact_path(artifact: OutputArtifactSpec) -> str:
+    return artifact if isinstance(artifact, str) else artifact.path
 
-    result_path = str(PurePosixPath(config_path).parent.parent.parent / "result.json")
-    result_exists = await _exec(sandbox, f"test -f {shlex.quote(result_path)}")
-    if result_exists.exit_code != _SUCCESS_EXIT_CODE:
-        raise SandboxError(f"Required model-library result artifact missing: {result_path}")
 
-    return {
-        MODEL_LIBRARY_CONFIG_ARTIFACT: config_path,
-        MODEL_LIBRARY_RESULT_ARTIFACT: result_path,
-    }
+def _output_artifact_source(artifact: OutputArtifactSpec) -> str:
+    artifact_path = _output_artifact_path(artifact)
+    source = artifact.source if not isinstance(artifact, str) else None
+    return source or str(OUTPUT_ARTIFACTS_SANDBOX_ROOT / artifact_path)
+
+
+def _format_output_artifact_source(source: str, task_id: str) -> str:
+    return source.replace("{task_id}", task_id)
+
+
+def _has_glob(source: str) -> bool:
+    return any(char in source for char in "*?[")
+
+
+def _find_root_for_glob(source: str) -> str:
+    glob_indices = [source.find(char) for char in "*?[" if source.find(char) != -1]
+    first_glob_index = min(glob_indices)
+    root = source[:first_glob_index].rsplit("/", 1)[0]
+    if not root or root == "/":
+        raise SandboxError(f"Output artifact glob source must include a non-root directory prefix: {source}")
+    return root
 
 
 async def _resolve_output_artifact_sandbox_path(
-    sandbox: AsyncSandbox,
-    artifact_path: str,
-    final_output: str | None,
-    model_library_paths: dict[str, str],
+    sandbox: AsyncSandbox, artifact: OutputArtifactSpec, task_id: str
 ) -> str:
-    sandbox_path = str(OUTPUT_ARTIFACTS_SANDBOX_ROOT / artifact_path)
-    quoted_path = shlex.quote(sandbox_path)
-    exists = await _exec(sandbox, f"test -f {quoted_path}")
-    if exists.exit_code == _SUCCESS_EXIT_CODE:
-        return sandbox_path
+    source = _format_output_artifact_source(_output_artifact_source(artifact), task_id)
+    if _has_glob(source):
+        find_root = _find_root_for_glob(source)
+        find_command = f"find {shlex.quote(find_root)} -type f -path {shlex.quote(source)} | sort | head -n 1"
+        source_result = await _exec(sandbox, find_command)
+        source_path = source_result.result.strip()
+        if source_result.exit_code == _SUCCESS_EXIT_CODE and source_path:
+            return source_path
+    else:
+        exists = await _exec(sandbox, f"test -f {shlex.quote(source)}")
+        if exists.exit_code == _SUCCESS_EXIT_CODE:
+            return source
 
-    if artifact_path in model_library_paths:
-        return model_library_paths[artifact_path]
-
-    if final_output is not None and artifact_path in MODEL_LIBRARY_OUTPUT_ARTIFACTS:
-        raise SandboxError(
-            f"Required output artifact missing: {sandbox_path} or model-library source under {final_output}"
-        )
-
-    raise SandboxError(f"Required output artifact missing: {sandbox_path}")
+    raise SandboxError(f"Required output artifact missing: {source}")
 
 
 async def upload_output_artifacts(
     sandbox: AsyncSandbox,
-    artifacts: list[str],
+    artifacts: list[OutputArtifactSpec],
     benchmark_id: str,
     task_id: str,
     aws: AWSCredentials,
@@ -952,15 +956,13 @@ async def upload_output_artifacts(
     final_output: str | None = None,
 ) -> None:
     """Upload declared small output artifacts from the sandbox directly to task S3 keys."""
+    # Retained temporarily for call-site compatibility; artifact sources are fully contract-declared.
+    _ = final_output
     total_bytes = 0
-    model_library_paths: dict[str, str] = {}
-    if final_output is not None and any(artifact_path in MODEL_LIBRARY_OUTPUT_ARTIFACTS for artifact_path in artifacts):
-        model_library_paths = await _model_library_artifact_paths(sandbox, final_output)
 
-    for artifact_path in artifacts:
-        sandbox_path = await _resolve_output_artifact_sandbox_path(
-            sandbox, artifact_path, final_output, model_library_paths
-        )
+    for artifact in artifacts:
+        artifact_path = _output_artifact_path(artifact)
+        sandbox_path = await _resolve_output_artifact_sandbox_path(sandbox, artifact, task_id)
         quoted_path = shlex.quote(sandbox_path)
 
         size_result = await _exec(sandbox, f"stat -c%s {quoted_path}")

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -36,8 +36,8 @@ from tenacity import (
     wait_fixed,
 )
 
-from tracker.aws.s3 import create_presigned_url, get_benchmark_contract_s3_key, upload_to_s3
-from tracker.database.models import AgentCausedExitReason, AgentContractRequest
+from tracker.aws.s3 import create_presigned_url, get_agent_result_s3_key, get_benchmark_contract_s3_key, upload_to_s3
+from tracker.database.models import AgentCausedExitReason, AgentContractRequest, MAX_OUTPUT_ARTIFACT_BYTES
 from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limit
 from tracker.exceptions import (
     AgentRunFailedError,
@@ -891,6 +891,122 @@ async def archive_and_upload_output(
             pass
 
 
+OUTPUT_ARTIFACTS_SANDBOX_ROOT = PurePosixPath("/tmp/valkyrie")
+OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES = 50 * 1024 * 1024
+MODEL_LIBRARY_CONFIG_ARTIFACT = "full_result/config.json"
+MODEL_LIBRARY_RESULT_ARTIFACT = "full_result/result.json"
+MODEL_LIBRARY_OUTPUT_ARTIFACTS = {
+    MODEL_LIBRARY_CONFIG_ARTIFACT,
+    MODEL_LIBRARY_RESULT_ARTIFACT,
+}
+
+
+async def _model_library_artifact_paths(sandbox: AsyncSandbox, final_output: str) -> dict[str, str]:
+    find_command = f"find {shlex.quote(final_output)} -type f -path '*/turns/init/config.json' | sort | head -n 1"
+    config_result = await _exec(sandbox, find_command)
+    config_path = config_result.result.strip()
+    if config_result.exit_code != _SUCCESS_EXIT_CODE or not config_path:
+        raise SandboxError(f"Required model-library config artifact missing under {final_output}")
+
+    result_path = str(PurePosixPath(config_path).parent.parent.parent / "result.json")
+    result_exists = await _exec(sandbox, f"test -f {shlex.quote(result_path)}")
+    if result_exists.exit_code != _SUCCESS_EXIT_CODE:
+        raise SandboxError(f"Required model-library result artifact missing: {result_path}")
+
+    return {
+        MODEL_LIBRARY_CONFIG_ARTIFACT: config_path,
+        MODEL_LIBRARY_RESULT_ARTIFACT: result_path,
+    }
+
+
+async def _resolve_output_artifact_sandbox_path(
+    sandbox: AsyncSandbox,
+    artifact_path: str,
+    final_output: str | None,
+    model_library_paths: dict[str, str],
+) -> str:
+    sandbox_path = str(OUTPUT_ARTIFACTS_SANDBOX_ROOT / artifact_path)
+    quoted_path = shlex.quote(sandbox_path)
+    exists = await _exec(sandbox, f"test -f {quoted_path}")
+    if exists.exit_code == _SUCCESS_EXIT_CODE:
+        return sandbox_path
+
+    if artifact_path in model_library_paths:
+        return model_library_paths[artifact_path]
+
+    if final_output is not None and artifact_path in MODEL_LIBRARY_OUTPUT_ARTIFACTS:
+        raise SandboxError(
+            f"Required output artifact missing: {sandbox_path} or model-library source under {final_output}"
+        )
+
+    raise SandboxError(f"Required output artifact missing: {sandbox_path}")
+
+
+async def upload_output_artifacts(
+    sandbox: AsyncSandbox,
+    artifacts: list[str],
+    benchmark_id: str,
+    task_id: str,
+    aws: AWSCredentials,
+    s3_bucket: str,
+    final_output: str | None = None,
+) -> None:
+    """Upload declared small output artifacts from the sandbox directly to task S3 keys."""
+    total_bytes = 0
+    model_library_paths: dict[str, str] = {}
+    if final_output is not None and any(artifact_path in MODEL_LIBRARY_OUTPUT_ARTIFACTS for artifact_path in artifacts):
+        model_library_paths = await _model_library_artifact_paths(sandbox, final_output)
+
+    for artifact_path in artifacts:
+        sandbox_path = await _resolve_output_artifact_sandbox_path(
+            sandbox, artifact_path, final_output, model_library_paths
+        )
+        quoted_path = shlex.quote(sandbox_path)
+
+        size_result = await _exec(sandbox, f"stat -c%s {quoted_path}")
+        if size_result.exit_code != _SUCCESS_EXIT_CODE:
+            raise SandboxError(f"Failed to stat output artifact: {sandbox_path}")
+
+        try:
+            artifact_bytes = int(size_result.result.strip())
+        except ValueError as e:
+            raise SandboxError(
+                f"Failed to parse output artifact size for {sandbox_path}: {size_result.result!r}"
+            ) from e
+
+        if artifact_bytes > MAX_OUTPUT_ARTIFACT_BYTES:
+            raise SandboxError(
+                f"Output artifact {sandbox_path} is too large: {artifact_bytes} bytes > {MAX_OUTPUT_ARTIFACT_BYTES} bytes"
+            )
+
+        total_bytes += artifact_bytes
+        if total_bytes > OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES:
+            raise SandboxError(
+                f"Output artifacts are too large: {total_bytes} bytes > {OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES} bytes"
+            )
+
+        b64_result = await _exec(sandbox, f"base64 {quoted_path}")
+        if b64_result.exit_code != _SUCCESS_EXIT_CODE:
+            raise SandboxError(f"Failed to read output artifact: {sandbox_path}")
+
+        s3_key = get_agent_result_s3_key(benchmark_id, task_id, artifact_path)
+        file_content = base64.b64decode(b64_result.result)
+        await upload_to_s3(file_content, s3_key, aws, s3_bucket)
+
+        logger.info(
+            "output_artifact.upload.complete",
+            extra={
+                "sandbox_id": sandbox.id,
+                "sandbox_name": sandbox.name,
+                "sandbox_path": sandbox_path,
+                "s3_key": s3_key,
+                "benchmark_id": benchmark_id,
+                "task_id": task_id,
+                "artifact_bytes": artifact_bytes,
+            },
+        )
+
+
 async def run_agent(
     sandbox: AsyncSandbox,
     contract: AgentContractRequest,
@@ -963,6 +1079,19 @@ async def run_agent(
                 benchmark_id=benchmark_id,
                 task_id=task_id,
             )
+
+    if contract.output_artifacts:
+        if benchmark_id is None:
+            raise SandboxError("benchmark_id is required to upload output artifacts")
+        await upload_output_artifacts(
+            sandbox,
+            contract.output_artifacts,
+            benchmark_id,
+            task_id,
+            aws,
+            s3_bucket,
+            final_output=contract.final_output,
+        )
 
     # Return why the agent terminated abnormally, or None on clean exit
     return exit_reason, agent_run_time

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -954,11 +954,8 @@ async def upload_output_artifacts(
     task_id: str,
     aws: AWSCredentials,
     s3_bucket: str,
-    final_output: str | None = None,
 ) -> None:
     """Upload declared small output artifacts from the sandbox directly to task S3 keys."""
-    # Retained temporarily for call-site compatibility; artifact sources are fully contract-declared.
-    _ = final_output
     total_bytes = 0
 
     for artifact in artifacts:
@@ -1093,7 +1090,6 @@ async def run_agent(
             task_id,
             aws,
             s3_bucket,
-            final_output=contract.final_output,
         )
 
     # Return why the agent terminated abnormally, or None on clean exit

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -47,6 +47,7 @@ from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limi
 from tracker.exceptions import (
     AgentRunFailedError,
     InvalidSandboxConfigurationError,
+    OutputArtifactError,
     PtyCreationError,
     SandboxError,
     SandboxSetupError,
@@ -923,7 +924,7 @@ def _find_root_for_glob(source: str) -> str:
     first_glob_index = min(glob_indices)
     root = source[:first_glob_index].rsplit("/", 1)[0]
     if not root or root == "/":
-        raise SandboxError(f"Output artifact glob source must include a non-root directory prefix: {source}")
+        raise OutputArtifactError(f"Output artifact glob source must include a non-root directory prefix: {source}")
     return root
 
 
@@ -943,7 +944,7 @@ async def _resolve_output_artifact_sandbox_path(
         if exists.exit_code == _SUCCESS_EXIT_CODE:
             return source
 
-    raise SandboxError(f"Required output artifact missing: {source}")
+    raise OutputArtifactError(f"Required output artifact missing: {source}")
 
 
 async def upload_output_artifacts(
@@ -967,29 +968,29 @@ async def upload_output_artifacts(
 
         size_result = await _exec(sandbox, f"stat -c%s {quoted_path}")
         if size_result.exit_code != _SUCCESS_EXIT_CODE:
-            raise SandboxError(f"Failed to stat output artifact: {sandbox_path}")
+            raise OutputArtifactError(f"Failed to stat output artifact: {sandbox_path}")
 
         try:
             artifact_bytes = int(size_result.result.strip())
         except ValueError as e:
-            raise SandboxError(
+            raise OutputArtifactError(
                 f"Failed to parse output artifact size for {sandbox_path}: {size_result.result!r}"
             ) from e
 
         if artifact_bytes > MAX_OUTPUT_ARTIFACT_BYTES:
-            raise SandboxError(
+            raise OutputArtifactError(
                 f"Output artifact {sandbox_path} is too large: {artifact_bytes} bytes > {MAX_OUTPUT_ARTIFACT_BYTES} bytes"
             )
 
         total_bytes += artifact_bytes
         if total_bytes > OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES:
-            raise SandboxError(
+            raise OutputArtifactError(
                 f"Output artifacts are too large: {total_bytes} bytes > {OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES} bytes"
             )
 
         b64_result = await _exec(sandbox, f"base64 {quoted_path}")
         if b64_result.exit_code != _SUCCESS_EXIT_CODE:
-            raise SandboxError(f"Failed to read output artifact: {sandbox_path}")
+            raise OutputArtifactError(f"Failed to read output artifact: {sandbox_path}")
 
         s3_key = get_agent_result_s3_key(benchmark_id, task_id, artifact_path)
         file_content = base64.b64decode(b64_result.result)

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -55,7 +55,7 @@ from tracker.daytona_retry import daytona_retry_callback, wait_daytona_rate_limi
 from pydantic import ValidationError
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
-from tracker.exceptions import SandboxSetupError, TrackerServiceError
+from tracker.exceptions import OutputArtifactError, SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, retry_callback
@@ -630,6 +630,16 @@ async def process_task(
     except SandboxSetupError as e:
         log_output(f"\n[ERROR] {e}")
         raise
+    except OutputArtifactError as e:
+        error_message = str(e)
+        logger.warning(error_message)
+        log_output(f"\n[ERROR] {error_message}")
+
+        with Session(bind=engine) as task_session:
+            task = fetch_task_row(task_row.id, task_session, org)
+            commit_task_error(task, task_session, error_message)
+
+        return {task_id: None}
     except ConnectionClosedError:
         seconds = int(time.monotonic() - last_log_time)
         error_message = (

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -11,9 +11,11 @@ from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 from websockets.http11 import Response
 
+import tracker.utils as utils_module
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.exceptions import OutputArtifactError
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import fetch_benchmark_row, process_benchmark, process_task, start_benchmark_request_to_benchmark
 
@@ -156,6 +158,33 @@ class TestBenchmarkServiceDisconnect:
         assert "rejected the WebSocket connection" in task_row.error_message
         assert "404" in task_row.error_message
 
+    async def test_output_artifact_error_marks_task_error_without_generic_exception(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        process_benchmark_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
+
+        async def _mock_run_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            raise OutputArtifactError("Required output artifact missing: /logs/result.json")
+
+        monkeypatch.setattr(utils_module, "run_agent", _mock_run_agent)
+
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+        assert result == {"task_0": None}
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.error_message is not None
+        assert "Output artifact error" in task_row.error_message
+        assert "Required output artifact missing" in task_row.error_message
+
     async def test_benchmark_service_error_produces_human_readable_message(
         self,
         contract: AgentContractRequest,
@@ -194,7 +223,7 @@ class TestBenchmarkServiceDisconnect:
         harness_config: HarnessConfig,
     ) -> None:
         """VALKYRIE-1Z: BenchmarkServiceError from final_score is caught at the benchmark level."""
-        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+        start_benchmark_request, _task_row, benchmark_id = self._create_task_env(
             contract, database_session, harness_config
         )
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -15,7 +15,13 @@ import tracker.observability.retry as retry_module
 import tracker.utils as utils_module
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest, OutputArtifact
-from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
+from tracker.exceptions import (
+    AgentRunFailedError,
+    OutputArtifactError,
+    SSLConnectionError,
+    SandboxError,
+    SandboxSetupError,
+)
 from tracker.sandbox import (
     create_sandbox,
     run_agent,
@@ -375,7 +381,7 @@ class TestOutputArtifacts:
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
 
-        with pytest.raises(SandboxError, match="Required output artifact missing"):
+        with pytest.raises(OutputArtifactError, match="Required output artifact missing"):
             await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", harness_config.aws, "bucket")
 
     async def test_upload_output_artifacts_fails_when_file_exceeds_tracker_limit(
@@ -396,7 +402,7 @@ class TestOutputArtifacts:
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
         monkeypatch.setattr(sandbox_module, "upload_to_s3", upload_mock)
 
-        with pytest.raises(SandboxError, match="too large"):
+        with pytest.raises(OutputArtifactError, match="too large"):
             await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", harness_config.aws, "bucket")
 
         upload_mock.assert_not_awaited()

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -16,7 +16,13 @@ import tracker.utils as utils_module
 from tracker import sandbox as sandbox_module
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
-from tracker.sandbox import create_sandbox, run_agent, stream_command_output, upload_agent_artifacts
+from tracker.sandbox import (
+    create_sandbox,
+    run_agent,
+    stream_command_output,
+    upload_agent_artifacts,
+    upload_output_artifacts,
+)
 from tracker.types import AWSCredentials
 
 _create_sandbox = getattr(sandbox_module, "_create_sandbox")
@@ -229,7 +235,234 @@ class TestPtyHandshakeSemaphore:
         }
 
 
+class TestOutputArtifacts:
+    async def test_upload_output_artifacts_uploads_declared_file_to_task_prefix(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        artifact = "full_result/turns.jsonl"
+        uploaded: list[tuple[bytes, str]] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command == "test -f /tmp/valkyrie/full_result/turns.jsonl":
+                return ExecuteResponse(exit_code=0, result="")
+            if command == "stat -c%s /tmp/valkyrie/full_result/turns.jsonl":
+                return ExecuteResponse(exit_code=0, result="12")
+            if command == "base64 /tmp/valkyrie/full_result/turns.jsonl":
+                return ExecuteResponse(exit_code=0, result="eyJ0dXJuIjoxfQo=")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_upload_to_s3(file_content: bytes, s3_key: str, _aws: Any, _s3_bucket: str) -> None:
+            uploaded.append((file_content, s3_key))
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await upload_output_artifacts(
+            mock_sandbox,
+            [artifact],
+            "benchmark-123",
+            "task_0",
+            harness_config.aws,
+            harness_config.s3_bucket,
+        )
+
+        assert uploaded == [(b'{"turn":1}\n', "benchmarks/benchmark-123/task_0/full_result/turns.jsonl")]
+
+    async def test_upload_output_artifacts_can_upload_model_library_files_from_final_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        uploaded: list[tuple[bytes, str]] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command == "find /logs -type f -path '*/turns/init/config.json' | sort | head -n 1":
+                return ExecuteResponse(exit_code=0, result="/logs/task/turns/init/config.json\n")
+            if command == "test -f /logs/task/result.json":
+                return ExecuteResponse(exit_code=0, result="")
+            if command == "test -f /tmp/valkyrie/full_result/config.json":
+                return ExecuteResponse(exit_code=1, result="")
+            if command == "stat -c%s /logs/task/turns/init/config.json":
+                return ExecuteResponse(exit_code=0, result="11")
+            if command == "base64 /logs/task/turns/init/config.json":
+                return ExecuteResponse(exit_code=0, result="eyJsbG0iOnt9fQo=")
+            if command == "test -f /tmp/valkyrie/full_result/result.json":
+                return ExecuteResponse(exit_code=1, result="")
+            if command == "stat -c%s /logs/task/result.json":
+                return ExecuteResponse(exit_code=0, result="13")
+            if command == "base64 /logs/task/result.json":
+                return ExecuteResponse(exit_code=0, result="eyJ0dXJucyI6W119Cg==")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_upload_to_s3(file_content: bytes, s3_key: str, _aws: Any, _s3_bucket: str) -> None:
+            uploaded.append((file_content, s3_key))
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await upload_output_artifacts(
+            mock_sandbox,
+            ["full_result/config.json", "full_result/result.json"],
+            "benchmark-123",
+            "task_0",
+            harness_config.aws,
+            harness_config.s3_bucket,
+            final_output="/logs",
+        )
+
+        assert uploaded == [
+            (b'{"llm":{}}\n', "benchmarks/benchmark-123/task_0/full_result/config.json"),
+            (b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/full_result/result.json"),
+        ]
+
+    async def test_upload_output_artifacts_uses_result_paired_with_model_library_config(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        uploaded: list[tuple[bytes, str]] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command == "find /logs -type f -path '*/turns/init/config.json' | sort | head -n 1":
+                return ExecuteResponse(exit_code=0, result="/logs/model-library-run/turns/init/config.json\n")
+            if command == "test -f /logs/model-library-run/result.json":
+                return ExecuteResponse(exit_code=0, result="")
+            if command == "test -f /tmp/valkyrie/full_result/result.json":
+                return ExecuteResponse(exit_code=1, result="")
+            if command == "stat -c%s /logs/model-library-run/result.json":
+                return ExecuteResponse(exit_code=0, result="13")
+            if command == "base64 /logs/model-library-run/result.json":
+                return ExecuteResponse(exit_code=0, result="eyJ0dXJucyI6W119Cg==")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_upload_to_s3(file_content: bytes, s3_key: str, _aws: Any, _s3_bucket: str) -> None:
+            uploaded.append((file_content, s3_key))
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await upload_output_artifacts(
+            mock_sandbox,
+            ["full_result/result.json"],
+            "benchmark-123",
+            "task_0",
+            harness_config.aws,
+            harness_config.s3_bucket,
+            final_output="/logs",
+        )
+
+        assert uploaded == [(b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/full_result/result.json")]
+
+    async def test_upload_output_artifacts_fails_when_declared_file_is_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        artifact = "full_result/missing.json"
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            assert command == "test -f /tmp/valkyrie/full_result/missing.json"
+            return ExecuteResponse(exit_code=1, result="")
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+
+        with pytest.raises(SandboxError, match="Required output artifact missing"):
+            await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", harness_config.aws, "bucket")
+
+    async def test_upload_output_artifacts_fails_when_file_exceeds_tracker_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        artifact = "full_result/large.json"
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command == "test -f /tmp/valkyrie/full_result/large.json":
+                return ExecuteResponse(exit_code=0, result="")
+            if command == "stat -c%s /tmp/valkyrie/full_result/large.json":
+                return ExecuteResponse(exit_code=0, result=str(sandbox_module.MAX_OUTPUT_ARTIFACT_BYTES + 1))
+            raise AssertionError(f"unexpected command: {command}")
+
+        upload_mock = AsyncMock()
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "upload_to_s3", upload_mock)
+
+        with pytest.raises(SandboxError, match="too large"):
+            await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", harness_config.aws, "bucket")
+
+        upload_mock.assert_not_awaited()
+
+
 class TestAgentOutputTelemetry:
+    async def test_run_agent_uploads_declared_output_artifacts(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="",
+            run_cmd="echo done",
+            final_output="/logs",
+            output_artifacts=["full_result/result.json"],
+        )
+        artifact_calls: list[str] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
+            if command.startswith("mkdir -p") or command == "test -e /logs":
+                return ExecuteResponse(exit_code=0, result="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_stream_command_output(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            return None, 0.0
+
+        async def fake_upload_output_artifacts(
+            _sandbox: Any,
+            artifacts: list[str],
+            benchmark_id: str,
+            task_id: str,
+            _aws: Any,
+            _s3_bucket: str,
+            final_output: str | None = None,
+        ) -> None:
+            artifact_calls.append(f"{benchmark_id}:{task_id}:{artifacts[0]}:{final_output}")
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
+        monkeypatch.setattr(sandbox_module, "upload_output_artifacts", fake_upload_output_artifacts)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await run_agent(
+            mock_sandbox,
+            contract,
+            "/tmp/problem.txt",
+            "task_0",
+            lambda _msg: None,
+            "/testbed",
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+            benchmark_id="benchmark-123",
+        )
+
+        assert artifact_calls == ["benchmark-123:task_0:full_result/result.json:/logs"]
+
     async def test_run_agent_threads_benchmark_id_to_archive_and_upload(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -247,15 +247,15 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         harness_config: Any,
     ) -> None:
-        artifact = "full_result/turns.jsonl"
+        artifact = "artifacts/turns.jsonl"
         uploaded: list[tuple[bytes, str]] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            if command == "test -f /tmp/valkyrie/full_result/turns.jsonl":
+            if command == "test -f /tmp/valkyrie/artifacts/turns.jsonl":
                 return ExecuteResponse(exit_code=0, result="")
-            if command == "stat -c%s /tmp/valkyrie/full_result/turns.jsonl":
+            if command == "stat -c%s /tmp/valkyrie/artifacts/turns.jsonl":
                 return ExecuteResponse(exit_code=0, result="12")
-            if command == "base64 /tmp/valkyrie/full_result/turns.jsonl":
+            if command == "base64 /tmp/valkyrie/artifacts/turns.jsonl":
                 return ExecuteResponse(exit_code=0, result="eyJ0dXJuIjoxfQo=")
             raise AssertionError(f"unexpected command: {command}")
 
@@ -278,7 +278,7 @@ class TestOutputArtifacts:
             harness_config.s3_bucket,
         )
 
-        assert uploaded == [(b'{"turn":1}\n', "benchmarks/benchmark-123/task_0/full_result/turns.jsonl")]
+        assert uploaded == [(b'{"turn":1}\n', "benchmarks/benchmark-123/task_0/artifacts/turns.jsonl")]
 
     async def test_upload_output_artifacts_can_upload_explicit_glob_sources(
         self,
@@ -315,8 +315,8 @@ class TestOutputArtifacts:
         await upload_output_artifacts(
             mock_sandbox,
             [
-                OutputArtifact(path="full_result/config.json", source="/logs/*/turns/init/config.json"),
-                OutputArtifact(path="full_result/result.json", source="/logs/*/result.json"),
+                OutputArtifact(path="artifacts/config.json", source="/logs/*/turns/init/config.json"),
+                OutputArtifact(path="artifacts/result.json", source="/logs/*/result.json"),
             ],
             "benchmark-123",
             "task_0",
@@ -325,8 +325,8 @@ class TestOutputArtifacts:
         )
 
         assert uploaded == [
-            (b'{"llm":{}}\n', "benchmarks/benchmark-123/task_0/full_result/config.json"),
-            (b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/full_result/result.json"),
+            (b'{"llm":{}}\n', "benchmarks/benchmark-123/task_0/artifacts/config.json"),
+            (b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/artifacts/result.json"),
         ]
 
     async def test_upload_output_artifacts_uses_result_paired_with_model_library_config(
@@ -357,24 +357,24 @@ class TestOutputArtifacts:
 
         await upload_output_artifacts(
             mock_sandbox,
-            [OutputArtifact(path="full_result/result.json", source="/logs/model-library-run/result.json")],
+            [OutputArtifact(path="artifacts/result.json", source="/logs/model-library-run/result.json")],
             "benchmark-123",
             "task_0",
             harness_config.aws,
             harness_config.s3_bucket,
         )
 
-        assert uploaded == [(b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/full_result/result.json")]
+        assert uploaded == [(b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/artifacts/result.json")]
 
     async def test_upload_output_artifacts_fails_when_declared_file_is_missing(
         self,
         monkeypatch: pytest.MonkeyPatch,
         harness_config: Any,
     ) -> None:
-        artifact = "full_result/missing.json"
+        artifact = "artifacts/missing.json"
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            assert command == "test -f /tmp/valkyrie/full_result/missing.json"
+            assert command == "test -f /tmp/valkyrie/artifacts/missing.json"
             return ExecuteResponse(exit_code=1, result="")
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
@@ -387,12 +387,12 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         harness_config: Any,
     ) -> None:
-        artifact = "full_result/large.json"
+        artifact = "artifacts/large.json"
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            if command == "test -f /tmp/valkyrie/full_result/large.json":
+            if command == "test -f /tmp/valkyrie/artifacts/large.json":
                 return ExecuteResponse(exit_code=0, result="")
-            if command == "stat -c%s /tmp/valkyrie/full_result/large.json":
+            if command == "stat -c%s /tmp/valkyrie/artifacts/large.json":
                 return ExecuteResponse(exit_code=0, result=str(sandbox_module.MAX_OUTPUT_ARTIFACT_BYTES + 1))
             raise AssertionError(f"unexpected command: {command}")
 
@@ -417,7 +417,7 @@ class TestAgentOutputTelemetry:
             install_cmd="",
             run_cmd="echo done",
             final_output="/logs",
-            output_artifacts=["full_result/result.json"],
+            output_artifacts=["artifacts/result.json"],
         )
         artifact_calls: list[str] = []
 
@@ -459,7 +459,7 @@ class TestAgentOutputTelemetry:
             benchmark_id="benchmark-123",
         )
 
-        assert artifact_calls == ["benchmark-123:task_0:full_result/result.json"]
+        assert artifact_calls == ["benchmark-123:task_0:artifacts/result.json"]
 
     async def test_run_agent_threads_benchmark_id_to_archive_and_upload(
         self,

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -14,7 +14,7 @@ import tracker.daytona_retry as daytona_retry_module
 import tracker.observability.retry as retry_module
 import tracker.utils as utils_module
 from tracker import sandbox as sandbox_module
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, OutputArtifact
 from tracker.exceptions import AgentRunFailedError, SSLConnectionError, SandboxError, SandboxSetupError
 from tracker.sandbox import (
     create_sandbox,
@@ -282,18 +282,14 @@ class TestOutputArtifacts:
         uploaded: list[tuple[bytes, str]] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            if command == "find /logs -type f -path '*/turns/init/config.json' | sort | head -n 1":
+            if command == "find /logs -type f -path '/logs/*/turns/init/config.json' | sort | head -n 1":
                 return ExecuteResponse(exit_code=0, result="/logs/task/turns/init/config.json\n")
-            if command == "test -f /logs/task/result.json":
-                return ExecuteResponse(exit_code=0, result="")
-            if command == "test -f /tmp/valkyrie/full_result/config.json":
-                return ExecuteResponse(exit_code=1, result="")
             if command == "stat -c%s /logs/task/turns/init/config.json":
                 return ExecuteResponse(exit_code=0, result="11")
             if command == "base64 /logs/task/turns/init/config.json":
                 return ExecuteResponse(exit_code=0, result="eyJsbG0iOnt9fQo=")
-            if command == "test -f /tmp/valkyrie/full_result/result.json":
-                return ExecuteResponse(exit_code=1, result="")
+            if command == "find /logs -type f -path '/logs/*/result.json' | sort | head -n 1":
+                return ExecuteResponse(exit_code=0, result="/logs/task/result.json\n")
             if command == "stat -c%s /logs/task/result.json":
                 return ExecuteResponse(exit_code=0, result="13")
             if command == "base64 /logs/task/result.json":
@@ -312,7 +308,10 @@ class TestOutputArtifacts:
 
         await upload_output_artifacts(
             mock_sandbox,
-            ["full_result/config.json", "full_result/result.json"],
+            [
+                OutputArtifact(path="full_result/config.json", source="/logs/*/turns/init/config.json"),
+                OutputArtifact(path="full_result/result.json", source="/logs/*/result.json"),
+            ],
             "benchmark-123",
             "task_0",
             harness_config.aws,
@@ -333,12 +332,8 @@ class TestOutputArtifacts:
         uploaded: list[tuple[bytes, str]] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecuteResponse:
-            if command == "find /logs -type f -path '*/turns/init/config.json' | sort | head -n 1":
-                return ExecuteResponse(exit_code=0, result="/logs/model-library-run/turns/init/config.json\n")
             if command == "test -f /logs/model-library-run/result.json":
                 return ExecuteResponse(exit_code=0, result="")
-            if command == "test -f /tmp/valkyrie/full_result/result.json":
-                return ExecuteResponse(exit_code=1, result="")
             if command == "stat -c%s /logs/model-library-run/result.json":
                 return ExecuteResponse(exit_code=0, result="13")
             if command == "base64 /logs/model-library-run/result.json":
@@ -357,7 +352,7 @@ class TestOutputArtifacts:
 
         await upload_output_artifacts(
             mock_sandbox,
-            ["full_result/result.json"],
+            [OutputArtifact(path="full_result/result.json", source="/logs/model-library-run/result.json")],
             "benchmark-123",
             "task_0",
             harness_config.aws,

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -280,7 +280,7 @@ class TestOutputArtifacts:
 
         assert uploaded == [(b'{"turn":1}\n', "benchmarks/benchmark-123/task_0/full_result/turns.jsonl")]
 
-    async def test_upload_output_artifacts_can_upload_model_library_files_from_final_output(
+    async def test_upload_output_artifacts_can_upload_explicit_glob_sources(
         self,
         monkeypatch: pytest.MonkeyPatch,
         harness_config: Any,
@@ -322,7 +322,6 @@ class TestOutputArtifacts:
             "task_0",
             harness_config.aws,
             harness_config.s3_bucket,
-            final_output="/logs",
         )
 
         assert uploaded == [
@@ -363,7 +362,6 @@ class TestOutputArtifacts:
             "task_0",
             harness_config.aws,
             harness_config.s3_bucket,
-            final_output="/logs",
         )
 
         assert uploaded == [(b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/full_result/result.json")]
@@ -438,9 +436,8 @@ class TestAgentOutputTelemetry:
             task_id: str,
             _aws: Any,
             _s3_bucket: str,
-            final_output: str | None = None,
         ) -> None:
-            artifact_calls.append(f"{benchmark_id}:{task_id}:{artifacts[0]}:{final_output}")
+            artifact_calls.append(f"{benchmark_id}:{task_id}:{artifacts[0]}")
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
         monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
@@ -462,7 +459,7 @@ class TestAgentOutputTelemetry:
             benchmark_id="benchmark-123",
         )
 
-        assert artifact_calls == ["benchmark-123:task_0:full_result/result.json:/logs"]
+        assert artifact_calls == ["benchmark-123:task_0:full_result/result.json"]
 
     async def test_run_agent_threads_benchmark_id_to_archive_and_upload(
         self,

--- a/src/valkyrie/cli/bundler.py
+++ b/src/valkyrie/cli/bundler.py
@@ -160,6 +160,7 @@ def _parse_yaml_contract(contract_path: Path, agent_config: AgentConfig) -> Agen
             run_cmd=agent_contract.format_run_cmd(validated_kwargs),
             install_cmd=agent_contract.install_cmd,
             final_output=str(agent_contract.final_output) if agent_contract.final_output is not None else None,
+            output_artifacts=agent_contract.output_artifacts,
             secrets=agent_contract.secrets,
         )
     except ContractValidationError:

--- a/src/valkyrie/cli/bundler.py
+++ b/src/valkyrie/cli/bundler.py
@@ -12,11 +12,11 @@ from typing import BinaryIO, Generator
 
 import yaml
 from pydantic import ValidationError as PydanticValidationError
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, OutputArtifact
 
 from valkyrie.cli.exceptions import BundlerError, ContractValidationError
 from valkyrie.contract import BaseAgentContract
-from valkyrie.schemas import AgentConfig, AgentContract
+from valkyrie.schemas import AgentConfig, AgentContract, OutputArtifact as ContractOutputArtifact
 
 
 def _zip_directory_to_file(directory: Path, output_path: Path) -> None:
@@ -154,13 +154,20 @@ def _parse_yaml_contract(contract_path: Path, agent_config: AgentConfig) -> Agen
 
         validated_kwargs = agent_contract.validate_kwargs(all_schema, user_values)
 
+        output_artifacts = [
+            OutputArtifact(path=artifact.path, source=artifact.source)
+            if isinstance(artifact, ContractOutputArtifact)
+            else artifact
+            for artifact in agent_contract.output_artifacts
+        ]
+
         return AgentContractRequest(
             name=agent_contract.name,
             model=agent_config.model,
             run_cmd=agent_contract.format_run_cmd(validated_kwargs),
             install_cmd=agent_contract.install_cmd,
             final_output=str(agent_contract.final_output) if agent_contract.final_output is not None else None,
-            output_artifacts=agent_contract.output_artifacts,
+            output_artifacts=output_artifacts,
             secrets=agent_contract.secrets,
         )
     except ContractValidationError:

--- a/src/valkyrie/contract.py
+++ b/src/valkyrie/contract.py
@@ -2,9 +2,12 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, OutputArtifact, OutputArtifactSpec
 
 from valkyrie.schemas import AgentConfig
+
+
+__all__ = ["BaseAgentContract", "OutputArtifact", "OutputArtifactSpec"]
 
 
 class BaseAgentContract(ABC):
@@ -97,8 +100,8 @@ class BaseAgentContract(ABC):
         ...
 
     @property
-    def output_artifacts(self) -> list[str]:
-        """Relative /tmp/valkyrie paths uploaded directly to the task S3 folder."""
+    def output_artifacts(self) -> list[OutputArtifactSpec]:
+        """Artifacts uploaded directly to the task S3 folder."""
         return []
 
     def to_request(self) -> AgentContractRequest:

--- a/src/valkyrie/contract.py
+++ b/src/valkyrie/contract.py
@@ -96,6 +96,11 @@ class BaseAgentContract(ABC):
         """
         ...
 
+    @property
+    def output_artifacts(self) -> list[str]:
+        """Relative /tmp/valkyrie paths uploaded directly to the task S3 folder."""
+        return []
+
     def to_request(self) -> AgentContractRequest:
         """
         Convert the contract to a request object for the tracker service.
@@ -113,5 +118,6 @@ class BaseAgentContract(ABC):
             ),
             install_cmd=self.install_cmd,
             final_output=str(self.final_output) if self.final_output else None,
+            output_artifacts=self.output_artifacts,
             secrets=self.secrets,
         )

--- a/src/valkyrie/schemas.py
+++ b/src/valkyrie/schemas.py
@@ -122,6 +122,17 @@ class AgentContract(BaseModel):
     ```
     """
 
+    output_artifacts: list[str] = []
+    """
+    Relative /tmp/valkyrie paths to upload directly into the task's S3 folder.
+    Keep them outside final_output if they should not be duplicated in the archive.
+
+    ```yaml
+    output_artifacts:
+      - full_result/turns.jsonl
+    ```
+    """
+
     secrets: dict[str, str] = {}
     """
     Secrets for the agent

--- a/src/valkyrie/schemas.py
+++ b/src/valkyrie/schemas.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 from pydantic import BaseModel, ValidationError, create_model, field_validator
@@ -88,6 +88,41 @@ class Parameter(BaseModel):
     """
 
 
+def _source_has_glob(source: str) -> bool:
+    return any(char in source for char in "*?[")
+
+
+def _source_glob_root(source: str) -> str:
+    glob_indices = [source.find(char) for char in "*?[" if source.find(char) != -1]
+    first_glob_index = min(glob_indices)
+    root = source[:first_glob_index].rsplit("/", 1)[0]
+    return root or "/"
+
+
+class OutputArtifact(BaseModel):
+    path: str
+    source: str | None = None
+
+    @field_validator("source")
+    @classmethod
+    def validate_source(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        if not value.startswith("/"):
+            raise ValueError("output_artifacts source paths must be absolute sandbox paths")
+
+        path = PurePosixPath(value)
+        if not path.parts or ".." in path.parts or "." in path.parts:
+            raise ValueError("output_artifacts source paths cannot contain empty, '.', or '..' path parts")
+        if _source_has_glob(value) and _source_glob_root(value) == "/":
+            raise ValueError("output_artifacts glob sources must include a non-root directory prefix")
+
+        return value
+
+
+OutputArtifactSpec = str | OutputArtifact
+
+
 class AgentContract(BaseModel):
     """
     Breakdown of the agent contract the yaml config file is converted into,
@@ -122,14 +157,18 @@ class AgentContract(BaseModel):
     ```
     """
 
-    output_artifacts: list[str] = []
+    output_artifacts: list[OutputArtifactSpec] = []
     """
-    Relative /tmp/valkyrie paths to upload directly into the task's S3 folder.
-    Keep them outside final_output if they should not be duplicated in the archive.
+    Artifacts to upload directly into the task's S3 folder.
+
+    String entries are shorthand for reading `/tmp/valkyrie/<path>` and uploading to `<path>`.
+    Object entries can set an explicit sandbox `source` and destination `path`.
 
     ```yaml
     output_artifacts:
       - full_result/turns.jsonl
+      - path: full_result/result.json
+        source: /logs/{task_id}/result.json
     ```
     """
 

--- a/src/valkyrie/schemas.py
+++ b/src/valkyrie/schemas.py
@@ -135,10 +135,12 @@ class AgentContract(BaseModel):
 
     ```yaml
     output_artifacts:
-      - full_result/turns.jsonl
-      - path: full_result/result.json
+      - artifacts/summary.json
+      - path: artifacts/result.json
         source: /logs/{task_id}/result.json
     ```
+    Valkyrie does not require a specific destination prefix. Vals benchmark ingestion conventionally uses
+    `vals_format/config.json` and `vals_format/result.json`.
     """
 
     secrets: dict[str, str] = {}

--- a/src/valkyrie/schemas.py
+++ b/src/valkyrie/schemas.py
@@ -1,10 +1,14 @@
 from enum import Enum
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, ValidationError, create_model, field_validator
+from tracker.database.models import OutputArtifact, OutputArtifactSpec
 
 from valkyrie.cli.exceptions import ContractValidationError
+
+
+__all__ = ["OutputArtifact", "OutputArtifactSpec"]
 
 
 class Defaults(str, Enum):
@@ -86,41 +90,6 @@ class Parameter(BaseModel):
       description: "Sampling temperature"
     ```
     """
-
-
-def _source_has_glob(source: str) -> bool:
-    return any(char in source for char in "*?[")
-
-
-def _source_glob_root(source: str) -> str:
-    glob_indices = [source.find(char) for char in "*?[" if source.find(char) != -1]
-    first_glob_index = min(glob_indices)
-    root = source[:first_glob_index].rsplit("/", 1)[0]
-    return root or "/"
-
-
-class OutputArtifact(BaseModel):
-    path: str
-    source: str | None = None
-
-    @field_validator("source")
-    @classmethod
-    def validate_source(cls, value: str | None) -> str | None:
-        if value is None:
-            return None
-        if not value.startswith("/"):
-            raise ValueError("output_artifacts source paths must be absolute sandbox paths")
-
-        path = PurePosixPath(value)
-        if not path.parts or ".." in path.parts or "." in path.parts:
-            raise ValueError("output_artifacts source paths cannot contain empty, '.', or '..' path parts")
-        if _source_has_glob(value) and _source_glob_root(value) == "/":
-            raise ValueError("output_artifacts glob sources must include a non-root directory prefix")
-
-        return value
-
-
-OutputArtifactSpec = str | OutputArtifact
 
 
 class AgentContract(BaseModel):

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -215,23 +215,25 @@ class TestFormatRunCmd:
 
 
 class TestOutputArtifactValidation:
-    def test_rejects_path_outside_full_result_prefix(self) -> None:
-        with pytest.raises(ValidationError, match="full_result"):
-            AgentContractRequest(
-                name="test-agent",
-                install_cmd="true",
-                run_cmd="echo {problem_statement_path}",
-                output_artifacts=["other/result.json"],
-            )
+    def test_accepts_relative_destination_outside_full_result_prefix(self) -> None:
+        request = AgentContractRequest(
+            name="test-agent",
+            install_cmd="true",
+            run_cmd="echo {problem_statement_path}",
+            output_artifacts=["metrics/result.json"],
+        )
 
-    def test_rejects_bare_full_result_path(self) -> None:
-        with pytest.raises(ValidationError, match="full_result"):
-            AgentContractRequest(
-                name="test-agent",
-                install_cmd="true",
-                run_cmd="echo {problem_statement_path}",
-                output_artifacts=["full_result"],
-            )
+        assert request.output_artifacts == ["metrics/result.json"]
+
+    def test_accepts_single_component_relative_destination(self) -> None:
+        request = AgentContractRequest(
+            name="test-agent",
+            install_cmd="true",
+            run_cmd="echo {problem_statement_path}",
+            output_artifacts=["result.json"],
+        )
+
+        assert request.output_artifacts == ["result.json"]
 
     def test_rejects_path_traversal(self) -> None:
         with pytest.raises(ValidationError, match="output_artifacts"):
@@ -259,6 +261,11 @@ class TestOutputArtifactValidation:
                 run_cmd="echo {problem_statement_path}",
                 output_artifacts=["full_result/result.json"] * 11,
             )
+
+    def test_empty_source_is_treated_as_default_source(self) -> None:
+        artifact = OutputArtifact(path="full_result/result.json", source="")
+
+        assert artifact.source is None
 
     def test_rejects_relative_source_path(self) -> None:
         with pytest.raises(ValidationError, match="absolute sandbox paths"):

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from pydantic import ValidationError
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, OutputArtifact
 
 from valkyrie.cli.bundler import _parse_yaml_contract  # type: ignore
 from valkyrie.schemas import AgentConfig, AgentContract, Parameter
@@ -260,6 +260,32 @@ class TestOutputArtifactValidation:
                 output_artifacts=["full_result/result.json"] * 11,
             )
 
+    def test_rejects_relative_source_path(self) -> None:
+        with pytest.raises(ValidationError, match="absolute sandbox paths"):
+            OutputArtifact(path="full_result/result.json", source="logs/result.json")
+
+    def test_rejects_root_glob_source_path(self) -> None:
+        with pytest.raises(ValidationError, match="non-root directory prefix"):
+            OutputArtifact(path="full_result/result.json", source="/*.json")
+
+    def test_accepts_explicit_source_and_destination(self) -> None:
+        request = AgentContractRequest(
+            name="test-agent",
+            install_cmd="true",
+            run_cmd="echo {problem_statement_path}",
+            output_artifacts=[
+                OutputArtifact(
+                    path="full_result/result.json",
+                    source="/logs/{task_id}/result.json",
+                )
+            ],
+        )
+
+        artifact = request.output_artifacts[0]
+        assert not isinstance(artifact, str)
+        assert artifact.path == "full_result/result.json"
+        assert artifact.source == "/logs/{task_id}/result.json"
+
 
 class TestRunCmdValidation:
     def test_missing_problem_statement_path_raises(self) -> None:
@@ -382,6 +408,8 @@ class TestParseYamlContract:
             final_output: /artifacts
             output_artifacts:
               - full_result/turns.jsonl
+              - path: full_result/result.json
+                source: /logs/{task_id}/result.json
             secrets:
               API_KEY: MySecretName
         """,
@@ -390,7 +418,10 @@ class TestParseYamlContract:
         result = _parse_yaml_contract(path, AgentConfig())
 
         assert result.final_output == "/artifacts"
-        assert result.output_artifacts == ["full_result/turns.jsonl"]
+        assert result.output_artifacts[0] == "full_result/turns.jsonl"
+        artifact = cast(OutputArtifact, result.output_artifacts[1])
+        assert artifact.path == "full_result/result.json"
+        assert artifact.source == "/logs/{task_id}/result.json"
         assert result.secrets == {"API_KEY": "MySecretName"}
 
     def test_model_from_agent_config(self, tmp_path: Path) -> None:

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -214,6 +214,53 @@ class TestFormatRunCmd:
         assert result == "agent --task {problem_statement_path} --temp 0.5 --id {task_id}"
 
 
+class TestOutputArtifactValidation:
+    def test_rejects_path_outside_full_result_prefix(self) -> None:
+        with pytest.raises(ValidationError, match="full_result"):
+            AgentContractRequest(
+                name="test-agent",
+                install_cmd="true",
+                run_cmd="echo {problem_statement_path}",
+                output_artifacts=["other/result.json"],
+            )
+
+    def test_rejects_bare_full_result_path(self) -> None:
+        with pytest.raises(ValidationError, match="full_result"):
+            AgentContractRequest(
+                name="test-agent",
+                install_cmd="true",
+                run_cmd="echo {problem_statement_path}",
+                output_artifacts=["full_result"],
+            )
+
+    def test_rejects_path_traversal(self) -> None:
+        with pytest.raises(ValidationError, match="output_artifacts"):
+            AgentContractRequest(
+                name="test-agent",
+                install_cmd="true",
+                run_cmd="echo {problem_statement_path}",
+                output_artifacts=["full_result/../secret.json"],
+            )
+
+    def test_rejects_absolute_path(self) -> None:
+        with pytest.raises(ValidationError, match="relative"):
+            AgentContractRequest(
+                name="test-agent",
+                install_cmd="true",
+                run_cmd="echo {problem_statement_path}",
+                output_artifacts=["/tmp/full_result/result.json"],
+            )
+
+    def test_rejects_too_many_output_artifacts(self) -> None:
+        with pytest.raises(ValidationError, match="output_artifacts"):
+            AgentContractRequest(
+                name="test-agent",
+                install_cmd="true",
+                run_cmd="echo {problem_statement_path}",
+                output_artifacts=["full_result/result.json"] * 11,
+            )
+
+
 class TestRunCmdValidation:
     def test_missing_problem_statement_path_raises(self) -> None:
         """
@@ -319,12 +366,12 @@ class TestParseYamlContract:
         with pytest.raises(ValueError, match="is required but was not provided"):
             _parse_yaml_contract(path, AgentConfig())
 
-    def test_secrets_and_final_output_passed_through(self, tmp_path: Path) -> None:
+    def test_secrets_final_output_and_output_artifacts_passed_through(self, tmp_path: Path) -> None:
         """
-        Validates that secrets and final_output from YAML are carried to the request.
+        Validates that secrets, final_output, and output_artifacts from YAML are carried to the request.
 
         Test Cases:
-        - YAML defines API_KEY secret and /artifacts final_output, both appear on the request
+        - YAML defines API_KEY secret, /artifacts final_output, and one direct output artifact
         """
         path = self._write_yaml(
             tmp_path,
@@ -333,6 +380,8 @@ class TestParseYamlContract:
             install_cmd: bash setup.sh
             run_cmd: "agent --task {problem_statement_path}"
             final_output: /artifacts
+            output_artifacts:
+              - full_result/turns.jsonl
             secrets:
               API_KEY: MySecretName
         """,
@@ -341,6 +390,7 @@ class TestParseYamlContract:
         result = _parse_yaml_contract(path, AgentConfig())
 
         assert result.final_output == "/artifacts"
+        assert result.output_artifacts == ["full_result/turns.jsonl"]
         assert result.secrets == {"API_KEY": "MySecretName"}
 
     def test_model_from_agent_config(self, tmp_path: Path) -> None:

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -215,7 +215,7 @@ class TestFormatRunCmd:
 
 
 class TestOutputArtifactValidation:
-    def test_accepts_relative_destination_outside_full_result_prefix(self) -> None:
+    def test_accepts_relative_destination_path(self) -> None:
         request = AgentContractRequest(
             name="test-agent",
             install_cmd="true",
@@ -241,7 +241,7 @@ class TestOutputArtifactValidation:
                 name="test-agent",
                 install_cmd="true",
                 run_cmd="echo {problem_statement_path}",
-                output_artifacts=["full_result/../secret.json"],
+                output_artifacts=["artifacts/../secret.json"],
             )
 
     def test_rejects_absolute_path(self) -> None:
@@ -250,7 +250,7 @@ class TestOutputArtifactValidation:
                 name="test-agent",
                 install_cmd="true",
                 run_cmd="echo {problem_statement_path}",
-                output_artifacts=["/tmp/full_result/result.json"],
+                output_artifacts=["/tmp/artifacts/result.json"],
             )
 
     def test_rejects_too_many_output_artifacts(self) -> None:
@@ -259,21 +259,21 @@ class TestOutputArtifactValidation:
                 name="test-agent",
                 install_cmd="true",
                 run_cmd="echo {problem_statement_path}",
-                output_artifacts=["full_result/result.json"] * 11,
+                output_artifacts=["artifacts/result.json"] * 11,
             )
 
     def test_empty_source_is_treated_as_default_source(self) -> None:
-        artifact = OutputArtifact(path="full_result/result.json", source="")
+        artifact = OutputArtifact(path="artifacts/result.json", source="")
 
         assert artifact.source is None
 
     def test_rejects_relative_source_path(self) -> None:
         with pytest.raises(ValidationError, match="absolute sandbox paths"):
-            OutputArtifact(path="full_result/result.json", source="logs/result.json")
+            OutputArtifact(path="artifacts/result.json", source="logs/result.json")
 
     def test_rejects_root_glob_source_path(self) -> None:
         with pytest.raises(ValidationError, match="non-root directory prefix"):
-            OutputArtifact(path="full_result/result.json", source="/*.json")
+            OutputArtifact(path="artifacts/result.json", source="/*.json")
 
     def test_accepts_explicit_source_and_destination(self) -> None:
         request = AgentContractRequest(
@@ -282,7 +282,7 @@ class TestOutputArtifactValidation:
             run_cmd="echo {problem_statement_path}",
             output_artifacts=[
                 OutputArtifact(
-                    path="full_result/result.json",
+                    path="artifacts/result.json",
                     source="/logs/{task_id}/result.json",
                 )
             ],
@@ -290,7 +290,7 @@ class TestOutputArtifactValidation:
 
         artifact = request.output_artifacts[0]
         assert not isinstance(artifact, str)
-        assert artifact.path == "full_result/result.json"
+        assert artifact.path == "artifacts/result.json"
         assert artifact.source == "/logs/{task_id}/result.json"
 
 
@@ -414,8 +414,8 @@ class TestParseYamlContract:
             run_cmd: "agent --task {problem_statement_path}"
             final_output: /artifacts
             output_artifacts:
-              - full_result/turns.jsonl
-              - path: full_result/result.json
+              - artifacts/turns.jsonl
+              - path: artifacts/result.json
                 source: /logs/{task_id}/result.json
             secrets:
               API_KEY: MySecretName
@@ -425,9 +425,9 @@ class TestParseYamlContract:
         result = _parse_yaml_contract(path, AgentConfig())
 
         assert result.final_output == "/artifacts"
-        assert result.output_artifacts[0] == "full_result/turns.jsonl"
+        assert result.output_artifacts[0] == "artifacts/turns.jsonl"
         artifact = cast(OutputArtifact, result.output_artifacts[1])
-        assert artifact.path == "full_result/result.json"
+        assert artifact.path == "artifacts/result.json"
         assert artifact.source == "/logs/{task_id}/result.json"
         assert result.secrets == {"API_KEY": "MySecretName"}
 


### PR DESCRIPTION
## What changed

This PR adds contract-declared direct sidecar uploads for small per-task artifacts, while leaving the existing `agent_output.tar.gz` archive behavior intact.

### Contract/API shape

- Add `output_artifacts` support for two declaration forms:
  - string shorthand: `full_result/turns.jsonl`
    - tracker reads `/tmp/valkyrie/full_result/turns.jsonl`
    - tracker uploads to `benchmarks/<run>/<task>/full_result/turns.jsonl`
  - explicit object: `{ path, source }`
    - tracker reads a contract-declared sandbox `source`
    - tracker uploads to the task S3 destination `path`
- Export `OutputArtifact` and `OutputArtifactSpec` from `valkyrie.contract` so Python contract implementations can stay typed without importing tracker internals directly.
- Normalize YAML contract artifacts at the CLI/bundler boundary because the public Valkyrie schema and tracker request schema use separate Pydantic model classes.

### Tracker behavior

- Upload declared sidecars to:

```text
benchmarks/<run>/<task>/full_result/*
```

- Keep tracker generic: no model-library-specific path pairing or fallback logic. Producer-specific path knowledge belongs in contracts.
- Expand `{task_id}` in explicit `source` values.
- Resolve explicit source globs inside the sandbox.
- Preserve existing final-output archive upload; selected files can be duplicated both inside `agent_output.tar.gz` and as direct sidecars.
- Missing or invalid declared sidecars now raise `OutputArtifactError`, not `SandboxError`, so deterministic contract/producer mismatches are not misclassified as sandbox infrastructure failures.

### Guardrails

- Destination `path` must be relative.
- Destination `path` must be under `full_result/`.
- Destination paths cannot contain `.`, `..`, or empty path parts.
- Explicit `source` must be an absolute sandbox path.
- Glob `source` values must include a non-root directory prefix, preventing root-wide `find / ...` scans.
- Max 10 declared artifacts per contract.
- Max 50 MiB per artifact.
- Max 50 MiB total sidecar bytes per task.
- Missing declared artifacts fail clearly with `OutputArtifactError` and mark the task `ERROR`.

### Docs/tests

- Update `docs/CONTRACTS.md` with string shorthand and explicit `source`/`path` examples.
- Add tests for explicit source/destination parsing, source validation, YAML pass-through, tracker upload behavior, and process-task handling of `OutputArtifactError`.

## Why

Shared benchmark aggregation needs cheap direct inputs for future Valkyrie runs without downloading or scanning every `agent_output.tar.gz`. The full archive remains available for debug/backcompat. Contracts declare exactly which existing or canonical files should be duplicated as direct S3 sidecars.

This also keeps storage ownership in tracker: benchmark services/agents declare artifacts, but do not upload arbitrary S3 keys themselves.

## Why the supporting files changed

| File | Reason |
|---|---|
| `services/tracker/src/tracker/database/models.py` | Tracker request schema and validation for string/object `output_artifacts`. |
| `services/tracker/src/tracker/sandbox.py` | Actual sandbox file resolution, size checks, and S3 upload. |
| `services/tracker/src/tracker/exceptions.py` | Adds `OutputArtifactError` so required sidecar failures are classified separately from sandbox infra failures. |
| `services/tracker/src/tracker/utils.py` | Catches `OutputArtifactError`, logs it clearly, and marks only the task as errored. |
| `src/valkyrie/schemas.py` | Public YAML contract schema must accept and validate the object form. |
| `src/valkyrie/cli/bundler.py` | Converts public contract artifacts into tracker request artifacts across the Pydantic model boundary. |
| `src/valkyrie/contract.py` | Gives Python contract authors typed artifact helpers via `valkyrie.contract`. |
| `docs/CONTRACTS.md` | Documents the new contract behavior and guardrails. |
| `tests/unit/test_agent_contract.py` / `services/tracker/tests/unit/test_sandbox.py` / `services/tracker/tests/unit/test_benchmark_service_disconnect.py` | Cover schema, validation, YAML pass-through, upload behavior, and task-level error classification. |

## How tested

- `PYTHONPATH=. uv run pytest tests/unit/test_agent_contract.py -q` → 30 passed
- `PYTHONPATH=.:services/tracker uv run pytest services/tracker/tests/unit/test_sandbox.py -q` → 54 passed, 1 unrelated pytest config warning
- `PYTHONPATH=.:services/tracker uv run pytest services/tracker/tests/unit/test_sandbox.py tests/unit/test_agent_contract.py -q` → 86 passed
- `PYTHONPATH=.:services/tracker uv run pytest services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_benchmark_service_disconnect.py tests/unit/test_agent_contract.py -q` → 92 passed
- `PYTHONPATH=.:services/tracker uv run ruff check services/tracker/src/tracker/exceptions.py services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_benchmark_service_disconnect.py` → passed
- `PYTHONPATH=.:services/tracker uv run basedpyright src/valkyrie/cli/bundler.py src/valkyrie/contract.py src/valkyrie/schemas.py` → 0 errors
- `PYTHONPATH=.:services/tracker uv run --project services/tracker basedpyright services/tracker/src/tracker/exceptions.py services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/database/models.py services/tracker/tests/unit/test_benchmark_service_disconnect.py` → 0 errors
- `git diff --check` → passed
