### PR TITLE
Migrate Daytona sandbox listing to cursor pagination

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "boto3-stubs[s3]",
     "moto[s3]",
     "fastapi[standard]>=0.135.3",
-    "daytona==0.176.1a1",
+    "daytona>=0.180.0",
     "sqlmodel>=0.0.38",
     "psycopg2-binary>=2.9.11",
     "httpx>=0.28.1",

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -95,7 +95,6 @@ _LIVE_DAYTONA_SANDBOX_STATES = [
     SandboxState.RESIZING,
     SandboxState.SNAPSHOTTING,
     SandboxState.FORKING,
-    SandboxState.UNKNOWN_DEFAULT_OPEN_API,
 ]
 
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1279,8 +1279,9 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,
 )
-async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona) -> list[AsyncSandbox]:
-    sandboxes: list[AsyncSandbox] = []
+async def fetch_sandboxes(
+    benchmark_row: Benchmark, daytona_client: AsyncDaytona
+) -> AsyncGenerator[AsyncSandbox, None]:
     async for sandbox in daytona_client.list(
         ListSandboxesQuery(
             labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)},
@@ -1288,19 +1289,7 @@ async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona
         )
     ):
         if sandbox.state not in _DELETED_DAYTONA_SANDBOX_STATES:
-            sandboxes.append(sandbox)
-
-    return sandboxes
-
-
-async def sandbox_generator(
-    benchmark_row: Benchmark, daytona_client: AsyncDaytona
-) -> AsyncGenerator[AsyncSandbox, None]:
-    """
-    Generator that yields all live sandboxes for a given benchmark.
-    """
-    for sandbox in await fetch_sandboxes(benchmark_row, daytona_client):
-        yield sandbox
+            yield sandbox
 
 
 async def force_stop_sandboxes(
@@ -1329,7 +1318,7 @@ async def force_stop_sandboxes(
 
         # Iterate through each running sandbox and stop it, collecting error messages
         results: dict[str, str | None] = {}
-        async for sandbox in sandbox_generator(benchmark_row, daytona_client):
+        async for sandbox in fetch_sandboxes(benchmark_row, daytona_client):
             result = await stop_sandbox(sandbox, daytona_client)
 
             results[sandbox.name] = result

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1279,9 +1279,7 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,
 )
-async def fetch_sandboxes(
-    benchmark_row: Benchmark, daytona_client: AsyncDaytona
-) -> AsyncGenerator[AsyncSandbox, None]:
+async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona) -> AsyncGenerator[AsyncSandbox, None]:
     async for sandbox in daytona_client.list(
         ListSandboxesQuery(
             labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)},

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
-from daytona import AsyncDaytona, AsyncPaginatedSandboxes, AsyncSandbox, SandboxState
+from daytona import AsyncDaytona, AsyncSandbox, ListSandboxesQuery, SandboxState
 from daytona.common.errors import DaytonaNotFoundError, DaytonaRateLimitError
 from fastapi import HTTPException, Request
 from opentelemetry import trace
@@ -77,6 +77,26 @@ logger = get_logger(__name__)
 _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
+_LIVE_DAYTONA_SANDBOX_STATES = [
+    SandboxState.CREATING,
+    SandboxState.RESTORING,
+    SandboxState.STARTED,
+    SandboxState.STOPPED,
+    SandboxState.STARTING,
+    SandboxState.STOPPING,
+    SandboxState.ERROR,
+    SandboxState.BUILD_FAILED,
+    SandboxState.PENDING_BUILD,
+    SandboxState.BUILDING_SNAPSHOT,
+    SandboxState.UNKNOWN,
+    SandboxState.PULLING_SNAPSHOT,
+    SandboxState.ARCHIVED,
+    SandboxState.ARCHIVING,
+    SandboxState.RESIZING,
+    SandboxState.SNAPSHOTTING,
+    SandboxState.FORKING,
+    SandboxState.UNKNOWN_DEFAULT_OPEN_API,
+]
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -1278,37 +1298,28 @@ async def stop_sandbox(sandbox: AsyncSandbox, daytona_client: AsyncDaytona) -> s
     before_sleep=daytona_retry_callback("valkyrie.sandbox.list", op="sandbox.list"),
     reraise=True,
 )
