### PR TITLE
Lazy load benchmark service health checks

### DIFF
--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -319,17 +319,17 @@ def service_list() -> None:
         with TrackerService(require_config=False) as tracker:
             services_by_name = {service.name: service for service in tracker.catalog_benchmark_services()}
             services_by_name.update({service.name: service for service in custom_entries})
-            services_list = (
-                tracker.check_benchmark_services(list(services_by_name.values())).services if services_by_name else []
+            services_list = list(services_by_name.values())
+            if not services_list:
+                click.echo(click.style("No benchmark services configured.", fg="yellow"))
+                return
+
+            paginate_services(
+                services_list,
+                check_services=lambda entries: tracker.check_benchmark_services(entries).services,
             )
     except TrackerServiceError as e:
         raise click.ClickException(str(e)) from e
-
-    if not services_list:
-        click.echo(click.style("No benchmark services configured.", fg="yellow"))
-        return
-
-    paginate_services(services_list)
 
 
 @config.group()

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -6,7 +6,7 @@ import shutil
 import tarfile
 import tempfile
 import urllib.request
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -20,6 +20,7 @@ from httpx import Response
 from tracker.database.models import BenchmarkStatus, DocentReadingStatus, TaskStatus
 from tracker.types import (
     BenchmarkDetails,
+    BenchmarkServiceEntry,
     BenchmarkServiceHealth,
     FetchBenchmarkResponse,
     FetchBenchmarksRequest,
@@ -911,7 +912,33 @@ def _service_source_domain(service: BenchmarkServiceHealth) -> str:
     return host.removeprefix(f"{service.name}.")
 
 
-def paginate_services(services: list[BenchmarkServiceHealth], limit: int = 10) -> None:
+def _unchecked_service(service: BenchmarkServiceEntry | BenchmarkServiceHealth) -> BenchmarkServiceHealth:
+    return BenchmarkServiceHealth(name=service.name, url=service.url, healthy=False, latency_ms=None)
+
+
+def _health_checked_page(
+    services: Sequence[BenchmarkServiceEntry | BenchmarkServiceHealth],
+    cache: dict[str, BenchmarkServiceHealth],
+    check_services: Callable[[list[BenchmarkServiceEntry]], list[BenchmarkServiceHealth]] | None,
+) -> list[BenchmarkServiceHealth]:
+    missing = [service for service in services if service.name not in cache]
+    if missing and check_services is not None:
+        entries = [BenchmarkServiceEntry(name=service.name, url=service.url) for service in missing]
+        cache.update({service.name: service for service in check_services(entries)})
+
+    for service in missing:
+        cache.setdefault(
+            service.name, service if isinstance(service, BenchmarkServiceHealth) else _unchecked_service(service)
+        )
+
+    return [cache[service.name] for service in services]
+
+
+def paginate_services(
+    services: Sequence[BenchmarkServiceEntry | BenchmarkServiceHealth],
+    limit: int = 10,
+    check_services: Callable[[list[BenchmarkServiceEntry]], list[BenchmarkServiceHealth]] | None = None,
+) -> None:
     """
     Interactive paginated display of services with vim-style navigation.
 
@@ -923,6 +950,7 @@ def paginate_services(services: list[BenchmarkServiceHealth], limit: int = 10) -
     offset = 0
     total_count = len(services)
     total_pages = max(1, (total_count + limit - 1) // limit)
+    health_cache: dict[str, BenchmarkServiceHealth] = {}
 
     while True:
         click.clear()
@@ -931,7 +959,7 @@ def paginate_services(services: list[BenchmarkServiceHealth], limit: int = 10) -
             click.echo(click.style("No benchmark services found.", fg="yellow"))
             break
 
-        page_services = services[offset : offset + limit]
+        page_services = _health_checked_page(services[offset : offset + limit], health_cache, check_services)
         rows = [
             {
                 "Benchmark": service.name,

--- a/src/valkyrie/cli/utils.py
+++ b/src/valkyrie/cli/utils.py
@@ -590,6 +590,10 @@ def format_no_benchmarks_found(
             click.echo(f"  • Started By: {', '.join(started_by)}")
 
 
+def _clear_pager() -> None:
+    click.echo("\033[2J\033[3J\033[1;1H", nl=False, color=True)
+
+
 def paginate_benchmarks(
     tracker: TrackerService,
     agent_name: str | None,
@@ -638,7 +642,7 @@ def paginate_benchmarks(
         total_count = response.total_count or 0
         total_pages = max(1, (total_count + limit - 1) // limit)
 
-        click.clear()
+        _clear_pager()
 
         if total_count == 0:
             format_no_benchmarks_found(agent_name, benchmark_name, model, dataset, label, status, started_by)
@@ -829,7 +833,7 @@ def paginate_agents(agents: list[tuple[str, datetime | None]], limit: int = 10) 
     total_pages = max(1, (total_count + limit - 1) // limit)
 
     while True:
-        click.clear()
+        _clear_pager()
 
         if total_count == 0:
             click.echo(click.style("No agents found.", fg="yellow"))
@@ -912,10 +916,6 @@ def _service_source_domain(service: BenchmarkServiceHealth) -> str:
     return host.removeprefix(f"{service.name}.")
 
 
-def _unchecked_service(service: BenchmarkServiceEntry | BenchmarkServiceHealth) -> BenchmarkServiceHealth:
-    return BenchmarkServiceHealth(name=service.name, url=service.url, healthy=False, latency_ms=None)
-
-
 def _health_checked_page(
     services: Sequence[BenchmarkServiceEntry | BenchmarkServiceHealth],
     cache: dict[str, BenchmarkServiceHealth],
@@ -927,9 +927,13 @@ def _health_checked_page(
         cache.update({service.name: service for service in check_services(entries)})
 
     for service in missing:
-        cache.setdefault(
-            service.name, service if isinstance(service, BenchmarkServiceHealth) else _unchecked_service(service)
-        )
+        if isinstance(service, BenchmarkServiceHealth):
+            cache.setdefault(service.name, service)
+        else:
+            cache.setdefault(
+                service.name,
+                BenchmarkServiceHealth(name=service.name, url=service.url, healthy=False, latency_ms=None),
+            )
 
     return [cache[service.name] for service in services]
 
@@ -946,20 +950,21 @@ def paginate_services(
         services: List of benchmark service health entries
         limit: Number of items per page
     """
-    current_page = 1
-    offset = 0
     total_count = len(services)
+    if total_count == 0:
+        _clear_pager()
+        click.echo(click.style("No benchmark services found.", fg="yellow"))
+        return
+
+    current_page = 1
     total_pages = max(1, (total_count + limit - 1) // limit)
     health_cache: dict[str, BenchmarkServiceHealth] = {}
 
     while True:
-        click.clear()
+        _clear_pager()
 
-        if total_count == 0:
-            click.echo(click.style("No benchmark services found.", fg="yellow"))
-            break
-
-        page_services = _health_checked_page(services[offset : offset + limit], health_cache, check_services)
+        page_start = (current_page - 1) * limit
+        page_services = _health_checked_page(services[page_start : page_start + limit], health_cache, check_services)
         rows = [
             {
                 "Benchmark": service.name,
@@ -985,9 +990,7 @@ def paginate_services(
 
         if char == "l" and current_page < total_pages:
             current_page += 1
-            offset += limit
         elif char == "h" and current_page > 1:
             current_page -= 1
-            offset -= limit
         elif char == "q" or char == "\x03":
             break

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -8,6 +8,7 @@ tracker-client behavior or CLI rendering that can regress without requiring live
 
 from datetime import datetime
 from functools import partial
+from collections.abc import Callable
 import json
 from pathlib import Path
 from uuid import UUID, uuid4
@@ -639,7 +640,7 @@ def test_service_list_merges_hosted_and_custom_services(
     def capture_paginated_services(
         services: list[BenchmarkServiceEntry],
         *,
-        check_services,
+        check_services: Callable[[list[BenchmarkServiceEntry]], list[BenchmarkServiceHealth]],
     ) -> None:
         captured_services.extend(check_services(services))
 

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -22,6 +22,7 @@ from conftest import FakeTrackerService
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, DocentReadingStatus, RetryMode, TaskStatus
 from tracker.types import (
     BenchmarkDetails,
+    BenchmarkServiceEntry,
     BenchmarkServiceHealth,
     BenchmarkTableRow,
     FetchBenchmarkResponse,
@@ -295,6 +296,49 @@ def test_paginate_services_renders_latency_as_response_status(monkeypatch: pytes
     assert captured_headers == ["Benchmark", "Service URL", "Source", "Latency"]
     assert [row["Source"] for row in captured_rows] == ["benchmarks.vals.ai", "localhost:9000"]
     assert [row["Latency"] for row in captured_rows] == ["23 ms", "-"]
+
+
+def test_paginate_services_health_checks_visible_pages_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Service pagination should defer health checks until a page is visible.
+
+    Test cases:
+    - The first page is health-checked before rendering.
+    - Moving forward checks only the next page, and moving back reuses cached results.
+    """
+    service_entries = [
+        BenchmarkServiceEntry(name="one", url="https://one.example"),
+        BenchmarkServiceEntry(name="two", url="https://two.example"),
+        BenchmarkServiceEntry(name="three", url="https://three.example"),
+    ]
+    checked_pages: list[list[str]] = []
+    rendered_pages: list[list[str]] = []
+    keys = iter(["l", "h", "q"])
+
+    def check_services(entries: list[BenchmarkServiceEntry]) -> list[BenchmarkServiceHealth]:
+        checked_pages.append([entry.name for entry in entries])
+        return [
+            FakeTrackerService.benchmark_service_health(entry.name, entry.url, latency_ms=len(checked_pages))
+            for entry in entries
+        ]
+
+    def fake_format_table(
+        rows: list[dict[str, str]],
+        _headers: list[str],
+        _current_page: int,
+        _total_pages: int,
+        _total_count: int,
+        _item_name: str,
+    ) -> None:
+        rendered_pages.append([row["Benchmark"] for row in rows])
+
+    monkeypatch.setattr(cli_main.click, "clear", lambda: None)
+    monkeypatch.setattr("valkyrie.cli.utils.click.getchar", lambda: next(keys))
+    monkeypatch.setattr("valkyrie.cli.utils.format_table", fake_format_table)
+
+    paginate_services(service_entries, limit=2, check_services=check_services)
+
+    assert checked_pages == [["one", "two"], ["three"]]
+    assert rendered_pages == [["one", "two"], ["three"], ["one", "two"]]
 
 
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -592,8 +636,12 @@ def test_service_list_merges_hosted_and_custom_services(
 
     captured_services: list[BenchmarkServiceHealth] = []
 
-    def capture_paginated_services(services: list[BenchmarkServiceHealth]) -> None:
-        captured_services.extend(services)
+    def capture_paginated_services(
+        services: list[BenchmarkServiceEntry],
+        *,
+        check_services,
+    ) -> None:
+        captured_services.extend(check_services(services))
 
     monkeypatch.setattr(cli_main, "TrackerService", FakeTrackerService)
     monkeypatch.setattr(cli_main, "paginate_services", capture_paginated_services)

--- a/tests/unit/test_tracker_service.py
+++ b/tests/unit/test_tracker_service.py
@@ -299,12 +299,16 @@ def test_paginate_services_renders_latency_as_response_status(monkeypatch: pytes
     assert [row["Latency"] for row in captured_rows] == ["23 ms", "-"]
 
 
-def test_paginate_services_health_checks_visible_pages_only(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_paginate_services_health_checks_visible_pages_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     """Service pagination should defer health checks until a page is visible.
 
     Test cases:
     - The first page is health-checked before rendering.
     - Moving forward checks only the next page, and moving back reuses cached results.
+    - Each page render clears the previous table output.
     """
     service_entries = [
         BenchmarkServiceEntry(name="one", url="https://one.example"),
@@ -332,7 +336,6 @@ def test_paginate_services_health_checks_visible_pages_only(monkeypatch: pytest.
     ) -> None:
         rendered_pages.append([row["Benchmark"] for row in rows])
 
-    monkeypatch.setattr(cli_main.click, "clear", lambda: None)
     monkeypatch.setattr("valkyrie.cli.utils.click.getchar", lambda: next(keys))
     monkeypatch.setattr("valkyrie.cli.utils.format_table", fake_format_table)
 
@@ -340,6 +343,7 @@ def test_paginate_services_health_checks_visible_pages_only(monkeypatch: pytest.
 
     assert checked_pages == [["one", "two"], ["three"]]
     assert rendered_pages == [["one", "two"], ["three"], ["one", "two"]]
+    assert capsys.readouterr().out.count("\033[2J\033[3J\033[1;1H") == 3
 
 
 def test_retry_or_resume_sends_retry_mode(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Lazy-loads benchmark service health checks so `valkyrie config service list` only pings services on the visible page.

## Changes
- Keep catalog discovery upfront through the tracker-backed service list flow
- Defer benchmark service health checks until a page is rendered
- Cache health-check results per service so paging backward does not re-ping the same services
- Add a focused test for page-scoped health checks

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Focused tracker and service-list tests, ruff, format check, and basedpyright passed locally.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
