### PR TITLE
bug(tracker): subset rescore counts stopped tasks in final_score

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -71,6 +71,7 @@ from tracker.utils import (
     create_benchmark_service_client,
     create_final_view,
     fetch_filtered_benchmark_rows,
+    fetch_final_score_inputs,
     fetch_harness_config,
     force_stop_sandboxes,
     initiate_stop_benchmark,
@@ -472,10 +473,13 @@ async def retrieve_results(
         final_view.evaluation_results = _filter_task_map(final_view.evaluation_results)
         final_view.task_errors = _filter_task_map(final_view.task_errors)
 
-        # Missing/errored tasks are passed to the benchmark service as {task_id: None}.
-        scored_results = dict(final_view.evaluation_results or {})
-        for task_id in final_view.task_errors or {}:
-            scored_results.setdefault(task_id, None)
+        # Include every requested task with its result or None, so tasks without a result
+        # (e.g. stopped/errored) still count toward the denominator instead of being dropped.
+        scored_results = {
+            task_id: result
+            for task_id, result in fetch_final_score_inputs(session, benchmark_row, org).items()
+            if task_id in task_ids_set
+        }
 
         effective_service_headers = forward_tracker_api_key(None, http_request.headers.get("x-api-key"))
         benchmark_service = benchmark_row.benchmark_service(

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -451,9 +451,12 @@ class TestFastapiServer:
 
         # Test case 9. task_ids subset filters evaluation_results and recomputes final_score
         observed_headers: dict[str, str] = {}
+        observed_results: dict[str, Any] = {}
 
         async def _mock_final_score(client: BenchmarkServiceClient, **kwargs: Any) -> FinalScoreResponse:
             observed_headers.update(client._headers)
+            observed_results.clear()
+            observed_results.update(kwargs["evaluation_results"])
             ids = list(kwargs["evaluation_results"].keys())
             return FinalScoreResponse(tasks_evaluated=ids, final_score=float(len(ids)), metadata={})
 
@@ -468,6 +471,19 @@ class TestFastapiServer:
         assert set(body["evaluation_results"]) == {"task_1", "task_3"}
         assert body["final_evaluation"]["final_score"] == 2.0
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
+
+        # Test case 10. A requested task without a result (stopped/errored/missing) is still
+        # scored: it is passed to the benchmark service as {task_id: None}, contributing to
+        # the denominator rather than being silently dropped from the subset.
+        response = client.get(
+            "/retrieve-results",
+            params=[("benchmark_id", str(benchmark_row.id)), ("task_ids", "task_1"), ("task_ids", "task_11")],
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+        assert response.status_code == 200
+        assert observed_results.keys() == {"task_1", "task_11"}
+        assert observed_results["task_11"] is None
+        assert response.json()["final_evaluation"]["final_score"] == 2.0
 
     async def test_benchmark_error_handling(
         self,


### PR DESCRIPTION
## Summary
`retrieve-results?task_ids=` recomputes the final score over a subset, but it built the scoring dict from the **display payload** (`final_view.evaluation_results` + `final_view.task_errors`):

```python
scored_results = dict(final_view.evaluation_results or {})
for task_id in final_view.task_errors or {}:
    scored_results.setdefault(task_id, None)
```

Those two sources are partial by design — `fetch_evaluation_results` inner-joins `EvaluationResult` (results only) and `fetch_tasks_with_errors` is `WHERE status == ERROR` (error messages only). A task in the requested subset that is **STOPPED** (or otherwise missing without a result) appears in neither, so it was dropped entirely from `scored_results`, fell out of the `final_score` denominator, and inflated the score.

### Scope
This only affects the **subset rescore path** (`retrieve-results` with `task_ids`). The normal run-end scoring path was already correct: #388 fixed it cleanly by switching `fetch_missing_tasks` to an outer join so both errored **and** stopped tasks count, and #374 later refactored that into `fetch_final_score_inputs`.

The subset path got a *partial* fix in 8d95fea, which back-filled `None` only from `task_errors` (ERROR-only) and so still missed STOPPED. This PR closes that remaining gap. Note it only bites on subset rescores of partially-stopped runs; a clean run (all FINISHED/ERROR) was unaffected.

## Changes
- `services/tracker/main.py`: build `scored_results` from `fetch_final_score_inputs` (the same all-rows `LEFT OUTER JOIN` the run-end path uses) filtered to the requested subset, so every requested task contributes with `None` for any missing result. The `final_view` display fields are still filtered and returned unchanged.
- `services/tracker/tests/unit/test_fastapi_server.py`: test case 10 — a subset containing a STOPPED task now passes `{task_id: None}` to the service and counts it (fails on the old logic: `dict_keys(['task_1']) == {'task_1', 'task_11'}`).

## Type of Change
- [x] Bug fix

## Testing
- [x] Unit test (fails on old logic, passes on new)