### PR TITLE
fix: address prod deploy review issues

### DIFF
--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -320,7 +320,11 @@ class Benchmark(SQLModel, table=True):
 
         task_state_counts = self.fetch_task_state_counts(session)
         total_tasks = sum(task_state_counts.values())
-        finished_tasks = task_state_counts.get(TaskStatus.FINISHED, 0) + task_state_counts.get(TaskStatus.ERROR, 0)
+        finished_tasks = (
+            task_state_counts.get(TaskStatus.FINISHED, 0)
+            + task_state_counts.get(TaskStatus.ERROR, 0)
+            + task_state_counts.get(TaskStatus.STOPPED, 0)
+        )
 
         return BenchmarkTableRow(
             id=self.id,

--- a/services/tracker/tests/unit/test_database_models.py
+++ b/services/tracker/tests/unit/test_database_models.py
@@ -1,0 +1,31 @@
+from sqlmodel import Session
+
+from tests.conftest import TEST_ORG_ID
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkArguments, Task, TaskStatus
+
+
+def test_create_benchmark_table_row_counts_stopped_tasks_as_finished(database_session: Session) -> None:
+    benchmark = Benchmark(
+        org_id=TEST_ORG_ID,
+        name="swebench",
+        arguments=BenchmarkArguments(
+            contract=AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run"),
+            concurrency=1,
+        ),
+    )
+    database_session.add(benchmark)
+    database_session.commit()
+
+    for task_id, status in (
+        ("finished", TaskStatus.FINISHED),
+        ("errored", TaskStatus.ERROR),
+        ("stopped", TaskStatus.STOPPED),
+        ("pending", TaskStatus.PENDING),
+    ):
+        database_session.add(Task(org_id=TEST_ORG_ID, benchmark=benchmark.id, task_id=task_id, status=status))
+    database_session.commit()
+
+    row = benchmark.create_benchmark_table_row(database_session)
+
+    assert row.total_tasks == 4
+    assert row.finished_tasks == 3

--- a/src/valkyrie/cli/tracker_service.py
+++ b/src/valkyrie/cli/tracker_service.py
@@ -40,7 +40,10 @@ _REQUIRED_CONFIG_KEYS = {
     "AWS_SECRET_ACCESS_KEY",
     "AWS_DEFAULT_REGION",
     "S3_BUCKET",
+}
+_SANDBOX_PROVIDER_SECRET_CONFIG_KEYS = {
     "SANDBOX_PROVIDER_SECRET_NAME",
+    "DAYTONA_SECRET_NAME",
 }
 
 
@@ -180,6 +183,8 @@ class TrackerService:
             harness_config: dict[str, str] = yaml.safe_load(f) or {}
 
         missing = _REQUIRED_CONFIG_KEYS - harness_config.keys()
+        if not (_SANDBOX_PROVIDER_SECRET_CONFIG_KEYS & harness_config.keys()):
+            missing.add("SANDBOX_PROVIDER_SECRET_NAME")
         if missing:
             raise TrackerServiceError(
                 f"Missing required config keys: {', '.join(sorted(missing))}. "
@@ -214,7 +219,8 @@ class TrackerService:
             "s3_bucket": flat["s3_bucket"],
             "log_group": flat["log_group"],
             "log_retention_policy": int(flat["log_retention_policy"]),
-            "sandbox_provider_secret_name": flat["sandbox_provider_secret_name"],
+            "sandbox_provider_secret_name": flat.get("sandbox_provider_secret_name")
+            or flat.get("daytona_secret_name", ""),
         }
 
     def health_check(self) -> Response:

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -251,6 +251,46 @@ def test_tracker_service_accepts_provider_secret_config(tmp_path: Path, monkeypa
     assert harness_config["sandbox_provider_secret_name"] == "DaytonaSecrets"
 
 
+def test_tracker_service_accepts_legacy_daytona_secret_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "valkyrie.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "AWS_ACCESS_KEY_ID": "aws-key",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                "S3_BUCKET": "bucket",
+                "DAYTONA_SECRET_NAME": "DaytonaSecrets",
+                "LOG_GROUP": "benchmarks",
+                "LOG_RETENTION_POLICY": 365,
+            }
+        )
+    )
+
+    monkeypatch.setattr(tracker_service_module, "_CONFIG_LOCATION", config_path)
+    client = FakeClient()
+
+    def build_client(**_kwargs: object) -> FakeClient:
+        return client
+
+    monkeypatch.setattr("valkyrie.cli.tracker_service.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    tracker.start_benchmark(
+        contract=AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run"),
+        benchmark_name="swebench",
+        concurrency=1,
+        ignore_custom_services=True,
+        task_ids=None,
+        slice_str=None,
+    )
+
+    assert client.json is not None
+    harness_config = client.json["harness_config"]
+    assert isinstance(harness_config, dict)
+    assert harness_config["sandbox_provider_secret_name"] == "DaytonaSecrets"
+
+
 def _command_option_flags(command: click.Command, param_name: str) -> set[str]:
     param = next(param for param in command.params if param.name == param_name)
     assert isinstance(param, click.Option)

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -291,6 +291,27 @@ def test_tracker_service_accepts_legacy_daytona_secret_config(tmp_path: Path, mo
     assert harness_config["sandbox_provider_secret_name"] == "DaytonaSecrets"
 
 
+def test_tracker_service_requires_provider_secret_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_path = tmp_path / "valkyrie.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "AWS_ACCESS_KEY_ID": "aws-key",
+                "AWS_SECRET_ACCESS_KEY": "aws-secret",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                "S3_BUCKET": "bucket",
+                "LOG_GROUP": "benchmarks",
+                "LOG_RETENTION_POLICY": 365,
+            }
+        )
+    )
+
+    monkeypatch.setattr(tracker_service_module, "_CONFIG_LOCATION", config_path)
+
+    with pytest.raises(TrackerServiceError, match="SANDBOX_PROVIDER_SECRET_NAME"):
+        TrackerService(base_url="http://tracker")
+
+
 def _command_option_flags(command: click.Command, param_name: str) -> set[str]:
     param = next(param for param in command.params if param.name == param_name)
     assert isinstance(param, click.Option)

