### PR TITLE
#minor: Add benchmark access list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Downloads an agent from S3 to your local machine and unzips it.
 
 ## Running Benchmarks 
 
+### List accessible benchmarks
+
+To see the hosted benchmarks and datasets your Valkyrie API key can access, run:
+
+```bash
+valkyrie benchmark list
+```
+
 ### Start a run
 
 To run a specific agent on a given benchmark, use the command

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -386,7 +386,7 @@ async def fetch_benchmark_tasks(
         try:
             return await benchmark_service.verify_task_ids(
                 task_ids=None,
-                slice_str=None,
+                slice_str=request.slice_str,
                 dataset=request.dataset,
             )
         finally:

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1,4 +1,5 @@
 import io
+import asyncio
 import logging
 import tarfile
 import traceback
@@ -51,6 +52,7 @@ from tracker.aws.s3 import (
     s3_object_exists,
 )
 from tracker.agent.schemas import AgentConfig
+from tracker.benchmark_catalog import hosted_benchmark_catalog
 from tracker.config import (
     AUTH_REQUIRED,
     ENVIRONMENT,
@@ -82,6 +84,9 @@ from tracker.types import (
     FetchBenchmarksResponse,
     FetchBenchmarkTasksRequest,
     HarnessConfig,
+    BenchmarkListEntry,
+    ListBenchmarksRequest,
+    ListBenchmarksResponse,
     Order,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
@@ -115,6 +120,7 @@ configure_logging()
 configure_observability("valkyrie-tracker", environment=ENVIRONMENT)
 
 logger = get_logger(__name__)
+_BENCHMARK_LIST_CONCURRENCY = 16
 
 
 def _operation_id(route: APIRoute) -> str:
@@ -366,6 +372,71 @@ async def start_benchmark(
             str(benchmark_row.id), request.harness_config.aws.aws_default_region, request.harness_config.s3_bucket
         ),
     )
+
+
+async def _check_benchmark_dataset(
+    benchmark_name: str,
+    dataset: str,
+    custom_benchmark_service: str | None,
+    service_headers: dict[str, str],
+    semaphore: asyncio.Semaphore,
+) -> str | None:
+    async with semaphore:
+        benchmark_service = create_benchmark_service_client(
+            url=custom_benchmark_service or create_benchmark_service_url(benchmark_name),
+            service_headers=service_headers,
+        )
+        try:
+            await benchmark_service.verify_task_ids(
+                task_ids=None,
+                slice_str="0:0",
+                dataset=None if dataset == "default" else dataset,
+            )
+            return dataset
+        except (BenchmarkServiceError, httpx.HTTPError):
+            return None
+        finally:
+            await benchmark_service.close()
+
+
+@app.post("/list-benchmarks")
+async def list_benchmarks(
+    http_request: Request,
+    request: ListBenchmarksRequest,
+    _org: Org = Depends(get_current_org),
+) -> ListBenchmarksResponse:
+    catalog = hosted_benchmark_catalog()
+    for benchmark_name in request.custom_benchmark_services:
+        catalog[benchmark_name] = ("default",)
+
+    semaphore = asyncio.Semaphore(_BENCHMARK_LIST_CONCURRENCY)
+
+    async def list_single_benchmark(benchmark_name: str, datasets: tuple[str, ...]) -> BenchmarkListEntry | None:
+        service_headers = forward_tracker_api_key(
+            request.service_headers_by_benchmark.get(benchmark_name),
+            http_request.headers.get("x-api-key"),
+        )
+        custom_benchmark_service = request.custom_benchmark_services.get(benchmark_name)
+        checks = [
+            _check_benchmark_dataset(
+                benchmark_name=benchmark_name,
+                dataset=dataset,
+                custom_benchmark_service=custom_benchmark_service,
+                service_headers=service_headers,
+                semaphore=semaphore,
+            )
+            for dataset in datasets
+        ]
+        checked_datasets = await asyncio.gather(*checks)
+        accessible_datasets = [dataset for dataset in checked_datasets if dataset is not None]
+        if not accessible_datasets and not request.include_inaccessible:
+            return None
+        return BenchmarkListEntry(benchmark_name=benchmark_name, datasets=accessible_datasets)
+
+    rows = await asyncio.gather(
+        *(list_single_benchmark(benchmark_name, datasets) for benchmark_name, datasets in sorted(catalog.items()))
+    )
+    return ListBenchmarksResponse(benchmarks=[row for row in rows if row is not None])
 
 
 @app.post("/fetch-benchmark-tasks")

--- a/services/tracker/src/tracker/benchmark_catalog.py
+++ b/services/tracker/src/tracker/benchmark_catalog.py
@@ -1,0 +1,79 @@
+"""Hosted benchmark catalog used for access listing."""
+
+import json
+import os
+from typing import cast
+
+HOSTED_BENCHMARK_DATASETS: dict[str, tuple[str, ...]] = {
+    "code-migration": ("cobol", "cli", "smoke", "public", "test", "validation"),
+    "cyberbench": ("default", "poc_l0", "patch", "poc_patch"),
+    "deep-swe": ("default", "deep-swe"),
+    "deepmind-formal-conjectures": (
+        "default",
+        "fc100_open",
+        "fc100_solved",
+        "open",
+        "non_open",
+        "research_solved_known_formal",
+        "all",
+    ),
+    "emb": ("default",),
+    "fabv2-anthropic": ("validation",),
+    "fabv2-exa": ("validation",),
+    "fabv2-internal": ("default", "validation", "test", "public", "vals_index"),
+    "fabv2-meta": ("validation",),
+    "fabv2-xai": ("validation",),
+    "harvey-legal-agent": ("default",),
+    "ioi": ("ioi2024", "ioi2025"),
+    "legal-research": ("default", "testing", "full", "test", "validation", "public"),
+    "programbench": ("default", "smoke"),
+    "proof-bench": ("validation", "test", "default"),
+    "skillsbench": ("default",),
+    "snap": (
+        "sample_1_target_both",
+        "sample_1_target_multi_turn",
+        "sample_1_target_web_search",
+        "sample_1_target_neither",
+        "sample_1_auditor_both",
+        "sample_1_auditor_multi_turn",
+        "sample_1_auditor_web_search",
+        "sample_1_auditor_neither",
+        "sample_2_target_both",
+        "sample_2_target_multi_turn",
+        "sample_2_target_web_search",
+        "sample_2_target_neither",
+        "sample_2_auditor_both",
+        "sample_2_auditor_multi_turn",
+        "sample_2_auditor_web_search",
+        "sample_2_auditor_neither",
+    ),
+    "swebench": ("default", "vals_index"),
+    "terminal-bench": ("default", "terminal-bench-2", "terminal-bench-2.1"),
+    "vcb": ("default", "test_set", "validation_set", "vals_index", "zeeter"),
+    "vcb-1-100": ("default", "candidate", "smoke"),
+}
+
+
+def _normalize_catalog(raw: object) -> dict[str, tuple[str, ...]]:
+    if not isinstance(raw, dict):
+        raise ValueError("benchmark catalog must be a JSON object")
+
+    catalog: dict[str, tuple[str, ...]] = {}
+    raw_catalog = cast(dict[object, object], raw)
+    for benchmark_name, datasets in raw_catalog.items():
+        if not isinstance(benchmark_name, str):
+            raise ValueError("benchmark catalog names must be strings")
+        if not isinstance(datasets, list):
+            raise ValueError(f"benchmark catalog datasets for {benchmark_name!r} must be a list of strings")
+        dataset_values = cast(list[object], datasets)
+        if not all(isinstance(dataset, str) for dataset in dataset_values):
+            raise ValueError(f"benchmark catalog datasets for {benchmark_name!r} must be a list of strings")
+        catalog[benchmark_name] = tuple(dataset for dataset in dataset_values if isinstance(dataset, str))
+    return dict(sorted(catalog.items()))
+
+
+def hosted_benchmark_catalog() -> dict[str, tuple[str, ...]]:
+    catalog_json = os.environ.get("BENCHMARK_DATASET_CATALOG_JSON")
+    if catalog_json:
+        return _normalize_catalog(json.loads(catalog_json))
+    return dict(sorted(HOSTED_BENCHMARK_DATASETS.items()))

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -88,6 +88,7 @@ class StartBenchmarkRequest(BaseModel):
 class FetchBenchmarkTasksRequest(BaseModel):
     benchmark_name: str
     dataset: str | None = None
+    slice_str: str | None = None
     custom_benchmark_service: str | None = None
     service_headers: dict[str, str] = Field(default_factory=dict)
 

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -93,6 +93,21 @@ class FetchBenchmarkTasksRequest(BaseModel):
     service_headers: dict[str, str] = Field(default_factory=dict)
 
 
+class ListBenchmarksRequest(BaseModel):
+    custom_benchmark_services: dict[str, str] = Field(default_factory=dict)
+    service_headers_by_benchmark: dict[str, dict[str, str]] = Field(default_factory=dict)
+    include_inaccessible: bool = False
+
+
+class BenchmarkListEntry(BaseModel):
+    benchmark_name: str
+    datasets: list[str]
+
+
+class ListBenchmarksResponse(BaseModel):
+    benchmarks: list[BenchmarkListEntry]
+
+
 class StartBenchmarkErrorResponse(BaseModel):
     benchmark_id: UUID
     error_message: str

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
-from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceUnauthenticatedError
+from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
 from dateutil.parser import isoparse
 from descope import DescopeClient
@@ -81,6 +81,45 @@ class TestFastapiServer:
 
         assert response.status_code == 200
         assert response.json() == {"task_ids": ["task_1", "task_2"]}
+
+    async def test_list_benchmarks(
+        self,
+        monkeypatch: MonkeyPatch,
+    ):
+        async def _mock_verify_task_ids(
+            self: BenchmarkServiceClient,
+            task_ids: list[str] | None,
+            slice_str: str | None,
+            dataset: str | None = None,
+        ) -> VerifyTaskIdsResponse:
+            del self, task_ids
+            assert slice_str == "0:0"
+            if dataset == "vals_index":
+                raise BenchmarkServiceError("Dataset not allowed")
+            return VerifyTaskIdsResponse(task_ids=[])
+
+        monkeypatch.setattr("main.hosted_benchmark_catalog", lambda: {"swebench": ("default", "vals_index")})
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        response = client.post("/list-benchmarks", json={})
+
+        assert response.status_code == 200
+        assert response.json() == {"benchmarks": [{"benchmark_name": "swebench", "datasets": ["default"]}]}
+
+    async def test_list_benchmarks_can_include_inaccessible(
+        self,
+        monkeypatch: MonkeyPatch,
+    ):
+        async def _mock_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            raise BenchmarkServiceError("Dataset not allowed")
+
+        monkeypatch.setattr("main.hosted_benchmark_catalog", lambda: {"swebench": ("default",)})
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        response = client.post("/list-benchmarks", json={"include_inaccessible": True})
+
+        assert response.status_code == 200
+        assert response.json() == {"benchmarks": [{"benchmark_name": "swebench", "datasets": []}]}
 
     async def test_start_benchmark(
         self,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -80,6 +80,75 @@ def config():
     pass
 
 
+HOSTED_BENCHMARK_DATASETS: dict[str, tuple[str, ...]] = {
+    "code-migration": ("cobol", "cli", "smoke", "public", "test", "validation"),
+    "cyberbench": ("default", "poc_l0", "patch", "poc_patch"),
+    "deep-swe": ("default", "deep-swe"),
+    "deepmind-formal-conjectures": (
+        "default",
+        "fc100_open",
+        "fc100_solved",
+        "open",
+        "non_open",
+        "research_solved_known_formal",
+        "all",
+    ),
+    "emb": ("default",),
+    "fabv2-anthropic": ("validation",),
+    "fabv2-exa": ("validation",),
+    "fabv2-internal": ("default", "validation", "test", "public", "vals_index"),
+    "fabv2-meta": ("validation",),
+    "fabv2-xai": ("validation",),
+    "harvey-legal-agent": ("default",),
+    "ioi": ("ioi2024", "ioi2025"),
+    "legal-research": ("default", "testing", "full", "test", "validation", "public"),
+    "programbench": ("default", "smoke"),
+    "proof-bench": ("validation", "test", "default"),
+    "skillsbench": ("default",),
+    "snap": (
+        "sample_1_target_both",
+        "sample_1_target_multi_turn",
+        "sample_1_target_web_search",
+        "sample_1_target_neither",
+        "sample_1_auditor_both",
+        "sample_1_auditor_multi_turn",
+        "sample_1_auditor_web_search",
+        "sample_1_auditor_neither",
+        "sample_2_target_both",
+        "sample_2_target_multi_turn",
+        "sample_2_target_web_search",
+        "sample_2_target_neither",
+        "sample_2_auditor_both",
+        "sample_2_auditor_multi_turn",
+        "sample_2_auditor_web_search",
+        "sample_2_auditor_neither",
+    ),
+    "swebench": ("default", "vals_index"),
+    "terminal-bench": ("default", "terminal-bench-2", "terminal-bench-2.1"),
+    "vcb": ("default", "test_set", "validation_set", "vals_index", "zeeter"),
+    "vcb-1-100": ("default", "candidate", "smoke"),
+}
+
+
+def _benchmark_catalog() -> dict[str, tuple[str, ...]]:
+    catalog = dict(HOSTED_BENCHMARK_DATASETS)
+    if CONFIG_LOCATION.exists():
+        with open(CONFIG_LOCATION) as f:
+            loaded_config = yaml.safe_load(f)
+        current = loaded_config if isinstance(loaded_config, dict) else {}
+        custom_services = current.get("custom_benchmark_services")
+        if isinstance(custom_services, dict):
+            for name in custom_services:
+                if isinstance(name, str):
+                    catalog.setdefault(name, ("default",))
+    return dict(sorted(catalog.items()))
+
+
+def _benchmark_service_headers(benchmark_name: str) -> dict[str, str]:
+    auth_credential = TrackerService.get_benchmark_auth(benchmark_name)
+    return {"Authorization": str(auth_credential)} if auth_credential else {}
+
+
 # Mapping between the expected key and default value
 # None means its user provided if not found
 _REQUIRED_ENVIRONMENT_VARIABLES: dict[str, str | None | int] = {
@@ -392,6 +461,55 @@ def auth_list() -> None:
         for name, credential in auth_credentials.items()
     ]
     format_table(rows, ["Benchmark", "Credential"], item_name="credential")
+
+
+@benchmark.command(
+    name="list",
+    help="List hosted benchmark datasets your Valkyrie config can access. \n\nExample:\nvalkyrie benchmark list",
+)
+@click.option(
+    "--include-inaccessible",
+    is_flag=True,
+    help="Also show benchmarks that were checked but had no accessible datasets.",
+)
+def benchmark_list(include_inaccessible: bool) -> None:
+    """
+    List hosted benchmark datasets available to the configured Valkyrie API key.
+    """
+    rows: list[dict[str, str]] = []
+
+    try:
+        with TrackerService() as tracker:
+            if not check_tracker_service_health(tracker):
+                return
+
+            for benchmark_name, datasets in _benchmark_catalog().items():
+                accessible_datasets: list[str] = []
+                service_headers = _benchmark_service_headers(benchmark_name)
+                for dataset in datasets:
+                    try:
+                        tracker.fetch_benchmark_tasks(
+                            benchmark_name,
+                            dataset=None if dataset == "default" else dataset,
+                            slice_str="0:0",
+                            service_headers=service_headers,
+                        )
+                    except TrackerServiceError:
+                        continue
+                    accessible_datasets.append(dataset)
+
+                if accessible_datasets:
+                    rows.append({"Benchmark": benchmark_name, "Datasets": ", ".join(accessible_datasets)})
+                elif include_inaccessible:
+                    rows.append({"Benchmark": benchmark_name, "Datasets": click.style("No access", fg="yellow")})
+
+        if not rows:
+            click.echo(click.style("No accessible benchmarks found.", fg="yellow"))
+            return
+
+        format_table(rows, ["Benchmark", "Datasets"], item_name="benchmark")
+    except TrackerServiceError as e:
+        raise click.ClickException(str(e))
 
 
 @benchmark.command(

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -80,75 +80,6 @@ def config():
     pass
 
 
-HOSTED_BENCHMARK_DATASETS: dict[str, tuple[str, ...]] = {
-    "code-migration": ("cobol", "cli", "smoke", "public", "test", "validation"),
-    "cyberbench": ("default", "poc_l0", "patch", "poc_patch"),
-    "deep-swe": ("default", "deep-swe"),
-    "deepmind-formal-conjectures": (
-        "default",
-        "fc100_open",
-        "fc100_solved",
-        "open",
-        "non_open",
-        "research_solved_known_formal",
-        "all",
-    ),
-    "emb": ("default",),
-    "fabv2-anthropic": ("validation",),
-    "fabv2-exa": ("validation",),
-    "fabv2-internal": ("default", "validation", "test", "public", "vals_index"),
-    "fabv2-meta": ("validation",),
-    "fabv2-xai": ("validation",),
-    "harvey-legal-agent": ("default",),
-    "ioi": ("ioi2024", "ioi2025"),
-    "legal-research": ("default", "testing", "full", "test", "validation", "public"),
-    "programbench": ("default", "smoke"),
-    "proof-bench": ("validation", "test", "default"),
-    "skillsbench": ("default",),
-    "snap": (
-        "sample_1_target_both",
-        "sample_1_target_multi_turn",
-        "sample_1_target_web_search",
-        "sample_1_target_neither",
-        "sample_1_auditor_both",
-        "sample_1_auditor_multi_turn",
-        "sample_1_auditor_web_search",
-        "sample_1_auditor_neither",
-        "sample_2_target_both",
-        "sample_2_target_multi_turn",
-        "sample_2_target_web_search",
-        "sample_2_target_neither",
-        "sample_2_auditor_both",
-        "sample_2_auditor_multi_turn",
-        "sample_2_auditor_web_search",
-        "sample_2_auditor_neither",
-    ),
-    "swebench": ("default", "vals_index"),
-    "terminal-bench": ("default", "terminal-bench-2", "terminal-bench-2.1"),
-    "vcb": ("default", "test_set", "validation_set", "vals_index", "zeeter"),
-    "vcb-1-100": ("default", "candidate", "smoke"),
-}
-
-
-def _benchmark_catalog() -> dict[str, tuple[str, ...]]:
-    catalog = dict(HOSTED_BENCHMARK_DATASETS)
-    if CONFIG_LOCATION.exists():
-        with open(CONFIG_LOCATION) as f:
-            loaded_config = yaml.safe_load(f)
-        current = loaded_config if isinstance(loaded_config, dict) else {}
-        custom_services = current.get("custom_benchmark_services")
-        if isinstance(custom_services, dict):
-            for name in custom_services:
-                if isinstance(name, str):
-                    catalog.setdefault(name, ("default",))
-    return dict(sorted(catalog.items()))
-
-
-def _benchmark_service_headers(benchmark_name: str) -> dict[str, str]:
-    auth_credential = TrackerService.get_benchmark_auth(benchmark_name)
-    return {"Authorization": str(auth_credential)} if auth_credential else {}
-
-
 # Mapping between the expected key and default value
 # None means its user provided if not found
 _REQUIRED_ENVIRONMENT_VARIABLES: dict[str, str | None | int] = {
@@ -483,25 +414,13 @@ def benchmark_list(include_inaccessible: bool) -> None:
             if not check_tracker_service_health(tracker):
                 return
 
-            for benchmark_name, datasets in _benchmark_catalog().items():
-                accessible_datasets: list[str] = []
-                service_headers = _benchmark_service_headers(benchmark_name)
-                for dataset in datasets:
-                    try:
-                        tracker.fetch_benchmark_tasks(
-                            benchmark_name,
-                            dataset=None if dataset == "default" else dataset,
-                            slice_str="0:0",
-                            service_headers=service_headers,
-                        )
-                    except TrackerServiceError:
-                        continue
-                    accessible_datasets.append(dataset)
+            response = tracker.list_benchmarks(include_inaccessible=include_inaccessible)
 
-                if accessible_datasets:
-                    rows.append({"Benchmark": benchmark_name, "Datasets": ", ".join(accessible_datasets)})
-                elif include_inaccessible:
-                    rows.append({"Benchmark": benchmark_name, "Datasets": click.style("No access", fg="yellow")})
+        for benchmark in response.benchmarks:
+            dataset_text = (
+                ", ".join(benchmark.datasets) if benchmark.datasets else click.style("No access", fg="yellow")
+            )
+            rows.append({"Benchmark": benchmark.benchmark_name, "Datasets": dataset_text})
 
         if not rows:
             click.echo(click.style("No accessible benchmarks found.", fg="yellow"))

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -440,6 +440,7 @@ class TrackerService:
         self,
         benchmark_name: str,
         dataset: str | None = None,
+        slice_str: str | None = None,
         ignore_custom_services: bool = False,
         service_headers: dict[str, str] | None = None,
     ) -> list[str]:
@@ -450,6 +451,7 @@ class TrackerService:
             payload = FetchBenchmarkTasksRequest(
                 benchmark_name=benchmark_name,
                 dataset=dataset,
+                slice_str=slice_str,
                 custom_benchmark_service=self.get_benchmark_service_url(benchmark_name)
                 if not ignore_custom_services
                 else None,

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -22,6 +22,8 @@ from tracker.types import (
     FetchBenchmarksResponse,
     FinalViewResponse,
     HarnessConfig,
+    ListBenchmarksRequest,
+    ListBenchmarksResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
@@ -128,6 +130,22 @@ class TrackerService:
 
         services = harness_config.get("custom_benchmark_services") or {}
         return services.get(benchmark_name)
+
+    def _custom_benchmark_services(self) -> dict[str, str]:
+        services = self._config.get("custom_benchmark_services")
+        if not isinstance(services, dict):
+            return {}
+        return {name: url for name, url in services.items() if isinstance(name, str) and isinstance(url, str)}
+
+    def _benchmark_service_headers_by_name(self) -> dict[str, dict[str, str]]:
+        auth_entries = self._config.get("benchmark_auth")
+        if not isinstance(auth_entries, dict):
+            return {}
+        return {
+            name: {"Authorization": credential}
+            for name, credential in auth_entries.items()
+            if isinstance(name, str) and isinstance(credential, str)
+        }
 
     @staticmethod
     def get_benchmark_auth(benchmark_name: str) -> str | None:
@@ -466,6 +484,23 @@ class TrackerService:
             return VerifyTaskIdsResponse.model_validate(response.json()).task_ids
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch task ids: {e}") from e
+
+    def list_benchmarks(self, include_inaccessible: bool = False) -> ListBenchmarksResponse:
+        try:
+            payload = ListBenchmarksRequest(
+                custom_benchmark_services=self._custom_benchmark_services(),
+                service_headers_by_benchmark=self._benchmark_service_headers_by_name(),
+                include_inaccessible=include_inaccessible,
+            )
+            response = self._client.post(f"{self._base_url}/list-benchmarks", json=payload.model_dump())
+
+            if response.status_code != 200:
+                details = _response_error_detail(response)
+                raise TrackerServiceError(f"Failed to list benchmarks: {details}")
+
+            return ListBenchmarksResponse.model_validate(response.json())
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to list benchmarks: {e}") from e
 
     def check_results_exist_in_s3(self, benchmark_id: UUID) -> bool:
         """

--- a/tests/unit/test_benchmark_list.py
+++ b/tests/unit/test_benchmark_list.py
@@ -1,0 +1,57 @@
+import pytest
+from click.testing import CliRunner
+
+from valkyrie.cli import main as cli_main
+from valkyrie.cli.exceptions import TrackerServiceError
+
+
+class FakeTrackerService:
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def __enter__(self) -> "FakeTrackerService":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    @staticmethod
+    def get_benchmark_auth(_benchmark_name: str) -> str | None:
+        return None
+
+    def close(self) -> None:
+        pass
+
+    def fetch_benchmark_tasks(
+        self,
+        benchmark_name: str,
+        dataset: str | None = None,
+        slice_str: str | None = None,
+        ignore_custom_services: bool = False,
+        service_headers: dict[str, str] | None = None,
+    ) -> list[str]:
+        del ignore_custom_services, service_headers
+        self.calls.append((benchmark_name, dataset, slice_str))
+        if (benchmark_name, dataset) in {("swebench", None), ("ioi", "ioi2024")}:
+            return []
+        raise TrackerServiceError("no access")
+
+
+def test_benchmark_list_outputs_accessible_benchmarks(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeTrackerService.calls = []
+    monkeypatch.setattr(
+        cli_main,
+        "HOSTED_BENCHMARK_DATASETS",
+        {"ioi": ("ioi2024", "ioi2025"), "swebench": ("default", "vals_index")},
+    )
+    monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
+    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
+
+    result = CliRunner().invoke(cli_main.cli, ["benchmark", "list"])
+
+    assert result.exit_code == 0
+    assert "swebench" in result.output
+    assert "default" in result.output
+    assert "ioi" in result.output
+    assert "ioi2024" in result.output
+    assert ("swebench", None, "0:0") in FakeTrackerService.calls
+    assert ("swebench", "vals_index", "0:0") in FakeTrackerService.calls

--- a/tests/unit/test_benchmark_list.py
+++ b/tests/unit/test_benchmark_list.py
@@ -1,48 +1,44 @@
-import pytest
 from click.testing import CliRunner
+import pytest
+from tracker.types import BenchmarkListEntry, ListBenchmarksResponse
 
 from valkyrie.cli import main as cli_main
 from valkyrie.cli.exceptions import TrackerServiceError
 
 
 class FakeTrackerService:
-    calls: list[tuple[str, str | None, str | None]] = []
-
     def __enter__(self) -> "FakeTrackerService":
         return self
 
     def __exit__(self, *_args: object) -> None:
         return None
 
-    @staticmethod
-    def get_benchmark_auth(_benchmark_name: str) -> str | None:
-        return None
-
     def close(self) -> None:
         pass
 
-    def fetch_benchmark_tasks(
-        self,
-        benchmark_name: str,
-        dataset: str | None = None,
-        slice_str: str | None = None,
-        ignore_custom_services: bool = False,
-        service_headers: dict[str, str] | None = None,
-    ) -> list[str]:
-        del ignore_custom_services, service_headers
-        self.calls.append((benchmark_name, dataset, slice_str))
-        if (benchmark_name, dataset) in {("swebench", None), ("ioi", "ioi2024")}:
-            return []
-        raise TrackerServiceError("no access")
+    def list_benchmarks(self, include_inaccessible: bool = False) -> ListBenchmarksResponse:
+        del include_inaccessible
+        return ListBenchmarksResponse(
+            benchmarks=[
+                BenchmarkListEntry(benchmark_name="ioi", datasets=["ioi2024"]),
+                BenchmarkListEntry(benchmark_name="swebench", datasets=["default"]),
+            ]
+        )
+
+
+class NoAccessTrackerService(FakeTrackerService):
+    def list_benchmarks(self, include_inaccessible: bool = False) -> ListBenchmarksResponse:
+        return ListBenchmarksResponse(
+            benchmarks=[BenchmarkListEntry(benchmark_name="swebench", datasets=[])] if include_inaccessible else []
+        )
+
+
+class BrokenTrackerService(FakeTrackerService):
+    def __init__(self) -> None:
+        raise TrackerServiceError("broken tracker")
 
 
 def test_benchmark_list_outputs_accessible_benchmarks(monkeypatch: pytest.MonkeyPatch) -> None:
-    FakeTrackerService.calls = []
-    monkeypatch.setattr(
-        cli_main,
-        "HOSTED_BENCHMARK_DATASETS",
-        {"ioi": ("ioi2024", "ioi2025"), "swebench": ("default", "vals_index")},
-    )
     monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
     monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
 
@@ -53,5 +49,43 @@ def test_benchmark_list_outputs_accessible_benchmarks(monkeypatch: pytest.Monkey
     assert "default" in result.output
     assert "ioi" in result.output
     assert "ioi2024" in result.output
-    assert ("swebench", None, "0:0") in FakeTrackerService.calls
-    assert ("swebench", "vals_index", "0:0") in FakeTrackerService.calls
+
+
+def test_benchmark_list_can_show_inaccessible_benchmarks(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_main, "TrackerService", NoAccessTrackerService)
+    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
+
+    result = CliRunner().invoke(cli_main.cli, ["benchmark", "list", "--include-inaccessible"])
+
+    assert result.exit_code == 0
+    assert "swebench" in result.output
+    assert "No access" in result.output
+
+
+def test_benchmark_list_prints_empty_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_main, "TrackerService", NoAccessTrackerService)
+    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
+
+    result = CliRunner().invoke(cli_main.cli, ["benchmark", "list"])
+
+    assert result.exit_code == 0
+    assert "No accessible benchmarks found." in result.output
+
+
+def test_benchmark_list_exits_when_tracker_is_unhealthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
+    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: False)
+
+    result = CliRunner().invoke(cli_main.cli, ["benchmark", "list"])
+
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_benchmark_list_surfaces_tracker_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli_main, "TrackerService", BrokenTrackerService)
+
+    result = CliRunner().invoke(cli_main.cli, ["benchmark", "list"])
+
+    assert result.exit_code != 0
+    assert "broken tracker" in result.output

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -7,6 +7,7 @@ import yaml
 from tracker.database.models import AgentContractRequest, RetryMode
 
 from valkyrie.cli import tracker_service as tracker_service_module
+from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.tracker_service import TrackerService
 
 
@@ -32,6 +33,34 @@ class FakeClient:
 
     def close(self) -> None:
         pass
+
+
+class ListBenchmarksErrorClient(FakeClient):
+    def post(
+        self,
+        url: str,
+        *,
+        params: dict[str, object] | None = None,
+        json: dict[str, object],
+    ) -> httpx.Response:
+        self.params = params
+        self.json = json
+        if url.endswith("/list-benchmarks"):
+            return httpx.Response(500, json={"detail": "server error"})
+        return super().post(url, params=params, json=json)
+
+
+class ListBenchmarksConnectionErrorClient(FakeClient):
+    def post(
+        self,
+        _url: str,
+        *,
+        params: dict[str, object] | None = None,
+        json: dict[str, object],
+    ) -> httpx.Response:
+        self.params = params
+        self.json = json
+        raise httpx.ConnectError("connection failed")
 
 
 def empty_config() -> dict[str, object]:
@@ -176,3 +205,61 @@ def test_list_benchmarks_sends_custom_services_and_auth(tmp_path: Path, monkeypa
         "service_headers_by_benchmark": {"custom-benchmark": {"Authorization": "Bearer token"}},
         "include_inaccessible": True,
     }
+
+
+def test_list_benchmarks_ignores_invalid_custom_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+
+    def config_with_invalid_entries() -> dict[str, object]:
+        return {
+            "custom_benchmark_services": {"custom-benchmark": 123, 1: "http://service"},
+            "benchmark_auth": {"custom-benchmark": 123},
+        }
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(config_with_invalid_entries))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    tracker.list_benchmarks()
+
+    assert client.json == {
+        "custom_benchmark_services": {},
+        "service_headers_by_benchmark": {},
+        "include_inaccessible": False,
+    }
+
+
+def test_list_benchmarks_surfaces_http_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = ListBenchmarksErrorClient()
+
+    def build_client(**_kwargs: object) -> ListBenchmarksErrorClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+
+    with pytest.raises(TrackerServiceError, match="server error"):
+        tracker.list_benchmarks()
+
+
+def test_list_benchmarks_surfaces_connection_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = ListBenchmarksConnectionErrorClient()
+
+    def build_client(**_kwargs: object) -> ListBenchmarksConnectionErrorClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+
+    with pytest.raises(TrackerServiceError, match="connection failed"):
+        tracker.list_benchmarks()

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -17,13 +17,15 @@ class FakeClient:
 
     def post(
         self,
-        _url: str,
+        url: str,
         *,
         params: dict[str, object] | None = None,
         json: dict[str, object],
     ) -> httpx.Response:
         self.params = params
         self.json = json
+        if url.endswith("/fetch-benchmark-tasks"):
+            return httpx.Response(200, json={"task_ids": []})
         return httpx.Response(200, json={"status": "success"})
 
     def close(self) -> None:
@@ -117,3 +119,22 @@ def test_tracker_service_accepts_provider_secret_config(tmp_path: Path, monkeypa
     harness_config = client.json["harness_config"]
     assert isinstance(harness_config, dict)
     assert harness_config["sandbox_provider_secret_name"] == "DaytonaSecrets"
+
+
+def test_fetch_benchmark_tasks_sends_slice(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    tracker.fetch_benchmark_tasks("swebench", dataset="default", slice_str="0:0")
+
+    assert client.json is not None
+    assert client.json["benchmark_name"] == "swebench"
+    assert client.json["dataset"] == "default"
+    assert client.json["slice_str"] == "0:0"

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -26,6 +26,8 @@ class FakeClient:
         self.json = json
         if url.endswith("/fetch-benchmark-tasks"):
             return httpx.Response(200, json={"task_ids": []})
+        if url.endswith("/list-benchmarks"):
+            return httpx.Response(200, json={"benchmarks": [{"benchmark_name": "swebench", "datasets": ["default"]}]})
         return httpx.Response(200, json={"status": "success"})
 
     def close(self) -> None:
@@ -138,3 +140,39 @@ def test_fetch_benchmark_tasks_sends_slice(monkeypatch: pytest.MonkeyPatch) -> N
     assert client.json["benchmark_name"] == "swebench"
     assert client.json["dataset"] == "default"
     assert client.json["slice_str"] == "0:0"
+
+
+def test_list_benchmarks_sends_custom_services_and_auth(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "valkyrie.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "AWS_ACCESS_KEY_ID": "aws-key",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                "S3_BUCKET": "bucket",
+                "SANDBOX_PROVIDER_SECRET_NAME": "DaytonaSecrets",
+                "LOG_GROUP": "benchmarks",
+                "LOG_RETENTION_POLICY": 365,
+                "custom_benchmark_services": {"custom-benchmark": "http://service"},
+                "benchmark_auth": {"custom-benchmark": "Bearer token"},
+            }
+        )
+    )
+    monkeypatch.setattr(tracker_service_module, "_CONFIG_LOCATION", config_path)
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    response = tracker.list_benchmarks(include_inaccessible=True)
+
+    assert response.benchmarks[0].benchmark_name == "swebench"
+    assert client.json == {
+        "custom_benchmark_services": {"custom-benchmark": "http://service"},
+        "service_headers_by_benchmark": {"custom-benchmark": {"Authorization": "Bearer token"}},
+        "include_inaccessible": True,
+    }


### PR DESCRIPTION
## Summary
Adds `valk benchmark list` so users can see which hosted benchmark datasets their configured Valkyrie credentials can access before starting a run.

## Changes
- Adds a Tracker `/list-benchmarks` endpoint that owns the hosted benchmark catalog and validates access server-side.
- Probes benchmark/dataset access concurrently with a bounded concurrency limit and `slice_str="0:0"`, avoiding full task ID downloads and avoiding sequential CLI-side O(N×M) calls.
- Extends `/fetch-benchmark-tasks` to pass an optional `slice_str` through to benchmark services.
- Includes configured custom benchmark services in the list command with the default dataset and any configured benchmark auth header.
- Documents the new command in the README.

## Related Issues
Closes #

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Commands run:
- `uv --directory /home/ubuntu/repos/Valkyrie run valk benchmark list --help`
- `make -C /home/ubuntu/repos/Valkyrie lint`
- `make -C /home/ubuntu/repos/Valkyrie typecheck`
- `uv --directory /home/ubuntu/repos/Valkyrie run pytest tests/unit`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff check .`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run pytest tests/unit --test-alembic`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run basedpyright src/tracker/benchmark_catalog.py src/tracker/types.py`

Note: full tracker `basedpyright` still reports the existing `main.py` final-view optional/unknown-type errors; the targeted new tracker files pass.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/a1b30e8b18aa4da2b7f360172a99c0dd
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->