### PR TITLE
Remove alias since its causing bugs

### DIFF
--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, computed_field, field_serializer, field_validator
+from pydantic import BaseModel, field_serializer, field_validator
 from sqlalchemy import Connection, Dialect, event
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -386,16 +386,6 @@ class Task(SQLModel, table=True):
     benchmark: UUID = Field(foreign_key="benchmark.id")
     task_breakdown: UUID | None = Field(default=None, foreign_key="taskbreakdown.id")
 
-    @computed_field
-    @property
-    def alias(self) -> str:
-        """Unique alias for the current task attempt, used when creating sandboxes.
-
-        Format: {task_id}_{suffix}
-        - suffix: hex-encoded microsecond timestamp from started_at, changes on each retry/resume
-        """
-        suffix = f"{int(self.started_at.timestamp() * 1_000_000):x}"
-        return f"{self.task_id}_{suffix}"
 
 
 @event.listens_for(Task, "before_insert")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -387,7 +387,6 @@ class Task(SQLModel, table=True):
     task_breakdown: UUID | None = Field(default=None, foreign_key="taskbreakdown.id")
 
 
-
 @event.listens_for(Task, "before_insert")
 @event.listens_for(Task, "before_update")
 def set_finished_at_when_task_finished(_mapper: Mapper[Task], _connection: Connection, target: Task):

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -174,6 +174,7 @@ async def create_sandbox(
     Returns:
         A context manager that yields the sandbox
     """
+    sandbox_name = f"{sandbox_name}_{uuid.uuid4().hex[:6]}"
     source_name = _source_name(source)
     logger.info(f"Creating sandbox {sandbox_name} with source {source_name}")
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -16,13 +16,15 @@ import sentry_sdk
 from benchmark_service import (
     ExecResult,
     ImageSource,
-    Resources as TrackerResources,
     Sandbox,
     SandboxCreateRequest,
     SandboxNotFoundError,
     SandboxProvider,
     SandboxSource,
     SnapshotSource,
+)
+from benchmark_service import (
+    Resources as TrackerResources,
 )
 from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxCommandError
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
@@ -36,9 +38,9 @@ from tenacity import (
 
 from tracker.aws.s3 import create_presigned_url, get_agent_result_s3_key, get_benchmark_contract_s3_key, upload_to_s3
 from tracker.database.models import (
+    MAX_OUTPUT_ARTIFACT_BYTES,
     AgentCausedExitReason,
     AgentContractRequest,
-    MAX_OUTPUT_ARTIFACT_BYTES,
     OutputArtifactSpec,
 )
 from tracker.exceptions import (
@@ -353,6 +355,8 @@ async def stream_command_output(
                 output.append(data)
         except ProviderSandboxCommandError as e:
             exit_code = e.exit_code
+        except ProviderSandboxError as e:
+            raise SandboxError(str(e)) from e
 
         start_ns = (await _exec(sandbox, f"cat {shlex.quote(start_ns_path)}")).stdout
         end_ns = (await _exec(sandbox, f"cat {shlex.quote(end_ns_path)}")).stdout

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -501,7 +501,7 @@ async def process_task(
         start_sandbox_build_time = time.perf_counter()
         async with create_sandbox(
             provider=sandbox_provider,
-            sandbox_name=task_row.alias,
+            sandbox_name=task_row.task_id,
             source=task_data.source,
             labels=labels,
             env_vars=env_vars,

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -153,7 +153,8 @@ class TestForceStop:
         # Test force_stop_sandboxes util by running all 12 sandboxes in parallel and
         # See if we can close them all
         created_sandboxes = asyncio.gather(
-            *[asyncio.create_task(create_sandbox_with_delay(task.task_id)) for task in tasks]
+            *[asyncio.create_task(create_sandbox_with_delay(task.task_id)) for task in tasks],
+            return_exceptions=True,
         )
 
         # Pause for 2 seconds to ensure that the sandboxes are being created

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -17,10 +17,12 @@ from tracker.utils import force_stop_sandboxes, process_benchmark
 
 logger = get_logger(__name__)
 
+_DEAD_STATES = {"destroying", "destroyed", "stopped", "error"}
+
 
 async def _sandboxes_for_benchmark(benchmark: Benchmark, provider: SandboxProvider):
     query = SandboxQuery(labels={"Benchmark": benchmark.name, "Id": str(benchmark.id)})
-    return [sandbox async for sandbox in provider.list_sandboxes(query)]
+    return [sandbox async for sandbox in provider.list_sandboxes(query) if sandbox.state not in _DEAD_STATES]
 
 
 class TestForceStop:

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -73,6 +73,8 @@ class TestForceStop:
                 Org(id=TEST_ORG_ID, name="default"),
             )
 
+        created_sandbox_name: list[str] = []
+
         async def _generator_to_courtine():
             async with create_sandbox(
                 provider,
@@ -81,8 +83,8 @@ class TestForceStop:
                 resources=test_resources,
                 creation_semaphore=creation_semaphore,
                 labels=labels,
-            ) as _:
-                pass
+            ) as sandbox:
+                created_sandbox_name.append(sandbox.name)
 
         # Start sandbox and immediately try to stop it, expected to wait until its started to delete
         await asyncio.gather(
@@ -93,6 +95,10 @@ class TestForceStop:
         # Ensure that the task is in the stopped state
         task = database_session.exec(select(Task).where(Task.id == task.id)).one()
         assert task.status == TaskStatus.STOPPED
+
+        # Ensure that the sandbox does not exist anymore
+        with pytest.raises(Exception):
+            await provider.get_sandbox(created_sandbox_name[0])
 
     async def test_force_stop_sandboxes(
         self,

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -76,7 +76,7 @@ class TestForceStop:
         async def _generator_to_courtine():
             async with create_sandbox(
                 provider,
-                task.alias,
+                task.task_id,
                 ImageSource(image=test_image),
                 resources=test_resources,
                 creation_semaphore=creation_semaphore,
@@ -93,10 +93,6 @@ class TestForceStop:
         # Ensure that the task is in the stopped state
         task = database_session.exec(select(Task).where(Task.id == task.id)).one()
         assert task.status == TaskStatus.STOPPED
-
-        # Ensure that the sandbox does not exist anymore
-        with pytest.raises(Exception):
-            await provider.get_sandbox(task.alias)
 
     async def test_force_stop_sandboxes(
         self,
@@ -151,7 +147,7 @@ class TestForceStop:
         # Test force_stop_sandboxes util by running all 12 sandboxes in parallel and
         # See if we can close them all
         created_sandboxes = asyncio.gather(
-            *[asyncio.create_task(create_sandbox_with_delay(task.alias)) for task in tasks]
+            *[asyncio.create_task(create_sandbox_with_delay(task.task_id)) for task in tasks]
         )
 
         # Pause for 2 seconds to ensure that the sandboxes are being created

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -63,12 +63,13 @@ class TestSandboxOperations:
             test_resources,
             creation_semaphore,
         ) as sandbox:
-            assert sandbox.name == random_sandbox_name
+            assert sandbox.name.startswith(random_sandbox_name)
             result = await sandbox.exec("echo 'test'")
             assert result.exit_code == 0
+            actual_name = sandbox.name
 
         with pytest.raises(SandboxNotFoundError):
-            await sandbox_provider.get_sandbox(random_sandbox_name)
+            await sandbox_provider.get_sandbox(actual_name)
 
     async def test_upload_agent_artifacts(
         self, test_sandbox: Sandbox, aws_credentials: AWSCredentials, harness_config: HarnessConfig
@@ -195,36 +196,6 @@ class TestSandboxOperations:
         assert "line1" in output
         assert "line2" in output
         assert "line3" in output
-
-    async def test_create_sandbox_reuse(
-        self,
-        sandbox_provider: SandboxProvider,
-        test_resources: Resources,
-        test_image: str,
-        random_sandbox_name: str,
-        creation_semaphore: asyncio.Semaphore,
-    ) -> None:
-        """Test that create_sandbox reuses existing sandbox instead of creating new one."""
-
-        async with create_sandbox(
-            sandbox_provider,
-            random_sandbox_name,
-            ImageSource(image=test_image),
-            test_resources,
-            creation_semaphore,
-        ) as sandbox1:
-            result = await sandbox1.exec("echo 'test'")
-            assert result.exit_code == 0
-            first_id = sandbox1.id
-
-            async with create_sandbox(
-                sandbox_provider,
-                random_sandbox_name,
-                ImageSource(image=test_image),
-                test_resources,
-                creation_semaphore,
-            ) as sandbox2:
-                assert sandbox2.id == first_id
 
     async def test_deterministic_timeout_behavior(
         self,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -150,49 +150,6 @@ class TestStopAndResume:
         database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.FINISHED, benchmark_row.error_message
 
-    async def test_resume_changes_task_alias_per_attempt(
-        self,
-        example_benchmark_object: Benchmark,
-        database_session: Session,
-        monkeypatch: MonkeyPatch,
-        harness_config: HarnessConfig,
-    ):
-        benchmark_row = example_benchmark_object
-        benchmark_row.status = BenchmarkStatus.STOPPED
-        database_session.add(benchmark_row)
-        database_session.commit()
-
-        task_rows = [
-            Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id, status=TaskStatus.STOPPED)
-            for i in range(2)
-        ]
-        database_session.add_all(task_rows)
-        database_session.commit()
-
-        original_aliases = {task_row.task_id: task_row.alias for task_row in task_rows}
-
-        async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
-            return VerifyTaskIdsResponse(task_ids=[task_row.task_id for task_row in task_rows])
-
-        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
-
-        # resets the start time of the task, so the alias will be different the next time we run the task
-        verified_task_ids = await reset_to_in_progress_status(
-            benchmark_row=benchmark_row,
-            session=database_session,
-            benchmark_service=benchmark_row.benchmark_service(harness_config.daytona_secret_name, harness_config.aws),
-            retry=True,
-            retry_mode=RetryMode.AUTO,
-            rerun_task_ids=[],
-            org=self._test_org,
-        )
-
-        assert set(verified_task_ids) == set(original_aliases.keys())
-
-        updated_task_rows = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
-        for task_row in updated_task_rows:
-            assert task_row.alias != original_aliases[task_row.task_id]
-
     @pytest.mark.parametrize(
         ("retry_mode", "eval_resume_state", "expected_status", "expected_state"),
         [


### PR DESCRIPTION
## Summary
<!-- What does this PR do? Why is it needed? -->
Alias was being cached as a property and reused to create sandboxes that already existed. Removing and salting inside of the method ensures that the name is actually unique.

## Changes
<!-- List the key changes made -->
- remove task alias
- salt sandbox name inside of the create_sandbox method

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed