### PR TITLE
Fix CloudWatch stream names for task ids

### DIFF
--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -15,6 +15,10 @@ if TYPE_CHECKING:
 _created_streams: set[str] = set()
 
 
+def _log_stream_name(task_id: str) -> str:
+    return task_id.replace(":", "_").replace("*", "_")
+
+
 @lru_cache(maxsize=32)
 def _cloudwatch_client(aws: "AWSCredentials") -> Any:
     """Cloudwatch client cached to share instances."""
@@ -58,7 +62,7 @@ def get_benchmark_log_url(benchmark_id: str, region: str, log_group: str, task_i
     base = f"https://{region}.console.aws.amazon.com/cloudwatch/home?region={region}"
     encoded_log_group = f"{log_group}$252F{benchmark_id}"
     if task_id:
-        return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{task_id}"
+        return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{_log_stream_name(task_id)}"
 
     return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}"
 
@@ -116,21 +120,22 @@ def write_benchmark_log_event(stream_key: str, message: str, aws: "AWSCredential
 
     client = _cloudwatch_client(aws)
     log_group_name = f"{log_group}/{benchmark_id}"
+    log_stream_name = _log_stream_name(task_id)
 
     if stream_key not in _created_streams:
         try:
-            client.create_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
+            client.create_log_stream(logGroupName=log_group_name, logStreamName=log_stream_name)  # pyright: ignore[reportUnknownMemberType]
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
                 raise
         except BotoCoreError as e:
-            raise CloudWatchError(f"Failed to create log stream '{task_id}': {e}") from e
+            raise CloudWatchError(f"Failed to create log stream '{log_stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
     try:
         client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
             logGroupName=log_group_name,
-            logStreamName=task_id,
+            logStreamName=log_stream_name,
             logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
         )
     except (ClientError, BotoCoreError) as e:

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import BotoCoreError, ClientError
 
-from tracker.aws.cloudwatch_logs import handle_cloudwatch_error
+from tracker.aws.cloudwatch_logs import get_benchmark_log_url, handle_cloudwatch_error
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.aws.s3 import handle_s3_error
 
@@ -38,6 +38,10 @@ class TestS3DecoratorClient:
 
 
 class TestCloudWatchClient:
+    def test_benchmark_log_url_uses_log_stream_name(self):
+        url = get_benchmark_log_url("run-id", "us-east-1", "benchmarks", "repo-name:Rust*variant")
+        assert url.endswith("/log-events/repo-name_Rust_variant")
+
     def test_cloudwatch_error_with_client(self):
         """Test that ClientError is caught buy the decorator"""
         client_error = ClientError({"Error": {"Code": "404", "Message": "Not found"}}, "CreateLogStream")


### PR DESCRIPTION
Narrow release-readiness hotfix for code-migration task IDs containing ':' or '*'.

Changes:
- sanitize CloudWatch log stream names before create/put log events
- use the same sanitized stream name in CloudWatch task log URLs
- add a focused unit test for task log URL behavior

Validation:
- cd services/tracker && uv run pytest tests/unit/test_aws_clients.py
- cd services/tracker && uv run ruff check src/tracker/aws/cloudwatch_logs.py tests/unit/test_aws_clients.py
- cd infra && AUTH_REQUIRED=true DESCOPE_PROJECT_ID=P2ktNOjz5Tgzs9wwS3VpShnCbmik uv run cdk diff TrackerStack WorkerStack