-async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona, page: int) -> AsyncPaginatedSandboxes:
-    return await daytona_client.list(
-        labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, limit=10, page=page
-    )
+async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona) -> list[AsyncSandbox]:
+    sandboxes: list[AsyncSandbox] = []
+    async for sandbox in daytona_client.list(
+        ListSandboxesQuery(
+            labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)},
+            limit=10,
+            states=_LIVE_DAYTONA_SANDBOX_STATES,
+        )
+    ):
+        sandboxes.append(sandbox)
+
+    return sandboxes
 
 
 async def sandbox_generator(
     benchmark_row: Benchmark, daytona_client: AsyncDaytona
 ) -> AsyncGenerator[AsyncSandbox, None]:
     """
-    Generator that yields all sandboxes for a given benchmark in paginated chunks of 10.
-
-    NOTE: At the time of this implementation there are several things weird with the dayyona api
-        1. If you delete the sandboxes in the list, the next page should be the first page (repopulated)
-        2. Final state is not DESTROYED, but rather DESTROYING
-        3. The total_pages count is not updated as you delete sandboxes
+    Generator that yields all live sandboxes for a given benchmark.
     """
-
-    paginated_sandboxes: AsyncPaginatedSandboxes = await fetch_sandboxes(benchmark_row, daytona_client, 1)
-
-    total_pages = paginated_sandboxes.total_pages
-    while (paginated_sandboxes.page <= total_pages) and paginated_sandboxes.items:
-        sandboxes = paginated_sandboxes.items
-        for sandbox in sandboxes:
-            if sandbox.state in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
-                continue
-
-            yield sandbox
-
-        # NOTE: Since we deleted the first 10 the first page will be populated with the next 10 sandboxes
-        paginated_sandboxes = await fetch_sandboxes(benchmark_row, daytona_client, int(paginated_sandboxes.page))
+    for sandbox in await fetch_sandboxes(benchmark_row, daytona_client):
+        yield sandbox
 
 
 async def force_stop_sandboxes(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -78,6 +78,7 @@ _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
 _DELETED_DAYTONA_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED)
+_DAYTONA_LIST_PAGE_SIZE = 100
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -1283,7 +1284,7 @@ async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona
     async for sandbox in daytona_client.list(
         ListSandboxesQuery(
             labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)},
-            limit=10,
+            limit=_DAYTONA_LIST_PAGE_SIZE,
         )
     ):
         if sandbox.state not in _DELETED_DAYTONA_SANDBOX_STATES:
@@ -1316,7 +1317,8 @@ async def force_stop_sandboxes(
 
         # Iterate through each running sandbox and stop it, collecting error messages
         results: dict[str, str | None] = {}
-        async for sandbox in fetch_sandboxes(benchmark_row, daytona_client):
+        sandboxes = [sandbox async for sandbox in fetch_sandboxes(benchmark_row, daytona_client)]
+        for sandbox in sandboxes:
             result = await stop_sandbox(sandbox, daytona_client)
 
             results[sandbox.name] = result

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -77,25 +77,7 @@ logger = get_logger(__name__)
 _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
-_LIVE_DAYTONA_SANDBOX_STATES = [
-    SandboxState.CREATING,
-    SandboxState.RESTORING,
-    SandboxState.STARTED,
-    SandboxState.STOPPED,
-    SandboxState.STARTING,
-    SandboxState.STOPPING,
-    SandboxState.ERROR,
-    SandboxState.BUILD_FAILED,
-    SandboxState.PENDING_BUILD,
-    SandboxState.BUILDING_SNAPSHOT,
-    SandboxState.UNKNOWN,
-    SandboxState.PULLING_SNAPSHOT,
-    SandboxState.ARCHIVED,
-    SandboxState.ARCHIVING,
-    SandboxState.RESIZING,
-    SandboxState.SNAPSHOTTING,
-    SandboxState.FORKING,
-]
+_DELETED_DAYTONA_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED)
 
 
 def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict[str, str]:
@@ -1303,10 +1285,10 @@ async def fetch_sandboxes(benchmark_row: Benchmark, daytona_client: AsyncDaytona
         ListSandboxesQuery(
             labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)},
             limit=10,
-            states=_LIVE_DAYTONA_SANDBOX_STATES,
         )
     ):
-        sandboxes.append(sandbox)
+        if sandbox.state not in _DELETED_DAYTONA_SANDBOX_STATES:
+            sandboxes.append(sandbox)
 
     return sandboxes
 

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -161,7 +161,7 @@ class TestForceStop:
         await created_sandboxes
 
         # Ensure that there are no more sandboxes left running
-        active = await fetch_sandboxes(example_benchmark_object, daytona_client)
+        active = [sandbox async for sandbox in fetch_sandboxes(example_benchmark_object, daytona_client)]
         assert len(active) == 0
 
         await daytona_client.close()
