### PR TITLE
Add run labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ valkyrie run start \
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--slice` | Slice the benchmark dataset (`start:stop:step`) |
 | `--dataset` | Dataset variant to run from the benchmark service. A single benchmark can expose multiple datasets (e.g. `default`, `test`, `validation`, `train`, `lite`) representing different task splits or difficulty levels. Defaults to `default` |
+| `-l` / `--label` | Label to attach to the run |
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
 | `-i` / `--interval` | Progress percentage threshold for Slack notification. Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
 | `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
@@ -241,6 +242,7 @@ valkyrie run list \
 | `--agent-name` | Filter by agent name |
 | `--benchmark-name` | Filter by benchmark name |
 | `--model` | Filter by model |
+| `-l` / `--label` | Filter by run label |
 | `--status` | Filter by status: `IN_PROGRESS`, `STOPPING`, `STOPPED`, `FINISHED`, `ERROR` |
 | `--order-by` | Order results (`desc` or `asc`) |
 | `--started-by` | Comma-separated list of starter emails (case-insensitive) |

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ valkyrie run start \
   -s ANTHROPIC_API_KEY devEvalInfraAnthropicKey \
   -k temperature 1 \
   --slice "0:10" \
+  --label swebench_sweagent
 ```
 
 | Flag | Description |
@@ -146,7 +147,7 @@ valkyrie run start \
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--slice` | Slice the benchmark dataset (`start:stop:step`) |
 | `--dataset` | Dataset variant to run from the benchmark service. A single benchmark can expose multiple datasets (e.g. `default`, `test`, `validation`, `train`, `lite`) representing different task splits or difficulty levels. Defaults to `default` |
