### PR TITLE
Rename Valkyrie agent outputs to run outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,22 +247,22 @@ valkyrie run list \
 
 Supports paginated navigation ([h] previous, [l] next, [q] quit).
 
-### Download agent outputs
+### Download run outputs
 
 ```bash
 # Download all task outputs for a run
-valkyrie agent outputs <id> --output-dir ./outputs
+valkyrie run outputs <id> --output-dir ./outputs
 
 # Download specific tasks (comma-separated)
-valkyrie agent outputs <id> --task-ids astropy__astropy-7606,django__django-10880
+valkyrie run outputs <id> --task-ids astropy__astropy-7606,django__django-10880
 ```
 
-Valkyrie agent outputs downloads the _output_ of the agent, Valkyrie run results downloads the scores and evaluation. 
+Valkyrie run outputs downloads the files produced during a run, while Valkyrie run results downloads the scores and evaluation. 
 
 ### Download a specific file or folder from a run
 
 ```bash
-valkyrie agent output <id> [subpath] [-o ./output-dir]
+valkyrie run output <id> [subpath] [-o ./output-dir]
 ```
 
 | Argument / Option | Description |

--- a/docs/HOSTED_MODE.md
+++ b/docs/HOSTED_MODE.md
@@ -79,7 +79,7 @@ Your AWS credentials must have the following permissions:
 
 | Service | Permissions | Used for |
 |---------|------------|----------|