@@ -263,7 +263,7 @@ class TestForceStop:
         daytona_client = benchmark_service.daytona_client
 
         # Try to fetch the sandboxes and see if any of them are still running
-        active = await fetch_sandboxes(example_benchmark_object, daytona_client)
+        active = [sandbox async for sandbox in fetch_sandboxes(example_benchmark_object, daytona_client)]
         assert len(active) == 0
 
         await daytona_client.close()

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -3,7 +3,6 @@ import asyncio
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import Resources as TrackerResources
-from daytona import SandboxState
 from fastapi.testclient import TestClient
 from sqlmodel import Session, col, select
 
@@ -162,12 +161,7 @@ class TestForceStop:
         await created_sandboxes
 
         # Ensure that there are no more sandboxes left running
-        sandboxes = await fetch_sandboxes(example_benchmark_object, daytona_client, 1)
-        active = [
-            sandbox
-            for sandbox in sandboxes.items
-            if sandbox.state not in (SandboxState.DESTROYING, SandboxState.DESTROYED)
-        ]
+        active = await fetch_sandboxes(example_benchmark_object, daytona_client)
         assert len(active) == 0
 
         await daytona_client.close()
@@ -269,12 +263,7 @@ class TestForceStop:
         daytona_client = benchmark_service.daytona_client
 
         # Try to fetch the sandboxes and see if any of them are still running
-        sandboxes = await fetch_sandboxes(example_benchmark_object, daytona_client, 1)
-        active = [
-            sandbox
-            for sandbox in sandboxes.items
-            if sandbox.state not in (SandboxState.DESTROYING, SandboxState.DESTROYED)
-        ]
+        active = await fetch_sandboxes(example_benchmark_object, daytona_client)
         assert len(active) == 0
 
         await daytona_client.close()

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -462,7 +462,10 @@ class TestAgentOutputTelemetry:
         daytona_client.list.side_effect = DaytonaError("transient")
 
         with pytest.raises(DaytonaError):
-            await _fetch_sandboxes.retry_with(stop=stop_after_attempt(3), wait=wait_none())(benchmark, daytona_client)
+            async for _ in _fetch_sandboxes.retry_with(stop=stop_after_attempt(3), wait=wait_none())(
+                benchmark, daytona_client
+            ):
+                pass
 
         assert daytona_client.list.call_count == 1
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -458,15 +458,13 @@ class TestAgentOutputTelemetry:
         benchmark = Mock()
         benchmark.name = "benchmark"
         benchmark.id = "benchmark-id"
-        daytona_client = AsyncMock()
-        daytona_client.list = AsyncMock(side_effect=DaytonaError("transient"))
+        daytona_client = Mock()
+        daytona_client.list.side_effect = DaytonaError("transient")
 
         with pytest.raises(DaytonaError):
-            await _fetch_sandboxes.retry_with(stop=stop_after_attempt(3), wait=wait_none())(
-                benchmark, daytona_client, 1
-            )
+            await _fetch_sandboxes.retry_with(stop=stop_after_attempt(3), wait=wait_none())(benchmark, daytona_client)
 
