### PR TITLE
change: parameterize deploy workflow to set up dev evironment #minor

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,13 +2,17 @@ name: Deploy to AWS
 
 on:
   push:
-    branches: [prod]
+    branches: [dev, prod]
 
   workflow_dispatch:
 
 permissions:
   contents: read
   id-token: write
+
+concurrency:
+  group: valkyrie-${{ github.ref_name }}-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:
@@ -20,6 +24,19 @@ jobs:
         with:
           submodules: recursive
           token: ${{ secrets.GH_PAT }}
+
+      - name: Resolve deploy stage
+        id: deploy-stage
+        run: |
+          case "${GITHUB_REF_NAME}" in
+            dev|prod)
+              echo "stage=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unsupported deploy ref '${GITHUB_REF_NAME}'. Run this workflow from dev or prod."
+              exit 1
+              ;;
+          esac
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -60,4 +77,4 @@ jobs:
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
         run: |
           cd infra
-          uv run cdk deploy --all --require-approval never
+          uv run cdk deploy --all -c stage=${{ steps.deploy-stage.outputs.stage }} --require-approval never

--- a/infra/app.py
+++ b/infra/app.py
@@ -41,6 +41,7 @@ worker = WorkerStack(
     stage=stage,
     vpc=shared.vpc,
     cluster=shared.cluster,
+    namespace=shared.namespace,
     redis_url=shared.redis_url,
     bucket=shared.bucket,
     database=tracker.database,

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -20,11 +20,7 @@ NAMESPACE = "local"
 
 # Tracker Service
 TRACKER_LOG_GROUP_NAME = "/valkyrie/tracker"
-TRACKER_CPU = 1024
-TRACKER_MEMORY = 2048
 TRACKER_DOMAIN = "benchmark-tracker.vals.ai"
-TRACKER_MIN_TASKS = 1
-TRACKER_MAX_TASKS = 2
 TRACKER_SCALING_CPU_PERCENT = 70
 
 # Health Checks
@@ -44,10 +40,6 @@ ELASTICACHE_NODE_TYPE = "cache.t4g.micro"
 
 # Worker Service
 WORKER_LOG_GROUP_NAME = "/valkyrie/worker"
-WORKER_CPU = 4096
-WORKER_MEMORY = 8192
-WORKER_MIN_TASKS = 2
-WORKER_MAX_TASKS = 4
 WORKER_SCALING_CPU_PERCENT = 70
 WORKER_STOP_TIMEOUT_SECONDS = 120  # If protection is enabled the task will not be deleted
 
@@ -57,9 +49,6 @@ POSTGRES_HEALTH_START_PERIOD_SECONDS = 10
 POSTGRES_USER = "tracker"
 POSTGRES_DB = "tracker"
 
-# RDS
-RDS_INSTANCE_CLASS = "t4g.small"
-RDS_ALLOCATED_STORAGE_GB = 20
 RDS_SECRET_NAME = "tracker-db-credentials"
 
 # Load Balancer

--- a/infra/monitoring_stack.py
+++ b/infra/monitoring_stack.py
@@ -13,7 +13,10 @@ from aws_cdk import (
     aws_rds,
     aws_sns,
 )
-from constants import VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV, get_slack_notification_config
+from constants import (
+    VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV,
+    get_slack_notification_config,
+)
 from constructs import Construct
 from dashboards import (
     create_alb_dashboard,
@@ -23,6 +26,7 @@ from dashboards import (
     create_redis_dashboard,
 )
 from stage import Stage
+from stage_config import config_for
 
 
 class MonitoringStack(cdk.Stack):
@@ -51,6 +55,7 @@ class MonitoringStack(cdk.Stack):
     ) -> None:
         super().__init__(scope, id, **kwargs)
         self.stage = stage
+        self.stage_config = config_for(stage)
 
         self.cluster = cluster
         self.tracker_service = tracker_service
@@ -213,19 +218,18 @@ class MonitoringStack(cdk.Stack):
             treat_missing_data=aws_cloudwatch.TreatMissingData.NOT_BREACHING,
         ).add_alarm_action(sns_action)
 
-        # Alarm 5: DB connections high (> 80% of max for t4g.small: ~170 connections)
-        # Max connections on t4g.small is ~170 (LEAST(DBInstanceClassMemory/9531392, 5000))
-        # Set threshold to 135 (roughly 80% of 170)
+        # Alarm 5: DB connections high
+        db_connection_threshold = self.stage_config.database.connection_alarm_threshold
         aws_cloudwatch.Alarm(
             self,
             "DbConnectionsHighAlarm",
             alarm_name=self.stage.phys("Valkyrie-DB-Connections-High"),
-            alarm_description="RDS database connections >= 135 (~80% of t4g.small max)",
+            alarm_description=f"RDS database connections >= {db_connection_threshold}",
             metric=database.metric_database_connections(
                 period=cdk.Duration.minutes(1),
                 statistic="Maximum",
             ),
-            threshold=135,
+            threshold=db_connection_threshold,
             evaluation_periods=5,
             datapoints_to_alarm=5,
             comparison_operator=aws_cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -1,0 +1,72 @@
+"""Per-stage infrastructure configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aws_cdk import aws_logs
+from stage import DEV, PROD, Stage
+
+
+@dataclass(frozen=True)
+class ServiceConfig:
+    cpu: int
+    memory_mib: int
+    min_tasks: int
+    max_tasks: int
+
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    instance_class: str
+    allocated_storage_gb: int
+    backup_retention_days: int
+    connection_alarm_threshold: int
+
+
+@dataclass(frozen=True)
+class StageConfig:
+    runtime_environment: str
+    tracker: ServiceConfig
+    worker: ServiceConfig
+    database: DatabaseConfig
+    service_log_retention: aws_logs.RetentionDays
+
+
+PROD_CONFIG = StageConfig(
+    runtime_environment="production",
+    tracker=ServiceConfig(cpu=1024, memory_mib=2048, min_tasks=1, max_tasks=2),
+    worker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=2, max_tasks=4),
+    database=DatabaseConfig(
+        instance_class="t4g.small",
+        allocated_storage_gb=20,
+        backup_retention_days=7,
+        connection_alarm_threshold=135,
+    ),
+    service_log_retention=aws_logs.RetentionDays.ONE_YEAR,
+)
+
+DEV_CONFIG = StageConfig(
+    runtime_environment="dev",
+    tracker=ServiceConfig(cpu=1024, memory_mib=2048, min_tasks=1, max_tasks=1),
+    worker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=1, max_tasks=2),
+    database=DatabaseConfig(
+        instance_class="t4g.micro",
+        allocated_storage_gb=20,
+        backup_retention_days=1,
+        connection_alarm_threshold=65,
+    ),
+    service_log_retention=aws_logs.RetentionDays.ONE_WEEK,
+)
+
+_STAGE_CONFIGS = {
+    PROD: PROD_CONFIG,
+    DEV: DEV_CONFIG,
+}
+
+
+def config_for(stage: Stage) -> StageConfig:
+    try:
+        return _STAGE_CONFIGS[stage.name]
+    except KeyError:
+        raise ValueError(f"unknown stage {stage.name!r}; expected {PROD!r} or {DEV!r}") from None

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -64,9 +64,9 @@ def _has_logical_id_prefix(template: assertions.Template, resource_type: str, pr
     return any(logical_id.startswith(prefix) for logical_id in template.find_resources(resource_type))
 
 
-def _monitoring_template() -> assertions.Template:
+def _monitoring_template(stage_name: str = PROD) -> assertions.Template:
     app = cdk.App()
-    stage = Stage(PROD)
+    stage = Stage(stage_name)
     resources = cdk.Stack(
         app,
         "MonitoringTestResources",
@@ -74,7 +74,7 @@ def _monitoring_template() -> assertions.Template:
     )
 
     vpc = aws_ec2.Vpc(resources, "Vpc", max_azs=2)
-    cluster = aws_ecs.Cluster(resources, "Cluster", vpc=vpc, cluster_name="AgenticHarnessCluster")
+    cluster = aws_ecs.Cluster(resources, "Cluster", vpc=vpc, cluster_name=stage.phys("AgenticHarnessCluster"))
 
     tracker_task = aws_ecs.FargateTaskDefinition(resources, "TrackerTask")
     tracker_task.add_container("TrackerContainer", image=aws_ecs.ContainerImage.from_registry("busybox"))
@@ -83,7 +83,7 @@ def _monitoring_template() -> assertions.Template:
         "TrackerService",
         cluster=cluster,
         task_definition=tracker_task,
-        service_name="Tracker",
+        service_name=stage.phys("Tracker"),
     )
 
     worker_task = aws_ecs.FargateTaskDefinition(resources, "WorkerTask")
@@ -93,7 +93,7 @@ def _monitoring_template() -> assertions.Template:
         "WorkerService",
         cluster=cluster,
         task_definition=worker_task,
-        service_name="Worker",
+        service_name=stage.phys("Worker"),
     )
 
     load_balancer = aws_elb.ApplicationLoadBalancer(resources, "LoadBalancer", vpc=vpc)
@@ -132,12 +132,12 @@ def _monitoring_template() -> assertions.Template:
     return assertions.Template.from_stack(monitoring)
 
 
-def _shared_template() -> assertions.Template:
+def _shared_template(stage_name: str = PROD) -> assertions.Template:
     app = cdk.App(context=SHARED_STACK_CONTEXT)
-    stage = Stage(PROD)
+    stage = Stage(stage_name)
     shared = SharedStack(
         app,
-        "SharedStack",
+        stage.stack_id("SharedStack"),
         stage=stage,
         env=cdk.Environment(account=TEST_AWS_ACCOUNT, region=TEST_AWS_REGION),
     )
@@ -269,18 +269,68 @@ class MonitoringStackTest(unittest.TestCase):
             ):
                 get_slack_notification_config(VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV)
 
-    def test_dev_stage_suffixes_service_log_group_names(self) -> None:
+    def test_dev_stage_wires_stage_config_to_resources(self) -> None:
         with mock.patch.dict(os.environ, {}, clear=True):
             tracker_template, worker_template = _service_templates(DEV)
+        with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
+            monitoring_template = _monitoring_template(DEV)
 
         tracker_template.has_resource_properties(
             "AWS::Logs::LogGroup",
-            {"LogGroupName": f"{TRACKER_LOG_GROUP_NAME}-dev"},
+            {"LogGroupName": f"{TRACKER_LOG_GROUP_NAME}-dev", "RetentionInDays": 7},
+        )
+        tracker_template.has_resource_properties(
+            "AWS::RDS::DBInstance",
+            {"DBInstanceClass": "db.t4g.micro", "BackupRetentionPeriod": 1},
+        )
+        tracker_template.has_resource_properties(
+            "AWS::ApplicationAutoScaling::ScalableTarget",
+            {"MinCapacity": 1, "MaxCapacity": 1},
+        )
+        worker_template.has_resource_properties(
+            "AWS::ECS::Service",
+            {"DesiredCount": 1},
+        )
+        worker_template.has_resource_properties(
+            "AWS::ApplicationAutoScaling::ScalableTarget",
+            {"MinCapacity": 1, "MaxCapacity": 2},
         )
         worker_template.has_resource_properties(
             "AWS::Logs::LogGroup",
-            {"LogGroupName": f"{WORKER_LOG_GROUP_NAME}-dev"},
+            {"LogGroupName": f"{WORKER_LOG_GROUP_NAME}-dev", "RetentionInDays": 7},
         )
+        monitoring_template.has_resource_properties(
+            "AWS::CloudWatch::Alarm",
+            {"AlarmName": "Valkyrie-DB-Connections-High-dev", "Threshold": 65},
+        )
+
+    def test_service_environment_labels_follow_stage(self) -> None:
+        for stage_name, expected_environment in ((PROD, "production"), (DEV, "dev")):
+            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, {}, clear=True):
+                tracker_template, worker_template = _service_templates(stage_name)
+
+                expected_env = assertions.Match.array_with(
+                    [
+                        {"Name": "BROKER_ENVIRONMENT", "Value": expected_environment},
+                        {"Name": "ENVIRONMENT", "Value": expected_environment},
+                    ]
+                )
+                tracker_template.has_resource_properties(
+                    "AWS::ECS::TaskDefinition",
+                    {
+                        "ContainerDefinitions": assertions.Match.array_with(
+                            [assertions.Match.object_like({"Environment": expected_env})]
+                        )
+                    },
+                )
+                worker_template.has_resource_properties(
+                    "AWS::ECS::TaskDefinition",
+                    {
+                        "ContainerDefinitions": assertions.Match.array_with(
+                            [assertions.Match.object_like({"Environment": expected_env})]
+                        )
+                    },
+                )
 
 
 if __name__ == "__main__":

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -168,6 +168,7 @@ def _service_templates(stage_name: str) -> tuple[assertions.Template, assertions
         stage=stage,
         vpc=shared.vpc,
         cluster=shared.cluster,
+        namespace=shared.namespace,
         redis_url=shared.redis_url,
         bucket=shared.bucket,
         database=tracker.database,
@@ -305,7 +306,10 @@ class MonitoringStackTest(unittest.TestCase):
         )
 
     def test_service_environment_labels_follow_stage(self) -> None:
-        for stage_name, expected_environment in ((PROD, "production"), (DEV, "dev")):
+        for stage_name, expected_environment, expected_namespace in (
+            (PROD, "production", "local"),
+            (DEV, "dev", "local-dev"),
+        ):
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, {}, clear=True):
                 tracker_template, worker_template = _service_templates(stage_name)
 
@@ -313,6 +317,7 @@ class MonitoringStackTest(unittest.TestCase):
                     [
                         {"Name": "BROKER_ENVIRONMENT", "Value": expected_environment},
                         {"Name": "ENVIRONMENT", "Value": expected_environment},
+                        {"Name": "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE", "Value": expected_namespace},
                     ]
                 )
                 tracker_template.has_resource_properties(

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -30,20 +30,15 @@ from constants import (
     POSTGRES_DB,
     POSTGRES_PORT,
     POSTGRES_USER,
-    RDS_ALLOCATED_STORAGE_GB,
-    RDS_INSTANCE_CLASS,
-    TRACKER_CPU,
     TRACKER_DOMAIN,
     TRACKER_LOG_GROUP_NAME,
-    TRACKER_MAX_TASKS,
-    TRACKER_MEMORY,
-    TRACKER_MIN_TASKS,
     TRACKER_PORT,
     TRACKER_SCALING_CPU_PERCENT,
     VPC_CIDR,
 )
 from constructs import Construct
 from stage import Stage
+from stage_config import config_for
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
     cpu_architecture=aws_ecs.CpuArchitecture.ARM64,
@@ -74,6 +69,7 @@ class TrackerStack(Stack):
         **kwargs: Any,
     ):
         super().__init__(scope, id, **kwargs)
+        stage_config = config_for(stage)
 
         # Docker image for the tracker API
         tracker_image = aws_ecs.ContainerImage.from_asset(
@@ -84,9 +80,9 @@ class TrackerStack(Stack):
 
         # Shared environment variables
         shared_env = {
-            "BROKER_ENVIRONMENT": "production",
+            "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket.bucket_name,
-            "ENVIRONMENT": "production",
+            "ENVIRONMENT": stage_config.runtime_environment,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
         }
 
@@ -112,17 +108,17 @@ class TrackerStack(Stack):
             engine=aws_rds.DatabaseInstanceEngine.postgres(
                 version=aws_rds.PostgresEngineVersion.VER_16,
             ),
-            instance_type=aws_ec2.InstanceType(RDS_INSTANCE_CLASS),
+            instance_type=aws_ec2.InstanceType(stage_config.database.instance_class),
             vpc=vpc,
             vpc_subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PUBLIC),
             security_groups=[db_security_group],
             credentials=aws_rds.Credentials.from_secret(self.db_credentials),
             database_name=POSTGRES_DB,
-            allocated_storage=RDS_ALLOCATED_STORAGE_GB,
+            allocated_storage=stage_config.database.allocated_storage_gb,
             publicly_accessible=True,
             deletion_protection=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
-            backup_retention=Duration.days(7),
+            backup_retention=Duration.days(stage_config.database.backup_retention_days),
         )
 
         db_env = {
@@ -158,8 +154,8 @@ class TrackerStack(Stack):
         tracker_task_def = aws_ecs.FargateTaskDefinition(
             self,
             "TrackerTaskDef",
-            cpu=TRACKER_CPU,
-            memory_limit_mib=TRACKER_MEMORY,
+            cpu=stage_config.tracker.cpu,
+            memory_limit_mib=stage_config.tracker.memory_mib,
             runtime_platform=_ARM64_PLATFORM,
         )
 
@@ -172,7 +168,7 @@ class TrackerStack(Stack):
                     self,
                     "TrackerLogGroup",
                     log_group_name=stage.phys(TRACKER_LOG_GROUP_NAME),
-                    retention=aws_logs.RetentionDays.ONE_YEAR,
+                    retention=stage_config.service_log_retention,
                     removal_policy=cdk.RemovalPolicy.DESTROY,
                 ),
             ),
@@ -204,7 +200,7 @@ class TrackerStack(Stack):
             self,
             "TrackerService",
             cluster=cluster,
-            desired_count=TRACKER_MIN_TASKS,
+            desired_count=stage_config.tracker.min_tasks,
             task_definition=tracker_task_def,
             service_name=stage.phys("Tracker"),
             circuit_breaker=aws_ecs.DeploymentCircuitBreaker(rollback=True),
@@ -255,8 +251,8 @@ class TrackerStack(Stack):
 
         # Tracker auto-scaling
         tracker_scaling = self.service.service.auto_scale_task_count(
-            min_capacity=TRACKER_MIN_TASKS,
-            max_capacity=TRACKER_MAX_TASKS,
+            min_capacity=stage_config.tracker.min_tasks,
+            max_capacity=stage_config.tracker.max_tasks,
         )
         tracker_scaling.scale_on_cpu_utilization(
             "CpuScaling",

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -83,6 +83,7 @@ class TrackerStack(Stack):
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket.bucket_name,
             "ENVIRONMENT": stage_config.runtime_environment,
+            "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
         }
 

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -22,16 +22,13 @@ from aws_cdk import (
 from aws_cdk.aws_ecr_assets import Platform
 from constants import (
     POSTGRES_DB,
-    WORKER_CPU,
     WORKER_LOG_GROUP_NAME,
-    WORKER_MAX_TASKS,
-    WORKER_MEMORY,
-    WORKER_MIN_TASKS,
     WORKER_SCALING_CPU_PERCENT,
     WORKER_STOP_TIMEOUT_SECONDS,
 )
 from constructs import Construct
 from stage import Stage
+from stage_config import config_for
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
     cpu_architecture=aws_ecs.CpuArchitecture.ARM64,
@@ -67,6 +64,7 @@ class WorkerStack(Stack):
         **kwargs: Any,
     ):
         super().__init__(scope, id, **kwargs)
+        stage_config = config_for(stage)
 
         # Reuse the tracker's security group so both services share the same
         # SG — benchmark services only need to whitelist one group.
@@ -79,9 +77,9 @@ class WorkerStack(Stack):
         )
 
         shared_env = {
-            "BROKER_ENVIRONMENT": "production",
+            "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket.bucket_name,
-            "ENVIRONMENT": "production",
+            "ENVIRONMENT": stage_config.runtime_environment,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
         }
 
@@ -107,8 +105,8 @@ class WorkerStack(Stack):
         worker_task_def = aws_ecs.FargateTaskDefinition(
             self,
             "WorkerTaskDef",
-            cpu=WORKER_CPU,
-            memory_limit_mib=WORKER_MEMORY,
+            cpu=stage_config.worker.cpu,
+            memory_limit_mib=stage_config.worker.memory_mib,
             runtime_platform=_ARM64_PLATFORM,
         )
 
@@ -121,7 +119,7 @@ class WorkerStack(Stack):
                     self,
                     "WorkerLogGroup",
                     log_group_name=stage.phys(WORKER_LOG_GROUP_NAME),
-                    retention=aws_logs.RetentionDays.ONE_YEAR,
+                    retention=stage_config.service_log_retention,
                     removal_policy=cdk.RemovalPolicy.DESTROY,
                 ),
             ),
@@ -161,7 +159,7 @@ class WorkerStack(Stack):
             "WorkerService",
             cluster=cluster,
             task_definition=worker_task_def,
-            desired_count=WORKER_MIN_TASKS,
+            desired_count=stage_config.worker.min_tasks,
             service_name=stage.phys("Worker"),
             security_groups=[tracker_sg],
             circuit_breaker=aws_ecs.DeploymentCircuitBreaker(rollback=True),
@@ -172,8 +170,8 @@ class WorkerStack(Stack):
 
         # Worker auto-scaling
         worker_scaling = self.worker_service.auto_scale_task_count(
-            min_capacity=WORKER_MIN_TASKS,
-            max_capacity=WORKER_MAX_TASKS,
+            min_capacity=stage_config.worker.min_tasks,
+            max_capacity=stage_config.worker.max_tasks,
         )
         worker_scaling.scale_on_cpu_utilization(
             "WorkerCpuScaling",

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -18,6 +18,7 @@ from aws_cdk import (
     aws_rds,
     aws_s3,
     aws_secretsmanager,
+    aws_servicediscovery,
 )
 from aws_cdk.aws_ecr_assets import Platform
 from constants import (
@@ -56,6 +57,7 @@ class WorkerStack(Stack):
         stage: Stage,
         vpc: aws_ec2.IVpc,
         cluster: aws_ecs.ICluster,
+        namespace: aws_servicediscovery.IPrivateDnsNamespace,
         redis_url: str,
         bucket: aws_s3.IBucket,
         database: aws_rds.DatabaseInstance,
@@ -80,6 +82,7 @@ class WorkerStack(Stack):
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket.bucket_name,
             "ENVIRONMENT": stage_config.runtime_environment,
+            "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
         }
 

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -55,6 +55,7 @@ TEST_DAYTONA_SECRET_NAME=       # AWS Secrets Manager secret containing Daytona 
 
 # Benchmark service
 BENCHMARK_SERVICE_BASE_URL=     # Use the domain of the benchmark service
+BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE=local  # Cloud Map namespace fallback when no base URL is set
 BENCHMARK_SERVICE_AUTH_KEY=     # Access key for authenticating with a benchmark service
 ```
 

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -16,7 +16,7 @@ load_dotenv()
 configure_logging()
 
 
-_CLOUDMAP_NAMESPACE: str = "local"
+_BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE: str = os.environ.get("BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE", "local")
 _CLOUDMAP_PORT = 8001
 _BENCHMARK_SERVICE_BASE_URL: str | None = os.environ.get("BENCHMARK_SERVICE_BASE_URL")
 
@@ -31,7 +31,7 @@ def create_benchmark_service_url(benchmark_name: str) -> str:
     if _BENCHMARK_SERVICE_BASE_URL:
         return f"https://{benchmark_name}.{_BENCHMARK_SERVICE_BASE_URL}"
 
-    return f"http://{benchmark_name}.{_CLOUDMAP_NAMESPACE}:{_CLOUDMAP_PORT}"
+    return f"http://{benchmark_name}.{_BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE}:{_CLOUDMAP_PORT}"
 
 
 AWS_S3_BUCKET = os.environ.get("AWS_S3_BUCKET", "agentic-harness")

--- a/services/tracker/src/tracker/logging/config.py
+++ b/services/tracker/src/tracker/logging/config.py
@@ -31,19 +31,22 @@ class DevFormatter(logging.Formatter):
         return f"{level} {record.name}:{context_str} {message}"
 
 
-_FORMATTERS = {
-    "production": {
-        "()": "pythonjsonlogger.json.JsonFormatter",
-        "fmt": (
-            "%(asctime)s %(levelname)s %(name)s %(module)s %(funcName)s %(message)s "
-            "%(request_id)s %(benchmark_id)s %(task_id)s"
-        ),
-        "rename_fields": {
-            "asctime": "timestamp",
-            "levelname": "level",
-            "name": "logger",
-        },
+_JSON_FORMATTER = {
+    "()": "pythonjsonlogger.json.JsonFormatter",
+    "fmt": (
+        "%(asctime)s %(levelname)s %(name)s %(module)s %(funcName)s %(message)s "
+        "%(request_id)s %(benchmark_id)s %(task_id)s"
+    ),
+    "rename_fields": {
+        "asctime": "timestamp",
+        "levelname": "level",
+        "name": "logger",
     },
+}
+
+_FORMATTERS = {
+    "production": _JSON_FORMATTER,
+    "dev": _JSON_FORMATTER,
     "development": {
         "()": "tracker.logging.config.DevFormatter",
         "fmt": "%(message)s",

--- a/services/tracker/tests/unit/test_logging.py
+++ b/services/tracker/tests/unit/test_logging.py
@@ -90,6 +90,20 @@ def test_configure_logging_production_json(capfd):
     assert "request_id" in line
 
 
+def test_configure_logging_dev_stage_json(capfd):
+    """Deployed dev stage uses structured logs."""
+    with patch.dict(os.environ, {"ENVIRONMENT": "dev", "LOG_LEVEL": "INFO"}):
+        configure_logging()
+
+    logger = logging.getLogger("tracker.test_deployed_dev")
+    logger.info("hello deployed dev")
+    captured = capfd.readouterr()
+    line = json.loads(captured.out.strip())
+    assert line["message"] == "hello deployed dev"
+    assert "timestamp" in line
+    assert "level" in line
+
+
 def test_configure_logging_includes_context_vars(capfd):
     """Context variables appear in structured JSON output."""
     with patch.dict(os.environ, {"ENVIRONMENT": "production", "LOG_LEVEL": "INFO"}):


### PR DESCRIPTION
## Summary
Parameterized the AWS deploy workflow so pushes to `dev` deploy the dev CDK stage while pushes to `prod` continue deploying prod.

## Changes
- Deploy workflow now triggers on `dev` and `prod`, resolves the stage from the branch name, and passes `-c stage=<stage>` to CDK.
- Added per-branch deploy concurrency to avoid overlapping CloudFormation updates for the same stage.
- Added `infra/stage_config.py` so prod/dev runtime labels, tracker/worker CPU, memory, task capacity, RDS class, storage, backup retention, log retention, and DB alarm thresholds live in per-stage configuration objects instead of scattered sizing constants.
- Made tracker and worker `ENVIRONMENT` / `BROKER_ENVIRONMENT` values stage-aware, preserving `production` for prod and using `dev` for dev.
- Taught tracker logging to accept deployed `ENVIRONMENT=dev` with the same structured JSON formatter as production, while local `development` keeps the human formatter.
- Downsized dev capacity while preserving prod sizing: tracker max 1 task, worker desired/min 1 and max 2, RDS `t4g.micro`, 1-day dev RDS backups, and 7-day dev tracker/worker log retention.
- Adjusted the dev DB connection alarm threshold for the smaller RDS class. `Dev-MonitoringStack` still synthesizes the stage-suffixed CloudWatch alarms.
- Added focused regression coverage for prod/dev task-definition env labels, dev stage resource wiring, and deployed `dev` logging.

## Related Issues
https://github.com/orgs/vals-ai/projects/3/views/2?pane=issue&itemId=196209376&issue=vals-ai%7Cvalkyrie-ticket-library%7C98

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested
- `uv run python -m unittest tests.test_monitoring_stack`
- `make test-unit` in `services/tracker`
- `uv run ruff check .` in `infra`
- `uv run ruff check src tests/unit/test_logging.py` in `services/tracker`
- `ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/deploy.yaml\"); puts \"yaml ok\""`
- `git diff --check`
- `CDK_DEFAULT_ACCOUNT=613431292675 CDK_DEFAULT_REGION=us-east-1 uv run cdk synth -c stage=prod -q`
- `CDK_DEFAULT_ACCOUNT=613431292675 CDK_DEFAULT_REGION=us-east-1 uv run cdk synth -c stage=dev -q`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed