### PR TITLE
fix: scope dev stack names to valkyrie

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,10 +1,10 @@
 .PHONY: help install deploy deploy-shared deploy-tracker hotswap diff destroy
 
 # Stage selection: STAGE=prod (default) or STAGE=dev. Passed to CDK as context;
-# STACK_PREFIX prefixes stack ids so STAGE=dev targets the Dev-* stacks.
+# STACK_PREFIX prefixes stack ids so STAGE=dev targets the Valk-Dev-* stacks.
 # Default prod => empty prefix, so every target is byte-identical to pre-stage behavior.
 STAGE ?= prod
-STACK_PREFIX := $(if $(filter-out prod,$(STAGE)),Dev-,)
+STACK_PREFIX := $(if $(filter-out prod,$(STAGE)),Valk-Dev-,)
 CDK_CTX := -c stage=$(STAGE)
 
 help:

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -1,8 +1,8 @@
 """Stage-aware naming helper.
 
-prod  → every helper is the identity function, so `cdk synth -c stage=prod` is
+prod  -> every helper is the identity function, so `cdk synth -c stage=prod` is
         byte-identical to the pre-refactor `cdk synth`.
-dev   → stacks get a "Dev-" construct-id prefix; physical names get a "-dev"
+dev   -> stacks get a "Valk-Dev-" construct-id prefix; physical names get a "-dev"
         suffix; FQDNs get "-dev" on their first label.
 
 """
@@ -13,6 +13,7 @@ import aws_cdk as cdk
 
 PROD = "prod"
 DEV = "dev"
+DEV_STACK_PREFIX = "Valk-Dev-"
 
 
 class Stage:
@@ -24,7 +25,7 @@ class Stage:
         return self.name == PROD
 
     def stack_id(self, base: str) -> str:
-        return base if self.is_prod else f"Dev-{base}"
+        return base if self.is_prod else f"{DEV_STACK_PREFIX}{base}"
 
     def phys(self, name: str) -> str:
         return name if self.is_prod else f"{name}-dev"

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -22,7 +22,7 @@ from constants import (
 )
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
-from stage import DEV, PROD, Stage
+from stage import DEV, DEV_STACK_PREFIX, PROD, Stage
 from tracker_stack import TrackerStack
 from worker_stack import WorkerStack
 
@@ -181,6 +181,10 @@ def _service_templates(stage_name: str) -> tuple[assertions.Template, assertions
 
 
 class MonitoringStackTest(unittest.TestCase):
+    def test_dev_stack_ids_are_valk_scoped(self) -> None:
+        self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")
+        self.assertEqual(Stage(DEV).stack_id("TrackerStack"), f"{DEV_STACK_PREFIX}TrackerStack")
+
     def test_alerts_topic_is_wired_to_slack(self) -> None:
         with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
             template = _monitoring_template()


### PR DESCRIPTION
## Summary
Scope Valkyrie dev CloudFormation stack IDs with a Valk prefix so they do not collide with other generic Dev-* stacks in the shared AWS account.

## Changes
- Rename dev CDK stack IDs from Dev-* to Valk-Dev-* while leaving prod stack IDs unchanged
- Update infra Makefile stage-specific stack targeting to use Valk-Dev-* names
- Add a focused test for prod/dev stack ID behavior

## Related Issues
Closes #

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Validation:
- uv run python -m unittest tests.test_monitoring_stack
- uv run ruff check .
- make -n STAGE=dev deploy-shared deploy-tracker
- cdk synth -c stage=dev
- cdk synth -c stage=prod
- git diff --check origin/dev..HEAD

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed