### PR TITLE
Allow connect after run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ valkyrie run start \
   --label swebench_sweagent
 ```
 
+Add `--connect` to stream updates after the run starts:
+
+```bash
+valkyrie run start --agent sweagent --benchmark swebench --connect
+```
+
 | Flag | Description |
 | --- | --- |
 | `--agent` | Agent name from S3 or path to agent directory (e.g., `sweagent` or `./agents/sweagent`). Agents on users machine are automatically uploaded to S3 before the benchmark starts. |
@@ -151,6 +157,7 @@ valkyrie run start \
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
 | `-i` / `--interval` | Progress percentage threshold for Slack notification. Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
 | `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
+| `--connect` | Stream run updates after the run starts |
 
 ### Monitor a run
 
@@ -208,6 +215,12 @@ valkyrie run retry <id>
 # Override concurrency on resume (works on retry)
 valkyrie run resume <id> --concurrency 20
 
+# Stream updates after resume
+valkyrie run resume <id> --connect
+
+# Stream updates after retry
+valkyrie run retry <id> --connect
+
 # Override agent secrets for resumed tasks
 valkyrie run resume <id> -s ANTHROPIC_API_KEY newSecretName
 
@@ -226,6 +239,7 @@ valkyrie benchmark tasks swebench --dataset default --output tasks.txt
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
+| `--connect` | Stream run updates after resume/retry |
 
 ### List runs
 

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -578,6 +578,12 @@ def tasks(
     is_flag=True,
     help="Ignore custom benchmark services that have been configured. Provides opt-out for custom services.",
 )
+@click.option(
+    "--connect",
+    is_flag=True,
+    required=False,
+    help="Connect to the tracker service to stream run updates after starting",
+)
 def start(
     agent: str,
     model: str | None,
@@ -594,6 +600,7 @@ def start(
     headers: tuple[tuple[str, str]],
     intervals: tuple[int, ...],
     ignore_custom_services: bool,
+    connect: bool,
 ):
     """
     Run an agent on a benchmark.
@@ -684,7 +691,10 @@ def start(
                         click.echo(detail)
                 return
 
-            format_start_benchmark_response(StartBenchmarkResponse.model_validate(response.json()))
+            start_response = StartBenchmarkResponse.model_validate(response.json())
+            format_start_benchmark_response(start_response)
+            if connect:
+                stream_benchmark_status(tracker, start_response.benchmark_id)
     except (BundlerError, TrackerServiceError, ContractValidationError) as e:
         raise click.ClickException(str(e))
 
@@ -991,6 +1001,12 @@ def analyze(run_id: UUID, no_cache: bool) -> None:
     default=False,
     help="Clear durable eval state and rerun generation.",
 )
+@click.option(
+    "--connect",
+    is_flag=True,
+    required=False,
+    help="Connect to the tracker service to stream run updates after resuming",
+)
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -1002,6 +1018,7 @@ def resume(
     secrets: tuple[tuple[str, str]],
     update_agent: bool,
     from_scratch: bool,
+    connect: bool,
 ):
     """
     Resume a run by its run id.
@@ -1052,6 +1069,8 @@ def resume(
                 + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")
             )
             click.echo("└" + "─" * 79)
+            if connect:
+                stream_benchmark_status(tracker, run_id)
     except (TrackerServiceError, S3Error) as e:
         raise click.ClickException(str(e))
 

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -695,6 +695,11 @@ def start(
             format_start_benchmark_response(start_response)
             if connect:
                 stream_benchmark_status(tracker, start_response.benchmark_id)
+            else:
+                click.echo(
+                    f"{'Track progress:':<17} "
+                    + click.style(f"valkyrie run fetch {start_response.benchmark_id} --connect", fg="cyan")
+                )
     except (BundlerError, TrackerServiceError, ContractValidationError) as e:
         raise click.ClickException(str(e))
 
@@ -1063,7 +1068,8 @@ def resume(
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))
             click.echo("┌─ Next Steps " + "─" * 66)
-            click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan"))
+            if not connect:
+                click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan"))
             click.echo(
                 f"│ {'Get results:':<17} "
                 + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -1069,7 +1069,9 @@ def resume(
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))
             click.echo("┌─ Next Steps " + "─" * 66)
             if not connect:
-                click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan"))
+                click.echo(
+                    f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan")
+                )
             click.echo(
                 f"│ {'Get results:':<17} "
                 + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -386,7 +386,6 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ {'CloudWatch:':<17} {start_benchmark_response.cloudwatch_url}")
     click.echo(f"│ {'S3 Bucket:':<17} {start_benchmark_response.s3_bucket_url}")
     click.echo("├" + "─" * 79)
-    click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {rid} --connect", fg="cyan"))
     click.echo(
         f"│ {'Get results:':<17} " + click.style(f"valkyrie run results {rid} --path ./results-{rid}.json", fg="cyan")
     )
@@ -395,7 +394,6 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ {'Retry:':<17} " + click.style(f"valkyrie run retry {rid}", fg="cyan"))
     click.echo(f"│ {'Agent outputs:':<17} " + click.style(f"valkyrie agent outputs {rid} --output-dir .", fg="cyan"))
     click.echo("└" + "─" * 79)
-    click.echo()
 
 
 def _stream_next_steps(benchmark_id: UUID, s3_url: str | None = None) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+from zoneinfo import ZoneInfo
+
+import httpx
+import pytest
+from tracker.database.models import AgentContractRequest
+
+from valkyrie.cli import main as cli_main
+
+
+class FakeTrackerService:
+    start_response: dict[str, object] = {}
+
+    @staticmethod
+    def get_benchmark_auth(_benchmark_name: str) -> None:
+        return None
+
+    @staticmethod
+    def get_webhook_secret() -> None:
+        return None
+
+    def __enter__(self) -> "FakeTrackerService":
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def start_benchmark(self, *_args: object, **_kwargs: object) -> httpx.Response:
+        return httpx.Response(200, json=self.start_response)
+
+    def fetch_benchmark(self, _run_id: object) -> SimpleNamespace:
+        return SimpleNamespace(benchmark_name="swebench")
+
+    def retry_or_resume_benchmark(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(status="success")
+
+
+@pytest.fixture
+def connect_stream_testbed(monkeypatch: pytest.MonkeyPatch) -> tuple[UUID, list[str]]:
+    started_run_id = uuid4()
+    streamed_run_ids: list[str] = []
+    FakeTrackerService.start_response = {
+        "benchmark_name": "swebench",
+        "agent_name": "agent",
+        "benchmark_id": str(started_run_id),
+        "concurrency": 5,
+        "started_at": datetime.now(ZoneInfo("UTC")).isoformat(),
+        "task_count": 1,
+        "cloudwatch_url": "https://cloudwatch.example/run",
+        "s3_bucket_url": "s3://bucket/benchmarks/run",
+    }
+
+    async def get_contract_from_s3(_agent: str, _agent_config: object) -> AgentContractRequest:
+        return AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run")
+
+    def stream_benchmark_status(_tracker: FakeTrackerService, run_id: object) -> None:
+        streamed_run_ids.append(str(run_id))
+
+    monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
+    monkeypatch.setattr(cli_main, "get_contract_from_s3", get_contract_from_s3)
+    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
+    monkeypatch.setattr(cli_main, "stream_benchmark_status", stream_benchmark_status)
+
+    return started_run_id, streamed_run_ids

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -163,6 +163,7 @@ def test_run_commands_connect_after_success(connect_stream_testbed: tuple[UUID, 
     Test cases:
     - Start streams the new run ID returned by the tracker.
     - Resume and retry stream the run ID supplied by the user.
+    - Connected commands skip the redundant track-progress next step.
     """
     started_run_id, streamed_run_ids = connect_stream_testbed
     resume_run_id = uuid4()
@@ -176,6 +177,7 @@ def test_run_commands_connect_after_success(connect_stream_testbed: tuple[UUID, 
     ):
         result = runner.invoke(cli_main.cli, command)
         assert result.exit_code == 0, result.output
+        assert "Track progress:" not in result.output
 
     assert streamed_run_ids == [str(started_run_id), str(resume_run_id), str(retry_run_id)]
 

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -1,8 +1,7 @@
 from datetime import datetime
 from pathlib import Path
-from types import SimpleNamespace
+from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
-from uuid import uuid4
 
 import click
 import httpx
@@ -158,62 +157,16 @@ def _command_option_flags(command: click.Command, param_name: str) -> set[str]:
     return {*param.opts}
 
 
-def test_run_commands_connect_after_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_commands_connect_after_success(connect_stream_testbed: tuple[UUID, list[str]]) -> None:
     """Connect should stream the run once start, resume, or retry succeeds.
 
     Test cases:
     - Start streams the new run ID returned by the tracker.
     - Resume and retry stream the run ID supplied by the user.
     """
-    started_run_id = uuid4()
+    started_run_id, streamed_run_ids = connect_stream_testbed
     resume_run_id = uuid4()
     retry_run_id = uuid4()
-    streamed_run_ids: list[str] = []
-    start_response = {
-        "benchmark_name": "swebench",
-        "agent_name": "agent",
-        "benchmark_id": str(started_run_id),
-        "concurrency": 5,
-        "started_at": datetime.now(ZoneInfo("UTC")).isoformat(),
-        "task_count": 1,
-        "cloudwatch_url": "https://cloudwatch.example/run",
-        "s3_bucket_url": "s3://bucket/benchmarks/run",
-    }
-
-    class FakeTrackerService:
-        @staticmethod
-        def get_benchmark_auth(_benchmark_name: str) -> None:
-            return None
-
-        @staticmethod
-        def get_webhook_secret() -> None:
-            return None
-
-        def __enter__(self) -> "FakeTrackerService":
-            return self
-
-        def __exit__(self, *_exc_info: object) -> None:
-            return None
-
-        def start_benchmark(self, *_args: object, **_kwargs: object) -> httpx.Response:
-            return httpx.Response(200, json=start_response)
-
-        def fetch_benchmark(self, _run_id: object) -> SimpleNamespace:
-            return SimpleNamespace(benchmark_name="swebench")
-
-        def retry_or_resume_benchmark(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
-            return SimpleNamespace(status="success")
-
-    async def get_contract_from_s3(_agent: str, _agent_config: object) -> AgentContractRequest:
-        return AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run")
-
-    def stream_benchmark_status(_tracker: FakeTrackerService, run_id: object) -> None:
-        streamed_run_ids.append(str(run_id))
-
-    monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
-    monkeypatch.setattr(cli_main, "get_contract_from_s3", get_contract_from_s3)
-    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
-    monkeypatch.setattr(cli_main, "stream_benchmark_status", stream_benchmark_status)
 
     runner = CliRunner()
     for command in (

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 from uuid import uuid4
 
@@ -7,6 +8,7 @@ import click
 import httpx
 import pytest
 import yaml
+from click.testing import CliRunner
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, DocentReadingStatus, RetryMode, TaskStatus
 from tracker.types import (
     BenchmarkDetails,
@@ -17,6 +19,7 @@ from tracker.types import (
 )
 
 from valkyrie.cli import tracker_service as tracker_service_module
+from valkyrie.cli import main as cli_main
 from valkyrie.cli.main import list_benchmarks, start
 from valkyrie.cli.tracker_service import TrackerService
 from valkyrie.cli.utils import format_benchmark_status, format_fetch_benchmarks_response
@@ -153,6 +156,75 @@ def _command_option_flags(command: click.Command, param_name: str) -> set[str]:
     param = next(param for param in command.params if param.name == param_name)
     assert isinstance(param, click.Option)
     return {*param.opts}
+
+
+def test_run_commands_connect_after_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Connect should stream the run once start, resume, or retry succeeds.
+
+    Test cases:
+    - Start streams the new run ID returned by the tracker.
+    - Resume and retry stream the run ID supplied by the user.
+    """
+    started_run_id = uuid4()
+    resume_run_id = uuid4()
+    retry_run_id = uuid4()
+    streamed_run_ids: list[str] = []
+    start_response = {
+        "benchmark_name": "swebench",
+        "agent_name": "agent",
+        "benchmark_id": str(started_run_id),
+        "concurrency": 5,
+        "started_at": datetime.now(ZoneInfo("UTC")).isoformat(),
+        "task_count": 1,
+        "cloudwatch_url": "https://cloudwatch.example/run",
+        "s3_bucket_url": "s3://bucket/benchmarks/run",
+    }
+
+    class FakeTrackerService:
+        @staticmethod
+        def get_benchmark_auth(_benchmark_name: str) -> None:
+            return None
+
+        @staticmethod
+        def get_webhook_secret() -> None:
+            return None
+
+        def __enter__(self) -> "FakeTrackerService":
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+        def start_benchmark(self, *_args: object, **_kwargs: object) -> httpx.Response:
+            return httpx.Response(200, json=start_response)
+
+        def fetch_benchmark(self, _run_id: object) -> SimpleNamespace:
+            return SimpleNamespace(benchmark_name="swebench")
+
+        def retry_or_resume_benchmark(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+            return SimpleNamespace(status="success")
+
+    async def get_contract_from_s3(_agent: str, _agent_config: object) -> AgentContractRequest:
+        return AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run")
+
+    def stream_benchmark_status(_tracker: FakeTrackerService, run_id: object) -> None:
+        streamed_run_ids.append(str(run_id))
+
+    monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
+    monkeypatch.setattr(cli_main, "get_contract_from_s3", get_contract_from_s3)
+    monkeypatch.setattr(cli_main, "check_tracker_service_health", lambda _tracker: True)
+    monkeypatch.setattr(cli_main, "stream_benchmark_status", stream_benchmark_status)
+
+    runner = CliRunner()
+    for command in (
+        ["run", "start", "--agent", "agent", "--benchmark", "swebench", "--connect"],
+        ["run", "resume", str(resume_run_id), "--connect"],
+        ["run", "retry", str(retry_run_id), "--connect"],
+    ):
+        result = runner.invoke(cli_main.cli, command)
+        assert result.exit_code == 0, result.output
+
+    assert streamed_run_ids == [str(started_run_id), str(resume_run_id), str(retry_run_id)]
 
 
 def test_run_label_cli_options_and_client_requests(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Allow `--connect` on run commands that can immediately stream run updates, so users can start, resume, or retry and then attach to the run stream without a separate `run fetch --connect` command.

## Changes
- Add `--connect` to `valk run start` and stream the returned run id after successful start.
- Add `--connect` to `valk run resume`; `valk run retry` inherits the same option through the shared resume command.
- Document `--connect` for start, resume, and retry.
- Add unit coverage for start, resume, and retry streaming after success.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
