### PR TITLE
Fix code migration readiness stalls

### DIFF
--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
 _created_streams: set[str] = set()
 
 
+def _log_stream_name(task_id: str) -> str:
+    return task_id.replace(":", "_").replace("*", "_")
+
+
 @lru_cache(maxsize=32)
 def _cloudwatch_client(aws: "AWSCredentials") -> Any:
     """Cloudwatch client cached to share instances."""
@@ -116,21 +120,22 @@ def write_benchmark_log_event(stream_key: str, message: str, aws: "AWSCredential
 
     client = _cloudwatch_client(aws)
     log_group_name = f"{log_group}/{benchmark_id}"
+    log_stream_name = _log_stream_name(task_id)
 
     if stream_key not in _created_streams:
         try:
-            client.create_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
+            client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)  # pyright: ignore[reportUnknownMemberType]
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
                 raise
         except BotoCoreError as e:
-            raise CloudWatchError(f"Failed to create log stream '{task_id}': {e}") from e
+            raise CloudWatchError(f"Failed to create log stream '{log_stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
     try:
         client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
             logGroupName=log_group_name,
-            logStreamName=task_id,
+            logStreamName=log_stream_name,
             logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
         )
     except (ClientError, BotoCoreError) as e:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,5 +1,6 @@
 """Sandbox management utilities for the tracker service."""
 
+import asyncio
 import base64
 import shlex
 import time
@@ -64,6 +65,7 @@ logger = get_logger(__name__)
 bundle_path = PurePosixPath("/bundle")
 SANDBOX_AUTO_STOP_INTERVAL = 10 * 60
 SANDBOX_CREATE_TIMEOUT = 360
