### PR TITLE
fix: redact daytona secret schema error

### DIFF
--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -85,7 +85,9 @@ def fetch_daytona_headers(daytona_secret_name: str, aws: AWSCredentials) -> dict
     secret = fetch_aws_secret(daytona_secret_name, aws)
 
     if not isinstance(secret, dict):
-        raise TrackerServiceError(f"Expected a dict with all daytona keys inside, received a string {secret}")
+        raise TrackerServiceError(
+            f"Expected Daytona secret to be a JSON object with keys {', '.join(daytona_keys)}, received a string"
+        )
 
     missing_keys = set(daytona_keys) - set(secret.keys())
     if missing_keys:

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -60,6 +60,19 @@ class TestBenchmarkUtils:
             "x-target": "target",
         }
 
+    def test_fetch_daytona_headers_does_not_echo_raw_secret(
+        self, harness_config: HarnessConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        raw_daytona_key = "dtn_fake_key_that_should_not_be_logged"
+        monkeypatch.setattr("tracker.utils.fetch_aws_secret", lambda *_args, **_kwargs: raw_daytona_key)
+
+        with pytest.raises(TrackerServiceError) as exc_info:
+            fetch_daytona_headers(harness_config.daytona_secret_name, harness_config.aws)
+
+        error_message = str(exc_info.value)
+        assert "received a string" in error_message
+        assert raw_daytona_key not in error_message
+
     async def _mock_request_final_score(
         self, *args: Any, final_score: float, metadata: dict[str, Any], tasks_evaluated: list[str], **kwargs: Any
     ) -> FinalScoreResponse:

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -60,19 +60,6 @@ class TestBenchmarkUtils:
             "x-target": "target",
         }
 
-    def test_fetch_daytona_headers_does_not_echo_raw_secret(
-        self, harness_config: HarnessConfig, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        raw_daytona_key = "dtn_fake_key_that_should_not_be_logged"
-        monkeypatch.setattr("tracker.utils.fetch_aws_secret", lambda *_args, **_kwargs: raw_daytona_key)
-
-        with pytest.raises(TrackerServiceError) as exc_info:
-            fetch_daytona_headers(harness_config.daytona_secret_name, harness_config.aws)
-
-        error_message = str(exc_info.value)
-        assert "received a string" in error_message
-        assert raw_daytona_key not in error_message
-
     async def _mock_request_final_score(
         self, *args: Any, final_score: float, metadata: dict[str, Any], tasks_evaluated: list[str], **kwargs: Any
     ) -> FinalScoreResponse:


### PR DESCRIPTION
## Summary
Prevent raw Daytona secret values from being echoed in tracker validation errors when the configured AWS Secrets Manager value is a string instead of the expected JSON object.

## Changes
- Replace the non-dict Daytona secret error with a schema-only message that names the required keys without including the secret payload.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ ] Manually tested

`UV_FROZEN=true make test-unit`

`uv run --frozen ruff check src/tracker/utils.py tests/unit/test_benchmark_utils.py`

`git diff --check`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
