### PR TITLE
Track agent metrics output

### DIFF
--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -87,6 +87,7 @@ class AgentContractRequest(BaseModel):
     install_cmd: str
     run_cmd: str
     final_output: str | None = None
+    metrics_output: str | None = None
     secrets: dict[str, str] = {}
 
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,7 @@
 """Sandbox management utilities for the tracker service."""
 
 import base64
+import json
 import shlex
 import time
 import uuid
@@ -889,6 +890,20 @@ async def archive_and_upload_output(
             await _exec(sandbox, f"rm -f {shlex.quote(archive_path)}")
         except Exception:
             pass
+
+
+async def read_agent_metrics(sandbox: AsyncSandbox, metrics_output: str | None) -> dict[str, Any] | None:
+    if metrics_output is None:
+        return None
+
+    result = await _exec(sandbox, f"cat {shlex.quote(metrics_output)}")
+    if result.exit_code != _SUCCESS_EXIT_CODE:
+        return None
+
+    try:
+        return json.loads(result.result)
+    except json.JSONDecodeError:
+        return None
 
 
 async def run_agent(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -59,7 +59,7 @@ from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, retry_callback
-from tracker.sandbox import create_sandbox, delete_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import create_sandbox, delete_sandbox, read_agent_metrics, run_agent, upload_agent_artifacts
 from tracker.types import (
     AverageTaskBreakdown,
     AWSCredentials,
@@ -561,6 +561,7 @@ async def process_task(
                 )
 
                 task_breakdown.agent_run_duration = agent_run_time
+                agent_metrics = await read_agent_metrics(sandbox, start_benchmark_request.contract.metrics_output)
 
                 with Session(bind=engine) as task_session:
                     task_session.add(task_breakdown)
@@ -590,6 +591,8 @@ async def process_task(
                     on_eval_resume_state=on_eval_resume_state,
                     dataset=start_benchmark_request.dataset,
                 )
+                if agent_metrics is not None:
+                    evaluation_result["agent_metrics"] = agent_metrics
 
                 task_breakdown.evaluation_run_duration = time.perf_counter() - evaluation_start_time
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -225,6 +225,39 @@ class TestPtyHandshakeSemaphore:
 
 
 class TestAgentOutputTelemetry:
+    async def test_read_agent_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sandbox_module,
+            "_exec",
+            AsyncMock(return_value=ExecuteResponse(exit_code=0, result='{"cost": {"total": 1.25}}')),
+        )
+
+        result = await sandbox_module.read_agent_metrics(Mock(), "/logs/metrics.json")
+
+        assert result == {"cost": {"total": 1.25}}
+
+    async def test_read_agent_metrics_missing_file(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sandbox_module,
+            "_exec",
+            AsyncMock(return_value=ExecuteResponse(exit_code=1, result="")),
+        )
+
+        result = await sandbox_module.read_agent_metrics(Mock(), "/logs/metrics.json")
+
+        assert result is None
+
+    async def test_read_agent_metrics_malformed_json(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            sandbox_module,
+            "_exec",
+            AsyncMock(return_value=ExecuteResponse(exit_code=0, result="{")),
+        )
+
+        result = await sandbox_module.read_agent_metrics(Mock(), "/logs/metrics.json")
+
+        assert result is None
+
     async def test_run_agent_threads_benchmark_id_to_archive_and_upload(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/src/valkyrie/cli/bundler.py
+++ b/src/valkyrie/cli/bundler.py
@@ -160,6 +160,7 @@ def _parse_yaml_contract(contract_path: Path, agent_config: AgentConfig) -> Agen
             run_cmd=agent_contract.format_run_cmd(validated_kwargs),
             install_cmd=agent_contract.install_cmd,
             final_output=str(agent_contract.final_output) if agent_contract.final_output is not None else None,
+            metrics_output=str(agent_contract.metrics_output) if agent_contract.metrics_output is not None else None,
             secrets=agent_contract.secrets,
         )
     except ContractValidationError:

--- a/src/valkyrie/contract.py
+++ b/src/valkyrie/contract.py
@@ -96,6 +96,11 @@ class BaseAgentContract(ABC):
         """
         ...
 
+    @property
+    def metrics_output(self) -> Path | None:
+        """Path to a JSON metrics file produced by the agent."""
+        return None
+
     def to_request(self) -> AgentContractRequest:
         """
         Convert the contract to a request object for the tracker service.
@@ -113,5 +118,6 @@ class BaseAgentContract(ABC):
             ),
             install_cmd=self.install_cmd,
             final_output=str(self.final_output) if self.final_output else None,
+            metrics_output=str(self.metrics_output) if self.metrics_output else None,
             secrets=self.secrets,
         )

--- a/src/valkyrie/schemas.py
+++ b/src/valkyrie/schemas.py
@@ -122,6 +122,15 @@ class AgentContract(BaseModel):
     ```
     """
 
+    metrics_output: Path | None = None
+    """
+    Path from the root of the sandbox to a JSON metrics file produced by the agent.
+
+    ```yaml
+    metrics_output: /artifacts/metrics.json
+    ```
+    """
+
     secrets: dict[str, str] = {}
     """
     Secrets for the agent

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -319,12 +319,12 @@ class TestParseYamlContract:
         with pytest.raises(ValueError, match="is required but was not provided"):
             _parse_yaml_contract(path, AgentConfig())
 
-    def test_secrets_and_final_output_passed_through(self, tmp_path: Path) -> None:
+    def test_outputs_and_secrets_passed_through(self, tmp_path: Path) -> None:
         """
-        Validates that secrets and final_output from YAML are carried to the request.
+        Validates that output paths and secrets from YAML are carried to the request.
 
         Test Cases:
-        - YAML defines API_KEY secret and /artifacts final_output, both appear on the request
+        - YAML defines output paths and API_KEY secret, all appear on the request
         """
         path = self._write_yaml(
             tmp_path,
@@ -333,6 +333,7 @@ class TestParseYamlContract:
             install_cmd: bash setup.sh
             run_cmd: "agent --task {problem_statement_path}"
             final_output: /artifacts
+            metrics_output: /artifacts/metrics.json
             secrets:
               API_KEY: MySecretName
         """,
@@ -341,6 +342,7 @@ class TestParseYamlContract:
         result = _parse_yaml_contract(path, AgentConfig())
 
         assert result.final_output == "/artifacts"
+        assert result.metrics_output == "/artifacts/metrics.json"
         assert result.secrets == {"API_KEY": "MySecretName"}
 
     def test_model_from_agent_config(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- carry `metrics_output` through Python and YAML agent contracts
- read the metrics JSON after the agent run and attach it to evaluation results
- cover YAML parsing and tracker metrics reading in unit tests

## Tests
- `PYTHONPATH=.:services/tracker uv run pytest tests/unit/test_agent_contract.py services/tracker/tests/unit/test_sandbox.py -q`
- `uv run ruff check services/tracker/src/tracker/database/models.py services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py src/valkyrie/contract.py src/valkyrie/schemas.py src/valkyrie/cli/bundler.py tests/unit/test_agent_contract.py services/tracker/tests/unit/test_sandbox.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->