### PR TITLE
Simplify CLI parsing helpers

### DIFF
--- a/src/valkyrie/cli/agent/lifecycle.py
+++ b/src/valkyrie/cli/agent/lifecycle.py
@@ -6,7 +6,7 @@ import click
 from tracker.exceptions import S3Error
 
 from valkyrie.cli.agent.storage import download_agent, install_agent, list_agents, push_agent, remove_agent
-from valkyrie.cli.display import format_table, local_time
+from valkyrie.cli.display import format_table, local_time, paginate_cli_pages
 
 
 @click.command(name="install", help="Installs agent from a github project to the users aws environment")
@@ -133,10 +133,6 @@ def list_installed_agents():
         raise click.ClickException(f"Unexpected error: {str(e)}")
 
 
-def _clear_pager() -> None:
-    click.echo("\033[2J\033[3J\033[1;1H", nl=False, color=True)
-
-
 def _format_agents_response(
     agents: list[tuple[str, datetime | None]],
     current_page: int,
@@ -153,31 +149,21 @@ def _format_agents_response(
 
 def paginate_agents(agents: list[tuple[str, datetime | None]], limit: int = 10) -> None:
     """Interactively page through installed agents."""
-    current_page = 1
-    offset = 0
-    total_count = len(agents)
-    total_pages = max(1, (total_count + limit - 1) // limit)
 
-    while True:
-        _clear_pager()
+    def load_page(offset: int, page_limit: int) -> tuple[int, list[tuple[str, datetime | None]]]:
+        return len(agents), agents[offset : offset + page_limit]
 
-        if total_count == 0:
-            click.echo(click.style("No agents found.", fg="yellow"))
-            break
-
-        page_agents = agents[offset : offset + limit]
+    def render_page(
+        page_agents: list[tuple[str, datetime | None]],
+        current_page: int,
+        total_pages: int,
+        total_count: int,
+    ) -> None:
         _format_agents_response(page_agents, current_page, total_pages, total_count)
 
-        if total_pages <= 1:
-            break
-
-        char = click.getchar()
-
-        if char == "l" and current_page < total_pages:
-            current_page += 1
-            offset += limit
-        elif char == "h" and current_page > 1:
-            current_page -= 1
-            offset -= limit
-        elif char == "q" or char == "\x03":
-            break
+    paginate_cli_pages(
+        load_page,
+        render_page,
+        limit=limit,
+        render_empty=lambda: click.echo(click.style("No agents found.", fg="yellow")),
+    )

--- a/src/valkyrie/cli/config/benchmark_services.py
+++ b/src/valkyrie/cli/config/benchmark_services.py
@@ -6,7 +6,7 @@ from tracker.types import BenchmarkServiceEntry, BenchmarkServiceHealth
 
 from valkyrie.cli.config.state import load_config, write_config
 from valkyrie.cli.exceptions import TrackerServiceError
-from valkyrie.cli.display import format_table
+from valkyrie.cli.display import format_table, paginate_cli_pages
 from valkyrie.cli.tracker_client import TrackerService
 
 
@@ -82,10 +82,6 @@ def service_list() -> None:
         raise click.ClickException(str(e)) from e
 
 
-def _clear_pager() -> None:
-    click.echo("\033[2J\033[3J\033[1;1H", nl=False, color=True)
-
-
 def _service_source_domain(service: BenchmarkServiceHealth) -> str:
     host = urlparse(service.url).netloc or service.url
     return host.removeprefix(f"{service.name}.")
@@ -119,21 +115,18 @@ def paginate_services(
     check_services: Callable[[list[BenchmarkServiceEntry]], list[BenchmarkServiceHealth]] | None = None,
 ) -> None:
     """Interactively page through benchmark service rows."""
-    total_count = len(services)
-    if total_count == 0:
-        _clear_pager()
-        click.echo(click.style("No benchmark services found.", fg="yellow"))
-        return
-
-    current_page = 1
-    total_pages = max(1, (total_count + limit - 1) // limit)
     health_cache: dict[str, BenchmarkServiceHealth] = {}
 
-    while True:
-        _clear_pager()
+    def load_page(offset: int, page_limit: int) -> tuple[int, list[BenchmarkServiceHealth]]:
+        page_services = _health_checked_page(services[offset : offset + page_limit], health_cache, check_services)
+        return len(services), page_services
 
-        page_start = (current_page - 1) * limit
-        page_services = _health_checked_page(services[page_start : page_start + limit], health_cache, check_services)
+    def render_page(
+        page_services: list[BenchmarkServiceHealth],
+        current_page: int,
+        total_pages: int,
+        total_count: int,
+    ) -> None:
         rows = [
             {
                 "Benchmark": service.name,
@@ -152,14 +145,9 @@ def paginate_services(
             "service",
         )
 
-        if total_pages <= 1:
-            break
-
-        char = click.getchar()
-
-        if char == "l" and current_page < total_pages:
-            current_page += 1
-        elif char == "h" and current_page > 1:
-            current_page -= 1
-        elif char == "q" or char == "\x03":
-            break
+    paginate_cli_pages(
+        load_page,
+        render_page,
+        limit=limit,
+        render_empty=lambda: click.echo(click.style("No benchmark services found.", fg="yellow")),
+    )

--- a/src/valkyrie/cli/display.py
+++ b/src/valkyrie/cli/display.py
@@ -91,7 +91,7 @@ def paginate_cli_pages(
         offset = (current_page - 1) * limit
         total_count, page = load_page(offset, limit)
         total_pages = max(1, (total_count + limit - 1) // limit)
-        if current_page > total_pages:
+        while current_page > total_pages:
             current_page = total_pages
             offset = (current_page - 1) * limit
             total_count, page = load_page(offset, limit)

--- a/src/valkyrie/cli/display.py
+++ b/src/valkyrie/cli/display.py
@@ -1,8 +1,12 @@
 """Shared CLI display helpers."""
 
+from collections.abc import Callable
 from datetime import datetime
+from typing import TypeVar
 
 import click
+
+Page = TypeVar("Page")
 
 
 def local_time(dt: datetime) -> str:
@@ -67,3 +71,48 @@ def format_table(
         click.echo(f"{total_text}{' ' * padding}{nav_text}")
     else:
         click.echo(total_text)
+
+
+def _clear_pager() -> None:
+    click.echo("\033[2J\033[3J\033[1;1H", nl=False, color=True)
+
+
+def paginate_cli_pages(
+    load_page: Callable[[int, int], tuple[int, Page]],
+    render_page: Callable[[Page, int, int, int], None],
+    *,
+    limit: int,
+    render_empty: Callable[[], None],
+) -> None:
+    """Page through CLI rows with h/l/q navigation."""
+    current_page = 1
+
+    while True:
+        offset = (current_page - 1) * limit
+        total_count, page = load_page(offset, limit)
+        total_pages = max(1, (total_count + limit - 1) // limit)
+        if current_page > total_pages:
+            current_page = total_pages
+            offset = (current_page - 1) * limit
+            total_count, page = load_page(offset, limit)
+            total_pages = max(1, (total_count + limit - 1) // limit)
+
+        _clear_pager()
+
+        if total_count == 0:
+            render_empty()
+            break
+
+        render_page(page, current_page, total_pages, total_count)
+
+        if total_pages <= 1:
+            break
+
+        char = click.getchar()
+
+        if char == "l" and current_page < total_pages:
+            current_page += 1
+        elif char == "h" and current_page > 1:
+            current_page -= 1
+        elif char == "q" or char == "\x03":
+            break

--- a/src/valkyrie/cli/run/list_runs.py
+++ b/src/valkyrie/cli/run/list_runs.py
@@ -3,7 +3,7 @@ from tracker.database.models import BenchmarkStatus
 from tracker.types import FetchBenchmarksRequest, FetchBenchmarksResponse, Order
 
 from valkyrie.cli.exceptions import TrackerServiceError
-from valkyrie.cli.display import format_table, short_local_time
+from valkyrie.cli.display import format_table, paginate_cli_pages, short_local_time
 from valkyrie.cli.run.progress import BenchmarkFormatter
 from valkyrie.cli.tracker_client import TrackerService
 
@@ -192,10 +192,6 @@ def format_no_benchmarks_found(
             click.echo(f"  • Started By: {', '.join(started_by)}")
 
 
-def _clear_pager() -> None:
-    click.echo("\033[2J\033[3J\033[1;1H", nl=False, color=True)
-
-
 def paginate_benchmarks(
     tracker: TrackerService,
     agent_name: str | None,
@@ -209,10 +205,8 @@ def paginate_benchmarks(
     started_by: list[str] | None = None,
 ) -> None:
     """Interactively page through runs."""
-    current_page = 1
-    offset = 0
 
-    while True:
+    def load_page(offset: int, page_limit: int) -> tuple[int, FetchBenchmarksResponse]:
         request = FetchBenchmarksRequest(
             agent_name=[agent_name] if agent_name else None,
             benchmark_name=[benchmark_name] if benchmark_name else None,
@@ -222,32 +216,25 @@ def paginate_benchmarks(
             status=[BenchmarkStatus(status)] if status else None,
             started_by=started_by,
             order_by=Order(order_by),
-            limit=limit,
+            limit=page_limit,
             offset=offset,
         )
-
         response = tracker.fetch_benchmarks(request)
-        total_count = response.total_count or 0
-        total_pages = max(1, (total_count + limit - 1) // limit)
+        return response.total_count or 0, response
 
-        _clear_pager()
-
-        if total_count == 0:
-            format_no_benchmarks_found(agent_name, benchmark_name, model, dataset, label, status, started_by)
-            break
-
+    def render_page(
+        response: FetchBenchmarksResponse,
+        current_page: int,
+        total_pages: int,
+        _total_count: int,
+    ) -> None:
         format_fetch_benchmarks_response(response, current_page, total_pages)
 
-        if total_pages <= 1:
-            break
-
-        char = click.getchar()
-
-        if char == "l" and current_page < total_pages:
-            current_page += 1
-            offset += limit
-        elif char == "h" and current_page > 1:
-            current_page -= 1
-            offset -= limit
-        elif char == "q" or char == "\x03":
-            break
+    paginate_cli_pages(
+        load_page,
+        render_page,
+        limit=limit,
+        render_empty=lambda: format_no_benchmarks_found(
+            agent_name, benchmark_name, model, dataset, label, status, started_by
+        ),
+    )

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -66,6 +66,14 @@ def _response_error_detail(response: Response) -> Any:
     return response.text
 
 
+def _parse_response(response: Response, action: str) -> Any:
+    """Parse a tracker JSON response, raising when the request failed."""
+    if response.status_code != 200:
+        details = _response_error_detail(response)
+        raise TrackerServiceError(f"{action}: {details}")
+    return response.json()
+
+
 def _resolve_sandbox_provider_config(
     config: dict[str, Any], config_values: dict[str, str], provider: str | None = None
 ) -> tuple[str, str]:
@@ -316,11 +324,8 @@ class TrackerService:
         try:
             response = self._client.get(f"{self._base_url}/benchmark-services")
 
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to list benchmark services: {details}")
-
-            return [BenchmarkServiceEntry.model_validate(service) for service in response.json().get("services", [])]
+            response_data = _parse_response(response, "Failed to list benchmark services")
+            return [BenchmarkServiceEntry.model_validate(service) for service in response_data.get("services", [])]
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to list benchmark services: {e}") from e
 
@@ -337,11 +342,9 @@ class TrackerService:
             payload = BenchmarkServicesRequest(services=services)
             response = self._client.post(f"{self._base_url}/benchmark-services", json=payload.model_dump())
 
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to check benchmark services: {details}")
-
-            return BenchmarkServicesResponse.model_validate(response.json())
+            return BenchmarkServicesResponse.model_validate(
+                _parse_response(response, "Failed to check benchmark services")
+            )
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to check benchmark services: {e}") from e
 
@@ -352,11 +355,7 @@ class TrackerService:
             with httpx.Client(timeout=120, headers={"X-Api-Key": api_key}) as client:
                 response = client.post(f"{base_url.rstrip('/')}/init")
 
-                if response.status_code != 200:
-                    details = _response_error_detail(response)
-                    raise TrackerServiceError(f"Failed to initialize org: {details}")
-
-                return response.json()
+                return _parse_response(response, "Failed to initialize org")
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to initialize org: {e}") from e
 
@@ -438,11 +437,7 @@ class TrackerService:
         try:
             response = self._client.get(f"{self._base_url}/fetch-benchmark", params={"benchmark_id": str(benchmark_id)})
 
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to fetch run: {details}")
-
-            return FetchBenchmarkResponse.model_validate(response.json())
+            return FetchBenchmarkResponse.model_validate(_parse_response(response, "Failed to fetch run"))
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch run: {e}") from e
 
@@ -542,11 +537,7 @@ class TrackerService:
 
             response = self._client.get(f"{self._base_url}/retrieve-results", params=params)
 
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to retrieve results: {details}")
-
-            response_data = response.json()
+            response_data = _parse_response(response, "Failed to retrieve results")
             if not s3:
                 return FinalViewResponse.model_validate(response_data)
 
@@ -576,11 +567,7 @@ class TrackerService:
             )
             response = self._client.post(f"{self._base_url}/fetch-benchmark-tasks", json=payload.model_dump())
 
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to fetch task ids: {details}")
-
-            return VerifyTaskIdsResponse.model_validate(response.json()).task_ids
+            return VerifyTaskIdsResponse.model_validate(_parse_response(response, "Failed to fetch task ids")).task_ids
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch task ids: {e}") from e
 
@@ -602,11 +589,7 @@ class TrackerService:
                 f"{self._base_url}/check-results-exist", params={"benchmark_id": str(benchmark_id)}
             )
 
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to check S3 results: {details}")
-
-            return response.json()["exists"]
+            return _parse_response(response, "Failed to check S3 results")["exists"]
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to check S3 results: {e}") from e
 
@@ -622,11 +605,8 @@ class TrackerService:
         """
         try:
             response = self._client.post(f"{self._base_url}/stop-benchmark/{benchmark_id}", params={"force": force})
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to stop run: {details}")
 
-            return StopBenchmarkResponse.model_validate(response.json())
+            return StopBenchmarkResponse.model_validate(_parse_response(response, "Failed to stop run"))
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stop run: {e}") from e
 
@@ -671,11 +651,8 @@ class TrackerService:
                 params=params,
                 json=body,
             )
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to start run: {details}")
 
-            return RetryOrResumeBenchmarkResponse.model_validate(response.json())
+            return RetryOrResumeBenchmarkResponse.model_validate(_parse_response(response, "Failed to start run"))
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to start run: {e}") from e
 
@@ -693,11 +670,8 @@ class TrackerService:
             response = self._client.get(
                 f"{self._base_url}/fetch-benchmarks", params=request.model_dump(exclude_none=True, mode="json")
             )
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to fetch runs: {details}")
 
-            return FetchBenchmarksResponse.model_validate(response.json())
+            return FetchBenchmarksResponse.model_validate(_parse_response(response, "Failed to fetch runs"))
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch runs: {e}") from e
 
@@ -737,10 +711,9 @@ class TrackerService:
         """
         try:
             response = self._client.get(f"{self._base_url}/fetch-benchmark-metadata/{benchmark_id}")
-            if response.status_code != 200:
-                details = _response_error_detail(response)
-                raise TrackerServiceError(f"Failed to fetch run metadata: {details}")
 
-            return FetchBenchmarkMetadataResponse.model_validate(response.json())
+            return FetchBenchmarkMetadataResponse.model_validate(
+                _parse_response(response, "Failed to fetch run metadata")
+            )
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch run metadata: {e}") from e

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -116,20 +116,27 @@ def test_paginate_cli_pages_clears_between_pages_and_handles_filtered_totals(
     """
     load_offsets: list[int] = []
     rendered_pages: list[tuple[list[str], int, int, int]] = []
+    page_responses = [
+        (8, ["one", "two"]),
+        (8, ["three", "four"]),
+        (8, ["five", "six"]),
+        (4, []),
+        (1, []),
+        (1, ["filtered"]),
+    ]
+    keys = iter(["l", "l", "l"])
 
     def load_page(offset: int, _limit: int) -> tuple[int, list[str]]:
+        response = page_responses[len(load_offsets)]
         load_offsets.append(offset)
-        if load_offsets == [0]:
-            return 4, ["one", "two"]
-        if offset == 2:
-            return 1, []
-        return 1, ["filtered"]
+
+        return response
 
     def render_page(page: list[str], current_page: int, total_pages: int, total_count: int) -> None:
         rendered_pages.append((page, current_page, total_pages, total_count))
         print(f"page={current_page}/{total_pages}:{','.join(page)}")
 
-    monkeypatch.setattr("valkyrie.cli.display.click.getchar", lambda: "l")
+    monkeypatch.setattr("valkyrie.cli.display.click.getchar", lambda: next(keys))
 
     paginate_cli_pages(
         load_page,
@@ -139,7 +146,13 @@ def test_paginate_cli_pages_clears_between_pages_and_handles_filtered_totals(
     )
 
     output = capsys.readouterr().out
-    assert load_offsets == [0, 2, 0]
-    assert rendered_pages == [(["one", "two"], 1, 2, 4), (["filtered"], 1, 1, 1)]
-    assert output.count("\033[2J\033[3J\033[1;1H") == 2
+    assert load_offsets == [0, 2, 4, 6, 2, 0]
+    assert rendered_pages == [
+        (["one", "two"], 1, 4, 8),
+        (["three", "four"], 2, 4, 8),
+        (["five", "six"], 3, 4, 8),
+        (["filtered"], 1, 1, 1),
+    ]
+    assert output.count("\033[2J\033[3J\033[1;1H") == 4
+    assert "page=2/1" not in output
     assert "empty" not in output

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -9,6 +9,7 @@ import pytest
 from tracker.database.models import BenchmarkStatus, DocentReadingStatus, TaskStatus
 from tracker.types import BenchmarkDetails, FetchBenchmarkResponse, StartBenchmarkResponse
 
+from valkyrie.cli.display import paginate_cli_pages
 from valkyrie.cli.run.outputs import download_run_outputs
 from valkyrie.cli.run.start import format_start_benchmark_response
 from valkyrie.cli.run.progress import _stream_next_steps, format_benchmark_status
@@ -101,3 +102,44 @@ def test_download_run_outputs_extracts_archive_and_nested_tars(tmp_path: Path) -
     assert (tmp_path / "task" / "output.txt").read_bytes() == b"run output"
     assert (tmp_path / "task" / "artifacts" / "nested.txt").read_bytes() == b"nested contents"
     assert not (tmp_path / "task" / "artifacts.tar.gz").exists()
+
+
+def test_paginate_cli_pages_clears_between_pages_and_handles_filtered_totals(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Shared table pagination should clear each render and recover when totals shrink.
+
+    Test cases:
+    - Moving forward clears the previous table before rendering the next page.
+    - If a filtered/refetched total invalidates the current page, pagination reloads a valid page.
+    """
+    load_offsets: list[int] = []
+    rendered_pages: list[tuple[list[str], int, int, int]] = []
+
+    def load_page(offset: int, _limit: int) -> tuple[int, list[str]]:
+        load_offsets.append(offset)
+        if load_offsets == [0]:
+            return 4, ["one", "two"]
+        if offset == 2:
+            return 1, []
+        return 1, ["filtered"]
+
+    def render_page(page: list[str], current_page: int, total_pages: int, total_count: int) -> None:
+        rendered_pages.append((page, current_page, total_pages, total_count))
+        print(f"page={current_page}/{total_pages}:{','.join(page)}")
+
+    monkeypatch.setattr("valkyrie.cli.display.click.getchar", lambda: "l")
+
+    paginate_cli_pages(
+        load_page,
+        render_page,
+        limit=2,
+        render_empty=lambda: print("empty"),
+    )
+
+    output = capsys.readouterr().out
+    assert load_offsets == [0, 2, 0]
+    assert rendered_pages == [(["one", "two"], 1, 2, 4), (["filtered"], 1, 1, 1)]
+    assert output.count("\033[2J\033[3J\033[1;1H") == 2
+    assert "empty" not in output

--- a/tests/unit/test_tracker_client.py
+++ b/tests/unit/test_tracker_client.py
@@ -176,22 +176,39 @@ def test_tracker_client_checks_health_on_context_entry(monkeypatch: pytest.Monke
             pass
 
 
-def test_parse_response_returns_json_and_raises_tracker_errors() -> None:
+@pytest.mark.parametrize(
+    ("response", "expected_payload", "error_match"),
+    [
+        pytest.param(httpx.Response(200, json={"ok": True}), {"ok": True}, None, id="success-json"),
+        pytest.param(
+            httpx.Response(404, json={"detail": "missing run"}),
+            None,
+            "Failed request: missing run",
+            id="failed-json-detail",
+        ),
+        pytest.param(
+            httpx.Response(500, text="plain failure"), None, "Failed request: plain failure", id="failed-text"
+        ),
+    ],
+)
+def test_parse_response_returns_json_and_raises_tracker_errors(
+    response: httpx.Response,
+    expected_payload: dict[str, bool] | None,
+    error_match: str | None,
+) -> None:
     """Tracker response parsing should normalize success and failure bodies.
 
     Test cases:
     - Successful JSON responses are returned unchanged.
     - Failed JSON and text responses raise the tracker error with useful detail.
     """
-    assert tracker_client_module._parse_response(httpx.Response(200, json={"ok": True}), "Failed request") == {
-        "ok": True
-    }
+    if error_match is not None:
+        with pytest.raises(TrackerServiceError, match=error_match):
+            tracker_client_module._parse_response(response, "Failed request")
 
-    with pytest.raises(TrackerServiceError, match="Failed request: missing run"):
-        tracker_client_module._parse_response(httpx.Response(404, json={"detail": "missing run"}), "Failed request")
+        return
 
-    with pytest.raises(TrackerServiceError, match="Failed request: plain failure"):
-        tracker_client_module._parse_response(httpx.Response(500, text="plain failure"), "Failed request")
+    assert tracker_client_module._parse_response(response, "Failed request") == expected_payload
 
 
 def test_fetch_run_outputs_raises_tracker_error_for_non_ok_response(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_tracker_client.py
+++ b/tests/unit/test_tracker_client.py
@@ -176,6 +176,24 @@ def test_tracker_client_checks_health_on_context_entry(monkeypatch: pytest.Monke
             pass
 
 
+def test_parse_response_returns_json_and_raises_tracker_errors() -> None:
+    """Tracker response parsing should normalize success and failure bodies.
+
+    Test cases:
+    - Successful JSON responses are returned unchanged.
+    - Failed JSON and text responses raise the tracker error with useful detail.
+    """
+    assert tracker_client_module._parse_response(httpx.Response(200, json={"ok": True}), "Failed request") == {
+        "ok": True
+    }
+
+    with pytest.raises(TrackerServiceError, match="Failed request: missing run"):
+        tracker_client_module._parse_response(httpx.Response(404, json={"detail": "missing run"}), "Failed request")
+
+    with pytest.raises(TrackerServiceError, match="Failed request: plain failure"):
+        tracker_client_module._parse_response(httpx.Response(500, text="plain failure"), "Failed request")
+
+
 def test_fetch_run_outputs_raises_tracker_error_for_non_ok_response(monkeypatch: pytest.MonkeyPatch) -> None:
     class ErrorClient(FakeClient):
         def get(


### PR DESCRIPTION
## Summary
Simplifies repeated CLI pagination and tracker JSON response parsing without changing command behavior.

## Changes
- Add one shared CLI pager for paginated table flows.
- Route agent list, run list, and benchmark service list through the shared pager.
- Add a private tracker response parser for normal JSON responses.
- Add focused unit coverage for response parsing and pager terminal clearing/refetch behavior.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Focused pytest, Ruff, basedpyright, and CLI help smoke checks passed.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Docs were not needed for this internal CLI refactor.