+_UPLOAD_AGENT_TIMEOUT_SECONDS = 300
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
@@ -270,7 +272,12 @@ async def upload_agent_artifacts(
     script = " && ".join(steps)
 
     try:
-        result = await _exec(sandbox, script)
+        result = await asyncio.wait_for(_exec(sandbox, script), timeout=_UPLOAD_AGENT_TIMEOUT_SECONDS)
+    except TimeoutError as e:
+        raise SandboxError(
+            f"Timed out uploading contract {contract.name} to sandbox {sandbox.name} "
+            f"after {_UPLOAD_AGENT_TIMEOUT_SECONDS}s"
+        ) from e
     except Exception as e:
         raise SandboxError(f"Failed to upload contract {contract.name} to sandbox {sandbox.name}: {e}") from e
 

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import BotoCoreError, ClientError
 
-from tracker.aws.cloudwatch_logs import handle_cloudwatch_error
+from tracker.aws.cloudwatch_logs import _log_stream_name, handle_cloudwatch_error
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.aws.s3 import handle_s3_error
 
@@ -38,6 +38,9 @@ class TestS3DecoratorClient:
 
 
 class TestCloudWatchClient:
+    def test_log_stream_name_replaces_invalid_characters(self):
+        assert _log_stream_name("repo-name:Rust*variant") == "repo-name_Rust_variant"
+
     def test_cloudwatch_error_with_client(self):
         """Test that ClientError is caught buy the decorator"""
         client_error = ClientError({"Error": {"Code": "404", "Message": "Not found"}}, "CreateLogStream")

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -486,6 +486,31 @@ class TestAgentOutputTelemetry:
 
 
 class TestUploadAgentArtifacts:
+    async def test_upload_timeout_raises_sandbox_error(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _slow_exec(*_args: Any, **_kwargs: Any) -> ExecResult:
+            await asyncio.sleep(1)
+            return ExecResult(exit_code=0, stdout="", stderr="")
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.name = "test-sandbox"
+
+        monkeypatch.setattr(sandbox_module, "_UPLOAD_AGENT_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(sandbox_module, "_exec", _slow_exec)
+        monkeypatch.setattr("tracker.sandbox.create_presigned_url", Mock(return_value="https://example.com/presigned"))
+
+        aws = AWSCredentials(
+            aws_access_key_id="test",
+            aws_secret_access_key="test",
+            aws_default_region="us-east-1",
+        )
+
+        with pytest.raises(SandboxError, match="Timed out uploading contract"):
+            await upload_agent_artifacts(mock_sandbox, contract, "bench-123", aws, "test-bucket")
+
     @pytest.mark.parametrize(
         "exit_code,retryable",
         [

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -627,9 +627,10 @@ def paginate_benchmarks(
             format_no_benchmarks_found(agent_name, benchmark_name, model, dataset, status, started_by)
             break
 
-        format_fetch_benchmarks_response(response, current_page, total_pages)
+        interactive = click.get_text_stream("stdin").isatty() and click.get_text_stream("stdout").isatty()
+        format_fetch_benchmarks_response(response, current_page, total_pages if interactive else 1)
 
-        if total_pages <= 1:
+        if total_pages <= 1 or not interactive:
             break
 
         char = click.getchar()

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -10,7 +10,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Coroutine, TypeVar
+from typing import Any, Coroutine, Protocol, TypeVar
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -33,6 +33,10 @@ from valkyrie.cli.tracker_service import TrackerService
 CONFIG_LOCATION: Path = Path("~/.config/valkyrie/valkyrie.yaml").expanduser()
 
 T = TypeVar("T")
+
+
+class BenchmarkFetcher(Protocol):
+    def fetch_benchmarks(self, request: FetchBenchmarksRequest) -> FetchBenchmarksResponse: ...
 
 
 class ConfigValue(str, Enum):
@@ -577,7 +581,7 @@ def format_no_benchmarks_found(
 
 
 def paginate_benchmarks(
-    tracker: TrackerService,
+    tracker: BenchmarkFetcher,
     agent_name: str | None,
     benchmark_name: str | None,
     model: str | None,

--- a/tests/unit/test_cli_pagination.py
+++ b/tests/unit/test_cli_pagination.py
@@ -1,0 +1,55 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from tracker.database.models import BenchmarkStatus
+from tracker.types import BenchmarkTableRow, FetchBenchmarksRequest, FetchBenchmarksResponse
+
+from valkyrie.cli.utils import paginate_benchmarks
+
+
+class FakeTracker:
+    def __init__(self) -> None:
+        self.requests: list[FetchBenchmarksRequest] = []
+
+    def fetch_benchmarks(self, request: FetchBenchmarksRequest) -> FetchBenchmarksResponse:
+        self.requests.append(request)
+        return FetchBenchmarksResponse(
+            benchmarks=[
+                BenchmarkTableRow(
+                    id=uuid4(),
+                    name="code-migration",
+                    agent_name="mini_swe_code_migration",
+                    model="openai/gpt-5.5",
+                    started_by_email=None,
+                    started_at=datetime(2026, 6, 3, tzinfo=UTC),
+                    finished_at=None,
+                    status=BenchmarkStatus.IN_PROGRESS,
+                    total_tasks=10,
+                    finished_tasks=5,
+                )
+            ],
+            total_count=6,
+        )
+
+
+def test_paginate_benchmarks_returns_in_noninteractive_shell(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr("valkyrie.cli.utils.click.getchar", lambda: pytest.fail("getchar should not be called"))
+    tracker = FakeTracker()
+
+    paginate_benchmarks(
+        tracker,
+        agent_name=None,
+        benchmark_name="code-migration",
+        model=None,
+        dataset=None,
+        status=None,
+        order_by="desc",
+    )
+
+    assert len(tracker.requests) == 1
+    output = capsys.readouterr().out
+    assert "Total: 6 run(s)" in output
+    assert "next" not in output


### PR DESCRIPTION
## Summary
- add a timeout around agent artifact upload so Daytona exec stalls fail and retry instead of hanging a run indefinitely
- normalize CloudWatch log stream names for task IDs containing ':' or '*'

## Why
While validating code-migration COBOL runs, the service deployed cleanly but the tracker worker stalled in upload_agent_artifacts after the bundle was already extracted in the sandbox. Concurrent code-migration CLI runs also emitted CloudWatch InvalidParameterException errors for task IDs like repo:Language.

## Tests
- uv run pytest services/tracker/tests/unit/test_aws_clients.py services/tracker/tests/unit/test_sandbox.py -q
- uv run ruff check services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/aws/cloudwatch_logs.py services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_aws_clients.py