### PR TITLE
feat: publish platform discovery handles

### DIFF
--- a/infra/platform_contract.py
+++ b/infra/platform_contract.py
@@ -1,0 +1,77 @@
+"""Valkyrie platform contract — discovery handles for co-deployed benchmark services.
+
+Valkyrie advertises its shared-infra handles (VPC, ECS cluster, Cloud Map namespace,
+tracker security group) so any co-deployed benchmark service can discover them WITHOUT
+referencing Valkyrie's internal stack/construct names. Consumers read the VPC by tag
+(a synth-time lookup cannot use SSM) and the rest by SSM parameter (deploy-time refs).
+
+CONSUMER-AGNOSTIC: this module must never name or assume any specific consumer. It
+publishes Valkyrie's own handles; who reads them is not Valkyrie's concern. The
+benchmark-services-registry mirrors this key schema in its own platform_contract.py —
+keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import aws_cdk as cdk
+from aws_cdk import aws_ec2, aws_ssm
+from constructs import Construct
+
+# VPC discovery tag; value is the stage name (e.g. "prod", "dev").
+VPC_STAGE_TAG = "valkyrie:shared-vpc-stage"
+
+
+def _key(stage_name: str, leaf: str) -> str:
+    return f"/valkyrie/platform/{stage_name}/{leaf}"
+
+
+def ecs_cluster_name_key(stage_name: str) -> str:
+    return _key(stage_name, "ecs-cluster-name")
+
+
+def cloudmap_namespace_name_key(stage_name: str) -> str:
+    return _key(stage_name, "cloudmap-namespace-name")
+
+
+def cloudmap_namespace_id_key(stage_name: str) -> str:
+    return _key(stage_name, "cloudmap-namespace-id")
+
+
+def cloudmap_namespace_arn_key(stage_name: str) -> str:
+    return _key(stage_name, "cloudmap-namespace-arn")
+
+
+def tracker_security_group_id_key(stage_name: str) -> str:
+    return _key(stage_name, "tracker-security-group-id")
+
+
+def tag_shared_vpc(vpc: aws_ec2.IVpc, stage_name: str) -> None:
+    cdk.Tags.of(vpc).add(VPC_STAGE_TAG, stage_name)
+
+
+def _param(scope: Construct, construct_id: str, key: str, value: str) -> None:
+    aws_ssm.StringParameter(scope, construct_id, parameter_name=key, string_value=value)
+
+
+def publish_shared_handles(
+    scope: Construct,
+    stage_name: str,
+    *,
+    cluster_name: str,
+    namespace_name: str,
+    namespace_id: str,
+    namespace_arn: str,
+) -> None:
+    _param(scope, "PlatformClusterNameParam", ecs_cluster_name_key(stage_name), cluster_name)
+    _param(scope, "PlatformNamespaceNameParam", cloudmap_namespace_name_key(stage_name), namespace_name)
+    _param(scope, "PlatformNamespaceIdParam", cloudmap_namespace_id_key(stage_name), namespace_id)
+    _param(scope, "PlatformNamespaceArnParam", cloudmap_namespace_arn_key(stage_name), namespace_arn)
+
+
+def publish_tracker_security_group(scope: Construct, stage_name: str, security_group_id: str) -> None:
+    _param(
+        scope,
+        "PlatformTrackerSgIdParam",
+        tracker_security_group_id_key(stage_name),
+        security_group_id,
+    )

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -28,6 +28,7 @@ from constants import (
     VPC_NAT_GATEWAYS,
     get_slack_notification_config,
 )
+import platform_contract
 from constructs import Construct
 from stage import Stage
 
@@ -84,6 +85,18 @@ class SharedStack(Stack):
             "AgenticHarnessNamespace",
             name=self.stage.phys(NAMESPACE),
             vpc=self.vpc,
+        )
+
+        # Advertise platform handles so co-deployed benchmark services can discover
+        # this shared infra without referencing Valkyrie's internal stack names.
+        platform_contract.tag_shared_vpc(self.vpc, self.stage.name)
+        platform_contract.publish_shared_handles(
+            self,
+            self.stage.name,
+            cluster_name=self.cluster.cluster_name,
+            namespace_name=self.namespace.namespace_name,
+            namespace_id=self.namespace.namespace_id,
+            namespace_arn=self.namespace.namespace_arn,
         )
 
         # Route53 hosted zone for vals.ai (shared by all services)

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -42,6 +42,7 @@ from constants import (
     TRACKER_SCALING_CPU_PERCENT,
     VPC_CIDR,
 )
+import platform_contract
 from constructs import Construct
 from stage import Stage
 
@@ -219,6 +220,13 @@ class TrackerStack(Stack):
 
         # Expose the inner FargateService for cross-stack security group rules
         self.tracker_fargate_service = self.service.service
+
+        # Advertise the tracker/worker security group for co-deployed services.
+        platform_contract.publish_tracker_security_group(
+            self,
+            stage.name,
+            self.tracker_fargate_service.connections.security_groups[0].security_group_id,
+        )
 
         # Cloud Map registration for internal access.
         # Intentionally unstaged: dev gets its own namespace, and benchmark


### PR DESCRIPTION
## Summary
Publishes stable platform discovery handles so co-deployed benchmark services can discover Valkyrie shared infra without depending on internal stack or construct names.

## Changes
- Add `infra/platform_contract.py` for SSM parameter keys and the shared VPC discovery tag.
- Tag the shared VPC by stage and publish ECS cluster plus Cloud Map namespace handles from `SharedStack`.
- Publish the tracker service security group ID from `TrackerStack`.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ ] Manually tested
- `git diff --check bw/phase3-cdk-stage-valkyrie...HEAD`
- `cd infra && uv run --with pytest python -m pytest --rootdir=. tests/test_monitoring_stack.py` (6 passed)
- `cd infra && uv run ruff check platform_contract.py shared.py tracker_stack.py`
- `cd infra && uv run basedpyright platform_contract.py` (0 errors)
- `cd infra && uv run basedpyright platform_contract.py shared.py tracker_stack.py` (fails on existing `DatabaseSecret` typing errors in `tracker_stack.py:120`, `tracker_stack.py:136`, and `tracker_stack.py:137`)

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed