### PR TITLE
feat: expose structured task error details

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -4,7 +4,7 @@ import tarfile
 import traceback
 from collections.abc import AsyncIterator
 from datetime import datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, TypeVar
 from uuid import UUID
 
 import httpx
@@ -115,6 +115,7 @@ configure_logging()
 configure_observability("valkyrie-tracker", environment=ENVIRONMENT)
 
 logger = get_logger(__name__)
+_TaskMapValue = TypeVar("_TaskMapValue")
 
 
 def _operation_id(route: APIRoute) -> str:
@@ -539,17 +540,19 @@ async def retrieve_results(
     """
     benchmark_row = session.get(Benchmark, benchmark_id, options=[joinedload(Benchmark.final_evaluation)])
     assert_org(benchmark_row, org)
+    assert benchmark_row is not None
 
     final_view = create_final_view(benchmark_row, session, org)
 
     if task_ids:
         task_ids_set = set(task_ids)
 
-        def _filter_task_map(task_map):
+        def _filter_task_map(task_map: dict[str, _TaskMapValue] | None) -> dict[str, _TaskMapValue] | None:
             return {task_id: value for task_id, value in (task_map or {}).items() if task_id in task_ids_set} or None
 
         final_view.evaluation_results = _filter_task_map(final_view.evaluation_results)
         final_view.task_errors = _filter_task_map(final_view.task_errors)
+        final_view.task_error_details = _filter_task_map(final_view.task_error_details)
 
         # Include every requested task with its result or None, so tasks without a result
         # (e.g. stopped/errored) still count toward the denominator instead of being dropped.

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -125,6 +125,13 @@ class AverageTaskBreakdown(BaseModel):
     sandbox_run_duration: float | None
 
 
+class TaskErrorDetail(BaseModel):
+    message: str
+    error_class: str
+    error_owner: str
+    phase: str
+
+
 class FinalViewResponse(BaseModel):
     benchmark_id: UUID
     benchmark_name: str
@@ -138,6 +145,7 @@ class FinalViewResponse(BaseModel):
     average_task_breakdown: AverageTaskBreakdown | None
     evaluation_results: dict[str, dict[str, Any]] | None
     task_errors: dict[str, str] | None
+    task_error_details: dict[str, TaskErrorDetail] | None = None
 
 
 class S3UploadResultsResponse(BaseModel):

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -78,6 +78,7 @@ from tracker.types import (
     HarnessConfig,
     Order,
     StartBenchmarkRequest,
+    TaskErrorDetail,
 )
 
 logger = get_logger(__name__)
@@ -859,6 +860,73 @@ def fetch_final_score_inputs(session: Session, benchmark_row: Benchmark, org: Or
     )
 
     return dict(task_rows)
+
+
+_DEFAULT_TASK_ERROR_MESSAGE = "No error message was provided"
+
+
+def classify_task_error(message: str) -> TaskErrorDetail:
+    message_lower = message.lower()
+    if "cleanroom_preflight_failed" in message_lower:
+        return TaskErrorDetail(
+            message=message,
+            error_class="cleanroom_preflight_failed",
+            error_owner="infra",
+            phase="preflight",
+        )
+    if "required output artifact missing" in message_lower or message_lower.startswith("output artifact error"):
+        return TaskErrorDetail(
+            message=message,
+            error_class="missing_output_artifact",
+            error_owner="model",
+            phase="agent_output",
+        )
+    if "benchmark service has not sent a message" in message_lower:
+        return TaskErrorDetail(
+            message=message,
+            error_class="benchmark_service_disconnect",
+            error_owner="infra",
+            phase="benchmark_service",
+        )
+    if (
+        "benchmark service returned an incompatible task response" in message_lower
+        or "benchmark service rejected the websocket connection" in message_lower
+    ):
+        return TaskErrorDetail(
+            message=message,
+            error_class="benchmark_service_protocol_error",
+            error_owner="infra",
+            phase="benchmark_service",
+        )
+    if "task container failed to start" in message_lower:
+        return TaskErrorDetail(
+            message=message,
+            error_class="setup_or_package_failed",
+            error_owner="infra",
+            phase="setup",
+        )
+    if message_lower.startswith("sandbox error:"):
+        return TaskErrorDetail(
+            message=message,
+            error_class="sandbox_runtime_error",
+            error_owner="infra",
+            phase="sandbox",
+        )
+    return TaskErrorDetail(message=message, error_class="task_error", error_owner="unknown", phase="unknown")
+
+
+def fetch_task_error_details(benchmark_row: Benchmark, session: Session) -> dict[str, TaskErrorDetail] | None:
+    rows = session.exec(
+        select(Task.task_id, Task.error_message)
+        .where(Task.benchmark == benchmark_row.id)
+        .where(Task.org_id == benchmark_row.org_id)
+        .where(Task.status == TaskStatus.ERROR)
+    ).all()
+    if not rows:
+        return None
+    return {
+        task_id: classify_task_error(error_message or _DEFAULT_TASK_ERROR_MESSAGE) for task_id, error_message in rows
+    }
 
 
 @broker.task
@@ -1758,6 +1826,7 @@ def create_final_view(benchmark_row: Benchmark, session: Session, org: Org) -> F
         final_evaluation=benchmark_row.final_evaluation,
         evaluation_results=benchmark_row.fetch_evaluation_results(session),
         task_errors=benchmark_row.fetch_tasks_with_errors(session),
+        task_error_details=fetch_task_error_details(benchmark_row, session),
         average_task_breakdown=fetch_average_task_breakdown(benchmark_row.id, session, org.id),
     )
 

--- a/services/tracker/tests/integration/test_process_benchmark.py
+++ b/services/tracker/tests/integration/test_process_benchmark.py
@@ -21,7 +21,7 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.types import HarnessConfig, StartBenchmarkRequest
-from tracker.utils import process_benchmark, start_benchmark_request_to_benchmark
+from tracker.utils import create_final_view, process_benchmark, start_benchmark_request_to_benchmark
 
 _TASK_ID: str = "astropy__astropy-12907"
 _TASK_IDS: list[str] = ["astropy__astropy-12907", "astropy__astropy-13033"]
@@ -247,6 +247,15 @@ async def test_process_benchmark_errors_when_all_tasks_fail_before_evaluation(
     assert tasks[0].status == TaskStatus.ERROR
     assert "Required output artifact missing" in (tasks[0].error_message or "")
     assert benchmark.fetch_evaluation_results(database_session) == {}
+
+    org = database_session.get(Org, TEST_ORG_ID)
+    assert org is not None
+    final_view = create_final_view(benchmark, database_session, org)
+    assert final_view.task_errors == {_TASK_ID: tasks[0].error_message}
+    assert final_view.task_error_details is not None
+    assert final_view.task_error_details[_TASK_ID].error_class == "missing_output_artifact"
+    assert final_view.task_error_details[_TASK_ID].error_owner == "model"
+    assert final_view.task_error_details[_TASK_ID].phase == "agent_output"
 
 
 async def test_concurrent_benchmarks_same_task(

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -28,12 +28,13 @@ from tracker.exceptions import TrackerServiceError
 from tracker.types import AWSCredentials, FetchBenchmarksRequest, HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     _parse_log_retention_policy,  # pyright: ignore[reportPrivateUsage]
+    classify_task_error,
     commit_task_error,
     create_task_rows,
     fetch_benchmark_row,
-    fetch_harness_config,
     fetch_filtered_benchmark_rows,
     fetch_final_score_inputs,
+    fetch_harness_config,
     fetch_sandbox_provider_config,
     has_runnable_tasks,
     set_benchmark_final_status,
@@ -44,6 +45,42 @@ from tracker.utils import (
 class TestBenchmarkUtils:
     _test_org = Org(id=TEST_ORG_ID, name="default")
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
+
+    @pytest.mark.parametrize(
+        ("message", "expected"),
+        [
+            (
+                "ProgramBench cleanroom preflight failed: cleanroom_preflight_failed; see /logs/programbench/preflight.json",
+                {"error_class": "cleanroom_preflight_failed", "error_owner": "infra", "phase": "preflight"},
+            ),
+            (
+                "Output artifact error: Required output artifact missing: /workspace/submission",
+                {"error_class": "missing_output_artifact", "error_owner": "model", "phase": "agent_output"},
+            ),
+            (
+                "Sandbox error: Failed to run command bash setup.sh, exit code: 42",
+                {"error_class": "sandbox_runtime_error", "error_owner": "infra", "phase": "sandbox"},
+            ),
+            (
+                "ProgramBench task container failed to start: task_cleanroom: Pulling from programbench/test",
+                {"error_class": "setup_or_package_failed", "error_owner": "infra", "phase": "setup"},
+            ),
+            (
+                "Benchmark service returned an incompatible task response. Missing or invalid fields: resources",
+                {
+                    "error_class": "benchmark_service_protocol_error",
+                    "error_owner": "infra",
+                    "phase": "benchmark_service",
+                },
+            ),
+            (
+                "Benchmark service has not sent a message, causing the connection to disconnect: last message received 600s ago",
+                {"error_class": "benchmark_service_disconnect", "error_owner": "infra", "phase": "benchmark_service"},
+            ),
+        ],
+    )
+    def test_classify_task_error(self, message: str, expected: dict[str, str]) -> None:
+        assert classify_task_error(message).model_dump() == {"message": message, **expected}
 
     def test_fetch_sandbox_provider_config_combines_provider_type_with_secret(
         self, harness_config: HarnessConfig, monkeypatch: pytest.MonkeyPatch

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -465,6 +465,25 @@ class TestFastapiServer:
         # If we did not get an error message, we return a default message
         assert response_json.get("task_errors").get("task_23") == "No error message was provided"
 
+        # Structured task error details preserve machine-readable metadata without changing task_errors.
+        assert response_json.get("task_error_details") == {
+            "task_22": {
+                "message": error_message,
+                "error_class": "task_error",
+                "error_owner": "unknown",
+                "phase": "unknown",
+            },
+            "task_23": {
+                "message": "No error message was provided",
+                "error_class": "task_error",
+                "error_owner": "unknown",
+                "phase": "unknown",
+            },
+        }
+        legacy_response_json = dict(response_json)
+        legacy_response_json.pop("task_error_details")
+        assert FinalViewResponse(**legacy_response_json).task_error_details is None
+
         # Test case 9. task_ids subset filters evaluation_results and recomputes final_score
         observed_headers: dict[str, str] = {}
         observed_results: dict[str, Any] = {}
@@ -500,6 +519,24 @@ class TestFastapiServer:
         assert observed_results.keys() == {"task_1", "task_11"}
         assert observed_results["task_11"] is None
         assert response.json()["final_evaluation"]["final_score"] == 2.0
+
+        # Test case 11. The same subset filtering applies to structured task error details.
+        response = client.get(
+            "/retrieve-results",
+            params=[("benchmark_id", str(benchmark_row.id)), ("task_ids", "task_22")],
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["task_errors"] == {"task_22": error_message}
+        assert body["task_error_details"] == {
+            "task_22": {
+                "message": error_message,
+                "error_class": "task_error",
+                "error_owner": "unknown",
+                "phase": "unknown",
+            }
+        }
 
     async def test_benchmark_error_handling(
         self,


### PR DESCRIPTION
## Summary
- Add optional `task_error_details` to tracker final-view results, keyed by task id, alongside the existing `task_errors` string map.
- Classify task-level errors into stable `message`, `error_class`, `error_owner`, and `phase` fields for common infra/model failure modes.
- Keep backward compatibility: older final-view payloads without `task_error_details` still parse, and existing `task_errors` behavior is unchanged.
- Apply `task_ids` subset filtering to `task_error_details` the same way as `task_errors` and `evaluation_results`.

## Why
ProgramBench issue vals-ai/valkyrie-ticket-library#100 needs better tracker-side observability before the full acceptance run. When all tasks fail before evaluation, the run currently collapses to generic benchmark-level text like `No tasks were completed successfully` plus raw `Sandbox error` strings. This PR preserves machine-readable per-task failure metadata in the normal `valkyrie run results` / final-view path.

Related to vals-ai/valkyrie-ticket-library#100 and complements vals-ai/agent-registry#70. Does **not** close #100; closure still requires the 200-task concurrency-50 acceptance run with no infrastructure-level errors.

## Error classes currently classified
- `cleanroom_preflight_failed` / `infra` / `preflight`
- `missing_output_artifact` / `model` / `agent_output`
- `sandbox_runtime_error` / `infra` / `sandbox`
- `setup_or_package_failed` / `infra` / `setup`
- `benchmark_service_protocol_error` / `infra` / `benchmark_service`
- `benchmark_service_disconnect` / `infra` / `benchmark_service`
- fallback: `task_error` / `unknown` / `unknown`

## Verification
- `uv run pytest tests/unit/test_fastapi_server.py::TestFastapiServer::test_retrieve_results tests/unit/test_benchmark_utils.py::TestBenchmarkUtils::test_classify_task_error -q` → `7 passed`
- `uv run pytest tests/unit/test_fastapi_server.py tests/unit/test_benchmark_utils.py tests/unit/test_benchmark_service_disconnect.py -q` → `53 passed`
- `uv run basedpyright src/tracker/types.py src/tracker/utils.py main.py` → `0 errors`
- `uv run ruff check src/tracker/types.py src/tracker/utils.py main.py tests/unit/test_fastapi_server.py tests/unit/test_benchmark_utils.py tests/integration/test_process_benchmark.py` → pass
- `python -m py_compile` on touched Python files → pass
- Independent read-only review after compatibility fix: no blocking findings.

## Not run
- `tests/integration/test_process_benchmark.py::test_process_benchmark_errors_when_all_tasks_fail_before_evaluation` locally, because this integration suite requires `TEST_DAYTONA_SECRET_NAME`. The test was updated to assert the final view includes structured error details when every task fails before evaluation.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->