### PR TITLE
fix: wait for deleting Daytona sandboxes before recreate

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -29,10 +29,13 @@ from daytona.common.errors import DaytonaConflictError, DaytonaConnectionError, 
 from daytona.handle.async_pty_handle import AsyncPtyHandle
 from opentelemetry import trace
 from tenacity import (
+    AsyncRetrying,
+    RetryError,
     retry,
     retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
+    stop_after_delay,
     wait_exponential,
     wait_fixed,
 )
@@ -68,7 +71,6 @@ bundle_path = PurePosixPath("/bundle")
 SNAPSHOT_IMAGE_PREFIX = "snapshot:"
 _SANDBOX_AUTOSTOP_INTERVAL_MINUTES = 10 * 60
 _SANDBOX_DELETE_WAIT_TIMEOUT_SECONDS = 360.0
-_SANDBOX_DELETE_WAIT_INITIAL_INTERVAL_SECONDS = 1.0
 _SANDBOX_DELETE_WAIT_MAX_INTERVAL_SECONDS = 10.0
 _DELETED_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED)
 
@@ -89,7 +91,6 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     """Delete sandbox if it is not already destroyed or being destroyed"""
     try:
         await sandbox.refresh_data()
-
         if sandbox.state not in _DELETED_SANDBOX_STATES:
             # Set auto-stop interval in-case we fail to delete the sandbox
             await sandbox.set_autostop_interval(interval=1)
@@ -104,34 +105,49 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
 
 
+class SandboxStillExistsError(DaytonaError):
+    def __init__(self, sandbox: AsyncSandbox) -> None:
+        self.sandbox = sandbox
+        super().__init__(f"Sandbox `{sandbox.name}` still exists")
+
+
+async def _raise_if_sandbox_exists(daytona: AsyncDaytona, sandbox_name: str, start: float) -> None:
+    sandbox = await daytona.get(sandbox_name)
+    logger.info(
+        "sandbox.delete.wait",
+        extra={
+            "sandbox_id": sandbox.id,
+            "sandbox_name": sandbox.name,
+            "sandbox_state": str(sandbox.state),
+            "elapsed_seconds": time.monotonic() - start,
+        },
+    )
+    raise SandboxStillExistsError(sandbox)
+
+
+def _sandbox_delete_wait_retryer() -> AsyncRetrying:
+    return AsyncRetrying(
+        sleep=asyncio.sleep,
+        retry=retry_if_exception_type(SandboxStillExistsError),
+        stop=stop_after_delay(_SANDBOX_DELETE_WAIT_TIMEOUT_SECONDS),
+        wait=wait_exponential(multiplier=1, min=1, max=_SANDBOX_DELETE_WAIT_MAX_INTERVAL_SECONDS),
+        before_sleep=daytona_retry_callback("valkyrie.sandbox.delete_wait", op="sandbox.delete_wait"),
+    )
+
 async def _wait_for_sandbox_delete(daytona: AsyncDaytona, sandbox_name: str) -> None:
     start = time.monotonic()
-    interval = _SANDBOX_DELETE_WAIT_INITIAL_INTERVAL_SECONDS
+    try:
+        await _sandbox_delete_wait_retryer()(_raise_if_sandbox_exists, daytona, sandbox_name, start)
+    except DaytonaNotFoundError:
+        return
+    except RetryError as e:
+        last_exception = e.last_attempt.exception()
+        if not isinstance(last_exception, SandboxStillExistsError):
+            raise
 
-    while True:
-        try:
-            sandbox = await daytona.get(sandbox_name)
-        except DaytonaNotFoundError:
-            return
-
-        elapsed_seconds = time.monotonic() - start
-        if elapsed_seconds >= _SANDBOX_DELETE_WAIT_TIMEOUT_SECONDS:
-            raise DaytonaError(
-                f"Timed out waiting for sandbox `{sandbox_name}` to be deleted; current state: {sandbox.state}"
-            )
-
-        logger.info(
-            "sandbox.delete.wait",
-            extra={
-                "sandbox_id": sandbox.id,
-                "sandbox_name": sandbox.name,
-                "sandbox_state": str(sandbox.state),
-                "elapsed_seconds": elapsed_seconds,
-                "sleep_seconds": interval,
-            },
-        )
-        await asyncio.sleep(interval)
-        interval = min(interval * 2, _SANDBOX_DELETE_WAIT_MAX_INTERVAL_SECONDS)
+        raise DaytonaError(
+            f"Timed out waiting for sandbox `{sandbox_name}` to be deleted; current state: {last_exception.sandbox.state}"
+        ) from e
 
 
 def _metric_image_name(image: str) -> str:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -134,6 +134,7 @@ def _sandbox_delete_wait_retryer() -> AsyncRetrying:
         before_sleep=daytona_retry_callback("valkyrie.sandbox.delete_wait", op="sandbox.delete_wait"),
     )
 