-| **S3** | `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` | Storing benchmark results, agent artifacts, and agent outputs |
+| **S3** | `s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`, `s3:ListBucket` | Storing benchmark results, agent artifacts, and run outputs |
 | **S3** | `s3:GetObject` (for presigned URLs) | Generating download links for results |
 | **CloudWatch Logs** | `logs:CreateLogGroup`, `logs:CreateLogStream`, `logs:PutLogEvents` | Streaming task execution logs |
 | **Secrets Manager** | `secretsmanager:GetSecretValue` | Retrieving sandbox provider credentials (Daytona) and webhook URLs |

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -845,8 +845,8 @@ async def _stream_run_outputs(
             async for key in list_s3_objects(prefix, harness_config.aws, harness_config.s3_bucket):
                 yield key
 
-    keys = output_keys()
     # Peek a single key so an empty result still returns 404 before the stream starts.
+    keys = output_keys()
     first_key = await anext(keys, None)
     if first_key is None:
         raise HTTPException(status_code=404, detail=f"No outputs found for run '{benchmark_id}'")

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -828,23 +828,13 @@ async def fetch_benchmark_metadata(
     return benchmark_row.benchmark_metadata
 
 
-@app.get("/fetch-agent-outputs/{benchmark_id}", response_model=None)
-async def fetch_agent_outputs(
+async def _stream_run_outputs(
     benchmark_id: TrackedBenchmarkId,
-    session: Session = Depends(get_session),
-    harness_config: HarnessConfig = Depends(fetch_harness_config),
-    org: Org = Depends(get_current_org),
-    task_ids: list[str] | None = Query(default=None),
+    session: Session,
+    harness_config: HarnessConfig,
+    org: Org,
+    task_ids: list[str] | None,
 ) -> StreamingResponse:
-    """
-    Stream a tar file with agent outputs to the client.
-
-    Usage:
-    curl -X GET http://<endpoint>/fetch-agent-outputs/<benchmark_id>
-
-    Returns:
-        StreamingResponse
-    """
     get_scoped(Benchmark, benchmark_id, session, org)
 
     benchmark_prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
@@ -855,8 +845,8 @@ async def fetch_agent_outputs(
             async for key in list_s3_objects(prefix, harness_config.aws, harness_config.s3_bucket):
                 yield key
 
-    # Peek a single key so an empty result still returns 404 before the stream starts.
     keys = output_keys()
+    # Peek a single key so an empty result still returns 404 before the stream starts.
     first_key = await anext(keys, None)
     if first_key is None:
         raise HTTPException(status_code=404, detail=f"No outputs found for run '{benchmark_id}'")
@@ -892,3 +882,34 @@ async def fetch_agent_outputs(
         media_type="application/x-tar",
         headers={"Content-Disposition": f"attachment; filename=benchmark_{benchmark_id}_outputs.tar"},
     )
+
+
+@app.get("/fetch-run-outputs/{benchmark_id}", response_model=None)
+async def fetch_run_outputs(
+    benchmark_id: TrackedBenchmarkId,
+    session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+    org: Org = Depends(get_current_org),
+    task_ids: list[str] | None = Query(default=None),
+) -> StreamingResponse:
+    """
+    Stream a tar file with run outputs to the client.
+
+    Usage:
+    curl -X GET http://<endpoint>/fetch-run-outputs/<benchmark_id>
+
+    Returns:
+        StreamingResponse
+    """
+    return await _stream_run_outputs(benchmark_id, session, harness_config, org, task_ids)
+
+
+@app.get("/fetch-agent-outputs/{benchmark_id}", response_model=None, include_in_schema=False)
+async def fetch_agent_outputs(
+    benchmark_id: TrackedBenchmarkId,
+    session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+    org: Org = Depends(get_current_org),
+    task_ids: list[str] | None = Query(default=None),
+) -> StreamingResponse:
+    return await _stream_run_outputs(benchmark_id, session, harness_config, org, task_ids)

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -828,13 +828,23 @@ async def fetch_benchmark_metadata(
     return benchmark_row.benchmark_metadata
 
 
-async def _stream_run_outputs(
+@app.get("/fetch-run-outputs/{benchmark_id}", response_model=None)
+async def fetch_run_outputs(
     benchmark_id: TrackedBenchmarkId,
-    session: Session,
-    harness_config: HarnessConfig,
-    org: Org,
-    task_ids: list[str] | None,
+    session: Session = Depends(get_session),
+    harness_config: HarnessConfig = Depends(fetch_harness_config),
+    org: Org = Depends(get_current_org),
+    task_ids: list[str] | None = Query(default=None),
 ) -> StreamingResponse:
+    """
+    Stream a tar file with run outputs to the client.
+
+    Usage:
+    curl -X GET http://<endpoint>/fetch-run-outputs/<benchmark_id>
+
+    Returns:
+        StreamingResponse
+    """
     get_scoped(Benchmark, benchmark_id, session, org)
 
     benchmark_prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
@@ -882,23 +892,3 @@ async def _stream_run_outputs(
         media_type="application/x-tar",
         headers={"Content-Disposition": f"attachment; filename=benchmark_{benchmark_id}_outputs.tar"},
     )
-
-
-@app.get("/fetch-run-outputs/{benchmark_id}", response_model=None)
-async def fetch_run_outputs(
-    benchmark_id: TrackedBenchmarkId,
-    session: Session = Depends(get_session),
-    harness_config: HarnessConfig = Depends(fetch_harness_config),
-    org: Org = Depends(get_current_org),
-    task_ids: list[str] | None = Query(default=None),
-) -> StreamingResponse:
-    """
-    Stream a tar file with run outputs to the client.
-
-    Usage:
-    curl -X GET http://<endpoint>/fetch-run-outputs/<benchmark_id>
-
-    Returns:
-        StreamingResponse
-    """
-    return await _stream_run_outputs(benchmark_id, session, harness_config, org, task_ids)

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -902,14 +902,3 @@ async def fetch_run_outputs(
         StreamingResponse
     """
     return await _stream_run_outputs(benchmark_id, session, harness_config, org, task_ids)
-
-
-@app.get("/fetch-agent-outputs/{benchmark_id}", response_model=None, include_in_schema=False)
-async def fetch_agent_outputs(
-    benchmark_id: TrackedBenchmarkId,
-    session: Session = Depends(get_session),
-    harness_config: HarnessConfig = Depends(fetch_harness_config),
-    org: Org = Depends(get_current_org),
-    task_ids: list[str] | None = Query(default=None),
-) -> StreamingResponse:
-    return await _stream_run_outputs(benchmark_id, session, harness_config, org, task_ids)

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -43,7 +43,7 @@ def _load_task_or_404(benchmark_id: UUID, task_id: str, org: Org, session: Sessi
 
 
 def _task_prefix(benchmark_id: UUID, task_id: str) -> str:
-    """S3 prefix for a task's artifacts (presigned URLs + agent outputs)."""
+    """S3 prefix for a task's artifacts (presigned URLs + run outputs)."""
     return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{task_id}/"
 
 

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -54,7 +54,7 @@ def get_benchmark_contract_s3_key(benchmark_id: str, contract_name: str) -> str:
 
 
 def get_agent_result_s3_key(benchmark_id: str, task_id: str, output_name: str) -> str:
-    """Get the S3 key for an agent output archive."""
+    """Get the S3 key for a run output archive."""
     return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{task_id}/{output_name}"
 
 

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -1,4 +1,7 @@
+from collections.abc import AsyncIterator
+import io
 import logging
+import tarfile
 from datetime import timezone
 from typing import Any
 from unittest.mock import MagicMock
@@ -973,6 +976,71 @@ class TestFastapiServer:
         response = client.get(f"/fetch-benchmark-metadata/{bench.id}")
         assert response.status_code == 200
         assert response.json()["started_by_email"] == "alice@vals.ai"
+
+    async def test_fetch_run_outputs_streams_tar(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ):
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        observed_prefixes: list[str] = []
+
+        async def _mock_list_s3_objects(prefix: str, *_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            observed_prefixes.append(prefix)
+            yield f"{prefix}output.txt"
+
+        async def _mock_download_many_from_s3(
+            keys: AsyncIterator[str], *_args: Any, **_kwargs: Any
+        ) -> AsyncIterator[tuple[str, bytes]]:
+            async for key in keys:
+                yield key, b"output contents"
+
+        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
+        monkeypatch.setattr("main.download_many_from_s3", _mock_download_many_from_s3)
+
+        response = client.get(
+            f"/fetch-run-outputs/{example_benchmark_object.id}",
+            params={"task_ids": ["task_1", "task_2"]},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "application/x-tar"
+        assert response.headers["content-disposition"] == (
+            f"attachment; filename=benchmark_{example_benchmark_object.id}_outputs.tar"
+        )
+        assert observed_prefixes == [
+            f"benchmarks/{example_benchmark_object.id}/task_1/",
+            f"benchmarks/{example_benchmark_object.id}/task_2/",
+        ]
+
+        with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:") as tar:
+            assert tar.getnames() == ["task_1/output.txt", "task_2/output.txt"]
+            task_file = tar.extractfile("task_1/output.txt")
+            assert task_file is not None
+            assert task_file.read() == b"output contents"
+
+    async def test_fetch_run_outputs_returns_404_when_empty(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ):
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        async def _mock_list_s3_objects(*_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            if False:
+                yield ""
+
+        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
+
+        response = client.get(f"/fetch-run-outputs/{example_benchmark_object.id}")
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": f"No outputs found for run '{example_benchmark_object.id}'"}
 
     async def test_benchmark_service_unauthenticated_error_returns(
         self,

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -1144,35 +1144,6 @@ def list_benchmarks(
         raise click.ClickException(str(e))
 
 
-def _download_outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None) -> None:
-    try:
-        with TrackerService() as tracker:
-            if not check_tracker_service_health(tracker):
-                return
-
-            metadata = tracker.fetch_benchmark_metadata(run_id)
-
-            if output_dir is None:
-                output_dir = Path(
-                    f"{metadata.benchmark_name}_{metadata.benchmark_arguments.contract.name}_{metadata.benchmark_id}"
-                )
-
-            click.echo(f"\r\033[KFetching run outputs for run {run_id}...", nl=False)
-
-            response = tracker.fetch_run_outputs(
-                run_id,
-                task_ids=resolve_task_ids(task_ids),
-            )
-
-            download_run_outputs(response, output_dir)
-
-            click.echo(click.style(f"\r\033[K✓ Run outputs extracted to: {output_dir}", fg="green"))
-
-    except TrackerServiceError as e:
-        click.echo(click.style(f"✗ Error: {e}", fg="red"), err=True)
-        raise click.Abort()
-
-
 @run.command(
     name="outputs",
     help="Fetch run outputs by run id. \n\nExample:\nvalkyrie run outputs 123e4567-e89b-12d3-a456-426614174000 --output-dir ./run_outputs",
@@ -1199,31 +1170,32 @@ def outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
         valkyrie run outputs 123e4567-e89b-12d3-a456-426614174000
         valkyrie run outputs 123e4567-e89b-12d3-a456-426614174000 --task-ids astropy__astropy-7606,django__django-10880
     """
-    _download_outputs(run_id, output_dir, task_ids)
+    try:
+        with TrackerService() as tracker:
+            if not check_tracker_service_health(tracker):
+                return
 
+            metadata = tracker.fetch_benchmark_metadata(run_id)
 
-@agent.command(
-    name="outputs",
-    help="Deprecated alias for `valkyrie run outputs`.",
-    hidden=True,
-)
-@click.argument("run_id", type=UUID)
-@click.option(
-    "--output-dir",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Directory to save run outputs (defaults to ./<benchmark>_<agent>_<run-id>)",
-)
-@click.option(
-    "--task-ids",
-    type=str,
-    required=False,
-    default=None,
-    help="Comma-separated list of task IDs to download (e.g., astropy__astropy-7606,django__django-10880)",
-)
-def agent_outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
-    """Deprecated alias for `valkyrie run outputs`."""
-    _download_outputs(run_id, output_dir, task_ids)
+            if output_dir is None:
+                output_dir = Path(
+                    f"{metadata.benchmark_name}_{metadata.benchmark_arguments.contract.name}_{metadata.benchmark_id}"
+                )
+
+            click.echo(f"\r\033[KFetching run outputs for run {run_id}...", nl=False)
+
+            response = tracker.fetch_run_outputs(
+                run_id,
+                task_ids=resolve_task_ids(task_ids),
+            )
+
+            download_run_outputs(response, output_dir)
+
+            click.echo(click.style(f"\r\033[K✓ Run outputs extracted to: {output_dir}", fg="green"))
+
+    except TrackerServiceError as e:
+        click.echo(click.style(f"✗ Error: {e}", fg="red"), err=True)
+        raise click.Abort()
 
 
 @run.command(name="output", help="Download files from a benchmark run by its ID.")
@@ -1383,21 +1355,6 @@ def list_installed_agents():
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")
-
-
-@agent.command(name="output", help="Deprecated alias for `valkyrie run output`.", hidden=True)
-@click.argument("benchmark_id", type=UUID)
-@click.argument("subpath", type=str, default="", required=False)
-@click.option(
-    "-o",
-    "--output-dir",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Directory to save downloaded files (defaults to ./<benchmark_id>)",
-)
-def agent_output_path(benchmark_id: UUID, subpath: str, output_dir: Path | None):
-    """Deprecated alias for `valkyrie run output`."""
-    output_path(benchmark_id, subpath, output_dir)
 
 
 if __name__ == "__main__":

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -33,7 +33,7 @@ from valkyrie.cli.utils import (
     CONFIG_LOCATION,
     ConfigValue,
     check_tracker_service_health,
-    download_agent_outputs,
+    download_run_outputs,
     download_final_view,
     format_agent_start_details,
     format_benchmark_status,
@@ -1144,33 +1144,7 @@ def list_benchmarks(
         raise click.ClickException(str(e))
 
 
-@agent.command(
-    name="outputs",
-    help="Fetch agent outputs by run id. \n\nExample:\nvalkyrie agent outputs 123e4567-e89b-12d3-a456-426614174000 --output-dir ./agent_outputs",
-)
-@click.argument("run_id", type=UUID)
-@click.option(
-    "--output-dir",
-    type=click.Path(path_type=Path),
-    default=None,
-    help="Directory to save agent outputs (defaults to ./agent_outputs/<run-id>)",
-)
-@click.option(
-    "--task-ids",
-    type=str,
-    required=False,
-    default=None,
-    help="Comma-separated list of task IDs to download (e.g., astropy__astropy-7606,django__django-10880)",
-)
-def outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
-    """
-    Fetch agent outputs for a benchmark by its run id.
-
-    Example:
-        valkyrie agent outputs 123e4567-e89b-12d3-a456-426614174000
-        valkyrie agent outputs 123e4567-e89b-12d3-a456-426614174000 --task-ids astropy__astropy-7606,django__django-10880
-    """
-
+def _download_outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None) -> None:
     try:
         with TrackerService() as tracker:
             if not check_tracker_service_health(tracker):
@@ -1183,23 +1157,76 @@ def outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
                     f"{metadata.benchmark_name}_{metadata.benchmark_arguments.contract.name}_{metadata.benchmark_id}"
                 )
 
-            click.echo(f"\r\033[KFetching agent outputs for run {run_id}...", nl=False)
+            click.echo(f"\r\033[KFetching run outputs for run {run_id}...", nl=False)
 
-            response = tracker.fetch_agent_outputs(
+            response = tracker.fetch_run_outputs(
                 run_id,
                 task_ids=resolve_task_ids(task_ids),
             )
 
-            download_agent_outputs(response, output_dir)
+            download_run_outputs(response, output_dir)
 
-            click.echo(click.style(f"\r\033[K✓ Agent outputs extracted to: {output_dir}", fg="green"))
+            click.echo(click.style(f"\r\033[K✓ Run outputs extracted to: {output_dir}", fg="green"))
 
     except TrackerServiceError as e:
         click.echo(click.style(f"✗ Error: {e}", fg="red"), err=True)
         raise click.Abort()
 
 
-@agent.command(name="output", help="Download files from a benchmark run by its ID.")
+@run.command(
+    name="outputs",
+    help="Fetch run outputs by run id. \n\nExample:\nvalkyrie run outputs 123e4567-e89b-12d3-a456-426614174000 --output-dir ./run_outputs",
+)
+@click.argument("run_id", type=UUID)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory to save run outputs (defaults to ./<benchmark>_<agent>_<run-id>)",
+)
+@click.option(
+    "--task-ids",
+    type=str,
+    required=False,
+    default=None,
+    help="Comma-separated list of task IDs to download (e.g., astropy__astropy-7606,django__django-10880)",
+)
+def outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
+    """
+    Fetch run outputs for a benchmark by its run id.
+
+    Example:
+        valkyrie run outputs 123e4567-e89b-12d3-a456-426614174000
+        valkyrie run outputs 123e4567-e89b-12d3-a456-426614174000 --task-ids astropy__astropy-7606,django__django-10880
+    """
+    _download_outputs(run_id, output_dir, task_ids)
+
+
+@agent.command(
+    name="outputs",
+    help="Deprecated alias for `valkyrie run outputs`.",
+    hidden=True,
+)
+@click.argument("run_id", type=UUID)
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory to save run outputs (defaults to ./<benchmark>_<agent>_<run-id>)",
+)
+@click.option(
+    "--task-ids",
+    type=str,
+    required=False,
+    default=None,
+    help="Comma-separated list of task IDs to download (e.g., astropy__astropy-7606,django__django-10880)",
+)
+def agent_outputs(run_id: UUID, output_dir: Path | None, task_ids: str | None):
+    """Deprecated alias for `valkyrie run outputs`."""
+    _download_outputs(run_id, output_dir, task_ids)
+
+
+@run.command(name="output", help="Download files from a benchmark run by its ID.")
 @click.argument("benchmark_id", type=UUID)
 @click.argument("subpath", type=str, default="", required=False)
 @click.option(
@@ -1214,9 +1241,9 @@ def output_path(benchmark_id: UUID, subpath: str, output_dir: Path | None):
     Download all files under a benchmark's S3 directory.
 
     Example:
-        valkyrie agent output 6f176c17-7199-4ebc-b931-973e5600c1c9
-        valkyrie agent output 6f176c17-7199-4ebc-b931-973e5600c1c9 astropy__astropy-7606
-        valkyrie agent output 6f176c17-7199-4ebc-b931-973e5600c1c9 swebench.json -o .
+        valkyrie run output 6f176c17-7199-4ebc-b931-973e5600c1c9
+        valkyrie run output 6f176c17-7199-4ebc-b931-973e5600c1c9 astropy__astropy-7606
+        valkyrie run output 6f176c17-7199-4ebc-b931-973e5600c1c9 swebench.json -o .
     """
     try:
         path = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}"
@@ -1356,6 +1383,21 @@ def list_installed_agents():
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")
+
+
+@agent.command(name="output", help="Deprecated alias for `valkyrie run output`.", hidden=True)
+@click.argument("benchmark_id", type=UUID)
+@click.argument("subpath", type=str, default="", required=False)
+@click.option(
+    "-o",
+    "--output-dir",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Directory to save downloaded files (defaults to ./<benchmark_id>)",
+)
+def agent_output_path(benchmark_id: UUID, subpath: str, output_dir: Path | None):
+    """Deprecated alias for `valkyrie run output`."""
+    output_path(benchmark_id, subpath, output_dir)
 
 
 if __name__ == "__main__":

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -582,29 +582,33 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch runs: {e}") from e
 
-    def fetch_agent_outputs(self, benchmark_id: UUID, task_ids: list[str] | None = None) -> Response:
+    def fetch_run_outputs(self, benchmark_id: UUID, task_ids: list[str] | None = None) -> Response:
         """
-        Fetch agent outputs for a benchmark by its benchmark id.
+        Fetch run outputs for a benchmark by its benchmark id.
 
         Args:
             benchmark_id: Benchmark id
             task_ids: Optional list of task ids to filter outputs
 
         Returns:
-            httpx Response with agent outputs
+            httpx Response with run outputs
         """
         try:
             params: dict[str, Any] = {}
             if task_ids:
                 params["task_ids"] = task_ids
-            response = self._client.get(f"{self._base_url}/fetch-agent-outputs/{benchmark_id}", params=params)
+            response = self._client.get(f"{self._base_url}/fetch-run-outputs/{benchmark_id}", params=params)
             if response.status_code != 200:
                 details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to fetch agent outputs: {details}")
+                raise TrackerServiceError(f"Failed to fetch run outputs: {details}")
 
             return response
         except httpx.HTTPError as e:
-            raise TrackerServiceError(f"Failed to fetch agent outputs: {e}") from e
+            raise TrackerServiceError(f"Failed to fetch run outputs: {e}") from e
+
+    def fetch_agent_outputs(self, benchmark_id: UUID, task_ids: list[str] | None = None) -> Response:
+        """Deprecated alias for fetch_run_outputs."""
+        return self.fetch_run_outputs(benchmark_id, task_ids=task_ids)
 
     def fetch_benchmark_metadata(self, benchmark_id: UUID) -> FetchBenchmarkMetadataResponse:
         """

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -606,10 +606,6 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch run outputs: {e}") from e
 
-    def fetch_agent_outputs(self, benchmark_id: UUID, task_ids: list[str] | None = None) -> Response:
-        """Deprecated alias for fetch_run_outputs."""
-        return self.fetch_run_outputs(benchmark_id, task_ids=task_ids)
-
     def fetch_benchmark_metadata(self, benchmark_id: UUID) -> FetchBenchmarkMetadataResponse:
         """
         Fetch benchmark metadata for a benchmark by its benchmark id.

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -694,9 +694,6 @@ def download_run_outputs(run_outputs_response: Response, output_dir: Path) -> No
     tmp_path.unlink()
 
 
-download_agent_outputs = download_run_outputs
-
-
 def download_final_view(path: Path, final_view: FinalViewResponse) -> None:
     if not path.parent.exists():
         raise click.ClickException(f"'{path.parent}' directory does not exist! Please create it first.")

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -391,7 +391,7 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ {'Stop:':<17} " + click.style(f"valkyrie run stop {rid}", fg="cyan"))
     click.echo(f"│ {'Resume:':<17} " + click.style(f"valkyrie run resume {rid}", fg="cyan"))
     click.echo(f"│ {'Retry:':<17} " + click.style(f"valkyrie run retry {rid}", fg="cyan"))
-    click.echo(f"│ {'Agent outputs:':<17} " + click.style(f"valkyrie agent outputs {rid} --output-dir .", fg="cyan"))
+    click.echo(f"│ {'Run outputs:':<17} " + click.style(f"valkyrie run outputs {rid} --output-dir .", fg="cyan"))
     click.echo("└" + "─" * 79)
     click.echo()
 
@@ -402,7 +402,7 @@ def _stream_next_steps(benchmark_id: UUID, s3_url: str | None = None) -> None:
     click.echo(
         f"│ {'Get results:':<17} " + click.style(f"valkyrie run results {rid} --path ./results-{rid}.json", fg="cyan")
     )
-    click.echo(f"│ {'Agent outputs:':<17} " + click.style(f"valkyrie agent outputs {rid} --output-dir .", fg="cyan"))
+    click.echo(f"│ {'Run outputs:':<17} " + click.style(f"valkyrie run outputs {rid} --output-dir .", fg="cyan"))
     if s3_url:
         click.echo(f"│ {'S3 view:':<17} " + click.style(s3_url, fg="cyan"))
     click.echo("└" + "─" * 79)
@@ -650,30 +650,30 @@ def paginate_benchmarks(
             break
 
 
-def download_agent_outputs(agent_outputs_response: Response, output_dir: Path) -> None:
+def download_run_outputs(run_outputs_response: Response, output_dir: Path) -> None:
     """
-    Download agent outputs from a response and extract them to a directory.
+    Download run outputs from a response and extract them to a directory.
 
     Args:
-        agent_outputs_response: Response with agent outputs
-        output_dir: Directory to save agent outputs
+        run_outputs_response: Response with run outputs
+        output_dir: Directory to save run outputs
     """
 
     # Create the output directory if it doesn't exist
     output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Download the agent outputs to a temporary file
+    # Download the run outputs to a temporary file
     with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as tmp_file:
         tmp_path = Path(tmp_file.name)
         click.echo("\r\033[KDownloading...", nl=False)
 
-        for chunk in agent_outputs_response.iter_bytes():
+        for chunk in run_outputs_response.iter_bytes():
             tmp_file.write(chunk)
 
     click.echo(f"\r\033[KExtracting archives to {output_dir}...", nl=False)
 
-    # Extract the agent outputs to the output directory
+    # Extract the run outputs to the output directory
     with tarfile.open(tmp_path, "r") as tar:
         tar.extractall(output_dir)
 
@@ -692,6 +692,9 @@ def download_agent_outputs(agent_outputs_response: Response, output_dir: Path) -
             nested_tar.unlink()
 
     tmp_path.unlink()
+
+
+download_agent_outputs = download_run_outputs
 
 
 def download_final_view(path: Path, final_view: FinalViewResponse) -> None:

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,11 +1,20 @@
+import io
+import tarfile
 from datetime import datetime, timezone
+from pathlib import Path
 from uuid import uuid4
 
+import httpx
 import pytest
 from tracker.database.models import BenchmarkStatus, DocentReadingStatus, TaskStatus
-from tracker.types import BenchmarkDetails, FetchBenchmarkResponse
+from tracker.types import BenchmarkDetails, FetchBenchmarkResponse, StartBenchmarkResponse
 
-from valkyrie.cli.utils import format_benchmark_status
+from valkyrie.cli.utils import (
+    _stream_next_steps,
+    download_run_outputs,
+    format_benchmark_status,
+    format_start_benchmark_response,
+)
 
 
 def test_format_benchmark_status_prints_final_score(capsys: pytest.CaptureFixture[str]) -> None:
@@ -36,3 +45,62 @@ def test_format_benchmark_status_prints_final_score(capsys: pytest.CaptureFixtur
     assert "Final score:" in output
     assert "83.2%" in output
     assert "3/4 (75.0%)" in output
+
+
+def test_format_start_benchmark_response_prints_run_outputs_command(capsys: pytest.CaptureFixture[str]) -> None:
+    run_id = uuid4()
+    response = StartBenchmarkResponse(
+        benchmark_name="swebench",
+        agent_name="agent",
+        benchmark_id=run_id,
+        concurrency=4,
+        started_at=datetime(2026, 6, 24, tzinfo=timezone.utc),
+        task_count=10,
+        cloudwatch_url="https://example.com/cloudwatch",
+        s3_bucket_url="s3://bucket/run",
+    )
+
+    format_start_benchmark_response(response)
+
+    output = capsys.readouterr().out
+    assert "Run outputs:" in output
+    assert f"valkyrie run outputs {run_id} --output-dir ." in output
+    assert "Agent outputs:" not in output
+
+
+def test_stream_next_steps_prints_run_outputs_command(capsys: pytest.CaptureFixture[str]) -> None:
+    run_id = uuid4()
+
+    _stream_next_steps(run_id, s3_url="s3://bucket/run")
+
+    output = capsys.readouterr().out
+    assert "Run outputs:" in output
+    assert f"valkyrie run outputs {run_id} --output-dir ." in output
+    assert "s3://bucket/run" in output
+
+
+def test_download_run_outputs_extracts_archive_and_nested_tars(tmp_path: Path) -> None:
+    nested_bytes = io.BytesIO()
+    with tarfile.open(fileobj=nested_bytes, mode="w:gz") as nested_tar:
+        nested_content = b"nested contents"
+        nested_info = tarfile.TarInfo("nested.txt")
+        nested_info.size = len(nested_content)
+        nested_tar.addfile(nested_info, io.BytesIO(nested_content))
+
+    response_bytes = io.BytesIO()
+    with tarfile.open(fileobj=response_bytes, mode="w") as tar:
+        output_content = b"run output"
+        output_info = tarfile.TarInfo("task/output.txt")
+        output_info.size = len(output_content)
+        tar.addfile(output_info, io.BytesIO(output_content))
+
+        nested_payload = nested_bytes.getvalue()
+        nested_info = tarfile.TarInfo("task/artifacts.tar.gz")
+        nested_info.size = len(nested_payload)
+        tar.addfile(nested_info, io.BytesIO(nested_payload))
+
+    download_run_outputs(httpx.Response(200, content=response_bytes.getvalue()), tmp_path)
+
+    assert (tmp_path / "task" / "output.txt").read_bytes() == b"run output"
+    assert (tmp_path / "task" / "artifacts" / "nested.txt").read_bytes() == b"nested contents"
+    assert not (tmp_path / "task" / "artifacts.tar.gz").exists()

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -69,25 +69,6 @@ def test_fetch_run_outputs_uses_run_outputs_endpoint(monkeypatch: pytest.MonkeyP
     assert client.params == {"task_ids": ["task-1", "task-2"]}
 
 
-def test_fetch_agent_outputs_is_legacy_alias(monkeypatch: pytest.MonkeyPatch) -> None:
-    client = FakeClient()
-
-    def build_client(**_kwargs: object) -> FakeClient:
-        return client
-
-    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
-    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
-    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
-
-    run_id = uuid4()
-    tracker = TrackerService(base_url="http://tracker")
-    response = tracker.fetch_agent_outputs(run_id)
-
-    assert response.content == b"tar"
-    assert client.url == f"http://tracker/fetch-run-outputs/{run_id}"
-    assert client.params == {}
-
-
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resume requests should carry retry mode and override secrets.
 

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -14,17 +14,29 @@ class FakeClient:
     def __init__(self) -> None:
         self.params: dict[str, object] | None = None
         self.json: dict[str, object] | None = None
+        self.url: str | None = None
 
     def post(
         self,
-        _url: str,
+        url: str,
         *,
         params: dict[str, object] | None = None,
         json: dict[str, object],
     ) -> httpx.Response:
+        self.url = url
         self.params = params
         self.json = json
         return httpx.Response(200, json={"status": "success"})
+
+    def get(
+        self,
+        url: str,
+        *,
+        params: dict[str, object] | None = None,
+    ) -> httpx.Response:
+        self.url = url
+        self.params = params
+        return httpx.Response(200, content=b"tar")
 
     def close(self) -> None:
         pass
@@ -36,6 +48,44 @@ def empty_config() -> dict[str, object]:
 
 def empty_config_keys(_tracker: TrackerService) -> dict[str, str]:
     return {}
+
+
+def test_fetch_run_outputs_uses_run_outputs_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    run_id = uuid4()
+    tracker = TrackerService(base_url="http://tracker")
+    response = tracker.fetch_run_outputs(run_id, task_ids=["task-1", "task-2"])
+
+    assert response.content == b"tar"
+    assert client.url == f"http://tracker/fetch-run-outputs/{run_id}"
+    assert client.params == {"task_ids": ["task-1", "task-2"]}
+
+
+def test_fetch_agent_outputs_is_legacy_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    run_id = uuid4()
+    tracker = TrackerService(base_url="http://tracker")
+    response = tracker.fetch_agent_outputs(run_id)
+
+    assert response.content == b"tar"
+    assert client.url == f"http://tracker/fetch-run-outputs/{run_id}"
+    assert client.params == {}
 
 
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -7,7 +7,7 @@ import yaml
 from tracker.database.models import AgentContractRequest, RetryMode
 
 from valkyrie.cli import tracker_service as tracker_service_module
-from valkyrie.cli.tracker_service import TrackerService
+from valkyrie.cli.tracker_service import TrackerService, TrackerServiceError
 
 
 class FakeClient:
@@ -67,6 +67,77 @@ def test_fetch_run_outputs_uses_run_outputs_endpoint(monkeypatch: pytest.MonkeyP
     assert response.content == b"tar"
     assert client.url == f"http://tracker/fetch-run-outputs/{run_id}"
     assert client.params == {"task_ids": ["task-1", "task-2"]}
+
+
+def test_fetch_run_outputs_omits_empty_task_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    run_id = uuid4()
+    tracker = TrackerService(base_url="http://tracker")
+    response = tracker.fetch_run_outputs(run_id)
+
+    assert response.content == b"tar"
+    assert client.url == f"http://tracker/fetch-run-outputs/{run_id}"
+    assert client.params == {}
+
+
+def test_fetch_run_outputs_raises_tracker_error_for_non_ok_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    class ErrorClient(FakeClient):
+        def get(
+            self,
+            url: str,
+            *,
+            params: dict[str, object] | None = None,
+        ) -> httpx.Response:
+            self.url = url
+            self.params = params
+            return httpx.Response(404, json={"detail": "No outputs found"})
+
+    client = ErrorClient()
+
+    def build_client(**_kwargs: object) -> ErrorClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    with pytest.raises(TrackerServiceError, match="Failed to fetch run outputs: No outputs found"):
+        tracker.fetch_run_outputs(uuid4())
+
+
+def test_fetch_run_outputs_raises_tracker_error_for_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FailingClient(FakeClient):
+        def get(
+            self,
+            url: str,
+            *,
+            params: dict[str, object] | None = None,
+        ) -> httpx.Response:
+            self.url = url
+            self.params = params
+            raise httpx.ConnectError("connection failed")
+
+    client = FailingClient()
+
+    def build_client(**_kwargs: object) -> FailingClient:
+        return client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    with pytest.raises(TrackerServiceError, match="Failed to fetch run outputs: connection failed"):
+        tracker.fetch_run_outputs(uuid4())
 
 
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Renames Valkyrie’s output-download surface from “agent outputs” to “run outputs” so downloads live under the `valkyrie run` workflow alongside fetch/results/stop/resume/retry.

## Changes
- Add `valkyrie run outputs` for tarball output downloads and keep `valkyrie run output` for direct S3 path downloads.
- Move the tracker client and FastAPI route to `/fetch-run-outputs/{run_id}`.
- Remove the old `agent outputs`/`agent output` CLI commands, `fetch_agent_outputs()` client method, `download_agent_outputs` alias, and `/fetch-agent-outputs/{run_id}` endpoint.
- Inline the run-output streaming logic into the single `/fetch-run-outputs/{run_id}` handler.
- Update README/hosted-mode wording and CLI next-step hints to say “run outputs”.
- Add unit coverage for `TrackerService.fetch_run_outputs()` and the tracker endpoint’s tar streaming/empty-output behavior.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Refactor
- [x] Docs / config

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed