### PR TITLE
Add resume secret overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ valkyrie run retry <id>
 # Override concurrency on resume (works on retry)
 valkyrie run resume <id> --concurrency 20
 
+# Override agent secrets for resumed tasks
+valkyrie run resume <id> -s ANTHROPIC_API_KEY newSecretName
+
 # Save every task ID in a benchmark dataset to a text file
 valkyrie benchmark tasks swebench --dataset default
 
@@ -214,6 +217,7 @@ valkyrie benchmark tasks swebench --dataset default --output tasks.txt
 | Option | Description |
 | --- | --- |
 | `--concurrency` | Override concurrency level |
+| `-s` / `--secret` | Secret pair as `ENV_VAR aws_secret_name`. Repeatable. Merged into the stored run contract before resumed/retried tasks are enqueued (CLI wins on conflict) |
 | `--task-ids` | Comma-separated task IDs to resume/retry. Any id without an existing row is created as fresh `PENDING` if valid in the current dataset — lets you grow scope without starting a new run. |
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -119,6 +119,13 @@ def _taskiq_labels() -> dict[str, str]:
     return {"request_id": request_id_var.get(), **trace_context}
 
 
+def _apply_resume_secrets(benchmark_row: Benchmark, secrets: dict[str, str]) -> None:
+    """Merge resume secrets into the stored agent contract."""
+    contract = benchmark_row.arguments.contract
+    updated_contract = contract.model_copy(update={"secrets": {**contract.secrets, **secrets}})
+    benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": updated_contract})
+
+
 @app.exception_handler(TrackerServiceError)
 async def tracker_service_error_handler(_request: Request, exc: TrackerServiceError):
     logger.error(exc, exc_info=True)
@@ -644,9 +651,7 @@ async def retry_or_resume_benchmark(
         )
 
     if secrets:
