### PR TITLE
Update CBS lock and provider lifecycle handling

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,5 +1,6 @@
 """Sandbox management utilities for the tracker service."""
 
+import asyncio
 import base64
 import shlex
 import time
@@ -7,7 +8,7 @@ import uuid
 from asyncio import Semaphore
 from collections import deque
 from collections.abc import Callable
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
 
@@ -182,7 +183,16 @@ async def create_sandbox(
     try:
         async with creation_semaphore:
             start = time.monotonic()
-            sandbox = await _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars)
+            create_task = asyncio.create_task(
+                _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars)
+            )
+            try:
+                sandbox = await asyncio.shield(create_task)
+            except asyncio.CancelledError:
+                with suppress(Exception):
+                    sandbox = await create_task
+                    await delete_sandbox(sandbox, provider)
+                raise
     except Exception as e:
         incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
         raise
@@ -352,6 +362,8 @@ async def stream_command_output(
                 output.append(data)
         except ProviderSandboxCommandError as e:
             exit_code = e.exit_code
+        except ProviderSandboxError as e:
+            raise SandboxError(str(e)) from e
 
         start_ns = (await _exec(sandbox, f"cat {shlex.quote(start_ns_path)}")).stdout
         end_ns = (await _exec(sandbox, f"cat {shlex.quote(end_ns_path)}")).stdout

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -75,6 +75,9 @@ logger = get_logger(__name__)
 
 _SANDBOX_CREATION_CAP: int = 10
 _PTY_TASK_RETRY_LIMIT: int = 1
+_SANDBOX_LIST_PAGE_SIZE: int = 100
+_SANDBOX_FORCE_STOP_MAX_PASSES: int = 5
+_SANDBOX_FORCE_STOP_SETTLE_SECONDS: float = 1.0
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
 
 
@@ -1286,7 +1289,9 @@ async def sandbox_generator(benchmark_row: Benchmark, provider: SandboxProvider)
     """
     Generator that yields all sandboxes for a given benchmark.
     """
-    query = SandboxQuery(labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)})
+    query = SandboxQuery(
+        labels={"Benchmark": benchmark_row.name, "Id": str(benchmark_row.id)}, page_size=_SANDBOX_LIST_PAGE_SIZE
+    )
     async for sandbox in provider.list_sandboxes(query):
         yield sandbox
 
@@ -1315,12 +1320,21 @@ async def force_stop_sandboxes(
 
     session.commit()
 
-    # Iterate through each running sandbox and stop it, collecting error messages
+    # Daytona list/delete is eventually consistent; keep the cleanup open briefly
+    # so in-flight creates and deletes settle before the caller continues.
     results: dict[str, str | None] = {}
     try:
-        async for sandbox in sandbox_generator(benchmark_row, provider):
-            result = await stop_sandbox(sandbox, provider)
-            results[sandbox.name] = result
+        for _ in range(_SANDBOX_FORCE_STOP_MAX_PASSES):
+            found_sandbox = False
+            async for sandbox in sandbox_generator(benchmark_row, provider):
+                found_sandbox = True
+                result = await stop_sandbox(sandbox, provider)
+                results[sandbox.name] = result
+
+            if not found_sandbox:
+                break
+
+            await asyncio.sleep(_SANDBOX_FORCE_STOP_SETTLE_SECONDS)
     finally:
         await benchmark_service.close()
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -458,6 +458,45 @@ class TestAgentOutputTelemetry:
         ]
         assert context_calls == [("sandbox-123", "ghcr.io/vals/swebench:latest")]
 
+    async def test_create_sandbox_deletes_if_cancelled_during_create(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        create_started = asyncio.Event()
+        create_finished = asyncio.Event()
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        async def fake_create_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            create_started.set()
+            await create_finished.wait()
+            return mock_sandbox
+
+        provider = AsyncMock()
+        delete_mock = AsyncMock()
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", fake_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", delete_mock)
+
+        async def use_sandbox() -> None:
+            async with create_sandbox(
+                provider=provider,
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                raise AssertionError("cancelled create should not yield")
+
+        task = asyncio.create_task(use_sandbox())
+        await create_started.wait()
+
+        task.cancel()
+        await asyncio.sleep(0)
+        create_finished.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        delete_mock.assert_awaited_once_with(mock_sandbox, provider)
+
     async def test_create_sandbox_emits_error_metric(self, monkeypatch: pytest.MonkeyPatch) -> None:
         create_error = RuntimeError("create failed")
         increments: list[tuple[str, dict[str, str]]] = []
@@ -567,6 +606,23 @@ class TestStreamCommandOutputAgentFailure:
         assert exec_commands[-1].startswith("rm -f ")
         assert ".start_ns" in exec_commands[-1]
         assert ".end_ns" in exec_commands[-1]
+
+    async def test_provider_sandbox_error_is_translated(self) -> None:
+        async def stream_command(_command: str) -> Any:
+            raise ProviderSandboxError("sandbox crashed during command execution")
+            yield
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "test-sandbox"
+        mock_sandbox.state = "destroying"
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = AsyncMock(return_value=ExecResult(exit_code=0))
+
+        with pytest.raises(SandboxError, match="sandbox crashed during command execution") as exc_info:
+            await sandbox_module.stream_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)
+
+        assert isinstance(exc_info.value.__cause__, ProviderSandboxError)
 
     @pytest.mark.parametrize("exit_code", [1, 2, 127])
     async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -830,12 +830,14 @@ class TestStopAndResume:
         database_session.commit()
 
         monkeypatch.setattr("tracker.utils.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils._SANDBOX_FORCE_STOP_SETTLE_SECONDS", 0)
 
         # Set benchmark status to STOPPING
         await initiate_stop_benchmark(benchmark_row, database_session, force=True, org=self._test_org)
         assert benchmark_row.status == BenchmarkStatus.STOPPING
 
-        async def _empty_list_sandboxes(*_args: Any, **_kwargs: Any):
+        async def _empty_list_sandboxes(query: Any):
+            assert query.page_size == 100
             if False:
                 yield None
 

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -328,8 +328,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.5.1.dev17+ge05f2d52f"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e05f2d52f8712e3005e8aea66a9b2e5fceb05f8d#e05f2d52f8712e3005e8aea66a9b2e5fceb05f8d" }
+version = "0.7.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#c82ef50d755e999a8894ebf93615d46efa6849cf" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -339,6 +339,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "pyyaml" },
+    { name = "starlette" },
     { name = "tenacity" },
     { name = "websockets" },
 ]
@@ -1880,7 +1881,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e05f2d52f8712e3005e8aea66a9b2e5fceb05f8d" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main" },
     { name = "daytona", specifier = ">=0.180.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.7.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#2648febcef8109bf4dd7968abb1870a52fd93cfd" }
+version = "0.7.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=main#c82ef50d755e999a8894ebf93615d46efa6849cf" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },


### PR DESCRIPTION
## Summary
- Update root and tracker uv.lock to create-benchmark-service 0.7.1 at merged CBS main commit c82ef50.
- Pulls in vals-ai/create-benchmark-service#58, which restores Daytona delete lifecycle conflict retry/normalization in the provider.
- Translate provider sandbox errors from sandbox.command back into tracker SandboxError so crash/lifecycle handling remains provider-generic.
- Use a 100 item sandbox list page size for force-stop, matching the old Daytona force-stop behavior.
- Keep force-stop cleanup open for a few short passes so Daytona list/delete and in-flight sandbox creates settle before the caller continues.
- Clean up sandbox creates that finish after task cancellation by waiting for the provider create call to resolve, deleting that sandbox, and then preserving cancellation.

## Validation
- uv run pytest services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_stop_and_resume.py -q, 39 passed.
- uv run ruff check services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_stop_and_resume.py.
- uv run ruff format --check services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_stop_and_resume.py.
- Cross-package regression through tracker.utils.stop_sandbox with locked CBS main passed: delete conflict is retried and stop_sandbox returns None.
- Tried removing the short force-stop settle loop entirely; live tracker integration failed in test_force_stop_sandboxes because callers continued while sandbox contexts were still observing deleted containers. Kept the loop but simplified it to stop on the first empty list pass.
- GitHub tracker integration workflow manually rerun on attempt 2 after the expected PR guard: passed, 27 integration tests in 3m1s.
- All PR checks are green on head c8c4a04.
