### PR TITLE
feat: wire up SNS alerts to slack

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,8 @@ jobs:
       - name: Deploy all stacks
         env:
           SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
-          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+          VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
+          DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID: ${{ secrets.DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID }}
           AUTH_REQUIRED: ${{ secrets.AUTH_REQUIRED }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
         run: |

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -1,5 +1,7 @@
 """Constants for infrastructure configuration."""
 
+import os
+
 # VPC
 VPC_CIDR = "10.0.0.0/16"
 VPC_MAX_AZS = 2
@@ -66,6 +68,27 @@ ALB_IDLE_TIMEOUT_SECONDS = 60
 # S3
 S3_BUCKET_NAME = "agentic-harness"
 
-# Slack notifications
-SLACK_WORKSPACE_ID = "T05929786PK"
-SLACK_CHANNEL_ID = "C0AF4987EF6"
+
+def get_slack_notification_config() -> tuple[str, str] | None:
+    workspace_id = os.environ.get("SLACK_WORKSPACE_ID")
+    channel_id = os.environ.get("SLACK_CHANNEL_ID")
+
+    if workspace_id and channel_id:
+        return workspace_id, channel_id
+
+    if not workspace_id and not channel_id:
+        return None
+
+    missing = [
+        name
+        for name, value in (
+            ("SLACK_WORKSPACE_ID", workspace_id),
+            ("SLACK_CHANNEL_ID", channel_id),
+        )
+        if not value
+    ]
+    raise RuntimeError(
+        "Incomplete Slack notification environment configuration. "
+        "Set both SLACK_WORKSPACE_ID and SLACK_CHANNEL_ID, or neither. "
+        "Missing: " + ", ".join(missing)
+    )

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -68,27 +68,24 @@ ALB_IDLE_TIMEOUT_SECONDS = 60
 # S3
 S3_BUCKET_NAME = "agentic-harness"
 
+# Slack notifications
+SLACK_WORKSPACE_ID_ENV = "SLACK_WORKSPACE_ID"
+VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV = "VALKYRIE_ALERTS_SLACK_CHANNEL_ID"
+DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV = "DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID"
 
-def get_slack_notification_config() -> tuple[str, str] | None:
-    workspace_id = os.environ.get("SLACK_WORKSPACE_ID")
-    channel_id = os.environ.get("SLACK_CHANNEL_ID")
 
-    if workspace_id and channel_id:
+def get_slack_notification_config(channel_id_env_var: str) -> tuple[str, str] | None:
+    workspace_id = os.environ.get(SLACK_WORKSPACE_ID_ENV)
+    channel_id = os.environ.get(channel_id_env_var)
+
+    if channel_id and workspace_id:
         return workspace_id, channel_id
 
-    if not workspace_id and not channel_id:
+    if not channel_id:
         return None
 
-    missing = [
-        name
-        for name, value in (
-            ("SLACK_WORKSPACE_ID", workspace_id),
-            ("SLACK_CHANNEL_ID", channel_id),
-        )
-        if not value
-    ]
     raise RuntimeError(
         "Incomplete Slack notification environment configuration. "
-        "Set both SLACK_WORKSPACE_ID and SLACK_CHANNEL_ID, or neither. "
-        "Missing: " + ", ".join(missing)
+        f"Set {SLACK_WORKSPACE_ID_ENV} when setting {channel_id_env_var}. "
+        f"Missing: {SLACK_WORKSPACE_ID_ENV}"
     )

--- a/infra/monitoring_stack.py
+++ b/infra/monitoring_stack.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import aws_cdk as cdk
 from aws_cdk import (
+    aws_chatbot,
     aws_cloudwatch,
     aws_cloudwatch_actions,
     aws_ecs,
@@ -12,6 +13,7 @@ from aws_cdk import (
     aws_rds,
     aws_sns,
 )
+from constants import get_slack_notification_config
 from constructs import Construct
 from dashboards import (
     create_alb_dashboard,
@@ -55,13 +57,23 @@ class MonitoringStack(cdk.Stack):
         self.database = database
         self.redis_cluster = redis_cluster
 
-        # SNS alerts topic. No subscribers yet.
         self.alerts_topic = aws_sns.Topic(
             self,
             "ValkyrieAlertsTopic",
             topic_name="Valkyrie-Alerts",
             display_name="Valkyrie infrastructure alerts",
         )
+        slack_config = get_slack_notification_config()
+        if slack_config is not None:
+            slack_workspace_id, slack_channel_id = slack_config
+            self.alerts_slack = aws_chatbot.SlackChannelConfiguration(
+                self,
+                "ValkyrieAlertsSlackChannel",
+                slack_channel_configuration_name="valkyrie-alerts",
+                slack_workspace_id=slack_workspace_id,
+                slack_channel_id=slack_channel_id,
+            )
+            self.alerts_slack.add_notification_topic(self.alerts_topic)  # type: ignore[arg-type]
 
         self._create_alarms(
             tracker_service=tracker_service,

--- a/infra/monitoring_stack.py
+++ b/infra/monitoring_stack.py
@@ -13,7 +13,7 @@ from aws_cdk import (
     aws_rds,
     aws_sns,
 )
-from constants import get_slack_notification_config
+from constants import VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV, get_slack_notification_config
 from constructs import Construct
 from dashboards import (
     create_alb_dashboard,
@@ -63,7 +63,7 @@ class MonitoringStack(cdk.Stack):
             topic_name="Valkyrie-Alerts",
             display_name="Valkyrie infrastructure alerts",
         )
-        slack_config = get_slack_notification_config()
+        slack_config = get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV)
         if slack_config is not None:
             slack_workspace_id, slack_channel_id = slack_config
             self.alerts_slack = aws_chatbot.SlackChannelConfiguration(

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -18,6 +18,7 @@ from aws_cdk import (
 )
 from constants import (
     CLUSTER_NAME,
+    DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV,
     ELASTICACHE_NODE_TYPE,
     NAMESPACE,
     REDIS_PORT,
@@ -51,7 +52,7 @@ class SharedStack(Stack):
             ],
         )
 
-        slack_config = get_slack_notification_config()
+        slack_config = get_slack_notification_config(DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV)
         if slack_config is not None:
             slack_workspace_id, slack_channel_id = slack_config
 

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -22,11 +22,10 @@ from constants import (
     NAMESPACE,
     REDIS_PORT,
     S3_BUCKET_NAME,
-    SLACK_CHANNEL_ID,
-    SLACK_WORKSPACE_ID,
     VPC_CIDR,
     VPC_MAX_AZS,
     VPC_NAT_GATEWAYS,
+    get_slack_notification_config,
 )
 from constructs import Construct
 
@@ -52,134 +51,131 @@ class SharedStack(Stack):
             ],
         )
 
-        # SNS topic for deployment notifications
-        notification_topic = aws_sns.Topic(
-            self,
-            "StackNotificationTopic",
-            topic_name="agentic-harness-notifications",
-        )
+        slack_config = get_slack_notification_config()
+        if slack_config is not None:
+            slack_workspace_id, slack_channel_id = slack_config
 
-        # Slack channel configuration
-        slack = aws_chatbot.SlackChannelConfiguration(
-            self,
-            "DeploymentNotificationsSlackChannel",
-            slack_channel_configuration_name="deployment-notifications",
-            slack_workspace_id=SLACK_WORKSPACE_ID,
-            slack_channel_id=SLACK_CHANNEL_ID,
-        )
-
-        slack.add_notification_topic(notification_topic)  # type: ignore[arg-type]
-
-        # Only notify for stacks deployed by this project
-        stack_names = ["SharedStack", "TrackerStack", "WorkerStack", "MonitoringStack"]
-
-        # EventBridge rule Slack notification for successful stack deployments
-        success_rule = aws_events.Rule(
-            self,
-            "StackDeploySuccessRule",
-            event_pattern=aws_events.EventPattern(
-                source=["aws.cloudformation"],
-                detail_type=["CloudFormation Stack Status Change"],
-                detail={
-                    "stack-id": [
-                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
-                        for name in stack_names
-                    ],
-                    "status-details": {
-                        "status": ["CREATE_COMPLETE", "UPDATE_COMPLETE"],
-                    },
-                },
-            ),
-        )
-
-        cfn_url = (
-            "<https://"
-            + aws_events.EventField.from_path("$.region")
-            + ".console.aws.amazon.com/cloudformation/home?region="
-            + aws_events.EventField.from_path("$.region")
-            + "#/stacks|CloudFormation Stack Notification>"
-        )
-
-        success_rule.add_target(
-            aws_events_targets.SnsTopic(  # type: ignore[arg-type]
-                notification_topic,  # type: ignore[arg-type]
-                message=aws_events.RuleTargetInput.from_object(
-                    {
-                        "version": "1.0",
-                        "source": "custom",
-                        "content": {
-                            "textType": "client-markdown",
-                            "title": ":white_check_mark: "
-                            + cfn_url
-                            + " | "
-                            + aws_events.EventField.from_path("$.region")
-                            + " | Account: "
-                            + aws_events.EventField.from_path("$.account"),
-                            "description": "CloudFormation stack deployment *SUCCEEDED*."
-                            + "\n\n*Stack*\n"
-                            + aws_events.EventField.from_path("$.detail.stack-id"),
-                        },
-                        "metadata": {
-                            "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
-                            "summary": "Deployment succeeded",
-                        },
-                    }
-                ),
+            notification_topic = aws_sns.Topic(
+                self,
+                "StackNotificationTopic",
+                topic_name="agentic-harness-notifications",
             )
-        )
+            slack = aws_chatbot.SlackChannelConfiguration(
+                self,
+                "DeploymentNotificationsSlackChannel",
+                slack_channel_configuration_name="deployment-notifications",
+                slack_workspace_id=slack_workspace_id,
+                slack_channel_id=slack_channel_id,
+            )
+            slack.add_notification_topic(notification_topic)  # type: ignore[arg-type]
 
-        # EventBridge rule Slack notification for failed stack deployments
-        failure_rule = aws_events.Rule(
-            self,
-            "StackDeployFailureRule",
-            event_pattern=aws_events.EventPattern(
-                source=["aws.cloudformation"],
-                detail_type=["CloudFormation Stack Status Change"],
-                detail={
-                    "stack-id": [
-                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
-                        for name in stack_names
-                    ],
-                    "status-details": {
-                        "status": [
-                            "CREATE_FAILED",
-                            "UPDATE_FAILED",
-                            "UPDATE_ROLLBACK_COMPLETE",
-                            "ROLLBACK_COMPLETE",
-                            "DELETE_FAILED",
+            stack_names = ["SharedStack", "TrackerStack", "WorkerStack", "MonitoringStack"]
+
+            success_rule = aws_events.Rule(
+                self,
+                "StackDeploySuccessRule",
+                event_pattern=aws_events.EventPattern(
+                    source=["aws.cloudformation"],
+                    detail_type=["CloudFormation Stack Status Change"],
+                    detail={
+                        "stack-id": [
+                            {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                            for name in stack_names
                         ],
+                        "status-details": {
+                            "status": ["CREATE_COMPLETE", "UPDATE_COMPLETE"],
+                        },
                     },
-                },
-            ),
-        )
-
-        failure_rule.add_target(
-            aws_events_targets.SnsTopic(  # type: ignore[arg-type]
-                notification_topic,  # type: ignore[arg-type]
-                message=aws_events.RuleTargetInput.from_object(
-                    {
-                        "version": "1.0",
-                        "source": "custom",
-                        "content": {
-                            "textType": "client-markdown",
-                            "title": ":rotating_light: "
-                            + cfn_url
-                            + " | "
-                            + aws_events.EventField.from_path("$.region")
-                            + " | Account: "
-                            + aws_events.EventField.from_path("$.account"),
-                            "description": "CloudFormation stack deployment *FAILED*."
-                            + "\n\n*Stack*\n"
-                            + aws_events.EventField.from_path("$.detail.stack-id"),
-                        },
-                        "metadata": {
-                            "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
-                            "summary": "Deployment failed",
-                        },
-                    }
                 ),
             )
-        )
+
+            cfn_url = (
+                "<https://"
+                + aws_events.EventField.from_path("$.region")
+                + ".console.aws.amazon.com/cloudformation/home?region="
+                + aws_events.EventField.from_path("$.region")
+                + "#/stacks|CloudFormation Stack Notification>"
+            )
+
+            success_rule.add_target(
+                aws_events_targets.SnsTopic(  # type: ignore[arg-type]
+                    notification_topic,  # type: ignore[arg-type]
+                    message=aws_events.RuleTargetInput.from_object(
+                        {
+                            "version": "1.0",
+                            "source": "custom",
+                            "content": {
+                                "textType": "client-markdown",
+                                "title": ":white_check_mark: "
+                                + cfn_url
+                                + " | "
+                                + aws_events.EventField.from_path("$.region")
+                                + " | Account: "
+                                + aws_events.EventField.from_path("$.account"),
+                                "description": "CloudFormation stack deployment *SUCCEEDED*."
+                                + "\n\n*Stack*\n"
+                                + aws_events.EventField.from_path("$.detail.stack-id"),
+                            },
+                            "metadata": {
+                                "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
+                                "summary": "Deployment succeeded",
+                            },
+                        }
+                    ),
+                )
+            )
+
+            failure_rule = aws_events.Rule(
+                self,
+                "StackDeployFailureRule",
+                event_pattern=aws_events.EventPattern(
+                    source=["aws.cloudformation"],
+                    detail_type=["CloudFormation Stack Status Change"],
+                    detail={
+                        "stack-id": [
+                            {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                            for name in stack_names
+                        ],
+                        "status-details": {
+                            "status": [
+                                "CREATE_FAILED",
+                                "UPDATE_FAILED",
+                                "UPDATE_ROLLBACK_COMPLETE",
+                                "ROLLBACK_COMPLETE",
+                                "DELETE_FAILED",
+                            ],
+                        },
+                    },
+                ),
+            )
+
+            failure_rule.add_target(
+                aws_events_targets.SnsTopic(  # type: ignore[arg-type]
+                    notification_topic,  # type: ignore[arg-type]
+                    message=aws_events.RuleTargetInput.from_object(
+                        {
+                            "version": "1.0",
+                            "source": "custom",
+                            "content": {
+                                "textType": "client-markdown",
+                                "title": ":rotating_light: "
+                                + cfn_url
+                                + " | "
+                                + aws_events.EventField.from_path("$.region")
+                                + " | Account: "
+                                + aws_events.EventField.from_path("$.account"),
+                                "description": "CloudFormation stack deployment *FAILED*."
+                                + "\n\n*Stack*\n"
+                                + aws_events.EventField.from_path("$.detail.stack-id"),
+                            },
+                            "metadata": {
+                                "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
+                                "summary": "Deployment failed",
+                            },
+                        }
+                    ),
+                )
+            )
 
         # shared ECS cluster
         self.cluster = aws_ecs.Cluster(

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -30,6 +30,16 @@ from constants import (
 )
 from constructs import Construct
 
+DEPLOYMENT_STACK_NAMES = ("SharedStack", "TrackerStack", "WorkerStack", "MonitoringStack")
+DEPLOYMENT_SUCCESS_STATUSES = ("CREATE_COMPLETE", "UPDATE_COMPLETE")
+DEPLOYMENT_FAILURE_STATUSES = (
+    "CREATE_FAILED",
+    "UPDATE_FAILED",
+    "UPDATE_ROLLBACK_COMPLETE",
+    "ROLLBACK_COMPLETE",
+    "DELETE_FAILED",
+)
+
 
 class SharedStack(Stack):
     """Shared infrastructure for all services."""
@@ -54,129 +64,7 @@ class SharedStack(Stack):
 
         slack_config = get_slack_notification_config(DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV)
         if slack_config is not None:
-            slack_workspace_id, slack_channel_id = slack_config
-
-            notification_topic = aws_sns.Topic(
-                self,
-                "StackNotificationTopic",
-                topic_name="agentic-harness-notifications",
-            )
-            slack = aws_chatbot.SlackChannelConfiguration(
-                self,
-                "DeploymentNotificationsSlackChannel",
-                slack_channel_configuration_name="deployment-notifications",
-                slack_workspace_id=slack_workspace_id,
-                slack_channel_id=slack_channel_id,
-            )
-            slack.add_notification_topic(notification_topic)  # type: ignore[arg-type]
-
-            stack_names = ["SharedStack", "TrackerStack", "WorkerStack", "MonitoringStack"]
-
-            success_rule = aws_events.Rule(
-                self,
-                "StackDeploySuccessRule",
-                event_pattern=aws_events.EventPattern(
-                    source=["aws.cloudformation"],
-                    detail_type=["CloudFormation Stack Status Change"],
-                    detail={
-                        "stack-id": [
-                            {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
-                            for name in stack_names
-                        ],
-                        "status-details": {
-                            "status": ["CREATE_COMPLETE", "UPDATE_COMPLETE"],
-                        },
-                    },
-                ),
-            )
-
-            cfn_url = (
-                "<https://"
-                + aws_events.EventField.from_path("$.region")
-                + ".console.aws.amazon.com/cloudformation/home?region="
-                + aws_events.EventField.from_path("$.region")
-                + "#/stacks|CloudFormation Stack Notification>"
-            )
-
-            success_rule.add_target(
-                aws_events_targets.SnsTopic(  # type: ignore[arg-type]
-                    notification_topic,  # type: ignore[arg-type]
-                    message=aws_events.RuleTargetInput.from_object(
-                        {
-                            "version": "1.0",
-                            "source": "custom",
-                            "content": {
-                                "textType": "client-markdown",
-                                "title": ":white_check_mark: "
-                                + cfn_url
-                                + " | "
-                                + aws_events.EventField.from_path("$.region")
-                                + " | Account: "
-                                + aws_events.EventField.from_path("$.account"),
-                                "description": "CloudFormation stack deployment *SUCCEEDED*."
-                                + "\n\n*Stack*\n"
-                                + aws_events.EventField.from_path("$.detail.stack-id"),
-                            },
-                            "metadata": {
-                                "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
-                                "summary": "Deployment succeeded",
-                            },
-                        }
-                    ),
-                )
-            )
-
-            failure_rule = aws_events.Rule(
-                self,
-                "StackDeployFailureRule",
-                event_pattern=aws_events.EventPattern(
-                    source=["aws.cloudformation"],
-                    detail_type=["CloudFormation Stack Status Change"],
-                    detail={
-                        "stack-id": [
-                            {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
-                            for name in stack_names
-                        ],
-                        "status-details": {
-                            "status": [
-                                "CREATE_FAILED",
-                                "UPDATE_FAILED",
-                                "UPDATE_ROLLBACK_COMPLETE",
-                                "ROLLBACK_COMPLETE",
-                                "DELETE_FAILED",
-                            ],
-                        },
-                    },
-                ),
-            )
-
-            failure_rule.add_target(
-                aws_events_targets.SnsTopic(  # type: ignore[arg-type]
-                    notification_topic,  # type: ignore[arg-type]
-                    message=aws_events.RuleTargetInput.from_object(
-                        {
-                            "version": "1.0",
-                            "source": "custom",
-                            "content": {
-                                "textType": "client-markdown",
-                                "title": ":rotating_light: "
-                                + cfn_url
-                                + " | "
-                                + aws_events.EventField.from_path("$.region")
-                                + " | Account: "
-                                + aws_events.EventField.from_path("$.account"),
-                                "description": "CloudFormation stack deployment *FAILED*."
-                                + "\n\n*Stack*\n"
-                                + aws_events.EventField.from_path("$.detail.stack-id"),
-                            },
-                            "metadata": {
-                                "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
-                                "summary": "Deployment failed",
-                            },
-                        }
-                    ),
-                )
-            )
+            self._create_deployment_notifications(*slack_config)
 
         # shared ECS cluster
         self.cluster = aws_ecs.Cluster(
@@ -256,4 +144,101 @@ class SharedStack(Stack):
                 ":",
                 self.redis_cluster.attr_redis_endpoint_port,
             ],
+        )
+
+    def _create_deployment_notifications(self, slack_workspace_id: str, slack_channel_id: str) -> None:
+        notification_topic = aws_sns.Topic(
+            self,
+            "StackNotificationTopic",
+            topic_name="agentic-harness-notifications",
+        )
+        slack = aws_chatbot.SlackChannelConfiguration(
+            self,
+            "DeploymentNotificationsSlackChannel",
+            slack_channel_configuration_name="deployment-notifications",
+            slack_workspace_id=slack_workspace_id,
+            slack_channel_id=slack_channel_id,
+        )
+        slack.add_notification_topic(notification_topic)  # type: ignore[arg-type]
+
+        cfn_url = (
+            "<https://"
+            + aws_events.EventField.from_path("$.region")
+            + ".console.aws.amazon.com/cloudformation/home?region="
+            + aws_events.EventField.from_path("$.region")
+            + "#/stacks|CloudFormation Stack Notification>"
+        )
+        self._add_deployment_notification_rule(
+            rule_id="StackDeploySuccessRule",
+            topic=notification_topic,
+            statuses=DEPLOYMENT_SUCCESS_STATUSES,
+            title_prefix=":white_check_mark: ",
+            description="CloudFormation stack deployment *SUCCEEDED*.",
+            summary="Deployment succeeded",
+            cfn_url=cfn_url,
+        )
+        self._add_deployment_notification_rule(
+            rule_id="StackDeployFailureRule",
+            topic=notification_topic,
+            statuses=DEPLOYMENT_FAILURE_STATUSES,
+            title_prefix=":rotating_light: ",
+            description="CloudFormation stack deployment *FAILED*.",
+            summary="Deployment failed",
+            cfn_url=cfn_url,
+        )
+
+    def _add_deployment_notification_rule(
+        self,
+        *,
+        rule_id: str,
+        topic: aws_sns.Topic,
+        statuses: tuple[str, ...],
+        title_prefix: str,
+        description: str,
+        summary: str,
+        cfn_url: str,
+    ) -> None:
+        rule = aws_events.Rule(
+            self,
+            rule_id,
+            event_pattern=aws_events.EventPattern(
+                source=["aws.cloudformation"],
+                detail_type=["CloudFormation Stack Status Change"],
+                detail={
+                    "stack-id": [
+                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                        for name in DEPLOYMENT_STACK_NAMES
+                    ],
+                    "status-details": {
+                        "status": list(statuses),
+                    },
+                },
+            ),
+        )
+        rule.add_target(
+            aws_events_targets.SnsTopic(  # type: ignore[arg-type]
+                topic,  # type: ignore[arg-type]
+                message=aws_events.RuleTargetInput.from_object(
+                    {
+                        "version": "1.0",
+                        "source": "custom",
+                        "content": {
+                            "textType": "client-markdown",
+                            "title": title_prefix
+                            + cfn_url
+                            + " | "
+                            + aws_events.EventField.from_path("$.region")
+                            + " | Account: "
+                            + aws_events.EventField.from_path("$.account"),
+                            "description": description
+                            + "\n\n*Stack*\n"
+                            + aws_events.EventField.from_path("$.detail.stack-id"),
+                        },
+                        "metadata": {
+                            "threadId": aws_events.EventField.from_path("$.detail.stack-id"),
+                            "summary": summary,
+                        },
+                    }
+                ),
+            )
         )

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -1,0 +1,168 @@
+import os
+import unittest
+from unittest import mock
+
+import aws_cdk as cdk
+from aws_cdk import (
+    assertions,
+    aws_ec2,
+    aws_ecs,
+    aws_elasticache,
+    aws_elasticloadbalancingv2 as aws_elb,
+    aws_rds,
+)
+
+from constants import get_slack_notification_config
+from monitoring_stack import MonitoringStack
+from shared import SharedStack
+
+TEST_SLACK_ENV = {"SLACK_WORKSPACE_ID": "TTESTWORKSPACE", "SLACK_CHANNEL_ID": "CTESTCHANNEL"}
+SHARED_STACK_CONTEXT = {
+    "availability-zones:account=613431292675:region=us-east-1": ["us-east-1a", "us-east-1b"],
+    "hosted-zone:account=613431292675:domainName=vals.ai:region=us-east-1": {
+        "Id": "/hostedzone/Z047985721WA50ZRLCDNC",
+        "Name": "vals.ai.",
+    },
+}
+
+
+def _monitoring_template() -> assertions.Template:
+    app = cdk.App()
+    resources = cdk.Stack(
+        app,
+        "MonitoringTestResources",
+        env=cdk.Environment(account="123456789012", region="us-west-2"),
+    )
+
+    vpc = aws_ec2.Vpc(resources, "Vpc", max_azs=2)
+    cluster = aws_ecs.Cluster(resources, "Cluster", vpc=vpc, cluster_name="AgenticHarnessCluster")
+
+    tracker_task = aws_ecs.FargateTaskDefinition(resources, "TrackerTask")
+    tracker_task.add_container("TrackerContainer", image=aws_ecs.ContainerImage.from_registry("busybox"))
+    tracker_service = aws_ecs.FargateService(
+        resources,
+        "TrackerService",
+        cluster=cluster,
+        task_definition=tracker_task,
+        service_name="Tracker",
+    )
+
+    worker_task = aws_ecs.FargateTaskDefinition(resources, "WorkerTask")
+    worker_task.add_container("WorkerContainer", image=aws_ecs.ContainerImage.from_registry("busybox"))
+    worker_service = aws_ecs.FargateService(
+        resources,
+        "WorkerService",
+        cluster=cluster,
+        task_definition=worker_task,
+        service_name="Worker",
+    )
+
+    load_balancer = aws_elb.ApplicationLoadBalancer(resources, "LoadBalancer", vpc=vpc)
+    target_group = aws_elb.ApplicationTargetGroup(resources, "TargetGroup", vpc=vpc, port=8000)
+    load_balancer.add_listener("HttpListener", port=80, default_target_groups=[target_group])
+    database = aws_rds.DatabaseInstance(
+        resources,
+        "Database",
+        engine=aws_rds.DatabaseInstanceEngine.postgres(version=aws_rds.PostgresEngineVersion.VER_16),
+        instance_type=aws_ec2.InstanceType("t4g.micro"),
+        vpc=vpc,
+        credentials=aws_rds.Credentials.from_generated_secret("tracker"),
+        allocated_storage=20,
+    )
+    redis_cluster = aws_elasticache.CfnCacheCluster(
+        resources,
+        "RedisCluster",
+        cache_node_type="cache.t4g.micro",
+        engine="redis",
+        num_cache_nodes=1,
+    )
+    monitoring = MonitoringStack(
+        app,
+        "MonitoringStack",
+        cluster=cluster,
+        tracker_service=tracker_service,
+        worker_service=worker_service,
+        load_balancer=load_balancer,
+        target_group=target_group,
+        database=database,
+        redis_cluster=redis_cluster,
+        env=cdk.Environment(account="123456789012", region="us-west-2"),
+    )
+
+    return assertions.Template.from_stack(monitoring)
+
+
+def _shared_template() -> assertions.Template:
+    app = cdk.App(context=SHARED_STACK_CONTEXT)
+    shared = SharedStack(
+        app,
+        "SharedStack",
+        env=cdk.Environment(account="613431292675", region="us-east-1"),
+    )
+
+    return assertions.Template.from_stack(shared)
+
+
+class MonitoringStackTest(unittest.TestCase):
+    def test_alerts_topic_is_wired_to_slack(self) -> None:
+        with mock.patch.dict(os.environ, TEST_SLACK_ENV, clear=True):
+            template = _monitoring_template()
+
+        template.has_resource_properties(
+            "AWS::Chatbot::SlackChannelConfiguration",
+            {
+                "ConfigurationName": "valkyrie-alerts",
+                "SlackChannelId": TEST_SLACK_ENV["SLACK_CHANNEL_ID"],
+                "SlackWorkspaceId": TEST_SLACK_ENV["SLACK_WORKSPACE_ID"],
+                "SnsTopicArns": assertions.Match.array_with(
+                    [{"Ref": assertions.Match.string_like_regexp("ValkyrieAlertsTopic")}]
+                ),
+            },
+        )
+
+    def test_runtime_exceptions_stay_out_of_cloudwatch_log_metric_filters(self) -> None:
+        with mock.patch.dict(os.environ, TEST_SLACK_ENV, clear=True):
+            template = _monitoring_template()
+
+        template.resource_count_is("AWS::Logs::MetricFilter", 0)
+
+    def test_slack_config_reads_environment(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {"SLACK_WORKSPACE_ID": "TENVWORKSPACE", "SLACK_CHANNEL_ID": "CENVCHANNEL"},
+            clear=True,
+        ):
+            self.assertEqual(
+                get_slack_notification_config(),
+                ("TENVWORKSPACE", "CENVCHANNEL"),
+            )
+
+    def test_missing_slack_environment_values_skip_slack_wiring(self) -> None:
+        for env in ({}, {"SLACK_WORKSPACE_ID": "", "SLACK_CHANNEL_ID": ""}):
+            with self.subTest(env=env), mock.patch.dict(os.environ, env, clear=True):
+                self.assertIsNone(get_slack_notification_config())
+                template = _monitoring_template()
+
+                template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
+
+    def test_missing_slack_environment_skips_deployment_notification_resources(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            template = _shared_template()
+
+        template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
+        template.resource_count_is("AWS::Events::Rule", 0)
+        template.resource_count_is("AWS::SNS::Topic", 0)
+
+    def test_partial_slack_environment_values_raise_clear_error(self) -> None:
+        with mock.patch.dict(os.environ, {"SLACK_WORKSPACE_ID": "TENVWORKSPACE"}, clear=True):
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Incomplete Slack notification environment configuration. "
+                "Set both SLACK_WORKSPACE_ID and SLACK_CHANNEL_ID, or neither. "
+                "Missing: SLACK_CHANNEL_ID",
+            ):
+                get_slack_notification_config()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -29,9 +29,6 @@ TEST_DEPLOYMENT_SLACK_ENV = {
     SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE",
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
 }
-TEST_ALL_SLACK_ENV = TEST_ALERTS_SLACK_ENV | {
-    DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
-}
 SHARED_STACK_CONTEXT = {
     "availability-zones:account=613431292675:region=us-east-1": ["us-east-1a", "us-east-1b"],
     "hosted-zone:account=613431292675:domainName=vals.ai:region=us-east-1": {
@@ -39,6 +36,22 @@ SHARED_STACK_CONTEXT = {
         "Name": "vals.ai.",
     },
 }
+
+
+def _has_resource_property(
+    template: assertions.Template,
+    resource_type: str,
+    property_name: str,
+    expected_value: object,
+) -> bool:
+    return any(
+        resource.get("Properties", {}).get(property_name) == expected_value
+        for resource in template.find_resources(resource_type).values()
+    )
+
+
+def _has_logical_id_prefix(template: assertions.Template, resource_type: str, prefix: str) -> bool:
+    return any(logical_id.startswith(prefix) for logical_id in template.find_resources(resource_type))
 
 
 def _monitoring_template() -> assertions.Template:
@@ -151,22 +164,20 @@ class MonitoringStackTest(unittest.TestCase):
             },
         )
 
-    def test_runtime_exceptions_stay_out_of_cloudwatch_log_metric_filters(self) -> None:
+    def test_pty_runtime_exceptions_stay_out_of_cloudwatch_log_metric_filters(self) -> None:
         with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
             template = _monitoring_template()
 
-        template.resource_count_is("AWS::Logs::MetricFilter", 0)
-
-    def test_slack_config_reads_environment(self) -> None:
-        with mock.patch.dict(os.environ, TEST_ALL_SLACK_ENV, clear=True):
-            self.assertEqual(
-                get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV),
-                ("TTESTWORKSPACE", "CALERTSCHANNEL"),
+        metric_filters = template.find_resources("AWS::Logs::MetricFilter")
+        filter_patterns = [
+            str(resource.get("Properties", {}).get("FilterPattern", "")) for resource in metric_filters.values()
+        ]
+        self.assertFalse(
+            any(
+                "PTY" in pattern or "server disconnected" in pattern or "server_disconnected" in pattern
+                for pattern in filter_patterns
             )
-            self.assertEqual(
-                get_slack_notification_config(DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV),
-                ("TTESTWORKSPACE", "CDEPLOYCHANNEL"),
-            )
+        )
 
     def test_missing_slack_environment_values_skip_slack_wiring(self) -> None:
         for env in (
@@ -179,16 +190,37 @@ class MonitoringStackTest(unittest.TestCase):
                 self.assertIsNone(get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV))
                 template = _monitoring_template()
 
-                template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
+                self.assertFalse(
+                    _has_resource_property(
+                        template,
+                        "AWS::Chatbot::SlackChannelConfiguration",
+                        "ConfigurationName",
+                        "valkyrie-alerts",
+                    )
+                )
 
     def test_missing_slack_environment_skips_deployment_notification_resources(self) -> None:
         for env in ({}, {SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE"}, TEST_ALERTS_SLACK_ENV):
             with self.subTest(env=env), mock.patch.dict(os.environ, env, clear=True):
                 template = _shared_template()
 
-                template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
-                template.resource_count_is("AWS::Events::Rule", 0)
-                template.resource_count_is("AWS::SNS::Topic", 0)
+                self.assertFalse(
+                    _has_resource_property(
+                        template,
+                        "AWS::Chatbot::SlackChannelConfiguration",
+                        "ConfigurationName",
+                        "deployment-notifications",
+                    )
+                )
+                self.assertFalse(_has_logical_id_prefix(template, "AWS::Events::Rule", "StackDeploy"))
+                self.assertFalse(
+                    _has_resource_property(
+                        template,
+                        "AWS::SNS::Topic",
+                        "TopicName",
+                        "agentic-harness-notifications",
+                    )
+                )
 
     def test_partial_slack_environment_values_raise_clear_error(self) -> None:
         with mock.patch.dict(

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -12,11 +12,26 @@ from aws_cdk import (
     aws_rds,
 )
 
-from constants import get_slack_notification_config
+from constants import (
+    DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV,
+    SLACK_WORKSPACE_ID_ENV,
+    VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV,
+    get_slack_notification_config,
+)
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
 
-TEST_SLACK_ENV = {"SLACK_WORKSPACE_ID": "TTESTWORKSPACE", "SLACK_CHANNEL_ID": "CTESTCHANNEL"}
+TEST_ALERTS_SLACK_ENV = {
+    SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE",
+    VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV: "CALERTSCHANNEL",
+}
+TEST_DEPLOYMENT_SLACK_ENV = {
+    SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE",
+    DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
+}
+TEST_ALL_SLACK_ENV = TEST_ALERTS_SLACK_ENV | {
+    DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
+}
 SHARED_STACK_CONTEXT = {
     "availability-zones:account=613431292675:region=us-east-1": ["us-east-1a", "us-east-1b"],
     "hosted-zone:account=613431292675:domainName=vals.ai:region=us-east-1": {
@@ -105,63 +120,89 @@ def _shared_template() -> assertions.Template:
 
 class MonitoringStackTest(unittest.TestCase):
     def test_alerts_topic_is_wired_to_slack(self) -> None:
-        with mock.patch.dict(os.environ, TEST_SLACK_ENV, clear=True):
+        with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
             template = _monitoring_template()
 
         template.has_resource_properties(
             "AWS::Chatbot::SlackChannelConfiguration",
             {
                 "ConfigurationName": "valkyrie-alerts",
-                "SlackChannelId": TEST_SLACK_ENV["SLACK_CHANNEL_ID"],
-                "SlackWorkspaceId": TEST_SLACK_ENV["SLACK_WORKSPACE_ID"],
+                "SlackChannelId": TEST_ALERTS_SLACK_ENV[VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV],
+                "SlackWorkspaceId": TEST_ALERTS_SLACK_ENV[SLACK_WORKSPACE_ID_ENV],
                 "SnsTopicArns": assertions.Match.array_with(
                     [{"Ref": assertions.Match.string_like_regexp("ValkyrieAlertsTopic")}]
                 ),
             },
         )
 
+    def test_deployment_notifications_are_wired_to_deployment_slack_channel(self) -> None:
+        with mock.patch.dict(os.environ, TEST_DEPLOYMENT_SLACK_ENV, clear=True):
+            template = _shared_template()
+
+        template.has_resource_properties(
+            "AWS::Chatbot::SlackChannelConfiguration",
+            {
+                "ConfigurationName": "deployment-notifications",
+                "SlackChannelId": TEST_DEPLOYMENT_SLACK_ENV[DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV],
+                "SlackWorkspaceId": TEST_DEPLOYMENT_SLACK_ENV[SLACK_WORKSPACE_ID_ENV],
+                "SnsTopicArns": assertions.Match.array_with(
+                    [{"Ref": assertions.Match.string_like_regexp("StackNotificationTopic")}]
+                ),
+            },
+        )
+
     def test_runtime_exceptions_stay_out_of_cloudwatch_log_metric_filters(self) -> None:
-        with mock.patch.dict(os.environ, TEST_SLACK_ENV, clear=True):
+        with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
             template = _monitoring_template()
 
         template.resource_count_is("AWS::Logs::MetricFilter", 0)
 
     def test_slack_config_reads_environment(self) -> None:
-        with mock.patch.dict(
-            os.environ,
-            {"SLACK_WORKSPACE_ID": "TENVWORKSPACE", "SLACK_CHANNEL_ID": "CENVCHANNEL"},
-            clear=True,
-        ):
+        with mock.patch.dict(os.environ, TEST_ALL_SLACK_ENV, clear=True):
             self.assertEqual(
-                get_slack_notification_config(),
-                ("TENVWORKSPACE", "CENVCHANNEL"),
+                get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV),
+                ("TTESTWORKSPACE", "CALERTSCHANNEL"),
+            )
+            self.assertEqual(
+                get_slack_notification_config(DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV),
+                ("TTESTWORKSPACE", "CDEPLOYCHANNEL"),
             )
 
     def test_missing_slack_environment_values_skip_slack_wiring(self) -> None:
-        for env in ({}, {"SLACK_WORKSPACE_ID": "", "SLACK_CHANNEL_ID": ""}):
+        for env in (
+            {},
+            {SLACK_WORKSPACE_ID_ENV: "", VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV: ""},
+            {SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE"},
+            TEST_DEPLOYMENT_SLACK_ENV,
+        ):
             with self.subTest(env=env), mock.patch.dict(os.environ, env, clear=True):
-                self.assertIsNone(get_slack_notification_config())
+                self.assertIsNone(get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV))
                 template = _monitoring_template()
 
                 template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
 
     def test_missing_slack_environment_skips_deployment_notification_resources(self) -> None:
-        with mock.patch.dict(os.environ, {}, clear=True):
-            template = _shared_template()
+        for env in ({}, {SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE"}, TEST_ALERTS_SLACK_ENV):
+            with self.subTest(env=env), mock.patch.dict(os.environ, env, clear=True):
+                template = _shared_template()
 
-        template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
-        template.resource_count_is("AWS::Events::Rule", 0)
-        template.resource_count_is("AWS::SNS::Topic", 0)
+                template.resource_count_is("AWS::Chatbot::SlackChannelConfiguration", 0)
+                template.resource_count_is("AWS::Events::Rule", 0)
+                template.resource_count_is("AWS::SNS::Topic", 0)
 
     def test_partial_slack_environment_values_raise_clear_error(self) -> None:
-        with mock.patch.dict(os.environ, {"SLACK_WORKSPACE_ID": "TENVWORKSPACE"}, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV: "CALERTSCHANNEL"},
+            clear=True,
+        ):
             with self.assertRaisesRegex(
                 RuntimeError,
                 "Incomplete Slack notification environment configuration. "
-                "Set both SLACK_WORKSPACE_ID and SLACK_CHANNEL_ID, or neither. "
-                "Missing: SLACK_CHANNEL_ID",
+                f"Set {SLACK_WORKSPACE_ID_ENV} when setting {VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV}. "
+                f"Missing: {SLACK_WORKSPACE_ID_ENV}",
             ):
-                get_slack_notification_config()
+                get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV)
 
 
 if __name__ == "__main__":

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -164,21 +164,6 @@ class MonitoringStackTest(unittest.TestCase):
             },
         )
 
-    def test_pty_runtime_exceptions_stay_out_of_cloudwatch_log_metric_filters(self) -> None:
-        with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
-            template = _monitoring_template()
-
-        metric_filters = template.find_resources("AWS::Logs::MetricFilter")
-        filter_patterns = [
-            str(resource.get("Properties", {}).get("FilterPattern", "")) for resource in metric_filters.values()
-        ]
-        self.assertFalse(
-            any(
-                "PTY" in pattern or "server disconnected" in pattern or "server_disconnected" in pattern
-                for pattern in filter_patterns
-            )
-        )
-
     def test_missing_slack_environment_values_skip_slack_wiring(self) -> None:
         for env in (
             {},


### PR DESCRIPTION
## Summary
Wires Valkyrie CloudWatch alarm notifications to the existing Slack alerts channel through AWS Chatbot. Slack IDs are read from deploy-time environment variables, so CI can inject them without hardcoding workspace or channel IDs in CDK source.

Alert notifications and deployment notifications now use separate Slack channel IDs. This keeps infrastructure alerts pointed at the Valkyrie alerts channel without forcing CloudFormation deploy success/failure messages into the same destination.

If Slack env vars are absent, deployment still succeeds and omits Slack notification resources. If a Slack channel ID is configured without `SLACK_WORKSPACE_ID`, synth fails with a clear configuration error.

## Changes
<!-- List the key changes made -->
- Add optional Slack notification config sourced from `SLACK_WORKSPACE_ID` plus a caller-specific channel env var.
- Connect the `Valkyrie-Alerts` SNS topic used by infrastructure alarms to an AWS Chatbot Slack channel configuration when `VALKYRIE_ALERTS_SLACK_CHANNEL_ID` is present.
- Keep deployment notification SNS/EventBridge/Chatbot resources optional and wire them to `DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID` when present.
- Extract deployment notification wiring out of the shared infra constructor into focused helper methods.
- Update the deploy workflow to inject the purpose-specific Slack channel env vars.
- Add minimal CDK assertion coverage for Slack alarm wiring, deployment notification wiring, missing Slack config behavior, and partial Slack config errors.

Slack-notified infrastructure alarms:
- `Valkyrie-Tracker-Unhealthy`: tracker ALB target group has at least one unhealthy target for 2 consecutive 1-minute periods.
- `Valkyrie-Worker-Service-Down`: worker ECS `RunningTaskCount` is below 1 for 3 consecutive 1-minute periods; missing data is treated as breaching.
- `Valkyrie-API-5XX-Rate-High`: tracker ALB target 5XX count is at least 10 in a 5-minute window.
- `Valkyrie-API-Latency-High`: tracker ALB target response time p99 is at least 5 seconds for 5 consecutive 1-minute periods.
- `Valkyrie-DB-Connections-High`: RDS database connections are at least 135 for 5 consecutive 1-minute periods.
- `Valkyrie-DB-Storage-Low`: RDS free storage is at or below 2 GiB in a 5-minute period.
- `Valkyrie-DB-CPU-High`: RDS CPU utilization is at least 80% for 10 consecutive 1-minute periods.
- `Valkyrie-Redis-Memory-High`: Redis `DatabaseMemoryUsagePercentage` is at least 80% for 5 consecutive 1-minute periods.
- `Valkyrie-Redis-Evictions`: Redis reports at least one eviction in a 5-minute window.

## Related Issues
<!-- Link any related issues -->
Closes vals-ai/valkyrie-ticket-library#51

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Docs / config

## Testing
<!-- How was this tested? -->
- [x] Added/updated unit tests
- [x] Manually tested

Commands run:
- `uv run python -m unittest tests/test_monitoring_stack.py -v`
- `uv run python -m unittest discover tests -v`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ruff check tests/test_monitoring_stack.py`
- `uv run ruff format --check tests/test_monitoring_stack.py`
- `uv run python -m py_compile tests/test_monitoring_stack.py`
- `uv run python -m py_compile shared.py tests/test_monitoring_stack.py`
- `uv run python -m py_compile app.py constants.py monitoring_stack.py shared.py tracker_stack.py worker_stack.py tests/test_monitoring_stack.py`
- `git diff --check`
- `uv run basedpyright shared.py tests/test_monitoring_stack.py`
- `env -u SLACK_WORKSPACE_ID -u VALKYRIE_ALERTS_SLACK_CHANNEL_ID -u DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID uv run cdk synth MonitoringStack --quiet --output /private/tmp/cdk-no-slack-out-review-fixes`
- `SLACK_WORKSPACE_ID=TENVWORKSPACE VALKYRIE_ALERTS_SLACK_CHANNEL_ID=CALERTS DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID=CDEPLOY uv run cdk synth MonitoringStack --quiet --output /private/tmp/cdk-with-slack-out-review-fixes`

Notes:
- Focused infra unit suite now covers 5 useful Slack notification behavior tests.
- No-Slack synth succeeded and emitted no Chatbot/deployment notification resources.
- Env-present synth emitted `MonitoringStack` alerts with `CALERTS` and `SharedStack` deployment notifications with `CDEPLOY`.
- `uv run basedpyright app.py constants.py monitoring_stack.py shared.py tracker_stack.py worker_stack.py tests/test_monitoring_stack.py` still reports the existing 7 CDK typing errors in `tracker_stack.py` / `worker_stack.py`; no new Slack config typing errors remain.

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
