### PR TITLE
Download run results to a unique path

### DIFF
--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -712,7 +712,12 @@ def fetch(run_id: UUID, connect: bool):
 
 @run.command(
     name="results",
-    help="Retrieve run results by its run id. \n\nExample:\nvalkyrie run results 123e4567-e89b-12d3-a456-426614174000 --path ./results.json",
+    help=(
+        "Retrieve run results by its run id. \n\n"
+        "Example:\n"
+        "valkyrie run results 123e4567-e89b-12d3-a456-426614174000 "
+        "--path ./results-123e4567-e89b-12d3-a456-426614174000.json"
+    ),
 )
 @click.argument("run_id", type=UUID)
 @click.option(
@@ -720,7 +725,7 @@ def fetch(run_id: UUID, connect: bool):
     type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
     default=None,
     required=False,
-    help="Path to save the results (default: ./<benchmark>.json)",
+    help="Path to save the results (default: ./results-<run_id>.json)",
 )
 @click.option(
     "--s3",
@@ -748,7 +753,7 @@ def results(run_id: UUID, path: Path | None, s3: bool, task_ids: str | None, tas
     Retrieve the results of a run by its run id.
 
     Example:
-        valkyrie run results e532551e-d51b-4912-983d-47695bd24174 --path ./results.json
+        valkyrie run results e532551e-d51b-4912-983d-47695bd24174 --path ./results-e532551e-d51b-4912-983d-47695bd24174.json
     """
     subset_task_ids = resolve_task_ids(task_ids, task_ids_file)
 
@@ -775,7 +780,7 @@ def results(run_id: UUID, path: Path | None, s3: bool, task_ids: str | None, tas
                             fg="yellow" if scored < len(subset_task_ids) else "green",
                         )
                     )
-                default_path: Path = Path(f"./{results_response.benchmark_name}.json")
+                default_path: Path = Path(f"./results-{run_id}.json")
 
                 download_final_view(path or default_path, results_response)
             else:
@@ -832,7 +837,7 @@ def stop(run_id: UUID, force: bool):
             click.echo("┌─ Next Steps " + "─" * 66)
             click.echo(
                 f"│ {'Get results:':<17} "
-                + click.style(f"valkyrie run results {run_id} --path ./results.json", fg="cyan")
+                + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")
             )
             click.echo("└" + "─" * 79)
     except TrackerServiceError as e:
@@ -1024,7 +1029,7 @@ def resume(
             click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan"))
             click.echo(
                 f"│ {'Get results:':<17} "
-                + click.style(f"valkyrie run results {run_id} --path ./results.json", fg="cyan")
+                + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")
             )
             click.echo("└" + "─" * 79)
     except (TrackerServiceError, S3Error) as e:

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -383,7 +383,9 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ {'S3 Bucket:':<17} {start_benchmark_response.s3_bucket_url}")
     click.echo("├" + "─" * 79)
     click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {rid} --connect", fg="cyan"))
-    click.echo(f"│ {'Get results:':<17} " + click.style(f"valkyrie run results {rid} --path ./results.json", fg="cyan"))
+    click.echo(
+        f"│ {'Get results:':<17} " + click.style(f"valkyrie run results {rid} --path ./results-{rid}.json", fg="cyan")
+    )
     click.echo(f"│ {'Stop:':<17} " + click.style(f"valkyrie run stop {rid}", fg="cyan"))
     click.echo(f"│ {'Resume:':<17} " + click.style(f"valkyrie run resume {rid}", fg="cyan"))
     click.echo(f"│ {'Retry:':<17} " + click.style(f"valkyrie run retry {rid}", fg="cyan"))
@@ -395,7 +397,9 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
 def _stream_next_steps(benchmark_id: UUID, s3_url: str | None = None) -> None:
     """Print next-step commands after a stream ends."""
     rid = benchmark_id
-    click.echo(f"│ {'Get results:':<17} " + click.style(f"valkyrie run results {rid} --path ./results.json", fg="cyan"))
+    click.echo(
+        f"│ {'Get results:':<17} " + click.style(f"valkyrie run results {rid} --path ./results-{rid}.json", fg="cyan")
+    )
     click.echo(f"│ {'Agent outputs:':<17} " + click.style(f"valkyrie agent outputs {rid} --output-dir .", fg="cyan"))
     if s3_url:
         click.echo(f"│ {'S3 view:':<17} " + click.style(s3_url, fg="cyan"))


### PR DESCRIPTION
## Summary
Update `valk run results <run_id>` so the default local output path is `results-<run_id>.json` instead of being derived from the benchmark name. This avoids collisions and makes downloaded result files easier to associate with a specific run.

## Changes
- Changed the default results download path to `./results-<run_id>.json`
- Updated CLI help text and next-step command suggestions to reflect the new default
- Added a focused CLI unit test for the default output filename

## Related Issues
Closes #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Ran:
- `uv run ruff check src/valkyrie/cli/main.py src/valkyrie/cli/utils.py tests/unit/test_cli_results.py`
- `uv run pytest tests/unit/test_cli_results.py tests/unit/test_agent_contract.py tests/unit/test_interval_validation.py tests/unit/test_cli_logging.py tests/unit/test_s3_client.py tests/unit/test_tracker_service.py -q`
- `uv run valk run results --help`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->