### PR TITLE
refactor: thread stage context through cdk infra

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,5 +1,12 @@
 .PHONY: help install deploy deploy-shared deploy-tracker hotswap diff destroy
 
+# Stage selection: STAGE=prod (default) or STAGE=dev. Passed to CDK as context;
+# STACK_PREFIX prefixes stack ids so STAGE=dev targets the Dev-* stacks.
+# Default prod => empty prefix, so every target is byte-identical to pre-stage behavior.
+STAGE ?= prod
+STACK_PREFIX := $(if $(filter-out prod,$(STAGE)),Dev-,)
+CDK_CTX := -c stage=$(STAGE)
+
 help:
 	@echo "Makefile for agentic-harness infrastructure"
 	@echo ""
@@ -23,20 +30,20 @@ venv_check:
 	fi
 
 deploy: venv_check
-	uv run cdk deploy --all --require-approval never
+	uv run cdk deploy --all $(CDK_CTX) --require-approval never
 
 deploy-shared: venv_check
-	uv run cdk deploy SharedStack --require-approval never
+	uv run cdk deploy $(STACK_PREFIX)SharedStack $(CDK_CTX) --require-approval never
 
 deploy-tracker: venv_check
-	uv run cdk deploy TrackerStack --require-approval never
+	uv run cdk deploy $(STACK_PREFIX)TrackerStack $(CDK_CTX) --require-approval never
 
 hotswap: venv_check
-	uv run cdk deploy --all --hotswap
+	uv run cdk deploy --all $(CDK_CTX) --hotswap
 
 diff: venv_check
-	uv run cdk diff
+	uv run cdk diff $(CDK_CTX)
 
 destroy: venv_check
 	@read -p "Are you sure you want to destroy all stacks? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
-	uv run cdk destroy --all
+	uv run cdk destroy --all $(CDK_CTX)

--- a/infra/app.py
+++ b/infra/app.py
@@ -5,10 +5,12 @@ import os
 import aws_cdk as cdk
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
+from stage import resolve
 from tracker_stack import TrackerStack
 from worker_stack import WorkerStack
 
 app = cdk.App()
