### PR TITLE
Pass benchmark identity to agent runs

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from asyncio import Semaphore
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import asynccontextmanager
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
@@ -72,11 +72,26 @@ bundle_path = PurePosixPath("/bundle")
 SANDBOX_AUTO_STOP_INTERVAL = 10 * 60
 SANDBOX_CREATE_TIMEOUT = 360
 CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS = 24 * 60 * 60
+AGENT_RUNTIME_ENV_KEYS = ("RUN_ID", "TASK_ID", "IDENTITY")
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
     """Get the path to a contract in the sandbox."""
     return bundle_path / contract_name
+
+
+def _runtime_env_assignments(env_vars: Mapping[str, str] | None) -> list[str]:
+    if not env_vars:
+        return []
+
+    return [shlex.quote(f"{key}={value}") for key in AGENT_RUNTIME_ENV_KEYS if (value := env_vars.get(key))]
+
+
+def _command_with_runtime_env(command: str, env_vars: Mapping[str, str] | None) -> str:
+    assignments = _runtime_env_assignments(env_vars)
+    if not assignments:
+        return command
+    return f"env {' '.join(assignments)} /bin/sh -c {shlex.quote(command)}"
 
 
 async def delete_sandbox(sandbox: Sandbox, provider: SandboxProvider) -> None:
@@ -559,6 +574,7 @@ async def run_agent(
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
     benchmark_id: str | None = None,
+    runtime_env_vars: Mapping[str, str] | None = None,
 ) -> tuple[AgentCausedExitReason | None, float]:
     """
     Run the agent inside the sandbox for a given task.
@@ -587,6 +603,8 @@ async def run_agent(
 
     for kwarg_key, kwarg_value in contract.kwargs.items():
         run_cmd = run_cmd.replace(f"{{{kwarg_key}}}", kwarg_value)
+
+    run_cmd = _command_with_runtime_env(run_cmd, runtime_env_vars)
 
     # Apply timeout if specified
     if agent_timeout is not None:

--- a/services/tracker/src/tracker/utils.py
+++ b/services/tracker/src/tracker/utils.py
@@ -66,7 +66,7 @@ from tracker.exceptions import OutputArtifactError, SandboxSetupError, TrackerSe
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, retry_callback
-from tracker.sandbox import create_sandbox, delete_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import AGENT_RUNTIME_ENV_KEYS, create_sandbox, delete_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     AverageTaskBreakdown,
     AWSCredentials,
@@ -516,6 +516,7 @@ async def process_task(
                 f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
             ),
         }
+        runtime_env_vars = {key: env_vars[key] for key in AGENT_RUNTIME_ENV_KEYS}
 
         # We don't want to track the task until the sandbox is actually created.
         task_breakdown = TaskBreakdown()
@@ -576,6 +577,7 @@ async def process_task(
                     agent_output_s3_key=agent_output_s3_key,
                     agent_timeout=task_data.agent_timeout,
                     benchmark_id=str(benchmark_id),
+                    runtime_env_vars=runtime_env_vars,
                 )
                 logger.info(
                     "agent.run.complete",

--- a/services/tracker/tests/unit/test_pty_retry.py
+++ b/services/tracker/tests/unit/test_pty_retry.py
@@ -1,3 +1,4 @@
+import json
 from asyncio import Semaphore
 from contextlib import asynccontextmanager
 from typing import Any, cast
@@ -260,6 +261,16 @@ class TestPtyRetry:
         assert all(record["entered"] and record["exited"] for record in transition_records)
         assert not any(record["message"].startswith("task.status_transition") for record in log_records)
         assert run_agent_kwargs["benchmark_id"] == str(benchmark_row.id)
+        assert run_agent_kwargs["runtime_env_vars"] == {
+            "RUN_ID": str(benchmark_row.id),
+            "TASK_ID": "task_0",
+            "IDENTITY": json.dumps(
+                {
+                    "benchmark_name": "swebench",
+                    "agent_name": contract.name,
+                }
+            ),
+        }
 
         event_names = [record["message"] for record in log_records]
         assert "agent.run.complete" in event_names

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 from collections import deque
 from collections.abc import Mapping
 from typing import Any
@@ -199,6 +200,65 @@ class TestOutputArtifacts:
 
 
 class TestAgentOutputTelemetry:
+    async def test_run_agent_prefixes_tracker_runtime_env_without_secrets(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="",
+            run_cmd="python agent.py && echo done",
+        )
+        commands: list[str] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
+            if command.startswith("mkdir -p"):
+                return ExecResult(exit_code=0, output="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fake_stream_command_output(_sandbox: Any, command: str, *_args: Any) -> tuple[None, float]:
+            commands.append(command)
+            return None, 0.0
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await run_agent(
+            mock_sandbox,
+            contract,
+            "/tmp/problem.txt",
+            "task_0",
+            lambda _msg: None,
+            "/testbed",
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+            agent_timeout=123,
+            runtime_env_vars={
+                "RUN_ID": "run-123",
+                "TASK_ID": "task_0",
+                "IDENTITY": '{"benchmark_name":"emb","agent_name":"test-agent"}',
+                "OPENAI_API_KEY": "secret-value",
+            },
+        )
+
+        assert len(commands) == 1
+        tokens = shlex.split(commands[0])
+        assert tokens[:4] == ["cd", "/testbed", "&&", "PYTHONSAFEPATH=1"]
+        assert tokens[4:6] == ["timeout", "123"]
+        env_index = tokens.index("env")
+        assert tokens[env_index + 1 : env_index + 4] == [
+            "RUN_ID=run-123",
+            "TASK_ID=task_0",
+            'IDENTITY={"benchmark_name":"emb","agent_name":"test-agent"}',
+        ]
+        assert tokens[env_index + 4 : env_index + 7] == ["/bin/sh", "-c", "python agent.py && echo done"]
+        assert "OPENAI_API_KEY=secret-value" not in tokens
+
     async def test_run_agent_uploads_declared_output_artifacts(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- pass tracker-owned `RUN_ID`, `TASK_ID`, and `IDENTITY` into the agent process
- wrap the agent command with an allowlisted env prefix so attribution reaches model-library/model-gateway for compound `run_cmd` values
- keep provider/API secrets out of the streamed command by only forwarding explicit runtime env keys

## Notes
- `QUESTION_ID` is intentionally not forwarded; Valkyrie owns `TASK_ID`, and model-library already falls back from `QUESTION_ID` to `TASK_ID` when resolving `question_id`.

## Validation
- `uv run pytest services/tracker/tests/unit/test_sandbox.py::TestAgentOutputTelemetry::test_run_agent_prefixes_tracker_runtime_env_without_secrets services/tracker/tests/unit/test_pty_retry.py::TestPtyRetry::test_process_task_spans_timed_status_transitions`
- `uv run ruff check services/tracker/src/tracker/sandbox.py services/tracker/src/tracker/utils.py services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/test_pty_retry.py`
- Local smoke: `fabv2-internal` / `fabv2_agent` / `google/gemini-3.1-flash-lite` finished 1/1, and the model gateway ledger showed the Valkyrie run id plus benchmark/agent identity.