-        assert daytona_client.list.await_count == 1
+        assert daytona_client.list.call_count == 1
 
     def test_daytona_retry_callback_emits_rate_limit_metrics(self, monkeypatch: pytest.MonkeyPatch) -> None:
         increments: list[tuple[str, dict[str, str]]] = []

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -41,6 +41,11 @@ from tracker.utils import (
 client = TestClient(app)
 
 
+async def _empty_async_iter():
+    if False:
+        yield None
+
+
 class TestStopAndResume:
     _test_org = Org(id=TEST_ORG_ID, name="default")
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
@@ -827,7 +832,7 @@ class TestStopAndResume:
 
         # Mock daytona client since its not required
         mock_daytona = AsyncMock()
-        mock_daytona.list = AsyncMock(return_value=AsyncMock(items=[], total_pages=0, page=1))
+        mock_daytona.list = Mock(return_value=_empty_async_iter())
         monkeypatch.setattr(
             Benchmark,
             "benchmark_service",

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.176.1a1"
+version = "0.182.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -408,14 +408,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/53/9d137853216e7bd15eea00e5742922c41f3ebe07ab3485d1fbcfed22c512/daytona-0.176.1a1.tar.gz", hash = "sha256:8f4c83c7f350937edb8426538c8dfd0d2a968546af492684a01ef46ac0d06960", size = 138578, upload-time = "2026-05-14T14:39:41.883Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/03/fd86e47c9b425020a27e69f51bca9137f1a671abeb56a3801cf94d7dd6d4/daytona-0.182.0.tar.gz", hash = "sha256:b666e9d98abc6774dea14a71b526c55a3d27595beb36fb03790fb61cf982de98", size = 141485, upload-time = "2026-05-26T14:06:47.425Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/94/61917c7852f0da926c916dabfb7b5badc8d795393a3bf5442e9bcd92caf1/daytona-0.176.1a1-py3-none-any.whl", hash = "sha256:2b2d2e9b6e550928c3202c15e0e9f8d639ebd0eded4a61f0cc337af72c7f85b4", size = 169581, upload-time = "2026-05-14T14:39:40.002Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b9/893daea1fb4f4e590bbe0ed2589a174118b929a29d202688b13f18278bd8/daytona-0.182.0-py3-none-any.whl", hash = "sha256:02d7fbb707c55ee26d25449e0a10205751546b7735da7aab807b6731ba20f98e", size = 172026, upload-time = "2026-05-26T14:06:45.646Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.176.1a1"
+version = "0.182.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -423,14 +423,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/61/db7f3f7dd03caf4d40ce4180fe44e1b94b97a9b07d4db5c7ccac5a039c0a/daytona_api_client-0.176.1a1.tar.gz", hash = "sha256:805cf1395c1e99e4a94a53a62fdd869986715d8d60365f579751740d3311ddb1", size = 148425, upload-time = "2026-05-14T14:38:44.752Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/27/e1be1cdf2d8229f531abb0bec27876016b8ce66811e18e895178fb9dfea1/daytona_api_client-0.182.0.tar.gz", hash = "sha256:e4c2636d2af3ae8529fd2ac2eb22d99ea8c233e6548b0c6a6c3b06c37ac0e82e", size = 145261, upload-time = "2026-05-26T14:06:04.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/bd/21da5fd6529d543fc9002150fcf80894a8e2eb9974192fd3c4d06cf2604d/daytona_api_client-0.176.1a1-py3-none-any.whl", hash = "sha256:3ad26b919d2c5b090bbc358b08fd19593a1c641edac253c7c56c18693f41f76c", size = 459976, upload-time = "2026-05-14T14:38:40.414Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/1d/2c061f18cacfd3e1006352f385c7670e4c9a51f2e57a0640e67b03892b06/daytona_api_client-0.182.0-py3-none-any.whl", hash = "sha256:adf25c92c8bdeef9060d5088d722164be62effdf37078be458e1e5144f214a84", size = 402306, upload-time = "2026-05-26T14:06:03.203Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.176.1a1"
+version = "0.182.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -439,14 +439,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/3d/d93acaf3548190199d87e91ad015edae945ae53a87822128082bf47dd267/daytona_api_client_async-0.176.1a1.tar.gz", hash = "sha256:f62bc09001948597422aa6f871db7023d2a4baf8725ab8f2163267833bd683c3", size = 148973, upload-time = "2026-05-14T14:38:42.575Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/f9/b8212e75866a5ee876d054eff3ed48af4da380895b3427eef1c3b6d02aad/daytona_api_client_async-0.182.0.tar.gz", hash = "sha256:65691777e095185c39eafbec259f2d9eaf9e4812396bcdbb95e20618f5ddb636", size = 145691, upload-time = "2026-05-26T14:06:12.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/ca/2c637924ad67cac15eee31d820d04610f117aa268057ccb4cc3b86343018/daytona_api_client_async-0.176.1a1-py3-none-any.whl", hash = "sha256:b3e96fc35cbc280cdb2e44d4acb6aa25007c2621cabfe3e9c95f038b75045b3a", size = 465879, upload-time = "2026-05-14T14:38:40.774Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ed/b40cc14e7d2d954d5510f27f8294777679c75c534ca5ecfbd780f22c37f7/daytona_api_client_async-0.182.0-py3-none-any.whl", hash = "sha256:b2489bd5ae41a1f40c2b760bbd7977099e89c4b87e3608ffa39b22bef077f46f", size = 405528, upload-time = "2026-05-26T14:06:10.342Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.176.1a1"
+version = "0.182.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -454,14 +454,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/a6/19ce458b619b1635659af4aa13a08fed1246c64b6bee6829e12bdae878c0/daytona_toolbox_api_client-0.176.1a1.tar.gz", hash = "sha256:247eb5dfed5ac338ac95c77ffcde0eccd0ce4bedf478a1a3c2c37aba5629b86b", size = 73860, upload-time = "2026-05-14T14:39:08.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/96/2d131392f77a8d19bae8506fae8b314b182b3a7a5876fcb9bccb17fe3113/daytona_toolbox_api_client-0.182.0.tar.gz", hash = "sha256:aca9d4f186e5bfb2896fadee424dee61aba36e07e8a24a014521c59fd14515e0", size = 77728, upload-time = "2026-05-26T14:05:45.864Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/e5/738a89090f02445c0314cda3c2878714a8187025d7e52232d40d180c0f28/daytona_toolbox_api_client-0.176.1a1-py3-none-any.whl", hash = "sha256:a444e1145e4c6144eb3b59a71e3878a0b2351ba2566276f8f3f0ce0e60833bda", size = 192855, upload-time = "2026-05-14T14:39:07.415Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/56/5bfea84cfe30aab99448cd1239cb5a7514f1a6ea4afb462e6d88486c856b/daytona_toolbox_api_client-0.182.0-py3-none-any.whl", hash = "sha256:b9ef51a58d042ce2099c2adb86936ae001c8caca38962a6a8076d92c9b9be00c", size = 205628, upload-time = "2026-05-26T14:05:44.413Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.176.1a1"
+version = "0.182.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -470,9 +470,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/20/7edcd949a1e1c3cb606fca253f1f0c8cbfb7e7b6add8673608c434a06cec/daytona_toolbox_api_client_async-0.176.1a1.tar.gz", hash = "sha256:498ced48b6987fcadd19500bae3f26b123378915164c4d61afa2b5d23b28093c", size = 67434, upload-time = "2026-05-14T14:38:41.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9b/71911ae1d4d14435e2486e25fa4777bd5385896afde69c1eabef1c694cda/daytona_toolbox_api_client_async-0.182.0.tar.gz", hash = "sha256:db59f98ea377c03c883f4c1b1afdf1a115a90583a4bc8651689bb713445fe9b2", size = 71331, upload-time = "2026-05-26T14:06:05.95Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/75/aefe52745478916b88cb0b54ffd95c82a398c609c80512da7d6492609186/daytona_toolbox_api_client_async-0.176.1a1-py3-none-any.whl", hash = "sha256:966662e6a1b02e52b5dc0ed7fa57a70f80bf734fc7597f91916002fc2162b6ab", size = 190994, upload-time = "2026-05-14T14:38:40.084Z" },
+    { url = "https://files.pythonhosted.org/packages/21/ea/45a5b41034131279f4c798ee5c8a016275c2cbe3d4cb1cfe583f7dbd82fc/daytona_toolbox_api_client_async-0.182.0-py3-none-any.whl", hash = "sha256:6adc4395fd6fbb75260616d5d5c20047ce715e8b6f7c7b6893b43afc3a0ac948", size = 203902, upload-time = "2026-05-26T14:06:03.47Z" },
 ]
 
 [[package]]
