### PR TITLE
Support bundled Python contract helper imports

### DIFF
--- a/src/valkyrie/cli/bundler.py
+++ b/src/valkyrie/cli/bundler.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import os
 import shutil
+import sys
 import tempfile
 import zipfile
 from contextlib import contextmanager
@@ -106,7 +107,10 @@ def get_contract_from_zip_bytes(agent_name: str, zip_bytes: bytes, agent_config:
                 for ext in (".yaml", ".yml", ".py"):
                     contract_member = f"{agent_name}/contract{ext}"
                     if contract_member in names:
-                        zf.extract(contract_member, tmp_path)
+                        if ext == ".py":
+                            zf.extractall(tmp_path)
+                        else:
+                            zf.extract(contract_member, tmp_path)
                         return get_contract(tmp_path / contract_member, agent_config)
 
             raise BundlerError(f"No contract file found in zip for agent '{agent_name}'")
@@ -124,7 +128,12 @@ def _parse_python_contract(contract_path: Path, agent_config: AgentConfig) -> Ag
 
     module = importlib.util.module_from_spec(spec)
 
-    spec.loader.exec_module(module)
+    contract_dir = str(contract_path.parent)
+    sys.path.insert(0, contract_dir)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path.remove(contract_dir)
 
     Contract: type[BaseAgentContract] = module.contract
 

--- a/src/valkyrie/cli/s3_client.py
+++ b/src/valkyrie/cli/s3_client.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib.util
 import io
 import re
+import sys
 import tempfile
 import zipfile
 from datetime import datetime, timezone
@@ -415,7 +416,12 @@ async def get_ingest_lambda_from_s3(agent_name: str) -> str | None:
                 if not spec or not spec.loader:
                     return None
                 module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
+                contract_dir = str(contract_path.parent)
+                sys.path.insert(0, contract_dir)
+                try:
+                    spec.loader.exec_module(module)
+                finally:
+                    sys.path.remove(contract_dir)
                 contract_cls = module.contract
                 return contract_cls(AgentConfig()).ingest_lambda
 

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -1,3 +1,5 @@
+import io
+import zipfile
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, cast
@@ -6,7 +8,7 @@ import pytest
 from pydantic import ValidationError
 from tracker.database.models import AgentContractRequest, OutputArtifact
 
-from valkyrie.cli.bundler import _parse_yaml_contract  # type: ignore
+from valkyrie.cli.bundler import _parse_yaml_contract, get_contract, get_contract_from_zip_bytes  # type: ignore
 from valkyrie.schemas import AgentConfig, AgentContract, Parameter
 
 
@@ -17,6 +19,92 @@ def _make_contract(**overrides: Any) -> AgentContract:
         "run_cmd": "agent --task {problem_statement_path}",
     }
     return AgentContract(**{**defaults, **overrides})
+
+
+def test_python_contract_can_import_bundled_helper(tmp_path: Path) -> None:
+    contract_path = tmp_path / "contract.py"
+    contract_path.write_text(
+        dedent(
+            """
+            from pathlib import Path
+            from valkyrie.contract import BaseAgentContract
+            from helper import SHARED_SECRETS
+
+
+            class TestContract(BaseAgentContract):
+                @property
+                def name(self) -> str:
+                    return "test_agent"
+
+                @property
+                def install_cmd(self) -> str:
+                    return "true"
+
+                @property
+                def secrets(self) -> dict[str, str]:
+                    return SHARED_SECRETS
+
+                @property
+                def final_output(self) -> Path | None:
+                    return None
+
+                def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, object]) -> str:
+                    return f"agent {problem_statement_path}"
+
+
+            contract = TestContract
+            """
+        )
+    )
+    (tmp_path / "helper.py").write_text('SHARED_SECRETS = {"OPENAI_API_KEY": "SharedSecret"}')
+
+    contract = get_contract(contract_path, AgentConfig())
+
+    assert contract.secrets == {"OPENAI_API_KEY": "SharedSecret"}
+
+
+def test_python_contract_from_zip_can_import_bundled_helper() -> None:
+    zip_stream = io.BytesIO()
+    with zipfile.ZipFile(zip_stream, "w") as zf:
+        zf.writestr(
+            "agent/contract.py",
+            dedent(
+                """
+                from pathlib import Path
+                from valkyrie.contract import BaseAgentContract
+                from helper import SHARED_SECRETS
+
+
+                class TestContract(BaseAgentContract):
+                    @property
+                    def name(self) -> str:
+                        return "test_agent"
+
+                    @property
+                    def install_cmd(self) -> str:
+                        return "true"
+
+                    @property
+                    def secrets(self) -> dict[str, str]:
+                        return SHARED_SECRETS
+
+                    @property
+                    def final_output(self) -> Path | None:
+                        return None
+
+                    def run_cmd(self, problem_statement_path: str, task_id: str, kwargs: dict[str, object]) -> str:
+                        return f"agent {problem_statement_path}"
+
+
+                contract = TestContract
+                """
+            ),
+        )
+        zf.writestr("agent/helper.py", 'SHARED_SECRETS = {"OPENAI_API_KEY": "SharedSecret"}')
+
+    contract = get_contract_from_zip_bytes("agent", zip_stream.getvalue(), AgentConfig())
+
+    assert contract.secrets == {"OPENAI_API_KEY": "SharedSecret"}
 
 
 class TestValidateKwargs:


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Python agent contracts loaded via `importlib.util.spec_from_file_location` could not import helper modules bundled beside `contract.py` (for example `from model_secrets import ...`). This adds the contract directory to `sys.path` while loading Python contracts and extracts the full zip for Python contract reads so adjacent helpers are available from S3-loaded bundles too.

## Changes
<!-- List the key changes made -->
- Load Python contracts with their parent directory temporarily on `sys.path`.
- Extract the full agent zip when reading Python contracts via `get_contract_from_zip_bytes`.
- Apply the same helper-import support to `get_ingest_lambda_from_s3`.
- Add unit coverage for local and zipped Python contracts importing adjacent helpers.

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [x] Added/updated unit tests
- [x] Manually tested

`make -C /home/ubuntu/repos/Valkyrie format-check`
`make -C /home/ubuntu/repos/Valkyrie lint`
`make -C /home/ubuntu/repos/Valkyrie typecheck`
`make -C /home/ubuntu/repos/Valkyrie unit-test`
`uv run --project /home/ubuntu/repos/Valkyrie/services/tracker ruff check /home/ubuntu/repos/Valkyrie/services/tracker/src /home/ubuntu/repos/Valkyrie/services/tracker/tests`
`uv run --project /home/ubuntu/repos/Valkyrie/services/tracker basedpyright -p /home/ubuntu/repos/Valkyrie/services/tracker/pyproject.toml`
`make -C /home/ubuntu/repos/Valkyrie/services/tracker test-unit`

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/fe5e8d0447a047a5a4a6778e04989918
Requested by: @BradenBug