### PR TITLE
#patch Forward task env to sandbox commands

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,7 @@
 """Sandbox management utilities for the tracker service."""
 
 import base64
+import re
 import shlex
 import time
 import uuid
@@ -72,6 +73,28 @@ bundle_path = PurePosixPath("/bundle")
 SANDBOX_AUTO_STOP_INTERVAL = 10 * 60
 SANDBOX_CREATE_TIMEOUT = 360
 CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS = 24 * 60 * 60
+_ENV_VAR_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _command_with_env_file(command: str, env_file_path: str | None = None) -> str:
+    if not env_file_path:
+        return command
+
+    return f". {shlex.quote(env_file_path)} && {{ {command}; }}"
+
+
+async def _upload_command_env(sandbox: Sandbox, env_vars: dict[str, str] | None = None) -> str | None:
+    if not env_vars:
+        return None
+
+    lines = [f"export {key}={shlex.quote(value)}" for key, value in env_vars.items() if _ENV_VAR_NAME.fullmatch(key)]
+    if not lines:
+        return None
+
+    env_file_path = f"{_STATUS_DIR}/{uuid.uuid4().hex}.env"
+    await _exec(sandbox, f"mkdir -p {shlex.quote(_STATUS_DIR)}")
+    await sandbox.upload_file(env_file_path, ("\n".join(lines) + "\n").encode())
+    return env_file_path
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
@@ -306,6 +329,7 @@ async def install_agent_dependencies(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
+    env_file_path: str | None = None,
 ) -> None:
     """Install agent dependencies in the sandbox."""
     if not contract.install_cmd:
@@ -315,7 +339,12 @@ async def install_agent_dependencies(
 
     contract_path = get_contract_path(contract.name)
 
-    await stream_command_output(sandbox, f"cd {shlex.quote(str(contract_path))} && {contract.install_cmd}", log_output)
+    await stream_command_output(
+        sandbox,
+        f"cd {shlex.quote(str(contract_path))} && {contract.install_cmd}",
+        log_output,
+        env_file_path=env_file_path,
+    )
 
     log_output(f"Finished installing dependencies for contract: {contract.name}")
 
@@ -343,6 +372,7 @@ async def stream_command_output(
     sandbox: Sandbox,
     command: str,
     on_output: Callable[[str], None],
+    env_file_path: str | None = None,
 ) -> tuple[AgentCausedExitReason | None, float]:
     output: deque[str] = deque(maxlen=50)
     run_id = uuid.uuid4().hex
@@ -360,7 +390,7 @@ async def stream_command_output(
     exit_code = _SUCCESS_EXIT_CODE
     try:
         try:
-            async for data in sandbox.command(timed_command):
+            async for data in sandbox.command(_command_with_env_file(timed_command, env_file_path)):
                 on_output(data)
                 output.append(data)
         except ProviderSandboxCommandError as e:
@@ -559,6 +589,7 @@ async def run_agent(
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
     benchmark_id: str | None = None,
+    env_vars: dict[str, str] | None = None,
 ) -> tuple[AgentCausedExitReason | None, float]:
     """
     Run the agent inside the sandbox for a given task.
@@ -581,24 +612,35 @@ async def run_agent(
     """
     log_output(f"Running agent {contract.name}")
 
-    await install_agent_dependencies(sandbox, contract, log_output)
+    env_file_path = await _upload_command_env(sandbox, env_vars)
+    try:
+        await install_agent_dependencies(sandbox, contract, log_output, env_file_path=env_file_path)
 
-    run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_path).replace("{task_id}", task_id)
+        run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_path).replace("{task_id}", task_id)
 
-    for kwarg_key, kwarg_value in contract.kwargs.items():
-        run_cmd = run_cmd.replace(f"{{{kwarg_key}}}", kwarg_value)
+        for kwarg_key, kwarg_value in contract.kwargs.items():
+            run_cmd = run_cmd.replace(f"{{{kwarg_key}}}", kwarg_value)
 
-    # Apply timeout if specified
-    if agent_timeout is not None:
-        run_cmd = f"timeout {agent_timeout} {run_cmd}"
+        # Apply timeout if specified
+        if agent_timeout is not None:
+            run_cmd = f"timeout {agent_timeout} {run_cmd}"
 
-    # Create cwd if it does not already exist
-    await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
+        # Create cwd if it does not already exist
+        await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
 
-    # Run the agent without including task directory dependencies
-    exit_reason, agent_run_time = await stream_command_output(
-        sandbox, f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}", log_output
-    )
+        # Run the agent without including task directory dependencies
+        exit_reason, agent_run_time = await stream_command_output(
+            sandbox,
+            f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}",
+            log_output,
+            env_file_path=env_file_path,
+        )
+    finally:
+        if env_file_path:
+            try:
+                await _exec(sandbox, f"rm -f {shlex.quote(env_file_path)}")
+            except Exception as e:
+                logger.warning(f"Failed to remove sandbox command env file {env_file_path}: {e}")
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         log_output(

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -507,6 +507,7 @@ async def process_task(
             **resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws),
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
+            "QUESTION_ID": task_row.task_id,
             "IDENTITY": json.dumps(identity),
             # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
             # are filterable per benchmark run and separable from other environments sharing the
@@ -575,6 +576,7 @@ async def process_task(
                     agent_output_s3_key=agent_output_s3_key,
                     agent_timeout=task_data.agent_timeout,
                     benchmark_id=str(benchmark_id),
+                    env_vars=env_vars,
                 )
                 logger.info(
                     "agent.run.complete",

--- a/services/tracker/tests/unit/test_process_task_env.py
+++ b/services/tracker/tests/unit/test_process_task_env.py
@@ -101,6 +101,7 @@ async def test_process_task_injects_tracker_owned_attribution_env(
         }
     )
     captured_env_vars: list[dict[str, str]] = []
+    captured_run_agent_env_vars: list[dict[str, str]] = []
 
     def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
         return {
@@ -117,17 +118,23 @@ async def test_process_task_injects_tracker_owned_attribution_env(
         captured_env_vars.append(env_vars)
         yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
 
+    async def _capture_run_agent(*_args: Any, env_vars: dict[str, str], **_kwargs: Any) -> tuple[None, float]:
+        captured_run_agent_env_vars.append(env_vars)
+        return None, 0.0
+
     monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_secrets)
     monkeypatch.setattr(utils_module, "create_sandbox", _capture_create_sandbox)
+    monkeypatch.setattr(utils_module, "run_agent", _capture_run_agent)
 
     result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
     assert result == {"task_0": {"status": "success", "score": 1.0}}
     assert len(captured_env_vars) == 1
     env_vars = captured_env_vars[0]
+    assert env_vars["QUESTION_ID"] == "task_0"
     assert env_vars["RUN_ID"] == str(benchmark_id)
-    assert "QUESTION_ID" not in env_vars
     assert env_vars["TASK_ID"] == "task_0"
+    assert env_vars["QUESTION_ID"] == "task_0"
     assert json.loads(env_vars["IDENTITY"]) == {
         "benchmark_name": "swebench",
         "agent_name": contract.name,
@@ -136,6 +143,7 @@ async def test_process_task_injects_tracker_owned_attribution_env(
     assert env_vars["UNRELATED_SECRET"] == "secret-value"
     assert env_vars["MODEL_GATEWAY_URL"] == "https://gateway.example.test"
     assert env_vars["MODEL_GATEWAY_API_KEY"] == "gateway-key"
+    assert captured_run_agent_env_vars == [env_vars]
 
 
 async def test_process_task_omits_identity_email_when_unavailable(

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -309,6 +309,71 @@ class TestAgentOutputTelemetry:
 
         assert archive_calls == ["benchmark-123:task_0:/tmp/agent_output"]
 
+    async def test_run_agent_uploads_command_env_for_agent_commands(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="echo install",
+            run_cmd="echo run",
+        )
+        exec_commands: list[str] = []
+        stream_env_files: list[str | None] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
+            exec_commands.append(command)
+            return ExecResult(exit_code=0)
+
+        async def fake_stream_command_output(
+            _sandbox: Any,
+            _command: str,
+            _on_output: Any,
+            *,
+            env_file_path: str | None = None,
+        ) -> tuple[None, float]:
+            stream_env_files.append(env_file_path)
+            return None, 0.0
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.upload_file = AsyncMock()
+
+        await run_agent(
+            mock_sandbox,
+            contract,
+            "/tmp/problem.txt",
+            "task_0",
+            lambda _msg: None,
+            "/testbed",
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+            env_vars={
+                "RUN_ID": "benchmark-123",
+                "TASK_ID": "task_0",
+                "QUESTION_ID": "task_0",
+                "IDENTITY": '{"agent":"test-agent"}',
+                "INVALID-KEY": "ignored",
+            },
+        )
+
+        upload_path, upload_content = mock_sandbox.upload_file.await_args.args
+        assert upload_path.startswith("/tmp/.valkyrie/")
+        assert upload_path.endswith(".env")
+        assert upload_content.decode() == (
+            "export RUN_ID=benchmark-123\n"
+            "export TASK_ID=task_0\n"
+            "export QUESTION_ID=task_0\n"
+            'export IDENTITY=\'{"agent":"test-agent"}\'\n'
+        )
+        assert stream_env_files == [upload_path, upload_path]
+        assert exec_commands[-1] == f"rm -f {upload_path}"
+
     def test_sandbox_retry_decorators_use_observability_retry_callbacks(self) -> None:
         upload_before_sleep = _upload_agent_artifacts.retry.before_sleep
         deps_before_sleep = _install_agent_dependencies.retry.before_sleep
@@ -538,7 +603,10 @@ class TestUploadAgentArtifacts:
 
 class TestStreamCommandOutputAgentFailure:
     async def test_stream_command_output_removes_timing_files(self) -> None:
-        async def stream_command(_command: str) -> Any:
+        streamed_commands: list[str] = []
+
+        async def stream_command(command: str) -> Any:
+            streamed_commands.append(command)
             yield "done\n"
 
         exec_commands: list[str] = []
@@ -559,11 +627,16 @@ class TestStreamCommandOutputAgentFailure:
         mock_sandbox.exec = exec_command
 
         exit_reason, duration = await sandbox_module.stream_command_output(
-            mock_sandbox, "run-agent.sh", on_output=lambda _: None
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=lambda _: None,
+            env_file_path="/tmp/.valkyrie/test.env",
         )
 
         assert exit_reason is None
         assert duration == 2
+        assert streamed_commands[0].startswith(". /tmp/.valkyrie/test.env && { ")
+        assert streamed_commands[0].endswith("; }")
         assert exec_commands[-1].startswith("rm -f ")
         assert ".start_ns" in exec_commands[-1]
         assert ".end_ns" in exec_commands[-1]


### PR DESCRIPTION
## Summary
Forward the per-task env that Tracker already builds into every agent command execution, so reused Valkyrie sandboxes receive fresh attribution (`RUN_ID`, `TASK_ID`, `QUESTION_ID`, `IDENTITY`) at the command boundary instead of relying only on sandbox creation-time env.

## Changes
- Upload a per-agent-run env file into the sandbox and source it around install/run command streams.
- Thread `env_vars` from `process_task` into `run_agent` and add `QUESTION_ID` alongside existing tracker-owned attribution env.
- Remove the uploaded env file after the agent command sequence.
- Add unit coverage for env propagation into `run_agent`, env-file upload/sourcing, invalid env-key filtering, and cleanup.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Commands run:
- `uv --directory /home/ubuntu/repos/Valkyrie run pytest services/tracker/tests/unit/test_process_task_env.py services/tracker/tests/unit/test_sandbox.py -q`
- `uv --directory /home/ubuntu/repos/Valkyrie run pytest services/tracker/tests/unit -q`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff check src tests`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run ruff format --check src tests`
- `UV_FROZEN=1 NODE_OPTIONS=--max-old-space-size=8192 uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run basedpyright src/tracker/sandbox.py tests/unit/test_process_task_env.py tests/unit/test_sandbox.py`

Note: full `basedpyright` hit a Node heap OOM in this workspace. Including `src/tracker/utils.py` still reports an existing `TaskStatus` dict-key type error at the unchanged benchmark table code path also present on `origin/dev`.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/1996a05600734c14a061aa0e4eb50a49
Requested by: @Chen-Oliver