+
 async def _wait_for_sandbox_delete(daytona: AsyncDaytona, sandbox_name: str) -> None:
     start = time.monotonic()
     try:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,5 +1,6 @@
 """Sandbox management utilities for the tracker service."""
 
+import asyncio
 import base64
 import shlex
 import time
@@ -24,7 +25,7 @@ from daytona import (
     Resources,
     SandboxState,
 )
-from daytona.common.errors import DaytonaConnectionError, DaytonaError
+from daytona.common.errors import DaytonaConflictError, DaytonaConnectionError, DaytonaError
 from daytona.handle.async_pty_handle import AsyncPtyHandle
 from opentelemetry import trace
 from tenacity import (
@@ -66,6 +67,10 @@ logger = get_logger(__name__)
 bundle_path = PurePosixPath("/bundle")
 SNAPSHOT_IMAGE_PREFIX = "snapshot:"
 _SANDBOX_AUTOSTOP_INTERVAL_MINUTES = 10 * 60
+_SANDBOX_DELETE_WAIT_TIMEOUT_SECONDS = 360.0
+_SANDBOX_DELETE_WAIT_INITIAL_INTERVAL_SECONDS = 1.0
+_SANDBOX_DELETE_WAIT_MAX_INTERVAL_SECONDS = 10.0
+_DELETED_SANDBOX_STATES = (SandboxState.DESTROYING, SandboxState.DESTROYED)
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
@@ -85,7 +90,7 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
     try:
         await sandbox.refresh_data()
 
-        if sandbox.state not in [SandboxState.DESTROYING, SandboxState.DESTROYED]:
+        if sandbox.state not in _DELETED_SANDBOX_STATES:
             # Set auto-stop interval in-case we fail to delete the sandbox
             await sandbox.set_autostop_interval(interval=1)
             await daytona.delete(sandbox)
@@ -97,6 +102,36 @@ async def delete_sandbox(sandbox: AsyncSandbox, daytona: AsyncDaytona) -> None:
         raise
     except Exception as e:
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
+
+
+async def _wait_for_sandbox_delete(daytona: AsyncDaytona, sandbox_name: str) -> None:
+    start = time.monotonic()
+    interval = _SANDBOX_DELETE_WAIT_INITIAL_INTERVAL_SECONDS
+
+    while True:
+        try:
+            sandbox = await daytona.get(sandbox_name)
+        except DaytonaNotFoundError:
+            return
+
+        elapsed_seconds = time.monotonic() - start
+        if elapsed_seconds >= _SANDBOX_DELETE_WAIT_TIMEOUT_SECONDS:
+            raise DaytonaError(
+                f"Timed out waiting for sandbox `{sandbox_name}` to be deleted; current state: {sandbox.state}"
+            )
+
+        logger.info(
+            "sandbox.delete.wait",
+            extra={
+                "sandbox_id": sandbox.id,
+                "sandbox_name": sandbox.name,
+                "sandbox_state": str(sandbox.state),
+                "elapsed_seconds": elapsed_seconds,
+                "sleep_seconds": interval,
+            },
+        )
+        await asyncio.sleep(interval)
+        interval = min(interval * 2, _SANDBOX_DELETE_WAIT_MAX_INTERVAL_SECONDS)
 
 
 def _metric_image_name(image: str) -> str:
@@ -161,17 +196,33 @@ async def _create_sandbox(
     # If the container already exists and is healthy we reuse it
     try:
         sandbox = await daytona.get(sandbox_name)
-
-        # Restart the sandbox creation process if it cannot be recovered
-        if sandbox.state not in (SandboxState.DESTROYING, SandboxState.DESTROYED, SandboxState.STOPPED):
-            await sandbox.wait_for_sandbox_start(timeout=0)
-            return sandbox
     except DaytonaNotFoundError:
         pass
     except DaytonaError as e:
         # Transient error (server disconnected, network blip, etc.) — fall through to create.
         logger.warning("Failed to get sandbox %s, will create instead: %s", sandbox_name, e)
+    else:
+        if sandbox.state in _DELETED_SANDBOX_STATES:
+            await _wait_for_sandbox_delete(daytona, sandbox_name)
+        elif sandbox.state != SandboxState.STOPPED:
+            await sandbox.wait_for_sandbox_start(timeout=0)
+            return sandbox
 
+    try:
+        return await _create_new_sandbox(daytona, sandbox_name, image, resources, labels, env_vars)
+    except DaytonaConflictError:
+        await _wait_for_sandbox_delete(daytona, sandbox_name)
+        raise
+
+
+async def _create_new_sandbox(
+    daytona: AsyncDaytona,
+    sandbox_name: str,
+    image: str,
+    resources: TrackerResources,
+    labels: dict[str, str] | None = None,
+    env_vars: dict[str, str] | None = None,
+) -> AsyncSandbox:
     if image.startswith(SNAPSHOT_IMAGE_PREFIX):
         snapshot_name = image[len(SNAPSHOT_IMAGE_PREFIX) :].strip()
         if not snapshot_name:

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -886,18 +886,16 @@ class TestAgentOutputTelemetry:
 
     async def test_wait_for_sandbox_delete_times_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
         existing_sandbox = SimpleNamespace(id="old-sandbox-id", name="task-alias", state=SandboxState.DESTROYING)
-        monotonic_values: deque[float] = deque([0.0, 361.0])
-
-        def fake_monotonic() -> float:
-            if monotonic_values:
-                return monotonic_values.popleft()
-            return 361.0
-
-        monkeypatch.setattr(sandbox_module.time, "monotonic", fake_monotonic)
 
         daytona = AsyncMock()
         daytona.get = AsyncMock(return_value=existing_sandbox)
 
+        original_retryer = sandbox_module._sandbox_delete_wait_retryer  # pyright: ignore[reportPrivateUsage]
+        monkeypatch.setattr(
+            sandbox_module,
+            "_sandbox_delete_wait_retryer",
+            lambda: original_retryer().copy(stop=stop_after_attempt(1), wait=wait_none()),
+        )
         with pytest.raises(DaytonaError, match="Timed out waiting for sandbox `task-alias` to be deleted"):
             await _wait_for_sandbox_delete(daytona, "task-alias")
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -7,7 +7,13 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from daytona import ExecuteResponse, SandboxState
-from daytona.common.errors import DaytonaConnectionError, DaytonaError, DaytonaNotFoundError, DaytonaRateLimitError
+from daytona.common.errors import (
+    DaytonaConflictError,
+    DaytonaConnectionError,
+    DaytonaError,
+    DaytonaNotFoundError,
+    DaytonaRateLimitError,
+)
 from tenacity import stop_after_attempt, wait_none
 
 import tracker.daytona_retry as daytona_retry_module
@@ -20,6 +26,7 @@ from tracker.sandbox import create_sandbox, run_agent, stream_command_output, up
 from tracker.types import AWSCredentials
 
 _create_sandbox = getattr(sandbox_module, "_create_sandbox")
+_wait_for_sandbox_delete = sandbox_module._wait_for_sandbox_delete  # pyright: ignore[reportPrivateUsage]
 _create_pty_session = getattr(sandbox_module, "_create_pty_session")
 _check_sandbox_health = getattr(sandbox_module, "_check_sandbox_health")
 _delete_sandbox = getattr(sandbox_module, "delete_sandbox")
@@ -796,6 +803,103 @@ class TestAgentOutputTelemetry:
 
         assert sandbox is mock_sandbox
         assert span_calls == [("task-alias", "ghcr.io/vals/swebench:latest", 2)]
+
+    async def test_create_sandbox_waits_for_deleting_sandbox_before_create(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        existing_sandbox = SimpleNamespace(id="old-sandbox-id", name="task-alias", state=SandboxState.DESTROYING)
+        created_sandbox = SimpleNamespace(id="new-sandbox-id", name="task-alias", state=SandboxState.STARTED)
+        events: list[str] = []
+
+        async def fake_wait_for_sandbox_delete(daytona: AsyncMock, sandbox_name: str) -> None:
+            assert sandbox_name == "task-alias"
+            events.append("wait")
+
+        async def fake_create_new_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            events.append("create")
+            return created_sandbox
+
+        monkeypatch.setattr(sandbox_module, "_wait_for_sandbox_delete", fake_wait_for_sandbox_delete)
+        monkeypatch.setattr(sandbox_module, "_create_new_sandbox", fake_create_new_sandbox)
+
+        daytona = AsyncMock()
+        daytona.get = AsyncMock(return_value=existing_sandbox)
+
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        sandbox = await _create_sandbox.retry_with(stop=stop_after_attempt(1), wait=wait_none())(
+            daytona,
+            "task-alias",
+            "ghcr.io/vals/swebench:latest",
+            resources,
+        )
+
+        assert sandbox is created_sandbox
+        assert events == ["wait", "create"]
+
+    async def test_create_sandbox_waits_after_conflict_before_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        created_sandbox = SimpleNamespace(id="new-sandbox-id", name="task-alias", state=SandboxState.STARTED)
+        events: list[str] = []
+
+        async def fake_wait_for_sandbox_delete(daytona: AsyncMock, sandbox_name: str) -> None:
+            assert sandbox_name == "task-alias"
+            events.append("wait")
+
+        async def fake_create_new_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            events.append("create")
+            if events.count("create") == 1:
+                raise DaytonaConflictError("Sandbox with name task-alias already exists")
+            return created_sandbox
+
+        monkeypatch.setattr(sandbox_module, "_wait_for_sandbox_delete", fake_wait_for_sandbox_delete)
+        monkeypatch.setattr(sandbox_module, "_create_new_sandbox", fake_create_new_sandbox)
+
+        daytona = AsyncMock()
+        daytona.get = AsyncMock(side_effect=DaytonaNotFoundError("missing"))
+
+        resources = sandbox_module.TrackerResources(vcpu=2, memory=4, disk=5)
+        sandbox = await _create_sandbox.retry_with(stop=stop_after_attempt(2), wait=wait_none())(
+            daytona,
+            "task-alias",
+            "ghcr.io/vals/swebench:latest",
+            resources,
+        )
+
+        assert sandbox is created_sandbox
+        assert events == ["create", "wait", "create"]
+
+    async def test_wait_for_sandbox_delete_polls_until_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        existing_sandbox = SimpleNamespace(id="old-sandbox-id", name="task-alias", state=SandboxState.DESTROYING)
+        sleep_calls: list[float] = []
+
+        async def fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr(sandbox_module.asyncio, "sleep", fake_sleep)
+
+        daytona = AsyncMock()
+        daytona.get = AsyncMock(side_effect=[existing_sandbox, DaytonaNotFoundError("missing")])
+
+        await _wait_for_sandbox_delete(daytona, "task-alias")
+
+        assert daytona.get.await_count == 2
+        assert sleep_calls == [1.0]
+
+    async def test_wait_for_sandbox_delete_times_out(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        existing_sandbox = SimpleNamespace(id="old-sandbox-id", name="task-alias", state=SandboxState.DESTROYING)
+        monotonic_values: deque[float] = deque([0.0, 361.0])
+
+        def fake_monotonic() -> float:
+            if monotonic_values:
+                return monotonic_values.popleft()
+            return 361.0
+
+        monkeypatch.setattr(sandbox_module.time, "monotonic", fake_monotonic)
+
+        daytona = AsyncMock()
+        daytona.get = AsyncMock(return_value=existing_sandbox)
+
+        with pytest.raises(DaytonaError, match="Timed out waiting for sandbox `task-alias` to be deleted"):
+            await _wait_for_sandbox_delete(daytona, "task-alias")
 
     async def test_delete_sandbox_tags_daytona_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
         daytona_error = DaytonaError("delete failed")


### PR DESCRIPTION
## Summary
Fixes the Daytona sandbox name collision retry path by waiting for an existing same-name sandbox to fully disappear before attempting to create a replacement. This replaces closed PR #428 and incorporates review feedback to use a Tenacity retryer for the delete wait.

## Changes
- Added `_wait_for_sandbox_delete` using a Tenacity `AsyncRetrying` retryer for `daytona.get(...)` to return not found before recreating a sandbox.
- Updated `_create_sandbox` to wait when the existing sandbox is `DESTROYING`/`DESTROYED`, and to wait after `DaytonaConflictError` before tenacity retries the create.
- Added unit coverage for deleting-state waits, conflict retry waits, delete polling, and timeout behavior.

## Related Issues
- Addresses Sentry `VALKYRIE-5K` / `DaytonaConflictError` sandbox name collisions.
- Replaces #428.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Ran:
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run pytest tests/unit/test_sandbox.py::TestAgentOutputTelemetry::test_wait_for_sandbox_delete_polls_until_not_found tests/unit/test_sandbox.py::TestAgentOutputTelemetry::test_wait_for_sandbox_delete_times_out -q`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run pytest tests/unit/test_sandbox.py -q`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff check src/tracker/sandbox.py tests/unit/test_sandbox.py`
- `make -C /home/ubuntu/repos/Valkyrie lint`
- `make -C /home/ubuntu/repos/Valkyrie typecheck`
- `make -C /home/ubuntu/repos/Valkyrie/services/tracker test-unit`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/ed1928f1f0c84f25b4db5e1713d67626
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->