@@ -1882,7 +1882,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.2.0" },
-    { name = "daytona", specifier = "==0.176.1a1" },
+    { name = "daytona", specifier = ">=0.180.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
Migrates tracker sandbox listing to Daytona SDK cursor pagination before the deprecated offset `page` API stops working.

## Changes
- Update tracker Daytona dependency from `daytona==0.176.1a1` to `daytona>=0.180.0` and lock to 0.182.0.
- Replace paginated sandbox listing with `ListSandboxesQuery` plus async iteration.
- Make `fetch_sandboxes` async-yield matching sandboxes directly instead of building an intermediate list.
- Preserve previous filtering behavior by excluding only `DESTROYING` / `DESTROYED` states locally.
- Use a 100-sandbox page size so force-stop snapshots include the full active test run while still following cursor pagination.
- Update force-stop integration/unit test call sites and async-iterator mocks.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Commands run:
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff format src/tracker/utils.py tests/unit/test_sandbox.py tests/integration/test_force_stop.py`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff check src/tracker/utils.py tests/unit/test_sandbox.py tests/unit/test_stop_and_resume.py tests/integration/test_force_stop.py`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run pytest tests/unit/test_sandbox.py::TestAgentOutputTelemetry::test_fetch_sandboxes_does_not_retry_non_rate_limit_daytona_errors tests/unit/test_stop_and_resume.py::TestStopAndResume::test_force_stop_edge_case -q`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/dde85d8c386840aeb433d5707d1f8a96
Requested by: @Chen-Oliver