### PR TITLE
tracker: run-level cloudwatch/s3 URLs + sortable task list

### DIFF
--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -105,7 +105,7 @@ def get_benchmark_tasks(
     benchmark_id: UUID,
     status: str = Query(default=""),
     task_id_search: str | None = None,
-    sort: Literal["", "task_id", "started_at", "duration", "status"] = Query(default=""),
+    sort: Literal["task_id", "started_at", "duration", "status"] = Query(default="started_at"),
     sort_dir: Literal["asc", "desc"] = Query(default="desc"),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
@@ -114,7 +114,7 @@ def get_benchmark_tasks(
 ) -> TasksResponse:
     """Paginated tasks for a benchmark, with optional status filter + task-id search.
 
-    sort=status desc surfaces errors first (attention priority). Default: newest first."""
+    sort=status desc surfaces errors first (attention priority). Default: started_at desc."""
     get_scoped(Benchmark, benchmark_id, session, org)
 
     statuses = parse_csv(status, TaskStatus)
@@ -134,14 +134,10 @@ def get_benchmark_tasks(
         "started_at": col(Task.started_at),
         "duration": func.coalesce(col(Task.finished_at), func.now()) - col(Task.started_at),
         "status": _STATUS_SORT_PRIORITY,
-    }.get(sort)
-
-    started_at_desc = col(Task.started_at).desc()
-    if sort_expr is None:
-        order_by = [started_at_desc]
-    else:
-        primary = sort_expr.asc() if sort_dir == "asc" else sort_expr.desc()
-        order_by = [primary, started_at_desc]  # tie-break newest-first for stable ordering
+    }[sort]
+    primary = sort_expr.asc() if sort_dir == "asc" else sort_expr.desc()
+    # Tie-break newest-first for stable ordering within equal keys.
+    order_by = [primary, col(Task.started_at).desc()]
 
     rows = session.exec(select(Task).where(*base_filters).order_by(*order_by).limit(limit).offset(offset)).all()
     total = session.exec(select(func.count(col(Task.id))).where(*base_filters)).one()

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -5,18 +5,23 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
+from sqlalchemy import case
 from sqlmodel import Session, col, func, select
 
 from tracker.api.parsing import parse_csv
 from tracker.auth import get_current_org
+from tracker.aws.cloudwatch_logs import get_benchmark_log_url
+from tracker.aws.s3 import create_benchmark_url
 from tracker.database.models import Benchmark, Org, Task, TaskStatus
 from tracker.database.scoping import get_scoped
 from tracker.database.session import get_session
 from tracker.types import (
+    HarnessConfig,
     SingleBenchmarkResponse,
     TaskSummary,
     TasksResponse,
 )
+from tracker.utils import try_fetch_harness_config
 
 router = APIRouter(prefix="/benchmarks")
 
@@ -26,10 +31,28 @@ def _escape_sql_like_pattern(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+# Attention priority — higher is more urgent, so ORDER BY ... DESC surfaces
+# errors first, then abnormal/successful terminal, then active, then queued.
+_STATUS_SORT_PRIORITY = case(
+    {
+        TaskStatus.ERROR: 6,
+        TaskStatus.STOPPED: 5,
+        TaskStatus.FINISHED: 4,
+        TaskStatus.EVALUATING: 3,
+        TaskStatus.IN_PROGRESS: 2,
+        TaskStatus.BUILDING: 1,
+        TaskStatus.PENDING: 0,
+    },
+    value=col(Task.status),
+    else_=-1,
+)
+
+
 @router.get("/{benchmark_id}", response_model=SingleBenchmarkResponse)
 def get_single_benchmark(
     benchmark_id: UUID,
     org: Org = Depends(get_current_org),
+    harness_config: HarnessConfig | None = Depends(try_fetch_harness_config),
     session: Session = Depends(get_session),
 ) -> SingleBenchmarkResponse:
     """Fetch a single benchmark with task counts + final score for the SingleRun page."""
@@ -42,6 +65,19 @@ def get_single_benchmark(
         + task_state_counts.get(TaskStatus.ERROR, 0)
         + task_state_counts.get(TaskStatus.STOPPED, 0)
     )
+
+    cloudwatch_url: str | None = None
+    s3_bucket_url: str | None = None
+    if harness_config and harness_config.aws.aws_default_region:
+        region = harness_config.aws.aws_default_region
+        if harness_config.log_group:
+            cloudwatch_url = get_benchmark_log_url(
+                benchmark_id=str(benchmark.id),
+                region=region,
+                log_group=harness_config.log_group,
+            )
+        if harness_config.s3_bucket:
+            s3_bucket_url = create_benchmark_url(str(benchmark.id), region, harness_config.s3_bucket)
 
     return SingleBenchmarkResponse(
         id=benchmark.id,
@@ -57,6 +93,8 @@ def get_single_benchmark(
         started_by_email=benchmark.started_by_email,
         final_score=benchmark.fetch_final_score(session),
         error_message=benchmark.error_message,
+        cloudwatch_url=cloudwatch_url,
+        s3_bucket_url=s3_bucket_url,
     )
 
 
@@ -65,12 +103,17 @@ def get_benchmark_tasks(
     benchmark_id: UUID,
     status: str = Query(default=""),
     task_id_search: str | None = None,
+    sort: str = Query(default=""),
+    sort_dir: str = Query(default="desc"),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     org: Org = Depends(get_current_org),
     session: Session = Depends(get_session),
 ) -> TasksResponse:
-    """Paginated tasks for a benchmark, with optional status filter + task-id search."""
+    """Paginated tasks for a benchmark, with optional status filter + task-id search.
+
+    sort selects the column (task_id | started_at | duration | status); sort_dir is
+    asc | desc. sort=status desc surfaces errors first. Default: newest first."""
     get_scoped(Benchmark, benchmark_id, session, org)
 
     statuses = parse_csv(status, TaskStatus)
@@ -85,9 +128,21 @@ def get_benchmark_tasks(
         escaped_search = _escape_sql_like_pattern(task_id_search)
         base_filters.append(col(Task.task_id).ilike(f"%{escaped_search}%", escape="\\"))
 
-    rows = session.exec(
-        select(Task).where(*base_filters).order_by(col(Task.started_at).desc()).limit(limit).offset(offset)
-    ).all()
+    sort_expr = {
+        "task_id": col(Task.task_id),
+        "started_at": col(Task.started_at),
+        "duration": func.coalesce(col(Task.finished_at), func.now()) - col(Task.started_at),
+        "status": _STATUS_SORT_PRIORITY,
+    }.get(sort)
+
+    started_at_desc = col(Task.started_at).desc()
+    if sort_expr is None:
+        order_by = [started_at_desc]
+    else:
+        primary = sort_expr.asc() if sort_dir == "asc" else sort_expr.desc()
+        order_by = [primary, started_at_desc]  # tie-break newest-first for stable ordering
+
+    rows = session.exec(select(Task).where(*base_filters).order_by(*order_by).limit(limit).offset(offset)).all()
     total = session.exec(select(func.count(col(Task.id))).where(*base_filters)).one()
 
     return TasksResponse(

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -104,8 +105,8 @@ def get_benchmark_tasks(
     benchmark_id: UUID,
     status: str = Query(default=""),
     task_id_search: str | None = None,
-    sort: str = Query(default=""),
-    sort_dir: str = Query(default="desc"),
+    sort: Literal["", "task_id", "started_at", "duration", "status"] = Query(default=""),
+    sort_dir: Literal["asc", "desc"] = Query(default="desc"),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     org: Org = Depends(get_current_org),
@@ -113,8 +114,7 @@ def get_benchmark_tasks(
 ) -> TasksResponse:
     """Paginated tasks for a benchmark, with optional status filter + task-id search.
 
-    sort selects the column (task_id | started_at | duration | status); sort_dir is
-    asc | desc. sort=status desc surfaces errors first. Default: newest first."""
+    sort=status desc surfaces errors first (attention priority). Default: newest first."""
     get_scoped(Benchmark, benchmark_id, session, org)
 
     statuses = parse_csv(status, TaskStatus)

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -66,18 +66,19 @@ def get_single_benchmark(
         + task_state_counts.get(TaskStatus.STOPPED, 0)
     )
 
+    # region + s3_bucket are required harness headers, so they're present whenever
+    # harness_config is; log_group is optional (no log group -> no CloudWatch link).
     cloudwatch_url: str | None = None
     s3_bucket_url: str | None = None
-    if harness_config and harness_config.aws.aws_default_region:
+    if harness_config:
         region = harness_config.aws.aws_default_region
+        s3_bucket_url = create_benchmark_url(str(benchmark.id), region, harness_config.s3_bucket)
         if harness_config.log_group:
             cloudwatch_url = get_benchmark_log_url(
                 benchmark_id=str(benchmark.id),
                 region=region,
                 log_group=harness_config.log_group,
             )
-        if harness_config.s3_bucket:
-            s3_bucket_url = create_benchmark_url(str(benchmark.id), region, harness_config.s3_bucket)
 
     return SingleBenchmarkResponse(
         id=benchmark.id,

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -296,6 +296,8 @@ class SingleBenchmarkResponse(BaseModel):
     started_by_email: str | None = None
     final_score: float | None = None
     error_message: str | None = None
+    cloudwatch_url: str | None = None
+    s3_bucket_url: str | None = None
 
     @field_serializer("started_at")
     def _serialize_started_at(self, value: datetime) -> str:

--- a/services/tracker/tests/integration/test_single_benchmark.py
+++ b/services/tracker/tests/integration/test_single_benchmark.py
@@ -94,6 +94,28 @@ def test_get_benchmark_tasks_filters_by_status(client, database_session):
     assert data["tasks"][0]["error_message"] == "boom"
 
 
+def test_get_benchmark_tasks_sort_by_status_surfaces_errors_first(client, database_session):
+    b = _make_bench()
+    database_session.add(b)
+    database_session.commit()
+    # Insert out of priority order.
+    for task_id, status in [
+        ("a-pending", TaskStatus.PENDING),
+        ("b-finished", TaskStatus.FINISHED),
+        ("c-error", TaskStatus.ERROR),
+        ("d-in-progress", TaskStatus.IN_PROGRESS),
+    ]:
+        database_session.add(Task(org_id=b.org_id, benchmark=b.id, task_id=task_id, status=status))
+    database_session.commit()
+
+    resp = client.get(
+        f"/benchmarks/{b.id}/tasks?sort=status",
+        headers={"Authorization": "Bearer fake"},
+    )
+    statuses = [t["status"] for t in resp.json()["tasks"]]
+    assert statuses == ["ERROR", "FINISHED", "IN_PROGRESS", "PENDING"]
+
+
 def test_unauth_returns_401(client):
     bogus = uuid4()
     assert client.get(f"/benchmarks/{bogus}").status_code == 401

--- a/services/tracker/tests/integration/test_single_benchmark.py
+++ b/services/tracker/tests/integration/test_single_benchmark.py
@@ -116,6 +116,65 @@ def test_get_benchmark_tasks_sort_by_status_surfaces_errors_first(client, databa
     assert statuses == ["ERROR", "FINISHED", "IN_PROGRESS", "PENDING"]
 
 
+_HARNESS_HEADERS = {
+    "Authorization": "Bearer fake",
+    "X-Harness-AWS-Access-Key-Id": "AKIA",
+    "X-Harness-AWS-Secret-Access-Key": "secret",
+    "X-Harness-AWS-Default-Region": "us-east-1",
+    "X-Harness-S3-Bucket": "agentic-harness",
+    "X-Harness-Log-Group": "benchmarks",
+    "X-Harness-Log-Retention-Policy": "30",
+}
+
+
+def test_get_single_benchmark_builds_run_console_urls_from_harness_headers(client, database_session):
+    b = _make_bench()
+    database_session.add(b)
+    database_session.commit()
+
+    data = client.get(f"/benchmarks/{b.id}", headers=_HARNESS_HEADERS).json()
+    assert "cloudwatch/home" in data["cloudwatch_url"]
+    assert str(b.id) in data["cloudwatch_url"]
+    assert "s3/buckets/agentic-harness" in data["s3_bucket_url"]
+    assert str(b.id) in data["s3_bucket_url"]
+
+
+def test_get_single_benchmark_omits_console_urls_without_harness_headers(client, database_session):
+    b = _make_bench()
+    database_session.add(b)
+    database_session.commit()
+
+    data = client.get(f"/benchmarks/{b.id}", headers={"Authorization": "Bearer fake"}).json()
+    assert data["cloudwatch_url"] is None
+    assert data["s3_bucket_url"] is None
+
+
+def test_get_single_benchmark_s3_url_without_log_group_skips_cloudwatch(client, database_session):
+    b = _make_bench()
+    database_session.add(b)
+    database_session.commit()
+
+    headers = {k: v for k, v in _HARNESS_HEADERS.items() if k != "X-Harness-Log-Group"}
+    data = client.get(f"/benchmarks/{b.id}", headers=headers).json()
+    assert data["cloudwatch_url"] is None
+    assert "s3/buckets/agentic-harness" in data["s3_bucket_url"]
+
+
+def test_get_benchmark_tasks_sort_by_task_id_ascending(client, database_session):
+    b = _make_bench()
+    database_session.add(b)
+    database_session.commit()
+    for task_id in ["t-c", "t-a", "t-b"]:
+        database_session.add(Task(org_id=b.org_id, benchmark=b.id, task_id=task_id, status=TaskStatus.PENDING))
+    database_session.commit()
+
+    data = client.get(
+        f"/benchmarks/{b.id}/tasks?sort=task_id&sort_dir=asc",
+        headers={"Authorization": "Bearer fake"},
+    ).json()
+    assert [t["task_id"] for t in data["tasks"]] == ["t-a", "t-b", "t-c"]
+
+
 def test_unauth_returns_401(client):
     bogus = uuid4()
     assert client.get(f"/benchmarks/{bogus}").status_code == 401


### PR DESCRIPTION
## Run-level console links
`GET /benchmarks/{id}` now returns `cloudwatch_url` + `s3_bucket_url` for the whole run, built from the `X-Harness-*` headers via `get_benchmark_log_url` / `create_benchmark_url` — the same helpers the start-benchmark flow already uses (no new URL logic). Both are null when harness headers are absent (`try_fetch_harness_config`).

## Sortable task list
`GET /benchmarks/{id}/tasks` gains `sort` (`task_id` | `started_at` | `duration` | `status`) and `sort_dir` (`asc`/`desc`). `status` orders by an attention-priority `CASE` so `desc` surfaces errors first (errors → stopped → finished → evaluating → in-progress → building → pending). Default remains newest-first.

Added a test for the status-priority ordering.

Pairs with platform PR vals-ai/platform#2454 (run-link buttons + sortable headers).