-        contract = benchmark_row.arguments.contract
-        updated_contract = contract.model_copy(update={"secrets": {**contract.secrets, **secrets}})
-        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": updated_contract})
+        _apply_resume_secrets(benchmark_row, secrets)
         session.add(benchmark_row)
         session.commit()
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -583,6 +583,7 @@ async def retry_or_resume_benchmark(
     concurrency: int | None = Query(default=None),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
+    secrets: dict[str, str] = Body(default={}),
     session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
@@ -642,8 +643,15 @@ async def retry_or_resume_benchmark(
             status="success",
         )
 
+    if secrets:
+        contract = benchmark_row.arguments.contract
+        updated_contract = contract.model_copy(update={"secrets": {**contract.secrets, **secrets}})
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": updated_contract})
+        session.add(benchmark_row)
+        session.commit()
+
     if concurrency is not None:
-        benchmark_row.arguments.concurrency = concurrency
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": concurrency})
         session.add(benchmark_row)
         session.commit()
 

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -518,6 +518,63 @@ class TestStopAndResume:
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
         assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
 
+    async def test_retry_or_resume_applies_secrets_to_stored_contract(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ):
+        """Resume secrets should update the contract used by resumed tasks.
+
+        Test cases:
+        - Existing env var mappings are replaced by resume overrides.
+        - New env var mappings are added to the stored contract before enqueue.
+        """
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        benchmark_row.arguments.contract.secrets = {
+            "ANTHROPIC_API_KEY": "old-secret",
+            "OPENAI_API_KEY": "openai-secret",
+        }
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        captured_request_json: dict[str, Any] = {}
+
+        async def _mock_reset_to_in_progress_status(*_args: Any, **_kwargs: Any):
+            return ["task_0"]
+
+        class _MockKicker:
+            def with_labels(self, **_kwargs: Any) -> "_MockKicker":
+                return self
+
+            async def kiq(self, **kwargs: Any) -> None:
+                captured_request_json.update(kwargs["start_benchmark_request_json"])
+
+        monkeypatch.setattr("main.reset_to_in_progress_status", _mock_reset_to_in_progress_status)
+        monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            json={
+                "task_ids": [],
+                "service_headers": {},
+                "secrets": {
+                    "ANTHROPIC_API_KEY": "new-secret",
+                    "GEMINI_API_KEY": "gemini-secret",
+                },
+            },
+        )
+
+        assert response.status_code == 200
+        assert captured_request_json["contract"]["secrets"] == {
+            "ANTHROPIC_API_KEY": "new-secret",
+            "OPENAI_API_KEY": "openai-secret",
+            "GEMINI_API_KEY": "gemini-secret",
+        }
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.arguments.contract.secrets == captured_request_json["contract"]["secrets"]
+
     async def test_running_retry_noops_without_error_tasks(
         self,
         example_benchmark_object: Benchmark,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -961,6 +961,15 @@ def analyze(run_id: UUID, no_cache: bool) -> None:
     help="Path or http(s) URL to a text file with one task ID per line",
 )
 @click.option(
+    "--secret",
+    "-s",
+    "secrets",
+    multiple=True,
+    nargs=2,
+    type=(str, str),
+    help="Secret as ENV_VAR aws_secret_name (e.g., -s ANTHROPIC_API_KEY devEvalInfraAnthropicKey)",
+)
+@click.option(
     "--update-agent",
     "-u",
     is_flag=True,
@@ -981,6 +990,7 @@ def resume(
     concurrency: int | None,
     task_ids: str | None,
     task_ids_file: str | None,
+    secrets: tuple[tuple[str, str]],
     update_agent: bool,
     from_scratch: bool,
 ):
@@ -1022,6 +1032,7 @@ def resume(
                 concurrency,
                 retry_task_ids,
                 service_headers=service_headers,
+                secrets={key: value for key, value in secrets},
             )
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -519,6 +519,7 @@ class TrackerService:
         concurrency: int | None,
         task_ids: list[str],
         service_headers: dict[str, str] | None = None,
+        secrets: dict[str, str] | None = None,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -530,6 +531,7 @@ class TrackerService:
             task_ids: List of task ids to force retry. Task ids without an existing row
                 are created as fresh PENDING if valid in the current dataset.
             service_headers: Optional headers for benchmark service authentication
+            secrets: Optional agent secret mappings to merge into the stored contract
 
         Returns:
             RetryOrResumeBenchmarkResponse with status and message
@@ -542,6 +544,8 @@ class TrackerService:
                 params["concurrency"] = concurrency
 
             body: dict[str, Any] = {"task_ids": task_ids, "service_headers": service_headers or {}}
+            if secrets:
+                body["secrets"] = secrets
 
             response = self._client.post(
                 f"{self._base_url}/retry-or-resume-benchmark/{benchmark_id}",

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -36,6 +36,12 @@ def empty_config_keys(_tracker: TrackerService) -> dict[str, str]:
 
 
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Resume requests should carry retry mode and override secrets.
+
+    Test cases:
+    - Retry mode and concurrency are query parameters.
+    - Secret overrides are sent in the JSON body with task IDs and service headers.
+    """
     client = FakeClient()
 
     def build_client(**_kwargs: object) -> FakeClient:
@@ -52,8 +58,13 @@ def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> No
         retry_mode=RetryMode.FROM_SCRATCH,
         concurrency=3,
         task_ids=["task-1"],
+        secrets={"ANTHROPIC_API_KEY": "new-secret"},
     )
 
     assert result.status == "success"
     assert client.params == {"retry": True, "retry_mode": "from_scratch", "concurrency": 3}
-    assert client.json == {"task_ids": ["task-1"], "service_headers": {}}
+    assert client.json == {
+        "task_ids": ["task-1"],
+        "service_headers": {},
+        "secrets": {"ANTHROPIC_API_KEY": "new-secret"},
+    }


### PR DESCRIPTION
## Summary
Allow resumed and retried Valkyrie runs to override agent secret mappings without starting a new run. This is needed when a paused run should continue with a different AWS Secrets Manager secret for one or more agent environment variables.

## Changes
- Added `-s` / `--secret` to `valkyrie run resume` and the existing `retry` alias.
- Passed resume secrets through the tracker client request body as `secrets`.
- Merged resume secrets into the stored benchmark contract before resumed or retried tasks are enqueued.
- Documented the resume secret override option in the README.
- Added regression coverage for the CLI client payload and tracker-side merge behavior.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Focused tests:
```bash
uv run pytest tests/unit/test_tracker_service.py::test_retry_or_resume_sends_retry_mode services/tracker/tests/unit/test_stop_and_resume.py::TestStopAndResume::test_retry_or_resume_applies_secrets_to_stored_contract
```

Lint/typecheck:
```bash
uv run ruff check .
uv run basedpyright
```

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
