### PR TITLE
Route tracker provider config through CBS

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -267,6 +267,12 @@ async def start_benchmark(
     # Prefer harness_config from X-Harness-* headers (web FE); fall back to request body (CLI).
     header_harness_config = try_fetch_harness_config(http_request)
     effective_harness_config = header_harness_config or request.harness_config
+    # TODO: Drop the top-level fallback after legacy clients have aged out.
+    provider_secret_name = request.harness_config.sandbox_provider_secret_name or request.sandbox_provider_secret_name
+    if provider_secret_name:
+        effective_harness_config = effective_harness_config.model_copy(
+            update={"sandbox_provider_secret_name": provider_secret_name}
+        )
 
     service_headers = dict(request.service_headers)
     if request.service_auth_header_name and request.service_auth_secret_name:
@@ -643,8 +649,17 @@ async def stop_benchmark(
     await initiate_stop_benchmark(benchmark_row, session, force, org)
 
     if force:
+        # TODO: Drop the row fallback after legacy benchmark rows have aged out.
+        provider_secret_name = (
+            benchmark_row.arguments.sandbox_provider_secret_name or harness_config.sandbox_provider_secret_name
+        )
         await force_stop_sandboxes(
-            benchmark_row, session, harness_config.sandbox_provider_secret_name, harness_config.aws, org
+            benchmark_row,
+            session,
+            provider_secret_name,
+            harness_config.aws,
+            org,
+            sandbox_provider=benchmark_row.arguments.sandbox_provider,
         )
 
     return StopBenchmarkResponse(

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -270,6 +270,12 @@ class Benchmark(SQLModel, table=True):
     ) -> "StartBenchmarkRequest":
         from tracker.types import StartBenchmarkRequest
 
+        # TODO: Remove this fallback after legacy benchmark rows have been migrated for a few weeks.
+        if self.arguments.sandbox_provider_secret_name:
+            harness_config = harness_config.model_copy(
+                update={"sandbox_provider_secret_name": self.arguments.sandbox_provider_secret_name}
+            )
+
         return StartBenchmarkRequest(
             contract=self.arguments.contract,
             benchmark_name=self.name,
@@ -280,7 +286,6 @@ class Benchmark(SQLModel, table=True):
             dataset=self.arguments.dataset,
             harness_config=harness_config,
             sandbox_provider=self.arguments.sandbox_provider,
-            sandbox_provider_secret_name=self.arguments.sandbox_provider_secret_name,
             custom_benchmark_service=self.custom_benchmark_service,
             webhook_secret_name=self.webhook_secret_name,
             webhook_intervals=self.webhook_intervals,

--- a/services/tracker/tests/integration/test_force_stop.py
+++ b/services/tracker/tests/integration/test_force_stop.py
@@ -116,6 +116,7 @@ class TestForceStop:
                 daytona_secret_name,
                 aws_credentials,
                 Org(id=TEST_ORG_ID, name="default"),
+                sandbox_provider="daytona",
             )
 
         created_sandbox_name: list[str] = []
@@ -216,6 +217,7 @@ class TestForceStop:
                 daytona_secret_name,
                 aws_credentials,
                 Org(id=TEST_ORG_ID, name="default"),
+                sandbox_provider="daytona",
             )
         finally:
             release_sandboxes.set()

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -300,16 +300,18 @@ class TestBenchmarkUtils:
             concurrency=5,
             task_ids=["task_0", "task_1", "task_2", "task_3", "task_4"],
             slice_str=":10",
-            harness_config=harness_config,
-            sandbox_provider_secret_name="ignored-request-secret",
+            harness_config=harness_config.model_copy(update={"sandbox_provider_secret_name": "ModalSecrets"}),
+            sandbox_provider="modal",
         )
 
         benchmark_row = start_benchmark_request_to_benchmark(original_start_benchmark_request, self._test_starter)
-        assert benchmark_row.arguments.sandbox_provider_secret_name == harness_config.sandbox_provider_secret_name
+        assert benchmark_row.arguments.sandbox_provider_secret_name == "ModalSecrets"
 
         recreated_start_benchmark_request = benchmark_row.start_benchmark_request(harness_config)
         assert recreated_start_benchmark_request == original_start_benchmark_request.model_copy(
-            update={"sandbox_provider_secret_name": harness_config.sandbox_provider_secret_name}
+            update={
+                "harness_config": harness_config.model_copy(update={"sandbox_provider_secret_name": "ModalSecrets"}),
+            }
         )
 
         # Assert we have 5 tasks in the database

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -225,6 +225,64 @@ class TestFastapiServer:
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
         assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
 
