### PR TITLE
fix(tracker): grade workspace on non-zero agent exit instead of erroring

### DIFF
--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -75,6 +75,9 @@ class AgentCausedExitReason(str, Enum):
 
     TIMEOUT = "TIMEOUT"
     OS_KILLED = "OS_KILLED"
+    # Agent self-terminated non-zero (e.g. crashed on a context-window limit).
+    # Agent-caused, not infra — the workspace is still gradeable, so continue.
+    AGENT_ERROR = "AGENT_ERROR"
 
 
 class RetryMode(str, Enum):

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -44,7 +44,6 @@ from tracker.database.models import (
     OutputArtifactSpec,
 )
 from tracker.exceptions import (
-    AgentRunFailedError,
     OutputArtifactError,
     SandboxError,
     SandboxSetupError,
@@ -376,7 +375,13 @@ async def stream_command_output(
         tail = "".join(output).strip().splitlines()
         recent = "\n".join(tail[-10:]) if tail else "(no output)"
         sentry_sdk.set_tag("agent_exit_code", str(exit_code))
-        raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
+        # A non-zero agent exit (e.g. the agent self-crashed on a context-window
+        # limit) is agent-caused, not infra — it still leaves a gradeable workspace.
+        # Treat it like TIMEOUT/OS_KILLED and continue to evaluation rather than
+        # failing the task. Genuine infra failures raise above (ProviderSandboxError /
+        # SandboxNotFoundError); reaching here means the command ran and exited non-zero.
+        on_output(f"[WARNING]: agent exited non-zero (exit code {exit_code}); evaluation will proceed.\nLast output:\n{recent}")
+        return AgentCausedExitReason.AGENT_ERROR, duration
     finally:
         try:
             await _exec(sandbox, f"rm -f {shlex.quote(start_ns_path)} {shlex.quote(end_ns_path)}")
@@ -596,6 +601,10 @@ async def run_agent(
     elif exit_reason == AgentCausedExitReason.OS_KILLED:
         log_output(
             f"[WARNING]:`{contract.name}` was killed by the OS (exit code {_OS_KILL_EXIT_CODE}, likely out-of-memory). The process has been terminated and evaluation will proceed."
+        )
+    elif exit_reason == AgentCausedExitReason.AGENT_ERROR:
+        log_output(
+            f"[WARNING]:`{contract.name}` exited non-zero (an agent-side failure, e.g. a context-window limit). The process has been terminated and evaluation will proceed."
         )
 
     # Upload any output from the agent to S3

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -10,9 +10,13 @@ from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxComm
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 
 from tracker import sandbox as sandbox_module
-from tracker.database.models import AgentContractRequest, MAX_OUTPUT_ARTIFACT_BYTES, OutputArtifact
+from tracker.database.models import (
+    AgentCausedExitReason,
+    AgentContractRequest,
+    MAX_OUTPUT_ARTIFACT_BYTES,
+    OutputArtifact,
+)
 from tracker.exceptions import (
-    AgentRunFailedError,
     OutputArtifactError,
     SSLConnectionError,
     SandboxError,
@@ -569,7 +573,7 @@ class TestStreamCommandOutputAgentFailure:
         assert ".end_ns" in exec_commands[-1]
 
     @pytest.mark.parametrize("exit_code", [1, 2, 127])
-    async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(
+    async def test_non_zero_exit_returns_agent_error_and_tags_exit_code(
         self, monkeypatch: pytest.MonkeyPatch, exit_code: int
     ) -> None:
         async def stream_command(_command: str) -> Any:
@@ -593,11 +597,16 @@ class TestStreamCommandOutputAgentFailure:
 
         monkeypatch.setattr("tracker.sandbox.sentry_sdk.set_tag", fake_set_tag)
 
-        with pytest.raises(AgentRunFailedError) as exc_info:
-            await sandbox_module.stream_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)
+        # A non-zero agent exit is agent-caused (the workspace is still gradeable),
+        # so it returns AGENT_ERROR and continues to evaluation rather than raising.
+        outputs: list[str] = []
+        exit_reason, duration = await sandbox_module.stream_command_output(
+            mock_sandbox, "run-agent.sh", on_output=outputs.append
+        )
 
-        assert isinstance(exc_info.value, SandboxError)
-        assert not isinstance(exc_info.value, SandboxSetupError)
-        assert f"exit code: {exit_code}" in str(exc_info.value)
-        assert "last line" in str(exc_info.value)
+        assert exit_reason == AgentCausedExitReason.AGENT_ERROR
+        assert duration == 2
         assert tagged == {"agent_exit_code": str(exit_code)}
+        joined = "".join(outputs)
+        assert f"exit code {exit_code}" in joined
+        assert "last line" in joined


### PR DESCRIPTION
## Problem
`run_agent` (`stream_command_output`, `services/tracker/src/tracker/sandbox.py`) branches on the agent's exit code:
- `SUCCESS` → continue to evaluation
- `TIMEOUT` (124) / `OS_KILLED` (137) → return an `AgentCausedExitReason` → **continue to evaluation**
- **any other non-zero → `raise AgentRunFailedError` → task errored, evaluation skipped**

So when the agent **self-crashes** — most commonly `MaxContextWindowExceededError` (exit 1) on large-codebase tasks — the task is discarded as a hard error, even though the agent left a perfectly gradeable partial migration in `/submission`. The `AgentCausedExitReason` docstring literally says these are "exit reasons caused by the agent that continue to evaluation" — a context-window crash is exactly that, it just wasn't whitelisted.

In the recent code-migration campaign this silently threw away **~42** real (low-scoring) attempts as "errors" instead of grading them.

## Fix
Treat a generic non-zero agent exit the same as timeout/OOM:
- Add `AgentCausedExitReason.AGENT_ERROR`.
- In `stream_command_output`, **return** `AGENT_ERROR` (logging the exit code + last output, keeping the sentry tag) instead of raising.
- `run_agent` logs a warning for `AGENT_ERROR` and proceeds to evaluation, mirroring TIMEOUT/OS_KILLED.

Genuine infra failures are unaffected — `ProviderSandboxError` / `SandboxNotFoundError` are caught and raised **above** this branch; reaching the exit-code branch means the command actually ran and returned a code (the gradeable case).

## Tests
Updated the exit-code test to assert the new return-and-continue behavior (returns `AGENT_ERROR`, tags `agent_exit_code`, surfaces last output via `on_output`). `ruff` + `basedpyright` clean; **167 tracker unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)