+stage = resolve(app)
 
 env = cdk.Environment(
     account=os.getenv("CDK_DEFAULT_ACCOUNT"),
@@ -16,12 +18,13 @@ env = cdk.Environment(
 )
 
 # Shared infrastructure (VPC, cluster, service discovery, Route53)
-shared = SharedStack(app, "SharedStack", env=env)
+shared = SharedStack(app, stage.stack_id("SharedStack"), stage=stage, env=env)
 
 # Tracker service (public-facing with ALB) + RDS database
 tracker = TrackerStack(
     app,
-    "TrackerStack",
+    stage.stack_id("TrackerStack"),
+    stage=stage,
     vpc=shared.vpc,
     cluster=shared.cluster,
     namespace=shared.namespace,
@@ -34,7 +37,8 @@ tracker = TrackerStack(
 # Worker service (Taskiq worker) - deployed independently
 worker = WorkerStack(
     app,
-    "WorkerStack",
+    stage.stack_id("WorkerStack"),
+    stage=stage,
     vpc=shared.vpc,
     cluster=shared.cluster,
     redis_url=shared.redis_url,
@@ -47,7 +51,8 @@ worker = WorkerStack(
 
 monitoring = MonitoringStack(
     app,
-    "MonitoringStack",
+    stage.stack_id("MonitoringStack"),
+    stage=stage,
     cluster=shared.cluster,
     tracker_service=tracker.tracker_fargate_service,
     worker_service=worker.worker_service,

--- a/infra/dashboards.py
+++ b/infra/dashboards.py
@@ -15,6 +15,7 @@ from aws_cdk import (
     aws_rds,
 )
 from constructs import Construct
+from stage import Stage
 
 # Default widget height for dashboard layouts. CloudWatch grids are 24 units wide.
 _WIDGET_HEIGHT = 6
@@ -24,6 +25,7 @@ _SINGLE_VALUE_HEIGHT = 3
 def create_overview_dashboard(
     scope: Construct,
     *,
+    stage: Stage,
     tracker_service: aws_ecs.FargateService,
     worker_service: aws_ecs.FargateService,
     load_balancer: aws_elb.ApplicationLoadBalancer,
@@ -35,7 +37,7 @@ def create_overview_dashboard(
     dashboard = aws_cloudwatch.Dashboard(
         scope,
         "ValkyrieOverviewDashboard",
-        dashboard_name="Valkyrie-Overview",
+        dashboard_name=stage.phys("Valkyrie-Overview"),
         default_interval=cdk.Duration.hours(3),
         period_override=aws_cloudwatch.PeriodOverride.AUTO,
     )
@@ -237,6 +239,7 @@ def create_overview_dashboard(
 def create_ecs_dashboard(
     scope: Construct,
     *,
+    stage: Stage,
     tracker_service: aws_ecs.FargateService,
     worker_service: aws_ecs.FargateService,
 ) -> aws_cloudwatch.Dashboard:
@@ -244,7 +247,7 @@ def create_ecs_dashboard(
     dashboard = aws_cloudwatch.Dashboard(
         scope,
         "ValkyrieEcsDashboard",
-        dashboard_name="Valkyrie-ECS",
+        dashboard_name=stage.phys("Valkyrie-ECS"),
         default_interval=cdk.Duration.hours(24),
         period_override=aws_cloudwatch.PeriodOverride.AUTO,
     )
@@ -357,6 +360,7 @@ def create_ecs_dashboard(
 def create_alb_dashboard(
     scope: Construct,
     *,
+    stage: Stage,
     load_balancer: aws_elb.ApplicationLoadBalancer,
     target_group: aws_elb.ApplicationTargetGroup,
 ) -> aws_cloudwatch.Dashboard:
@@ -364,7 +368,7 @@ def create_alb_dashboard(
     dashboard = aws_cloudwatch.Dashboard(
         scope,
         "ValkyrieAlbDashboard",
-        dashboard_name="Valkyrie-ALB",
+        dashboard_name=stage.phys("Valkyrie-ALB"),
         default_interval=cdk.Duration.hours(24),
         period_override=aws_cloudwatch.PeriodOverride.AUTO,
     )
@@ -517,6 +521,7 @@ def create_alb_dashboard(
 def create_rds_dashboard(
     scope: Construct,
     *,
+    stage: Stage,
     database: aws_rds.DatabaseInstance,
     region: str,
 ) -> aws_cloudwatch.Dashboard:
@@ -524,7 +529,7 @@ def create_rds_dashboard(
     dashboard = aws_cloudwatch.Dashboard(
         scope,
         "ValkyrieRdsDashboard",
-        dashboard_name="Valkyrie-RDS",
+        dashboard_name=stage.phys("Valkyrie-RDS"),
         default_interval=cdk.Duration.hours(24),
         period_override=aws_cloudwatch.PeriodOverride.AUTO,
     )
@@ -695,13 +700,14 @@ def create_rds_dashboard(
 def create_redis_dashboard(
     scope: Construct,
     *,
+    stage: Stage,
     redis_cluster: aws_elasticache.CfnCacheCluster,
 ) -> aws_cloudwatch.Dashboard:
     """`Valkyrie-Redis` -- ElastiCache metrics including command breakdown."""
     dashboard = aws_cloudwatch.Dashboard(
         scope,
         "ValkyrieRedisDashboard",
-        dashboard_name="Valkyrie-Redis",
+        dashboard_name=stage.phys("Valkyrie-Redis"),
         default_interval=cdk.Duration.hours(24),
         period_override=aws_cloudwatch.PeriodOverride.AUTO,
     )

--- a/infra/monitoring_stack.py
+++ b/infra/monitoring_stack.py
@@ -22,6 +22,7 @@ from dashboards import (
     create_rds_dashboard,
     create_redis_dashboard,
 )
+from stage import Stage
 
 
 class MonitoringStack(cdk.Stack):
@@ -38,6 +39,7 @@ class MonitoringStack(cdk.Stack):
         scope: Construct,
         id: str,
         *,
+        stage: Stage,
         cluster: aws_ecs.ICluster,
         tracker_service: aws_ecs.FargateService,
         worker_service: aws_ecs.FargateService,
@@ -48,6 +50,7 @@ class MonitoringStack(cdk.Stack):
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, id, **kwargs)
+        self.stage = stage
 
         self.cluster = cluster
         self.tracker_service = tracker_service
@@ -60,7 +63,7 @@ class MonitoringStack(cdk.Stack):
         self.alerts_topic = aws_sns.Topic(
             self,
             "ValkyrieAlertsTopic",
-            topic_name="Valkyrie-Alerts",
+            topic_name=self.stage.phys("Valkyrie-Alerts"),
             display_name="Valkyrie infrastructure alerts",
         )
         slack_config = get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV)
@@ -69,7 +72,7 @@ class MonitoringStack(cdk.Stack):
             self.alerts_slack = aws_chatbot.SlackChannelConfiguration(
                 self,
                 "ValkyrieAlertsSlackChannel",
-                slack_channel_configuration_name="valkyrie-alerts",
+                slack_channel_configuration_name=self.stage.phys("valkyrie-alerts"),
                 slack_workspace_id=slack_workspace_id,
                 slack_channel_id=slack_channel_id,
             )
@@ -86,6 +89,7 @@ class MonitoringStack(cdk.Stack):
 
         self.overview_dashboard = create_overview_dashboard(
             self,
+            stage=self.stage,
             tracker_service=tracker_service,
             worker_service=worker_service,
             load_balancer=load_balancer,
@@ -95,21 +99,25 @@ class MonitoringStack(cdk.Stack):
         )
         self.ecs_dashboard = create_ecs_dashboard(
             self,
+            stage=self.stage,
             tracker_service=tracker_service,
             worker_service=worker_service,
         )
         self.alb_dashboard = create_alb_dashboard(
             self,
+            stage=self.stage,
             load_balancer=load_balancer,
             target_group=target_group,
         )
         self.rds_dashboard = create_rds_dashboard(
             self,
+            stage=self.stage,
             database=database,
             region=self.region,
         )
         self.redis_dashboard = create_redis_dashboard(
             self,
+            stage=self.stage,
             redis_cluster=redis_cluster,
         )
 
@@ -131,7 +139,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "TrackerUnhealthyAlarm",
-            alarm_name="Valkyrie-Tracker-Unhealthy",
+            alarm_name=self.stage.phys("Valkyrie-Tracker-Unhealthy"),
             alarm_description="Tracker ALB has at least one unhealthy target for 2+ minutes",
             metric=target_group.metric_unhealthy_host_count(
                 period=cdk.Duration.minutes(1),
@@ -149,7 +157,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "WorkerServiceDownAlarm",
-            alarm_name="Valkyrie-Worker-Service-Down",
+            alarm_name=self.stage.phys("Valkyrie-Worker-Service-Down"),
             alarm_description=(
                 "Worker Fargate running task count = 0 for 3+ minutes. "
                 "Worker containers not running (min=1 autoscale floor breached)."
@@ -175,7 +183,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "HighFiveXXRateAlarm",
-            alarm_name="Valkyrie-API-5XX-Rate-High",
+            alarm_name=self.stage.phys("Valkyrie-API-5XX-Rate-High"),
             alarm_description="API returning 10+ 5XX responses in a 5-minute window",
             metric=load_balancer.metric_http_code_target(
                 code=aws_elb.HttpCodeTarget.TARGET_5XX_COUNT,
@@ -192,7 +200,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "HighApiLatencyAlarm",
-            alarm_name="Valkyrie-API-Latency-High",
+            alarm_name=self.stage.phys("Valkyrie-API-Latency-High"),
             alarm_description="API target response time p99 >= 5s for 5+ minutes",
             metric=load_balancer.metric_target_response_time(
                 period=cdk.Duration.minutes(1),
@@ -211,7 +219,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "DbConnectionsHighAlarm",
-            alarm_name="Valkyrie-DB-Connections-High",
+            alarm_name=self.stage.phys("Valkyrie-DB-Connections-High"),
             alarm_description="RDS database connections >= 135 (~80% of t4g.small max)",
             metric=database.metric_database_connections(
                 period=cdk.Duration.minutes(1),
@@ -228,7 +236,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "DbStorageLowAlarm",
-            alarm_name="Valkyrie-DB-Storage-Low",
+            alarm_name=self.stage.phys("Valkyrie-DB-Storage-Low"),
             alarm_description="RDS free storage space <= 2 GB",
             metric=database.metric_free_storage_space(
                 period=cdk.Duration.minutes(5),
@@ -244,7 +252,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "DbCpuHighAlarm",
-            alarm_name="Valkyrie-DB-CPU-High",
+            alarm_name=self.stage.phys("Valkyrie-DB-CPU-High"),
             alarm_description="RDS CPU utilization >= 80% for 10+ minutes",
             metric=database.metric_cpu_utilization(
                 period=cdk.Duration.minutes(1),
@@ -261,7 +269,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "RedisMemoryHighAlarm",
-            alarm_name="Valkyrie-Redis-Memory-High",
+            alarm_name=self.stage.phys("Valkyrie-Redis-Memory-High"),
             alarm_description="Redis memory usage >= 80% for 5+ minutes",
             metric=aws_cloudwatch.Metric(
                 namespace="AWS/ElastiCache",
@@ -281,7 +289,7 @@ class MonitoringStack(cdk.Stack):
         aws_cloudwatch.Alarm(
             self,
             "RedisEvictionsAlarm",
-            alarm_name="Valkyrie-Redis-Evictions",
+            alarm_name=self.stage.phys("Valkyrie-Redis-Evictions"),
             alarm_description="Redis evicted 1+ keys in a 5-minute window (data loss in queue)",
             metric=aws_cloudwatch.Metric(
                 namespace="AWS/ElastiCache",

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -29,6 +29,7 @@ from constants import (
     get_slack_notification_config,
 )
 from constructs import Construct
+from stage import Stage
 
 DEPLOYMENT_STACK_NAMES = ("SharedStack", "TrackerStack", "WorkerStack", "MonitoringStack")
 DEPLOYMENT_SUCCESS_STATUSES = ("CREATE_COMPLETE", "UPDATE_COMPLETE")
@@ -44,8 +45,9 @@ DEPLOYMENT_FAILURE_STATUSES = (
 class SharedStack(Stack):
     """Shared infrastructure for all services."""
 
-    def __init__(self, scope: Construct, id: str, **kwargs: Any):
+    def __init__(self, scope: Construct, id: str, stage: Stage, **kwargs: Any):
         super().__init__(scope, id, **kwargs)
+        self.stage = stage
 
         # shared VPC - public subnets only, no NAT gateway (cost savings)
         self.vpc = aws_ec2.Vpc(
@@ -71,7 +73,7 @@ class SharedStack(Stack):
             self,
             "AgenticHarnessCluster",
             vpc=self.vpc,
-            cluster_name=CLUSTER_NAME,
+            cluster_name=self.stage.phys(CLUSTER_NAME),
             container_insights=True,
         )
 
@@ -80,7 +82,7 @@ class SharedStack(Stack):
         self.namespace = aws_servicediscovery.PrivateDnsNamespace(
             self,
             "AgenticHarnessNamespace",
-            name=NAMESPACE,
+            name=self.stage.phys(NAMESPACE),
             vpc=self.vpc,
         )
 
@@ -95,7 +97,7 @@ class SharedStack(Stack):
         self.bucket = aws_s3.Bucket(
             self,
             "AgenticHarnessBucket",
-            bucket_name=S3_BUCKET_NAME,
+            bucket_name=self.stage.phys(S3_BUCKET_NAME),
             removal_policy=cdk.RemovalPolicy.RETAIN,
             block_public_access=aws_s3.BlockPublicAccess.BLOCK_ALL,
         )
@@ -150,12 +152,12 @@ class SharedStack(Stack):
         notification_topic = aws_sns.Topic(
             self,
             "StackNotificationTopic",
-            topic_name="agentic-harness-notifications",
+            topic_name=self.stage.phys("agentic-harness-notifications"),
         )
         slack = aws_chatbot.SlackChannelConfiguration(
             self,
             "DeploymentNotificationsSlackChannel",
-            slack_channel_configuration_name="deployment-notifications",
+            slack_channel_configuration_name=self.stage.phys("deployment-notifications"),
             slack_workspace_id=slack_workspace_id,
             slack_channel_id=slack_channel_id,
         )
@@ -206,7 +208,9 @@ class SharedStack(Stack):
                 detail_type=["CloudFormation Stack Status Change"],
                 detail={
                     "stack-id": [
-                        {"prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{name}/"}
+                        {
+                            "prefix": f"arn:aws:cloudformation:{self.region}:{self.account}:stack/{self.stage.stack_id(name)}/"
+                        }
                         for name in DEPLOYMENT_STACK_NAMES
                     ],
                     "status-details": {

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -1,0 +1,52 @@
+"""Stage-aware naming for the two-environment (prod/dev) CDK refactor.
+
+prod  → every helper is the identity function, so `cdk synth -c stage=prod` is
+        byte-identical to the pre-refactor `cdk synth`.
+dev   → stacks get a "Dev-" construct-id prefix; physical names get a "-dev"
+        suffix; FQDNs get "-dev" on their first label.
+
+CONVENTION CONTRACT: benchmark-services-registry/infra/stage.py is a near-copy of
+this module (it adds an ssm() method) and its dev cross-repo lookups assume EXACTLY
+these dev names: VPC "Dev-SharedStack/AgenticHarnessVpc", cluster
+"AgenticHarnessCluster-dev", service-discovery namespace "local-dev" (tracker
+reachable at "tracker.local-dev"), SNS topic "agentic-harness-notifications-dev".
+The two repos share no code and this contract is comment-enforced only — keep them
+in sync; drift silently breaks dev discovery.
+"""
+
+from __future__ import annotations
+
+import aws_cdk as cdk
+
+PROD = "prod"
+DEV = "dev"
+
+
+class Stage:
+    def __init__(self, name: str) -> None:
+        self.name: str = name
+
+    @property
+    def is_prod(self) -> bool:
+        return self.name == PROD
+
+    def stack_id(self, base: str) -> str:
+        return base if self.is_prod else f"Dev-{base}"
+
+    def phys(self, name: str) -> str:
+        return name if self.is_prod else f"{name}-dev"
+
+    def domain(self, fqdn: str) -> str:
+        # "benchmark-tracker.vals.ai" -> "benchmark-tracker-dev.vals.ai"
+        assert "." in fqdn, f"domain() requires a FQDN with a dot, got {fqdn!r}"
+        if self.is_prod:
+            return fqdn
+        first, _, rest = fqdn.partition(".")
+        return f"{first}-dev.{rest}"
+
+
+def resolve(app: cdk.App) -> Stage:
+    name = app.node.try_get_context("stage") or PROD
+    if name not in (PROD, DEV):
+        raise ValueError(f"unknown stage {name!r}; expected {PROD!r} or {DEV!r}")
+    return Stage(name)

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -1,17 +1,10 @@
-"""Stage-aware naming for the two-environment (prod/dev) CDK refactor.
+"""Stage-aware naming helper.
 
 prod  → every helper is the identity function, so `cdk synth -c stage=prod` is
         byte-identical to the pre-refactor `cdk synth`.
 dev   → stacks get a "Dev-" construct-id prefix; physical names get a "-dev"
         suffix; FQDNs get "-dev" on their first label.
 
-CONVENTION CONTRACT: benchmark-services-registry/infra/stage.py is a near-copy of
-this module (it adds an ssm() method) and its dev cross-repo lookups assume EXACTLY
-these dev names: VPC "Dev-SharedStack/AgenticHarnessVpc", cluster
-"AgenticHarnessCluster-dev", service-discovery namespace "local-dev" (tracker
-reachable at "tracker.local-dev"), SNS topic "agentic-harness-notifications-dev".
-The two repos share no code and this contract is comment-enforced only — keep them
-in sync; drift silently breaks dev discovery.
 """
 
 from __future__ import annotations

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -15,11 +15,16 @@ from aws_cdk import (
 from constants import (
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV,
     SLACK_WORKSPACE_ID_ENV,
+    TRACKER_LOG_GROUP_NAME,
     VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV,
+    WORKER_LOG_GROUP_NAME,
     get_slack_notification_config,
 )
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
+from stage import DEV, PROD, Stage
+from tracker_stack import TrackerStack
+from worker_stack import WorkerStack
 
 TEST_ALERTS_SLACK_ENV = {
     SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE",
@@ -56,6 +61,7 @@ def _has_logical_id_prefix(template: assertions.Template, resource_type: str, pr
 
 def _monitoring_template() -> assertions.Template:
     app = cdk.App()
+    stage = Stage(PROD)
     resources = cdk.Stack(
         app,
         "MonitoringTestResources",
@@ -107,6 +113,7 @@ def _monitoring_template() -> assertions.Template:
     monitoring = MonitoringStack(
         app,
         "MonitoringStack",
+        stage=stage,
         cluster=cluster,
         tracker_service=tracker_service,
         worker_service=worker_service,
@@ -122,13 +129,49 @@ def _monitoring_template() -> assertions.Template:
 
 def _shared_template() -> assertions.Template:
     app = cdk.App(context=SHARED_STACK_CONTEXT)
+    stage = Stage(PROD)
     shared = SharedStack(
         app,
         "SharedStack",
+        stage=stage,
         env=cdk.Environment(account="613431292675", region="us-east-1"),
     )
 
     return assertions.Template.from_stack(shared)
+
+
+def _service_templates(stage_name: str) -> tuple[assertions.Template, assertions.Template]:
+    app = cdk.App(context=SHARED_STACK_CONTEXT)
+    stage = Stage(stage_name)
+    env = cdk.Environment(account="613431292675", region="us-east-1")
+    shared = SharedStack(app, stage.stack_id("SharedStack"), stage=stage, env=env)
+    tracker = TrackerStack(
+        app,
+        stage.stack_id("TrackerStack"),
+        stage=stage,
+        vpc=shared.vpc,
+        cluster=shared.cluster,
+        namespace=shared.namespace,
+        hosted_zone=shared.hosted_zone,
+        bucket=shared.bucket,
+        redis_url=shared.redis_url,
+        env=env,
+    )
+    worker = WorkerStack(
+        app,
+        stage.stack_id("WorkerStack"),
+        stage=stage,
+        vpc=shared.vpc,
+        cluster=shared.cluster,
+        redis_url=shared.redis_url,
+        bucket=shared.bucket,
+        database=tracker.database,
+        db_credentials=tracker.db_credentials,
+        tracker_service=tracker.tracker_fargate_service,
+        env=env,
+    )
+
+    return assertions.Template.from_stack(tracker), assertions.Template.from_stack(worker)
 
 
 class MonitoringStackTest(unittest.TestCase):
@@ -220,6 +263,19 @@ class MonitoringStackTest(unittest.TestCase):
                 f"Missing: {SLACK_WORKSPACE_ID_ENV}",
             ):
                 get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV)
+
+    def test_dev_stage_suffixes_service_log_group_names(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            tracker_template, worker_template = _service_templates(DEV)
+
+        tracker_template.has_resource_properties(
+            "AWS::Logs::LogGroup",
+            {"LogGroupName": f"{TRACKER_LOG_GROUP_NAME}-dev"},
+        )
+        worker_template.has_resource_properties(
+            "AWS::Logs::LogGroup",
+            {"LogGroupName": f"{WORKER_LOG_GROUP_NAME}-dev"},
+        )
 
 
 if __name__ == "__main__":

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -34,10 +34,15 @@ TEST_DEPLOYMENT_SLACK_ENV = {
     SLACK_WORKSPACE_ID_ENV: "TTESTWORKSPACE",
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
 }
+TEST_AWS_ACCOUNT = os.environ.get("CDK_DEFAULT_ACCOUNT", "123456789012")
+TEST_AWS_REGION = os.environ.get("CDK_DEFAULT_REGION", "us-east-1")
 SHARED_STACK_CONTEXT = {
-    "availability-zones:account=613431292675:region=us-east-1": ["us-east-1a", "us-east-1b"],
-    "hosted-zone:account=613431292675:domainName=vals.ai:region=us-east-1": {
-        "Id": "/hostedzone/Z047985721WA50ZRLCDNC",
+    f"availability-zones:account={TEST_AWS_ACCOUNT}:region={TEST_AWS_REGION}": [
+        f"{TEST_AWS_REGION}a",
+        f"{TEST_AWS_REGION}b",
+    ],
+    f"hosted-zone:account={TEST_AWS_ACCOUNT}:domainName=vals.ai:region={TEST_AWS_REGION}": {
+        "Id": "/hostedzone/ZTESTVALKYRIE",
         "Name": "vals.ai.",
     },
 }
@@ -134,7 +139,7 @@ def _shared_template() -> assertions.Template:
         app,
         "SharedStack",
         stage=stage,
-        env=cdk.Environment(account="613431292675", region="us-east-1"),
+        env=cdk.Environment(account=TEST_AWS_ACCOUNT, region=TEST_AWS_REGION),
     )
 
     return assertions.Template.from_stack(shared)
@@ -143,7 +148,7 @@ def _shared_template() -> assertions.Template:
 def _service_templates(stage_name: str) -> tuple[assertions.Template, assertions.Template]:
     app = cdk.App(context=SHARED_STACK_CONTEXT)
     stage = Stage(stage_name)
-    env = cdk.Environment(account="613431292675", region="us-east-1")
+    env = cdk.Environment(account=TEST_AWS_ACCOUNT, region=TEST_AWS_REGION)
     shared = SharedStack(app, stage.stack_id("SharedStack"), stage=stage, env=env)
     tracker = TrackerStack(
         app,

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -171,7 +171,7 @@ class TrackerStack(Stack):
                 log_group=aws_logs.LogGroup(
                     self,
                     "TrackerLogGroup",
-                    log_group_name=TRACKER_LOG_GROUP_NAME,
+                    log_group_name=stage.phys(TRACKER_LOG_GROUP_NAME),
                     retention=aws_logs.RetentionDays.ONE_YEAR,
                     removal_policy=cdk.RemovalPolicy.DESTROY,
                 ),

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -43,6 +43,7 @@ from constants import (
     VPC_CIDR,
 )
 from constructs import Construct
+from stage import Stage
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
     cpu_architecture=aws_ecs.CpuArchitecture.ARM64,
@@ -63,6 +64,7 @@ class TrackerStack(Stack):
         self,
         scope: Construct,
         id: str,
+        stage: Stage,
         vpc: aws_ec2.IVpc,
         cluster: aws_ecs.ICluster,
         namespace: aws_servicediscovery.IPrivateDnsNamespace,
@@ -204,9 +206,9 @@ class TrackerStack(Stack):
             cluster=cluster,
             desired_count=TRACKER_MIN_TASKS,
             task_definition=tracker_task_def,
-            service_name="Tracker",
+            service_name=stage.phys("Tracker"),
             circuit_breaker=aws_ecs.DeploymentCircuitBreaker(rollback=True),
-            domain_name=TRACKER_DOMAIN,
+            domain_name=stage.domain(TRACKER_DOMAIN),
             domain_zone=hosted_zone,
             protocol=aws_elasticloadbalancingv2.ApplicationProtocol.HTTPS,
             redirect_http=True,
@@ -218,7 +220,9 @@ class TrackerStack(Stack):
         # Expose the inner FargateService for cross-stack security group rules
         self.tracker_fargate_service = self.service.service
 
-        # Cloud Map registration for internal access
+        # Cloud Map registration for internal access.
+        # Intentionally unstaged: dev gets its own namespace, and benchmark
+        # services reach the tracker by the same internal name in either env.
         self.service.service.enable_cloud_map(
             name="tracker",
             cloud_map_namespace=namespace,

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -31,6 +31,7 @@ from constants import (
     WORKER_STOP_TIMEOUT_SECONDS,
 )
 from constructs import Construct
+from stage import Stage
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
     cpu_architecture=aws_ecs.CpuArchitecture.ARM64,
@@ -55,6 +56,7 @@ class WorkerStack(Stack):
         self,
         scope: Construct,
         id: str,
+        stage: Stage,
         vpc: aws_ec2.IVpc,
         cluster: aws_ecs.ICluster,
         redis_url: str,
@@ -160,7 +162,7 @@ class WorkerStack(Stack):
             cluster=cluster,
             task_definition=worker_task_def,
             desired_count=WORKER_MIN_TASKS,
-            service_name="Worker",
+            service_name=stage.phys("Worker"),
             security_groups=[tracker_sg],
             circuit_breaker=aws_ecs.DeploymentCircuitBreaker(rollback=True),
             min_healthy_percent=100,

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -120,7 +120,7 @@ class WorkerStack(Stack):
                 log_group=aws_logs.LogGroup(
                     self,
                     "WorkerLogGroup",
-                    log_group_name=WORKER_LOG_GROUP_NAME,
+                    log_group_name=stage.phys(WORKER_LOG_GROUP_NAME),
                     retention=aws_logs.RetentionDays.ONE_YEAR,
                     removal_policy=cdk.RemovalPolicy.DESTROY,
                 ),


### PR DESCRIPTION
## Summary
Adds a prod/dev `stage` context to the Valkyrie CDK app — a prerequisite for standing up a dev environment alongside prod. Refactor only: no resources are deployed and prod output is unchanged.

## Changes
- add `infra/stage.py` helper — prod is the identity case; dev gets a `Dev-` stack-id prefix and a `-dev` suffix on physical names
- thread `stage` through `SharedStack`, `TrackerStack`, `WorkerStack`, `MonitoringStack` and the dashboard builders
- stage the physical names: S3 bucket, ECS cluster, service-discovery namespace, SNS topics, Slack config, ECS service names, alarms, dashboards, tracker domain, and the EventBridge stack-name filter list
- `Makefile` `STAGE` passthrough (default `prod`) + `STACK_PREFIX` so `STAGE=dev` targets the `Dev-*` stacks

## Type of Change
- [x] Refactor

## Testing
- [x] Manually tested
- Verified `cdk synth -c stage=prod` is template-byte-identical to the prior output (no template drift); `cdk synth -c stage=dev` produces `Dev-*` stacks with no leaked globally-unique prod names.

## Checklist
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed