### PR TITLE
fix: skip slack env for dev deploys

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -68,11 +68,21 @@ jobs:
           cd infra
           uv sync
 
-      - name: Deploy all stacks
+      - name: Deploy all stacks with Slack notifications
+        if: steps.deploy-stage.outputs.stage == 'prod'
         env:
           SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
           VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
           DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID: ${{ secrets.DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID }}
+          AUTH_REQUIRED: ${{ secrets.AUTH_REQUIRED }}
+          DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
+        run: |
+          cd infra
+          uv run cdk deploy --all -c stage=${{ steps.deploy-stage.outputs.stage }} --require-approval never
+
+      - name: Deploy all stacks without Slack notifications
+        if: steps.deploy-stage.outputs.stage != 'prod'
+        env:
           AUTH_REQUIRED: ${{ secrets.AUTH_REQUIRED }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
         run: |


### PR DESCRIPTION
## Summary
Fixes the dev deploy failure caused by creating AWS Chatbot Slack configurations for channels already configured in the AWS account.

## Changes
- Split the deploy workflow into a prod path that passes Slack notification secrets and a non-prod path that omits them.
- Keep `AUTH_REQUIRED` and `DESCOPE_PROJECT_ID` available to both deploy paths.
- Preserve the existing CDK behavior where missing Slack channel IDs skip Chatbot wiring.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested
- `yq '.' .github/workflows/deploy.yaml >/dev/null`
- `uv run python -m unittest tests/test_monitoring_stack.py -v`
- `env -u SLACK_WORKSPACE_ID -u VALKYRIE_ALERTS_SLACK_CHANNEL_ID -u DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 uv run cdk synth Dev-SharedStack Dev-MonitoringStack -c stage=dev --output /private/tmp/valkyrie-pr-dev-no-slack-synth`
- `env SLACK_WORKSPACE_ID=TTESTWORKSPACE VALKYRIE_ALERTS_SLACK_CHANNEL_ID=CALERTSCHANNEL DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID=CDEPLOYCHANNEL CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-1 uv run cdk synth SharedStack MonitoringStack -c stage=prod --output /private/tmp/valkyrie-pr-prod-with-slack-synth`
- Verified synthesized dev templates contain 0 `AWS::Chatbot::SlackChannelConfiguration` resources in `Dev-SharedStack` and `Dev-MonitoringStack`.
- Verified synthesized prod templates still contain `deployment-notifications` and `valkyrie-alerts`.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->