+    async def test_start_benchmark_keeps_selected_provider_secret_with_harness_headers(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        harness_config: HarnessConfig,
+    ):
+        """Start requests should keep the provider secret chosen by the client.
+
+        Test cases:
+        - Harness headers provide AWS config without a provider secret.
+        - The selected provider secret from the request body is stored and queued.
+        """
+        captured_request_json: dict[str, Any] = {}
+        selected_harness_config = harness_config.model_copy(update={"sandbox_provider_secret_name": "ModalSecrets"})
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=10,
+            task_ids=None,
+            harness_config=selected_harness_config,
+            sandbox_provider="modal",
+        )
+
+        async def _mock_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        class _MockKicker:
+            def with_labels(self, **_kwargs: Any) -> "_MockKicker":
+                return self
+
+            async def kiq(self, **kwargs: Any) -> None:
+                captured_request_json.update(kwargs["start_benchmark_request_json"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+        monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+
+        response = client.post(
+            "/start-benchmark",
+            json=request.model_dump(),
+            headers={
+                "x-harness-aws-access-key-id": harness_config.aws.aws_access_key_id,
+                "x-harness-aws-secret-access-key": harness_config.aws.aws_secret_access_key,
+                "x-harness-aws-default-region": harness_config.aws.aws_default_region,
+                "x-harness-s3-bucket": harness_config.s3_bucket,
+                "x-harness-log-group": harness_config.log_group,
+                "x-harness-log-retention-policy": str(harness_config.log_retention_policy),
+            },
+        )
+
+        assert response.status_code == 200
+        benchmark_row = database_session.get(Benchmark, UUID(response.json()["benchmark_id"]))
+        assert benchmark_row
+        assert benchmark_row.arguments.sandbox_provider == "modal"
+        assert benchmark_row.arguments.sandbox_provider_secret_name == "ModalSecrets"
+        assert captured_request_json["sandbox_provider"] == "modal"
+        assert captured_request_json["harness_config"]["sandbox_provider_secret_name"] == "ModalSecrets"
+
     async def test_fetch_benchmark(self, database_session: Session, example_benchmark_object: Benchmark):
         """
         Test fetch benchmark of the fastapi server.

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -537,6 +537,9 @@ class TestStopAndResume:
     ):
         benchmark_row = example_benchmark_object
         benchmark_row.status = BenchmarkStatus.STOPPED
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(
+            update={"sandbox_provider": "modal", "sandbox_provider_secret_name": "ModalSecrets"}
+        )
         database_session.add(benchmark_row)
         database_session.commit()
 
@@ -568,9 +571,55 @@ class TestStopAndResume:
         assert response.status_code == 200
         assert observed_headers["X-Descope-Api-Key"] == "tracker-api-key"
         assert captured_request_json["concurrency"] == 20
+        assert captured_request_json["sandbox_provider"] == "modal"
+        assert captured_request_json["harness_config"]["sandbox_provider_secret_name"] == "ModalSecrets"
         assert captured_request_json["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
         database_session.refresh(benchmark_row)
         assert benchmark_row.arguments.concurrency == 20
+
+    async def test_force_stop_uses_stored_provider_secret(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ):
+        """Force stop should use the provider secret stored with the run.
+
+        Test cases:
+        - A modal run is force-stopped with its stored provider and secret.
+        - The current harness config secret is not used for the stored run.
+        """
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(
+            update={"sandbox_provider": "modal", "sandbox_provider_secret_name": "ModalSecrets"}
+        )
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        captured: dict[str, str | None] = {}
+
+        async def _mock_force_stop_sandboxes(
+            _benchmark_row: Benchmark,
+            _session: Session,
+            sandbox_provider_secret_name: str,
+            _aws: Any,
+            _org: Org,
+            *,
+            sandbox_provider: str,
+        ) -> None:
+            captured["sandbox_provider_secret_name"] = sandbox_provider_secret_name
+            captured["sandbox_provider"] = sandbox_provider
+
+        monkeypatch.setattr("main.force_stop_sandboxes", _mock_force_stop_sandboxes)
+
+        response = client.post(f"/stop-benchmark/{benchmark_row.id}?force=true")
+
+        assert response.status_code == 200
+        assert captured == {
+            "sandbox_provider_secret_name": "ModalSecrets",
+            "sandbox_provider": "modal",
+        }
 
     async def test_retry_or_resume_applies_secrets_to_stored_contract(
         self,
@@ -933,6 +982,7 @@ class TestStopAndResume:
             harness_config.sandbox_provider_secret_name,
             harness_config.aws,
             self._test_org,
+            sandbox_provider="daytona",
         )
 
         database_session.refresh(benchmark_row)


### PR DESCRIPTION
## Summary
Route tracker runtime provider and provider-secret selection through the tracker/CBS execution paths so benchmark rows, resume, and force-stop use the selected sandbox provider config.

## Changes
- Store the selected sandbox provider and provider secret on benchmark rows.
- Preserve provider secret selection when starting, resuming, and force-stopping runs.
- Add focused tracker coverage for provider-secret propagation.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Stack: bottom PR for tracker/CBS support. Top PR: #496 for CLI config and provider options.