--- a/uv.lock
+++ b/uv.lock
@@ -2672,7 +2672,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.1" },
-    { name = "daytona", specifier = ">=0.180.0" },
+    { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
Fixes two correctness issues found during review of the prod deploy candidate:
- `Benchmark.create_benchmark_table_row()` now counts stopped tasks as finished, matching `build_benchmark_table_rows()` and progress semantics.
- Tracker CLI harness config now accepts the legacy `DAYTONA_SECRET_NAME` key as a fallback for `SANDBOX_PROVIDER_SECRET_NAME`.

Also syncs the root `uv.lock` Daytona requirement with the tracker service's existing `daytona>=0.189.0` dependency.

## Changes
- Include `TaskStatus.STOPPED` in `finished_tasks` for benchmark table rows.
- Split required CLI config keys so either sandbox provider secret key is accepted.
- Add regression tests for stopped task progress, legacy Daytona secret config, and missing provider secret validation.
- Update the root lockfile's Daytona requirement metadata to match `services/tracker/pyproject.toml`.

## Related Issues
Related to prod deploy PR #493 review findings.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Ran:
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run pytest /home/ubuntu/repos/Valkyrie/services/tracker/tests/unit/test_database_models.py`
- `UV_FROZEN=1 uv --directory /home/ubuntu/repos/Valkyrie run pytest /home/ubuntu/repos/Valkyrie/tests/unit/test_tracker_service.py::test_tracker_service_accepts_provider_secret_config /home/ubuntu/repos/Valkyrie/tests/unit/test_tracker_service.py::test_tracker_service_accepts_legacy_daytona_secret_config /home/ubuntu/repos/Valkyrie/tests/unit/test_tracker_service.py::test_tracker_service_requires_provider_secret_config`
- `make -C /home/ubuntu/repos/Valkyrie lint`
- `make -C /home/ubuntu/repos/Valkyrie typecheck`
- `uv --directory /home/ubuntu/repos/Valkyrie/services/tracker run basedpyright /home/ubuntu/repos/Valkyrie/services/tracker/src/tracker/database/models.py /home/ubuntu/repos/Valkyrie/services/tracker/tests/unit/test_database_models.py`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/80f12ef512944e18a930e9bb0959eeda
Requested by: @JarettForzano