### PR TITLE
feat: allow retry to trigger export lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,9 @@ valkyrie run resume <id>
 # Retry errored tasks
 valkyrie run retry <id>
 
+# Attach or re-run the post-run Lambda, including after all tasks completed
+valkyrie run retry <id> --lambda my-post-benchmark-handler
+
 # Override concurrency on resume (works on retry)
 valkyrie run resume <id> --concurrency 20
 
@@ -308,6 +311,7 @@ valkyrie benchmark tasks swebench --dataset default --output tasks.txt
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
+| `--lambda` | Attach a post-run Lambda for resumed/retried finalization. If there are no runnable tasks, the Lambda is invoked immediately. |
 
 ### List runs
 

--- a/docs/LAMBDA_USAGE.md
+++ b/docs/LAMBDA_USAGE.md
@@ -11,6 +11,14 @@ valkyrie run start \
 
 The lambda is invoked once after all tasks finish and results are uploaded. If the lambda fails (uncaught exception or `statusCode >= 400`), the run will be marked as `ERROR`.
 
+If you forgot `--lambda` when starting the run, attach it with `run retry`:
+
+```bash
+valkyrie run retry <run_id> --lambda my-post-benchmark-handler
+```
+
+When the run has no errored or stopped tasks left to execute, retry does not enqueue task work and invokes the lambda immediately.
+
 ## Payload
 
 The tracker invokes your lambda with the full `BenchmarkArguments` plus the `benchmark_id`:

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -643,7 +643,11 @@ async def retry_or_resume_benchmark(
 
     if not verified_task_ids:
         if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
-            invoke_benchmark_lambda(benchmark_row, harness_config)
+            try:
+                invoke_benchmark_lambda(benchmark_row, harness_config)
+            except Exception as e:
+                logger.warning("Post-run Lambda invocation failed during retry/resume: %s", e)
+                raise HTTPException(status_code=502, detail=f"Post-run Lambda invocation failed: {e}") from e
         return RetryOrResumeBenchmarkResponse(
             status="success",
         )

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -74,6 +74,7 @@ from tracker.utils import (
     fetch_harness_config,
     force_stop_sandboxes,
     initiate_stop_benchmark,
+    invoke_benchmark_lambda,
     process_benchmark,
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
@@ -579,6 +580,7 @@ async def retry_or_resume_benchmark(
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
+    lambda_function: str | None = Body(default=None),
     session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
@@ -596,6 +598,7 @@ async def retry_or_resume_benchmark(
         concurrency: Optional new concurrency level (overrides original value)
         task_ids: Optional list of specific task IDs to run. If a task id is not yet
             registered but is valid in the current dataset, a fresh PENDING row is created.
+        lambda_function: Optional lambda function to attach before retry/resume finalization.
 
     Returns:
         RetryOrResumeBenchmarkResponse
@@ -616,6 +619,11 @@ async def retry_or_resume_benchmark(
     if concurrency is not None and concurrency < 1:
         raise HTTPException(status_code=400, detail="Concurrency must be greater than 0.")
 
+    if lambda_function:
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"lambda_function": lambda_function})
+        session.add(benchmark_row)
+        session.commit()
+
     effective_service_headers = forward_tracker_api_key(
         service_headers,
         http_request.headers.get("x-api-key"),
@@ -633,7 +641,9 @@ async def retry_or_resume_benchmark(
         org=org,
     )
 
-    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not verified_task_ids:
+    if not verified_task_ids:
+        if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+            invoke_benchmark_lambda(benchmark_row, harness_config)
         return RetryOrResumeBenchmarkResponse(
             status="success",
         )

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -113,6 +113,17 @@ def create_benchmark_service_client(
     return BenchmarkServiceClient(url=url, headers=headers)
 
 
+def invoke_benchmark_lambda(benchmark_row: Benchmark, harness_config: HarnessConfig) -> None:
+    arguments = benchmark_row.arguments
+    if not arguments.lambda_function:
+        return
+
+    lambda_payload: dict[str, Any] = arguments.model_dump()
+    lambda_payload["benchmark_id"] = str(benchmark_row.id)
+
+    invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
+
+
 def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest, run_starter: RequestIdentity) -> Benchmark:
     """Convert a StartBenchmarkRequest to a Benchmark database model."""
     return Benchmark(
@@ -939,15 +950,7 @@ async def process_benchmark(
 
             await upload_final_view(benchmark_row, final_view, harness_config)
 
-            # If the user has chosen to invoke a lambda function at the end of the benchmark
-            # We run it but do not let a failure affect the benchmark status
-            arguments = benchmark_row.arguments
-            if arguments.lambda_function:
-                # Expose the benchmark arguments and the benchmark id inside of the lambda
-                lambda_payload: dict[str, Any] = arguments.model_dump()
-                lambda_payload["benchmark_id"] = str(benchmark_id)
-
-                invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
+            invoke_benchmark_lambda(benchmark_row, harness_config)
 
     except BenchmarkServiceUnauthenticatedError as e:
         logfire.warn("process_benchmark failed due to benchmark service auth error")

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -736,6 +736,32 @@ class TestStopAndResume:
         assert payload["benchmark_id"] == str(benchmark_row.id)
         assert payload["lambda_function"] == "late-export-lambda"
 
+    async def test_retry_complete_run_reports_lambda_failure(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.FINISHED
+        benchmark_row.arguments.lambda_function = "missing-export-lambda"
+        database_session.add(benchmark_row)
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED)
+        )
+        database_session.commit()
+
+        def _mock_invoke_lambda(_client: Any, function_name: str, _payload: dict[str, Any]) -> dict[str, int]:
+            raise RuntimeError(f"{function_name} not found")
+
+        monkeypatch.setattr("tracker.utils.lambda_client", lambda _aws: object())
+        monkeypatch.setattr("tracker.utils.invoke_lambda", _mock_invoke_lambda)
+
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true")
+
+        assert response.status_code == 502
+        assert response.json() == {"detail": "Post-run Lambda invocation failed: missing-export-lambda not found"}
+
     async def test_running_retry_repairs_error_and_later_finalizes_same_run(
         self,
         contract: AgentContractRequest,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -659,6 +659,83 @@ class TestStopAndResume:
             "task_finished": TaskStatus.FINISHED,
         }
 
+    async def test_retry_complete_run_invokes_lambda_without_enqueuing_tasks(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.FINISHED
+        benchmark_row.arguments.lambda_function = "export-lambda"
+        database_session.add(benchmark_row)
+        database_session.add_all(
+            [
+                Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+                Task(org_id=TEST_ORG_ID, task_id="task_1", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+            ]
+        )
+        database_session.commit()
+
+        def _unexpected_kicker() -> None:
+            raise AssertionError("retrying a complete run should not enqueue task work")
+
+        lambda_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _mock_invoke_lambda(_client: Any, function_name: str, payload: dict[str, Any]) -> dict[str, int]:
+            lambda_calls.append((function_name, payload))
+            return {"statusCode": 200}
+
+        monkeypatch.setattr("main.process_benchmark.kicker", _unexpected_kicker)
+        monkeypatch.setattr("tracker.utils.lambda_client", lambda _aws: object())
+        monkeypatch.setattr("tracker.utils.invoke_lambda", _mock_invoke_lambda)
+
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+        assert len(lambda_calls) == 1
+        function_name, payload = lambda_calls[0]
+        assert function_name == "export-lambda"
+        assert payload["benchmark_id"] == str(benchmark_row.id)
+        assert payload["lambda_function"] == "export-lambda"
+
+    async def test_retry_can_attach_lambda_to_complete_run(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ):
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.FINISHED
+        database_session.add(benchmark_row)
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED)
+        )
+        database_session.commit()
+
+        lambda_calls: list[tuple[str, dict[str, Any]]] = []
+
+        def _mock_invoke_lambda(_client: Any, function_name: str, payload: dict[str, Any]) -> dict[str, int]:
+            lambda_calls.append((function_name, payload))
+            return {"statusCode": 200}
+
+        monkeypatch.setattr("tracker.utils.lambda_client", lambda _aws: object())
+        monkeypatch.setattr("tracker.utils.invoke_lambda", _mock_invoke_lambda)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true",
+            json={"task_ids": [], "lambda_function": "late-export-lambda"},
+        )
+
+        assert response.status_code == 200
+        assert benchmark_row.arguments.lambda_function == "late-export-lambda"
+        assert len(lambda_calls) == 1
+        function_name, payload = lambda_calls[0]
+        assert function_name == "late-export-lambda"
+        assert payload["benchmark_id"] == str(benchmark_row.id)
+        assert payload["lambda_function"] == "late-export-lambda"
+
     async def test_running_retry_repairs_error_and_later_finalizes_same_run(
         self,
         contract: AgentContractRequest,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -968,6 +968,14 @@ def analyze(run_id: UUID, no_cache: bool) -> None:
     default=False,
     help="Clear durable eval state and rerun generation.",
 )
+@click.option(
+    "--lambda",
+    "lambda_function",
+    type=str,
+    default=None,
+    required=False,
+    help="Lambda function to invoke after retry/resume finalization.",
+)
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -978,6 +986,7 @@ def resume(
     task_ids_file: str | None,
     update_agent: bool,
     from_scratch: bool,
+    lambda_function: str | None,
 ):
     """
     Resume a run by its run id.
@@ -1010,6 +1019,9 @@ def resume(
                 asyncio.run(update_benchmark_agent_version(agent_name, str(run_id)))
                 click.echo(click.style("\r\033[K✓ Agent updated", fg="green"))
 
+            if lambda_function:
+                click.echo(f"Attaching lambda for finalization: {lambda_function}")
+
             _ = tracker.retry_or_resume_benchmark(
                 run_id,
                 retry,
@@ -1017,6 +1029,7 @@ def resume(
                 concurrency,
                 retry_task_ids,
                 service_headers=service_headers,
+                lambda_function=lambda_function,
             )
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -519,6 +519,7 @@ class TrackerService:
         concurrency: int | None,
         task_ids: list[str],
         service_headers: dict[str, str] | None = None,
+        lambda_function: str | None = None,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -530,6 +531,7 @@ class TrackerService:
             task_ids: List of task ids to force retry. Task ids without an existing row
                 are created as fresh PENDING if valid in the current dataset.
             service_headers: Optional headers for benchmark service authentication
+            lambda_function: Optional lambda function to attach before retry/resume.
 
         Returns:
             RetryOrResumeBenchmarkResponse with status and message
@@ -542,6 +544,8 @@ class TrackerService:
                 params["concurrency"] = concurrency
 
             body: dict[str, Any] = {"task_ids": task_ids, "service_headers": service_headers or {}}
+            if lambda_function:
+                body["lambda_function"] = lambda_function
 
             response = self._client.post(
                 f"{self._base_url}/retry-or-resume-benchmark/{benchmark_id}",


### PR DESCRIPTION
## Summary
Adds support for attaching or re-running the post-run export Lambda through `valkyrie run retry`, covering the case where `--lambda` was forgotten when the run started. Also confirms that retrying a completed run with no runnable tasks invokes the Lambda without enqueueing task work.

## Changes
- Added `--lambda` to the shared `run resume` / `run retry` CLI path.
- Persist the supplied Lambda on retry/resume before finalization.
- Invoke the saved post-run Lambda immediately when retry/resume finds no runnable tasks and the run is already terminal.
- Return a clear 502 response if immediate Lambda invocation fails instead of surfacing an unhandled exception.
- Reused the post-run Lambda payload builder between normal completion and retry finalization.
- Updated Lambda docs and README retry examples.

## Related Issues
Closes #

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Commands run:
- `cd /home/ubuntu/repos/Valkyrie/services/tracker && uv run pytest tests/unit/test_stop_and_resume.py -q`
- `cd /home/ubuntu/repos/Valkyrie && make style`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/b0020fa676d74a109456f8f2f4bdcff5
Requested by: @oalmatov
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->