### PR TITLE
tracker: drop run_by_email, consolidate run attribution on started_by_email

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -314,7 +314,6 @@ async def start_benchmark(
 
     # Create benchmark row only after pre-flight checks pass.
     benchmark_row = start_benchmark_request_to_benchmark(request, run_starter)
-    benchmark_row.run_by_email = http_request.headers.get("x-harness-run-by-email")
     session.add(benchmark_row)
     session.commit()
     benchmark_id_var.set(str(benchmark_row.id))

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -54,7 +54,7 @@ def get_single_benchmark(
         total_tasks=total,
         finished_tasks=finished,
         task_state_counts={status.value: count for status, count in task_state_counts.items()},
-        run_by_email=benchmark.run_by_email,
+        started_by_email=benchmark.started_by_email,
         final_score=benchmark.fetch_final_score(session),
         error_message=benchmark.error_message,
     )

--- a/services/tracker/src/tracker/database/migrations/versions/b2c3d4e5f6a7_drop_run_by_email.py
+++ b/services/tracker/src/tracker/database/migrations/versions/b2c3d4e5f6a7_drop_run_by_email.py
@@ -1,0 +1,38 @@
+"""drop benchmark.run_by_email (consolidate on started_by_email)
+
+Backfills historical run_by_email values onto started_by_email, then drops the
+redundant column — the run starter (from x-api-key) is the single source of truth.
+
+Revision ID: b2c3d4e5f6a7
+Revises: 9f1a69961211
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b2c3d4e5f6a7"
+down_revision: Union[str, Sequence[str], None] = "9f1a69961211"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE benchmark SET started_by_email = run_by_email "
+        "WHERE started_by_email IS NULL AND run_by_email IS NOT NULL"
+    )
+    op.drop_column("benchmark", "run_by_email")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "benchmark",
+        sa.Column("run_by_email", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+    op.execute("UPDATE benchmark SET run_by_email = started_by_email")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -229,7 +229,6 @@ class Benchmark(SQLModel, table=True):
     started_at: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo("UTC")))
     finished_at: datetime | None = None
     status: BenchmarkStatus = Field(default=BenchmarkStatus.IN_PROGRESS)
-    run_by_email: str | None = Field(default=None)
 
     error_message: str | None = Field(default=None)
     webhook_secret_name: str | None = Field(default=None)
@@ -335,7 +334,6 @@ class Benchmark(SQLModel, table=True):
             total_tasks=total_tasks,
             finished_tasks=finished_tasks,
             task_state_counts={k.value: v for k, v in task_state_counts.items()},
-            run_by_email=self.run_by_email,
             final_score=(self.final_evaluation.final_score if self.final_evaluation else None),
         )
 

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -195,7 +195,6 @@ class BenchmarkTableRow(BaseModel):
     # Per-TaskStatus counts: {"PENDING": 1, "IN_PROGRESS": 2, "FINISHED": 4, ...}.
     # Absent keys mean zero; sum equals total_tasks.
     task_state_counts: dict[str, int] = {}
-    run_by_email: str | None = None
     final_score: float | None = None
     error_message: str | None = None
 
@@ -289,7 +288,7 @@ class SingleBenchmarkResponse(BaseModel):
     total_tasks: int
     finished_tasks: int
     task_state_counts: dict[str, int] = {}
-    run_by_email: str | None = None
+    started_by_email: str | None = None
     final_score: float | None = None
     error_message: str | None = None
 

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1690,7 +1690,6 @@ def build_benchmark_table_rows(benchmarks: Sequence[Benchmark], session: Session
                     + counts.get(TaskStatus.STOPPED, 0)
                 ),
                 task_state_counts={k.value: v for k, v in counts.items()},
-                run_by_email=b.run_by_email,
                 final_score=b.final_evaluation.final_score if b.final_evaluation else None,
             )
         )

--- a/services/tracker/tests/integration/test_fetch_benchmarks_keyset.py
+++ b/services/tracker/tests/integration/test_fetch_benchmarks_keyset.py
@@ -68,7 +68,7 @@ def client(monkeypatch, database_session: Session):
     main_mod.app.dependency_overrides.clear()
 
 
-def _seed(session: Session, n: int, run_by_email: str | None = None, start_status=None) -> list[Benchmark]:
+def _seed(session: Session, n: int, started_by_email: str | None = None, start_status=None) -> list[Benchmark]:
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
     rows = []
     for i in range(n):
@@ -80,7 +80,7 @@ def _seed(session: Session, n: int, run_by_email: str | None = None, start_statu
             name=f"bench-{i}",
             started_at=base + timedelta(minutes=i),
             status=status,
-            run_by_email=run_by_email,
+            started_by_email=started_by_email,
             arguments=BenchmarkArguments(
                 contract=AgentContractRequest(name="a", install_cmd="i", run_cmd="r"),
                 concurrency=1,
@@ -145,16 +145,9 @@ def test_legacy_offset_limit_still_works(client, database_session):
     assert data["total_count"] == 3
 
 
-def test_table_row_includes_run_by_email(client, database_session):
-    _seed(database_session, 1, run_by_email="emailtest@x.com")
+def test_table_row_includes_started_by_email(client, database_session):
+    _seed(database_session, 1, started_by_email="emailtest@x.com")
 
     resp = client.get("/fetch-benchmarks", headers={"x-api-key": "fake-key"})
     data = resp.json()
-    assert data["benchmarks"][0]["run_by_email"] == "emailtest@x.com"
-
-
-def test_table_row_run_by_email_null_when_unattributed(client, database_session):
-    _seed(database_session, 1, run_by_email=None)
-    resp = client.get("/fetch-benchmarks", headers={"x-api-key": "fake-key"})
-    data = resp.json()
-    assert data["benchmarks"][0]["run_by_email"] is None
+    assert data["benchmarks"][0]["started_by_email"] == "emailtest@x.com"


### PR DESCRIPTION
`run_by_email` (populated only from the platform proxy's `X-Harness-Run-By-Email` header) duplicated `started_by_email`. With per-user Valkyrie configs, each user authenticates to the tracker with their **own `x-api-key`**, so `run_starter.email` (resolved from that key) is the single source of truth for who started a run — the side-channel header isn't needed.

## Changes
- Remove `run_by_email` from the `Benchmark` model, response types (`BenchmarkTableRow`, `SingleBenchmarkResponse`), the list-row builder, and the row mappers.
- Single-run endpoint now returns `started_by_email`.
- Drop the start-handler's `X-Harness-Run-By-Email` read; `started_by_email` is set from `run_starter.email` at row creation.
- Migration `b2c3d4e5f6a7`: backfills `started_by_email` from `run_by_email`, then drops the column.
- Tests updated; removed a trivial null-serialization test.

## Pairs with
Platform PR vals-ai/platform#2452 (stops sending the header; reads `started_by_email`).

## Note
In `AUTH_REQUIRED=false` (self-hosted) mode there's no authenticated identity, so `started_by_email` is null for new runs — attribution requires hosted mode + a per-user, email-bound Descope key.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->