### PR TITLE
tracker: sanitize CloudWatch logStreamName (no ':' or '*')

### DIFF
--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -1,3 +1,4 @@
+import re
 import time
 from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any
@@ -14,6 +15,18 @@ if TYPE_CHECKING:
     from tracker.types import AWSCredentials
 
 _created_streams: set[str] = set()
+
+
+def _sanitize_log_stream_name(task_id: str) -> str:
+    """Make a task_id safe to use as a CloudWatch logStreamName.
+
+    AWS requires log stream names to match the regex ``[^:*]*`` (no ``:`` or
+    ``*``). Some task ids carry these characters (e.g. model-suffixed ids like
+    ``provider/model:fast``), which makes ``CreateLogStream`` raise
+    ``InvalidParameterException`` and silently drops the run's logs. Replace the
+    forbidden characters so logging degrades gracefully instead of failing.
+    """
+    return re.sub(r"[:*]", "_", task_id)
 
 
 @lru_cache(maxsize=32)
@@ -62,7 +75,7 @@ def get_benchmark_log_url(benchmark_id: str, region: str, log_group: str, task_i
     base = f"https://{safe_region}.console.aws.amazon.com/cloudwatch/home?region={safe_region}"
     encoded_log_group = f"{safe_log_group}$252F{safe_benchmark_id}"
     if task_id:
-        safe_task_id = quote(task_id, safe="-_.")
+        safe_task_id = quote(_sanitize_log_stream_name(task_id), safe="-_.")
         return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{safe_task_id}"
 
     return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}"
