### PR TITLE
Have strict paths for valkyrie related logs

### DIFF
--- a/infra/constants.py
+++ b/infra/constants.py
@@ -17,6 +17,7 @@ ALLOWED_IPS: list[tuple[str, str]] = [
 NAMESPACE = "local"
 
 # Tracker Service
+TRACKER_LOG_GROUP_NAME = "/valkyrie/tracker"
 TRACKER_CPU = 1024
 TRACKER_MEMORY = 2048
 TRACKER_DOMAIN = "benchmark-tracker.vals.ai"
@@ -40,6 +41,7 @@ POSTGRES_PORT = 5432
 ELASTICACHE_NODE_TYPE = "cache.t4g.micro"
 
 # Worker Service
+WORKER_LOG_GROUP_NAME = "/valkyrie/worker"
 WORKER_CPU = 4096
 WORKER_MEMORY = 8192
 WORKER_MIN_TASKS = 2

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -34,6 +34,7 @@ from constants import (
     RDS_INSTANCE_CLASS,
     TRACKER_CPU,
     TRACKER_DOMAIN,
+    TRACKER_LOG_GROUP_NAME,
     TRACKER_MAX_TASKS,
     TRACKER_MEMORY,
     TRACKER_MIN_TASKS,
@@ -168,6 +169,7 @@ class TrackerStack(Stack):
                 log_group=aws_logs.LogGroup(
                     self,
                     "TrackerLogGroup",
+                    log_group_name=TRACKER_LOG_GROUP_NAME,
                     retention=aws_logs.RetentionDays.ONE_YEAR,
                     removal_policy=cdk.RemovalPolicy.DESTROY,
                 ),

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -23,6 +23,7 @@ from aws_cdk.aws_ecr_assets import Platform
 from constants import (
     POSTGRES_DB,
     WORKER_CPU,
+    WORKER_LOG_GROUP_NAME,
     WORKER_MAX_TASKS,
     WORKER_MEMORY,
     WORKER_MIN_TASKS,
@@ -117,6 +118,7 @@ class WorkerStack(Stack):
                 log_group=aws_logs.LogGroup(
                     self,
                     "WorkerLogGroup",
+                    log_group_name=WORKER_LOG_GROUP_NAME,
                     retention=aws_logs.RetentionDays.ONE_YEAR,
                     removal_policy=cdk.RemovalPolicy.DESTROY,
                 ),


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Logs are consolidated under a specific path now, before AWS created one by default which is non-deterministic. We need to have a path specified so third party tools can easily access them.

## Changes
<!-- List the key changes made -->
- Add worker log-group path
- Add tracker log-group path

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->