### PR TITLE
#patch: Bump create-benchmark-service to v0.8.2

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]==2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service>=0.8.1",
+    "create-benchmark-service>=0.8.2",
     "aioboto3>=7.0.0",
 ]
 
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.8.1" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.8.2" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -367,8 +367,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.8.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.1#a3e5ca2b46c570fd0d0ab7eedffd21cb96dfdd17" }
+version = "0.8.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.2#2f1d6c3158f11c5c20246af44b08f7a65cd6bfb7" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -1924,7 +1924,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.2" },
     { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.8.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.1#a3e5ca2b46c570fd0d0ab7eedffd21cb96dfdd17" }
+version = "0.8.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.2#2f1d6c3158f11c5c20246af44b08f7a65cd6bfb7" }
 dependencies = [
     { name = "cachetools" },
     { name = "click" },
@@ -2671,7 +2671,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.8.2" },
     { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary
Updates Valkyrie’s tracker dependency pin for `create-benchmark-service` from `v0.8.1` to `v0.8.2`, and refreshes both the tracker and root uv lockfiles to the new git tag/commit.

## Changes
- Bumped `services/tracker/pyproject.toml` to require `create-benchmark-service>=0.8.2` and source the `v0.8.2` tag.
- Regenerated `services/tracker/uv.lock` and root `uv.lock` with `create-benchmark-service==0.8.2` at `2f1d6c3158f11c5c20246af44b08f7a65cd6bfb7`.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ ] Manually tested

Dependency-only update. Verified `uv --directory services/tracker sync --dev` and `uv --directory . sync --dev` resolve/install `create-benchmark-service==0.8.2`.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/ba676a7a491f4ad9973d9211fd373790
Requested by: @JarettForzano