### PR TITLE
Retry Daytona fd transport exec failures

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -31,6 +31,7 @@ from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 from opentelemetry import trace
 from tenacity import (
     retry,
+    retry_if_exception,
     retry_if_exception_type,
     retry_if_not_exception_type,
     stop_after_attempt,
@@ -318,9 +319,21 @@ _TIMEOUT_EXIT_CODE: int = 124
 _OS_KILL_EXIT_CODE: int = 137
 _SUCCESS_EXIT_CODE: int = 0
 _STATUS_DIR = "/tmp/.valkyrie"
+_FD_TRANSPORT_ERROR_MARKERS = ("file descriptor", "is used by transport", "tcptransport")
+
+
+def _is_fd_transport_error(exc: BaseException) -> bool:
+    error = str(exc).lower()
+    return isinstance(exc, SandboxError) and all(marker in error for marker in _FD_TRANSPORT_ERROR_MARKERS)
 
 
 @logfire.instrument("sandbox.exec", extract_args=False)
+@retry(
+    retry=retry_if_exception(_is_fd_transport_error),
+    reraise=True,
+    stop=stop_after_attempt(3),
+    before_sleep=retry_callback("valkyrie.sandbox.exec"),
+)
 async def _exec(sandbox: Sandbox, command: str) -> ExecResult:
     _set_sandbox_span_attributes(sandbox)
     try:

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -409,6 +409,28 @@ class TestAgentOutputTelemetry:
         with pytest.raises(SandboxError, match="exec failed"):
             await _exec(mock_sandbox, "echo hi")
 
+        assert mock_sandbox.exec.await_count == 1
+
+    async def test_exec_retries_fd_transport_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sandbox_module, "_set_sandbox_span_attributes", Mock(), raising=False)
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.exec = AsyncMock(
+            side_effect=[
+                ProviderSandboxError(
+                    "Sandbox operation failed for name=task-alias, id=sandbox-123: "
+                    "Failed to execute command: File descriptor 97 is used by transport "
+                    "<TCPTransport closed=False reading=True 0xaaaadbc577b0>"
+                ),
+                ExecResult(exit_code=0, output="ok"),
+            ]
+        )
+
+        result = await _exec(mock_sandbox, "echo hi")
+
+        assert result.output == "ok"
+        assert mock_sandbox.exec.await_count == 2
+
     async def test_create_sandbox_emits_create_duration_and_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-123"


### PR DESCRIPTION
## Summary
Retry Daytona sandbox exec failures that match the local asyncio/aiohttp fd transport collision seen in VALKYRIE-60. The error is raised before the command reaches the sandbox, so treating only this exact transport signature as transient avoids failing tasks on a client-side connection race while preserving deterministic command failures.

## Changes
- Added a targeted `_exec` retry predicate for provider errors containing `File descriptor ... is used by transport <TCPTransport ...>`.
- Wired the retry through the existing Valkyrie sandbox retry observability callback.
- Added unit coverage proving fd transport errors retry once and generic provider exec errors are still surfaced without retry.

## Related Issues
Related: VALKYRIE-60

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Commands run:
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run pytest tests/unit/test_sandbox.py -q`
- `make -C /home/ubuntu/repos/Valkyrie lint`
- `make -C /home/ubuntu/repos/Valkyrie typecheck`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff check .`

CI:
- Required checks passed: `run-ruff-lint`, `run-basedpyright`, `tracker-unit-tests`, `cli-unit-tests`, `cli-tool-smoke-test`.
- `tracker-integration-tests` failed at the workflow guard with `Check must be run manually on PRs`; it did not execute tests.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/65ce5a9a3d6944cdba3521c974e41b87
Requested by: @Chen-Oliver