@@ -121,21 +134,22 @@ def write_benchmark_log_event(stream_key: str, message: str, aws: "AWSCredential
 
     client = _cloudwatch_client(aws)
     log_group_name = f"{log_group}/{benchmark_id}"
+    stream_name = _sanitize_log_stream_name(task_id)
 
     if stream_key not in _created_streams:
         try:
-            client.create_log_stream(logGroupName=log_group_name, logStreamName=task_id)  # pyright: ignore[reportUnknownMemberType]
+            client.create_log_stream(logGroupName=log_group_name, logStreamName=stream_name)  # pyright: ignore[reportUnknownMemberType]
         except ClientError as e:
             if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
                 raise
         except BotoCoreError as e:
-            raise CloudWatchError(f"Failed to create log stream '{task_id}': {e}") from e
+            raise CloudWatchError(f"Failed to create log stream '{stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
     try:
         client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
             logGroupName=log_group_name,
-            logStreamName=task_id,
+            logStreamName=stream_name,
             logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
         )
     except (ClientError, BotoCoreError) as e:

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -1,9 +1,24 @@
+from unittest.mock import MagicMock
+
 import pytest
 from botocore.exceptions import BotoCoreError, ClientError
 
-from tracker.aws.cloudwatch_logs import _sanitize_log_stream_name, handle_cloudwatch_error
+from tracker.aws import cloudwatch_logs
+from tracker.aws.cloudwatch_logs import (
+    _sanitize_log_stream_name,
+    get_benchmark_log_url,
+    handle_cloudwatch_error,
+    write_benchmark_log_event,
+)
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.aws.s3 import handle_s3_error
+from tracker.types import AWSCredentials
+
+_AWS = AWSCredentials(
+    aws_access_key_id="test-key",
+    aws_secret_access_key="test-secret",
+    aws_default_region="us-east-1",
+)
 
 
 class TestS3DecoratorClient:
@@ -89,3 +104,44 @@ class TestSanitizeLogStreamName:
 
         for raw in ["openai/gpt-5.5", "laguna-xs.2:fast", "x*:y", "plain_id"]:
             assert re.fullmatch(r"[^:*]*", _sanitize_log_stream_name(raw))
+
+
+class TestGetBenchmarkLogUrl:
+    def test_sanitizes_task_id_in_url(self):
+        url = get_benchmark_log_url("bench123", "us-east-1", "/valkyrie/worker", task_id="provider/model:fast")
+        # task id is sanitized before being url-quoted into the log-events path
+        assert "model_fast" in url
+        assert "model:fast" not in url
+
+    def test_no_task_id_omits_log_events(self):
+        url = get_benchmark_log_url("bench123", "us-east-1", "/valkyrie/worker")
+        assert "log-events" not in url
+
+
+class TestWriteBenchmarkLogEvent:
+    def _mock_client(self, monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+        client = MagicMock()
+        monkeypatch.setattr(cloudwatch_logs, "_cloudwatch_client", lambda aws: client)
+        monkeypatch.setattr(cloudwatch_logs, "_created_streams", set())
+        return client
+
+    def test_creates_stream_and_puts_event_with_sanitized_name(self, monkeypatch: pytest.MonkeyPatch):
+        client = self._mock_client(monkeypatch)
+
+        # stream_key splits on the first ':' -> task_id keeps its own ':'
+        write_benchmark_log_event("bench123:provider/model:fast", "hello", _AWS, "/valkyrie/worker")
+
+        client.create_log_stream.assert_called_once_with(
+            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
+        )
+        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
+
+    def test_create_stream_botocore_error_reports_sanitized_name(self, monkeypatch: pytest.MonkeyPatch):
+        client = self._mock_client(monkeypatch)
+        client.create_log_stream.side_effect = BotoCoreError()
+
+        with pytest.raises(CloudWatchError) as exc_info:
+            write_benchmark_log_event("bench123:provider/model:fast", "hello", _AWS, "/valkyrie/worker")
+
+        assert "provider/model_fast" in str(exc_info.value)
+        client.put_log_events.assert_not_called()

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -1,7 +1,7 @@
 import pytest
 from botocore.exceptions import BotoCoreError, ClientError
 
-from tracker.aws.cloudwatch_logs import handle_cloudwatch_error
+from tracker.aws.cloudwatch_logs import _sanitize_log_stream_name, handle_cloudwatch_error
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.aws.s3 import handle_s3_error
 
@@ -65,3 +65,27 @@ class TestCloudWatchClient:
 
         assert "Failed to connect to CloudWatch" in str(exc_info.value)
         assert exc_info.value.__cause__ == botocore_error
+
+
+class TestSanitizeLogStreamName:
+    """logStreamName must satisfy AWS constraint [^:*]* (no ':' or '*')."""
+
+    def test_replaces_colon(self):
+        assert _sanitize_log_stream_name("provider/model:fast") == "provider/model_fast"
+
+    def test_replaces_asterisk(self):
+        assert _sanitize_log_stream_name("task*glob") == "task_glob"
+
+    def test_replaces_both_and_multiple(self):
+        assert _sanitize_log_stream_name("a:b:c*d") == "a_b_c_d"
+
+    def test_preserves_clean_name(self):
+        # plain ids and the allowed '/' are left intact
+        assert _sanitize_log_stream_name("water_intake_tracker") == "water_intake_tracker"
+        assert _sanitize_log_stream_name("group/sub/name") == "group/sub/name"
+
+    def test_result_matches_aws_constraint(self):
+        import re
+
+        for raw in ["openai/gpt-5.5", "laguna-xs.2:fast", "x*:y", "plain_id"]:
+            assert re.fullmatch(r"[^:*]*", _sanitize_log_stream_name(raw))


### PR DESCRIPTION
## Problem

`CreateLogStream` rejects log stream names containing `:` or `*` — AWS enforces the regex `[^:*]*`. `write_benchmark_log_event` (`services/tracker/src/tracker/aws/cloudwatch_logs.py`) passed `task_id` **verbatim** as `logStreamName`, so any task id carrying those characters (e.g. model-suffixed ids like `provider/model:fast`, `laguna-xs.2:fast`) made the call fail with:

```
CloudWatchError: Failed to create cloudwatch stream: InvalidParameterException:
Value at 'logStreamName' failed to satisfy constraint:
Member must satisfy regular expression pattern: [^:*]*
```

The write runs in a fire-and-forget future whose exception is swallowed (`asyncio: Future exception was never retrieved`), so the run's CloudWatch logs were **silently dropped** while the worker log (`/valkyrie/worker`) spammed the traceback.

## Fix

- Add `_sanitize_log_stream_name()` — `re.sub(r"[:*]", "_", task_id)`.
- Apply it at `create_log_stream`, `put_log_events`, and the console-URL builder (`get_benchmark_log_url`) so the printed URL points at the actual (sanitized) stream.
- Clean snake_case ids and the allowed `/` are unchanged, so existing streams keep their names.

## Test

`services/tracker/tests/unit/test_aws_clients.py::TestSanitizeLogStreamName` — colon/asterisk replacement, idempotency on clean names, and that every result satisfies `[^:*]*`. Full file: `9 passed`.

## Notes

- Discovered while debugging a `vcb-1-100` calibration sweep. The vcb-1-100 task ids are clean snake_case, so this error came from other benchmarks' model-suffixed streams on the shared worker — it was log noise there, not the cause of that sweep's stall. Still a real latent bug for any `:`/`*`-bearing task id.
- Stream **deduplication** (`_created_streams`) still keys off the original `stream_key`, so identity is unchanged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/484" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->