-| `-l` / `--label` | Label to attach to the run |
+| `-l` / `--label` | Label to attach to the run, can filter by when using `valk run list -l <LABEL>`. Can only set one label per run.  |
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
 | `-i` / `--interval` | Progress percentage threshold for Slack notification. Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
 | `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
@@ -234,7 +235,8 @@ valkyrie run list \
   --benchmark-name swebench \
   --status IN_PROGRESS \
   --order-by DESC \
-  --started-by alice@vals.ai,bob@vals.ai
+  --started-by alice@vals.ai,bob@vals.ai \
+  --label swebench_claude_code
 ```
 
 | Option | Description |

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -442,6 +442,7 @@ async def fetch_benchmark(
         s3_bucket_url=create_benchmark_url(
             str(benchmark_row.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
         ),
+        label=benchmark_row.label,
     )
 
 
@@ -766,6 +767,7 @@ async def fetch_benchmarks(
     started_by: list[str] | None = Query(default=None),
     model: str | None = Query(default=None),
     dataset: str | None = Query(default=None),
+    label: str | None = Query(default=None),
     started_after: datetime | None = Query(default=None),
     started_before: datetime | None = Query(default=None),
     order_by: Order = Query(default=Order.DESC),
@@ -790,6 +792,7 @@ async def fetch_benchmarks(
         started_by=started_by,
         model=model,
         dataset=dataset,
+        label=label,
         started_after=started_after,
         started_before=started_before,
         order_by=order_by,

--- a/services/tracker/src/tracker/database/migrations/versions/7c3d2a1f9b8e_add_run_label.py
+++ b/services/tracker/src/tracker/database/migrations/versions/7c3d2a1f9b8e_add_run_label.py
@@ -1,0 +1,32 @@
+"""add run label
+
+Revision ID: 7c3d2a1f9b8e
+Revises: b2c3d4e5f6a7
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7c3d2a1f9b8e"
+down_revision: Union[str, Sequence[str], None] = "b2c3d4e5f6a7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column("benchmark", sa.Column("label", sqlmodel.sql.sqltypes.AutoString(), nullable=True))
+    op.create_index(op.f("ix_benchmark_label"), "benchmark", ["label"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_benchmark_label"), table_name="benchmark")
+    op.drop_column("benchmark", "label")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -229,6 +229,7 @@ class Benchmark(SQLModel, table=True):
     started_at: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo("UTC")))
     finished_at: datetime | None = None
     status: BenchmarkStatus = Field(default=BenchmarkStatus.IN_PROGRESS)
+    label: str | None = Field(default=None, index=True)
 
     error_message: str | None = Field(default=None)
     webhook_secret_name: str | None = Field(default=None)
@@ -335,6 +336,7 @@ class Benchmark(SQLModel, table=True):
             finished_tasks=finished_tasks,
             task_state_counts={k.value: v for k, v in task_state_counts.items()},
             final_score=(self.final_evaluation.final_score if self.final_evaluation else None),
+            label=self.label,
         )
 
     def fetch_task_state_counts(self, session: Session) -> dict[TaskStatus, int]:

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -59,6 +59,7 @@ class StartBenchmarkRequest(BaseModel):
     contract: AgentContractRequest
     benchmark_name: str
     concurrency: int = 5
+    label: str | None = None
     task_ids: list[str] | None = None
     slice_str: str | None = None
     lambda_function: str | None = None
@@ -113,6 +114,7 @@ class FetchBenchmarkResponse(BaseModel):
     benchmark_id: UUID
     details: BenchmarkDetails
     s3_bucket_url: str
+    label: str | None = None
 
 
 class AverageTaskBreakdown(BaseModel):
@@ -168,6 +170,7 @@ class FetchBenchmarksRequest(BaseModel):
     benchmark_name: list[str] | None = None
     model: str | None = None
     dataset: str | None = None
+    label: str | None = None
     status: list[BenchmarkStatus] | None = None
     started_by: list[str] | None = None
     started_after: datetime | None = None
@@ -184,6 +187,7 @@ class BenchmarkTableRow(BaseModel):
     id: UUID
     name: str
     agent_name: str
+    label: str | None = None
     model: str | None
     dataset: str = "default"
     started_by_email: str | None

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -118,6 +118,7 @@ def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest, run_sta
     return Benchmark(
         org_id=run_starter.org.id,
         name=request.benchmark_name,
+        label=request.label,
         custom_benchmark_service=request.custom_benchmark_service,
         webhook_secret_name=request.webhook_secret_name,
         webhook_intervals=request.webhook_intervals,
@@ -1288,6 +1289,7 @@ async def stream_benchmark_results(
                     s3_bucket_url=create_benchmark_url(
                         str(fresh_benchmark.id), harness_config.aws.aws_default_region, harness_config.s3_bucket
                     ),
+                    label=fresh_benchmark.label,
                 )
 
                 yield f"{DATA_PREFIX} {response_data.model_dump_json()}\n\n"
@@ -1584,6 +1586,9 @@ def fetch_filtered_benchmark_rows(
         else:
             query = query.where(dataset_value == request.dataset)
 
+    if request.label is not None:
+        query = query.where(Benchmark.label == request.label)
+
     if request.benchmark_name:
         if len(request.benchmark_name) == 1:
             query = query.where(Benchmark.name == request.benchmark_name[0])
@@ -1681,6 +1686,7 @@ def build_benchmark_table_rows(benchmarks: Sequence[Benchmark], session: Session
                 id=b.id,
                 name=b.name,
                 agent_name=b.arguments.contract.name,
+                label=b.label,
                 model=b.arguments.contract.model,
                 dataset=b.arguments.dataset or "default",
                 started_by_email=b.started_by_email,

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -1587,7 +1587,7 @@ def fetch_filtered_benchmark_rows(
             query = query.where(dataset_value == request.dataset)
 
     if request.label is not None:
-        query = query.where(Benchmark.label == request.label)
+        query = query.where(func.lower(Benchmark.label) == request.label.lower())
 
     if request.benchmark_name:
         if len(request.benchmark_name) == 1:
@@ -1676,7 +1676,7 @@ def build_benchmark_table_rows(benchmarks: Sequence[Benchmark], session: Session
     ).all()
     counts_by_bench: dict[UUID, dict[TaskStatus, int]] = {}
     for bench_id, status, count in count_rows:
-        counts_by_bench.setdefault(bench_id, {})[status] = count
+        counts_by_bench.setdefault(bench_id, {})[cast(TaskStatus, status)] = count
 
     rows: list[BenchmarkTableRow] = []
     for b in benchmarks:

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -568,6 +568,7 @@ def _make_benchmark(
     *,
     started_by_email: str | None,
     name: str = "swebench",
+    label: str | None = None,
 ) -> Benchmark:
     bench = Benchmark(
         org_id=TEST_ORG_ID,
@@ -575,6 +576,7 @@ def _make_benchmark(
         arguments=BenchmarkArguments(contract=contract, concurrency=1),
         started_by_email=started_by_email,
         started_by_id="K-" + (started_by_email or "none"),
+        label=label,
     )
     session.add(bench)
     session.commit()
@@ -688,6 +690,29 @@ def test_fetch_filtered_started_by_does_not_leak_across_orgs(database_session: S
     )
     assert total == 1
     assert rows[0].org_id == TEST_ORG_ID
+
+
+def test_fetch_filtered_by_label(database_session: Session, contract: AgentContractRequest):
+    """Label filtering should return only runs with the exact requested label.
+
+    Test cases:
+    - A matching label returns the labeled run.
+    - Unlabeled and differently labeled runs are excluded.
+    """
+    org = database_session.get(Org, TEST_ORG_ID)
+    assert org is not None
+    _make_benchmark(database_session, contract, started_by_email="alice@vals.ai", label="nightly")
+    _make_benchmark(database_session, contract, started_by_email="bob@vals.ai", label="manual")
+    _make_benchmark(database_session, contract, started_by_email="carol@vals.ai", label=None)
+
+    rows, total, _ = fetch_filtered_benchmark_rows(
+        FetchBenchmarksRequest(label="nightly", limit=10),
+        database_session,
+        org,
+    )
+
+    assert total == 1
+    assert rows[0].label == "nightly"
 
 
 def test_parse_log_retention_policy_rejects_invalid_value():

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -27,7 +27,7 @@ from tracker.database.models import (
 from tracker.exceptions import TrackerServiceError
 from tracker.types import AWSCredentials, FetchBenchmarksRequest, HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
-    _parse_log_retention_policy,
+    _parse_log_retention_policy,  # pyright: ignore[reportPrivateUsage]
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
@@ -639,7 +639,7 @@ def test_fetch_filtered_started_by_none_skips_filter(database_session: Session, 
     _make_benchmark(database_session, contract, started_by_email="alice@vals.ai")
     _make_benchmark(database_session, contract, started_by_email=None)
 
-    rows, total, _ = fetch_filtered_benchmark_rows(
+    _, total, _ = fetch_filtered_benchmark_rows(
         FetchBenchmarksRequest(started_by=None, limit=10),
         database_session,
         org,
@@ -693,26 +693,26 @@ def test_fetch_filtered_started_by_does_not_leak_across_orgs(database_session: S
 
 
 def test_fetch_filtered_by_label(database_session: Session, contract: AgentContractRequest):
-    """Label filtering should return only runs with the exact requested label.
+    """Label filtering should ignore case while preserving stored label casing.
 
     Test cases:
-    - A matching label returns the labeled run.
+    - A mixed-case label returns when queried with different casing.
     - Unlabeled and differently labeled runs are excluded.
     """
     org = database_session.get(Org, TEST_ORG_ID)
     assert org is not None
-    _make_benchmark(database_session, contract, started_by_email="alice@vals.ai", label="nightly")
+    _make_benchmark(database_session, contract, started_by_email="alice@vals.ai", label="Nightly")
     _make_benchmark(database_session, contract, started_by_email="bob@vals.ai", label="manual")
     _make_benchmark(database_session, contract, started_by_email="carol@vals.ai", label=None)
 
     rows, total, _ = fetch_filtered_benchmark_rows(
-        FetchBenchmarksRequest(label="nightly", limit=10),
+        FetchBenchmarksRequest(label="nightLY", limit=10),
         database_session,
         org,
     )
 
     assert total == 1
-    assert rows[0].label == "nightly"
+    assert rows[0].label == "Nightly"
 
 
 def test_parse_log_retention_policy_rejects_invalid_value():

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -939,6 +939,57 @@ class TestFastapiServer:
         assert len(rows) == 2
         assert {r["started_by_email"] for r in rows} == {"alice@vals.ai", "bob@vals.ai"}
 
+    async def test_run_label_is_persisted_fetchable_and_filterable(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        harness_config: HarnessConfig,
+    ):
+        """Run labels should persist on start and be visible through fetch and list.
+
+        Test cases:
+            - Start stores the label on the benchmark row.
+            - Fetch and list responses expose the label, and list can filter by it.
+        """
+
+        async def _mock_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=1,
+            task_ids=None,
+            harness_config=harness_config,
+            label="nightly",
+        )
+        start_response = client.post("/start-benchmark", json=request.model_dump())
+        assert start_response.status_code == 200
+        benchmark_id = UUID(start_response.json()["benchmark_id"])
+
+        benchmark_row = database_session.get(Benchmark, benchmark_id)
+        assert benchmark_row is not None
+        assert benchmark_row.label == "nightly"
+
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", status=TaskStatus.PENDING, benchmark=benchmark_id)
+        )
+        database_session.commit()
+
+        fetch_response = client.get("/fetch-benchmark", params={"benchmark_id": str(benchmark_id)})
+        assert fetch_response.status_code == 200
+        assert fetch_response.json()["label"] == "nightly"
+
+        list_response = client.get("/fetch-benchmarks", params={"label": "nightly", "limit": 10})
+        assert list_response.status_code == 200
+        rows = list_response.json()["benchmarks"]
+        assert len(rows) == 1
+        assert rows[0]["id"] == str(benchmark_id)
+        assert rows[0]["label"] == "nightly"
+
     async def test_fetch_benchmark_metadata_includes_started_by_email(
         self,
         contract: AgentContractRequest,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -530,6 +530,14 @@ def tasks(
     help="Dataset name to use from the benchmark service (defaults to 'default')",
 )
 @click.option(
+    "--label",
+    "-l",
+    type=str,
+    required=False,
+    default=None,
+    help="Label to attach to the run",
+)
+@click.option(
     "--kwarg",
     "-k",
     "kwargs",
@@ -580,6 +588,7 @@ def start(
     task_ids_file: str | None,
     slice_str: str | None,
     dataset: str | None,
+    label: str | None,
     kwargs: tuple[tuple[str, str]],
     secrets: tuple[tuple[str, str]],
     headers: tuple[tuple[str, str]],
@@ -654,6 +663,7 @@ def start(
                 ignore_custom_services,
                 formatted_task_ids,
                 slice_str,
+                label,
                 lambda_function,
                 dataset,
                 service_headers=service_headers or None,
@@ -1086,6 +1096,13 @@ run.add_command(retry_command)
     help="Dataset name (e.g., default, terminal-bench-2.1)",
 )
 @click.option(
+    "--label",
+    "-l",
+    type=str,
+    required=False,
+    help="Run label",
+)
+@click.option(
     "--status",
     type=click.Choice([option.value for option in BenchmarkStatus], case_sensitive=False),
     required=False,
@@ -1111,6 +1128,7 @@ def list_benchmarks(
     benchmark_name: str | None,
     model: str | None,
     dataset: str | None,
+    label: str | None,
     status: str | None,
     order_by: str = "desc",
     started_by: str | None = None,
@@ -1136,6 +1154,7 @@ def list_benchmarks(
                 benchmark_name,
                 model,
                 dataset,
+                label,
                 status,
                 order_by,
                 started_by=started_by_list or None,

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -257,6 +257,7 @@ class TrackerService:
         ignore_custom_services: bool,
         task_ids: list[str] | None,
         slice_str: str | None,
+        label: str | None = None,
         lambda_function: str | None = None,
         dataset: str | None = None,
         service_headers: dict[str, str] | None = None,
@@ -272,6 +273,7 @@ class TrackerService:
             concurrency: Number of concurrent tasks
             task_ids: Optional list of specific task IDs to run
             slice_str: Optional slice string for task selection
+            label: Optional run label
             lambda_function: Optional lambda function to invoke after benchmark
 
         Returns:
@@ -285,6 +287,7 @@ class TrackerService:
                 contract=contract,
                 benchmark_name=benchmark_name,
                 concurrency=concurrency,
+                label=label,
                 task_ids=task_ids,
                 slice_str=slice_str,
                 lambda_function=lambda_function,

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -252,6 +252,8 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     click.echo("┌─ Run Status " + "─" * 66)
     click.echo(f"│ {'Benchmark:':<12} {benchmark_response.benchmark_name}")
     click.echo(f"│ {'Run ID:':<12} {benchmark_response.benchmark_id}")
+    if benchmark_response.label:
+        click.echo(f"│ {'Label:':<12} {benchmark_response.label}")
     click.echo(f"│ {'Started at:':<12} {local_time(details.started_at)}")
     click.echo(f"│ {'S3:':<12} {benchmark_response.s3_bucket_url}")
     analysis_line = _format_docent_analysis(details, benchmark_response.benchmark_id)
@@ -508,6 +510,7 @@ def format_fetch_benchmarks_response(
                 "ID": str(benchmark.id),
                 "Benchmark": benchmark.name,
                 "Agent": benchmark.agent_name,
+                "Label": benchmark.label or "-",
                 "Started By": benchmark.started_by_email or "—",
                 "Model": benchmark.model or "-",
                 "Dataset": benchmark.dataset or "default",
@@ -527,6 +530,7 @@ def format_fetch_benchmarks_response(
             "ID",
             "Benchmark",
             "Agent",
+            "Label",
             "Started By",
             "Model",
             "Dataset",
@@ -547,6 +551,7 @@ def format_no_benchmarks_found(
     benchmark_name: str | None,
     model: str | None,
     dataset: str | None,
+    label: str | None,
     status: str | None,
     started_by: list[str] | None = None,
 ) -> None:
@@ -558,13 +563,14 @@ def format_no_benchmarks_found(
         benchmark_name: Benchmark name filter
         model: Model name filter
         dataset: Dataset name filter
+        label: Run label filter
         status: Status filter
         started_by: Optional list of starter emails filter
     """
     click.echo()
     click.echo(click.style("No runs found matching the specified filters.", fg="yellow"))
     click.echo()
-    if any([agent_name, benchmark_name, model, dataset, status, started_by]):
+    if any([agent_name, benchmark_name, model, dataset, label, status, started_by]):
         click.echo("Filters applied:")
         if agent_name:
             click.echo(f"  • Agent: {agent_name}")
@@ -574,6 +580,8 @@ def format_no_benchmarks_found(
             click.echo(f"  • Model: {model}")
         if dataset:
             click.echo(f"  • Dataset: {dataset}")
+        if label:
+            click.echo(f"  • Label: {label}")
         if status:
             click.echo(f"  • Status: {status}")
         if started_by:
@@ -586,6 +594,7 @@ def paginate_benchmarks(
     benchmark_name: str | None,
     model: str | None,
     dataset: str | None,
+    label: str | None,
     status: str | None,
     order_by: str,
     limit: int = 5,
@@ -600,6 +609,7 @@ def paginate_benchmarks(
         benchmark_name: Optional benchmark name filter
         model: Optional model name filter
         dataset: Optional dataset name filter
+        label: Optional run label filter
         status: Optional status filter
         order_by: Order (asc/desc)
         limit: Number of items per page
@@ -614,6 +624,7 @@ def paginate_benchmarks(
             benchmark_name=[benchmark_name] if benchmark_name else None,
             model=model,
             dataset=dataset,
+            label=label,
             status=[BenchmarkStatus(status)] if status else None,
             started_by=started_by,
             order_by=Order(order_by),
@@ -628,7 +639,7 @@ def paginate_benchmarks(
         click.clear()
 
         if total_count == 0:
-            format_no_benchmarks_found(agent_name, benchmark_name, model, dataset, status, started_by)
+            format_no_benchmarks_found(agent_name, benchmark_name, model, dataset, label, status, started_by)
             break
 
         format_fetch_benchmarks_response(response, current_page, total_pages)

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -8,7 +8,13 @@ import httpx
 import pytest
 import yaml
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, DocentReadingStatus, RetryMode, TaskStatus
-from tracker.types import BenchmarkDetails, BenchmarkTableRow, FetchBenchmarkResponse, FetchBenchmarksRequest, FetchBenchmarksResponse
+from tracker.types import (
+    BenchmarkDetails,
+    BenchmarkTableRow,
+    FetchBenchmarkResponse,
+    FetchBenchmarksRequest,
+    FetchBenchmarksResponse,
+)
 
 from valkyrie.cli import tracker_service as tracker_service_module
 from valkyrie.cli.main import list_benchmarks, start

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -1,13 +1,19 @@
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 from uuid import uuid4
 
+import click
 import httpx
 import pytest
 import yaml
-from tracker.database.models import AgentContractRequest, RetryMode
+from tracker.database.models import AgentContractRequest, BenchmarkStatus, DocentReadingStatus, RetryMode, TaskStatus
+from tracker.types import BenchmarkDetails, BenchmarkTableRow, FetchBenchmarkResponse, FetchBenchmarksRequest, FetchBenchmarksResponse
 
 from valkyrie.cli import tracker_service as tracker_service_module
+from valkyrie.cli.main import list_benchmarks, start
 from valkyrie.cli.tracker_service import TrackerService
+from valkyrie.cli.utils import format_benchmark_status, format_fetch_benchmarks_response
 
 
 class FakeClient:
@@ -26,6 +32,10 @@ class FakeClient:
         self.json = json
         return httpx.Response(200, json={"status": "success"})
 
+    def get(self, _url: str, *, params: dict[str, object] | None = None) -> httpx.Response:
+        self.params = params
+        return httpx.Response(200, json={"benchmarks": [], "total_count": 0})
+
     def close(self) -> None:
         pass
 
@@ -36,6 +46,20 @@ def empty_config() -> dict[str, object]:
 
 def empty_config_keys(_tracker: TrackerService) -> dict[str, str]:
     return {}
+
+
+def harness_config_payload(_tracker: TrackerService) -> dict[str, object]:
+    return {
+        "aws": {
+            "aws_access_key_id": "aws-key",
+            "aws_secret_access_key": "aws-secret",
+            "aws_default_region": "us-east-1",
+        },
+        "s3_bucket": "bucket",
+        "log_group": "benchmarks",
+        "log_retention_policy": 365,
+        "sandbox_provider_secret_name": "DaytonaSecrets",
+    }
 
 
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -117,3 +141,104 @@ def test_tracker_service_accepts_provider_secret_config(tmp_path: Path, monkeypa
     harness_config = client.json["harness_config"]
     assert isinstance(harness_config, dict)
     assert harness_config["sandbox_provider_secret_name"] == "DaytonaSecrets"
+
+
+def _command_option_flags(command: click.Command, param_name: str) -> set[str]:
+    param = next(param for param in command.params if param.name == param_name)
+    assert isinstance(param, click.Option)
+    return {*param.opts}
+
+
+def test_run_label_cli_options_and_client_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run labels should be accepted by start and sent as list filters.
+
+    Test cases:
+    - Click exposes `--label` and `-l` on run start and run list.
+    - Tracker client start and list requests carry the label value.
+    """
+    assert _command_option_flags(start, "label") >= {"--label", "-l"}
+    assert _command_option_flags(list_benchmarks, "label") >= {"--label", "-l"}
+
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr(TrackerService, "_build_harness_config_payload", harness_config_payload)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    tracker.start_benchmark(
+        contract=AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run"),
+        benchmark_name="swebench",
+        concurrency=1,
+        ignore_custom_services=True,
+        task_ids=None,
+        slice_str=None,
+        label="nightly",
+    )
+    assert client.json is not None
+    assert client.json["label"] == "nightly"
+
+    tracker.fetch_benchmarks(FetchBenchmarksRequest(label="nightly"))
+    assert client.params is not None
+    assert client.params["label"] == "nightly"
+
+
+def test_run_label_fetch_and_list_output(capsys: pytest.CaptureFixture[str]) -> None:
+    """Run fetch and list output should include labels when present.
+
+    Test cases:
+    - `valk run fetch` renders the label row.
+    - `valk run list` includes a Label column.
+    """
+    run_id = uuid4()
+    started_at = datetime.now(ZoneInfo("UTC"))
+    details = BenchmarkDetails(
+        status=BenchmarkStatus.IN_PROGRESS,
+        started_at=started_at,
+        total_tasks=1,
+        finished_tasks=0,
+        task_breakdown={TaskStatus.PENDING: 1},
+        docent_reading_status=DocentReadingStatus.IDLE,
+    )
+
+    format_benchmark_status(
+        FetchBenchmarkResponse(
+            benchmark_name="swebench",
+            benchmark_id=run_id,
+            details=details,
+            s3_bucket_url="s3://bucket/benchmarks/run",
+            label="nightly",
+        )
+    )
+    fetch_output = capsys.readouterr().out
+    assert "Label:" in fetch_output
+    assert "nightly" in fetch_output
+
+    format_fetch_benchmarks_response(
+        FetchBenchmarksResponse(
+            benchmarks=[
+                BenchmarkTableRow(
+                    id=run_id,
+                    name="swebench",
+                    agent_name="agent",
+                    model="openai/gpt-5.5",
+                    dataset="default",
+                    started_by_email=None,
+                    started_at=started_at,
+                    finished_at=None,
+                    status=BenchmarkStatus.IN_PROGRESS,
+                    total_tasks=1,
+                    finished_tasks=0,
+                    label="nightly",
+                )
+            ],
+            total_count=1,
+        )
+    )
+    list_output = capsys.readouterr().out
+    assert "Label" in list_output
+    assert "nightly" in list_output


### PR DESCRIPTION
## Summary
Adds optional run labels so runs can be tagged at start time, filtered in `run list`, and shown in `run fetch`.

## Changes
- Added `--label` / `-l` to `valkyrie run start` and `valkyrie run list`.
- Persisted `benchmark.label` with a new tracker migration and exact-match list filtering.
- Exposed labels in fetch and list responses and CLI formatting.
- Updated README docs and added focused regression coverage.

<img width="1105" height="278" alt="image" src="https://github.com/user-attachments/assets/fd1ef9bf-344b-445c-bb98-ecee6ada190f" />

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed