### PR TITLE
Guard task generations across stop and retry

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -77,6 +77,7 @@ jobs:
           AUTH_REQUIRED: ${{ secrets.AUTH_REQUIRED }}
           BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
+          TOKENIZED_RETRY_BATCHES_ENABLED: ${{ vars.TOKENIZED_RETRY_BATCHES_ENABLED }}
         run: |
           cd infra
           uv run cdk deploy --all -c stage=${{ steps.deploy-stage.outputs.stage }} --require-approval never
@@ -87,6 +88,7 @@ jobs:
           AUTH_REQUIRED: ${{ secrets.AUTH_REQUIRED }}
           BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
+          TOKENIZED_RETRY_BATCHES_ENABLED: ${{ vars.TOKENIZED_RETRY_BATCHES_ENABLED }}
         run: |
           cd infra
           uv run cdk deploy --all -c stage=${{ steps.deploy-stage.outputs.stage }} --require-approval never

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -317,18 +317,27 @@ class MonitoringStackTest(unittest.TestCase):
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, {}, clear=True):
                 tracker_template, worker_template = _service_templates(stage_name)
 
-                expected_env = assertions.Match.array_with(
-                    [
-                        {"Name": "BROKER_ENVIRONMENT", "Value": expected_environment},
-                        {"Name": "ENVIRONMENT", "Value": expected_environment},
-                        {"Name": "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE", "Value": expected_namespace},
-                    ]
-                )
+                expected_items = [
+                    {"Name": "BROKER_ENVIRONMENT", "Value": expected_environment},
+                    {"Name": "ENVIRONMENT", "Value": expected_environment},
+                    {"Name": "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE", "Value": expected_namespace},
+                ]
                 tracker_template.has_resource_properties(
                     "AWS::ECS::TaskDefinition",
                     {
                         "ContainerDefinitions": assertions.Match.array_with(
-                            [assertions.Match.object_like({"Environment": expected_env})]
+                            [
+                                assertions.Match.object_like(
+                                    {
+                                        "Environment": assertions.Match.array_with(
+                                            [
+                                                *expected_items,
+                                                {"Name": "TOKENIZED_RETRY_BATCHES_ENABLED", "Value": "false"},
+                                            ]
+                                        )
+                                    }
+                                )
+                            ]
                         )
                     },
                 )
@@ -336,10 +345,31 @@ class MonitoringStackTest(unittest.TestCase):
                     "AWS::ECS::TaskDefinition",
                     {
                         "ContainerDefinitions": assertions.Match.array_with(
-                            [assertions.Match.object_like({"Environment": expected_env})]
+                            [assertions.Match.object_like({"Environment": assertions.Match.array_with(expected_items)})]
                         )
                     },
                 )
+
+    def test_tracker_can_enable_tokenized_retry_batches(self) -> None:
+        with mock.patch.dict(os.environ, {"TOKENIZED_RETRY_BATCHES_ENABLED": "true"}, clear=True):
+            tracker_template, _ = _service_templates(PROD)
+
+        tracker_template.has_resource_properties(
+            "AWS::ECS::TaskDefinition",
+            {
+                "ContainerDefinitions": assertions.Match.array_with(
+                    [
+                        assertions.Match.object_like(
+                            {
+                                "Environment": assertions.Match.array_with(
+                                    [{"Name": "TOKENIZED_RETRY_BATCHES_ENABLED", "Value": "true"}]
+                                )
+                            }
+                        )
+                    ]
+                )
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -182,6 +182,9 @@ class TrackerStack(Stack):
                 "BENCHMARK_CATALOG_URL": os.environ.get("BENCHMARK_CATALOG_URL", ""),
                 "DESCOPE_PROJECT_ID": os.environ.get("DESCOPE_PROJECT_ID", ""),
                 "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
+                "TOKENIZED_RETRY_BATCHES_ENABLED": (
+                    "true" if os.environ.get("TOKENIZED_RETRY_BATCHES_ENABLED", "false").lower() == "true" else "false"
+                ),
             },
             secrets={
                 **db_secrets,

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -54,6 +54,7 @@ from tracker.agent.schemas import AgentConfig
 from tracker.config import (
     AUTH_REQUIRED,
     ENVIRONMENT,
+    TOKENIZED_RETRY_BATCHES_ENABLED,
     create_benchmark_service_url,
 )
 from tracker.database.models import (
@@ -98,6 +99,7 @@ from tracker.utils import (
     commit_benchmark_error,
     create_benchmark_service_client,
     create_final_view,
+    create_task_rows,
     fetch_filtered_benchmark_rows,
     fetch_final_score_inputs,
     fetch_harness_config,
@@ -110,6 +112,7 @@ from tracker.utils import (
     stream_benchmark_results,
     upload_final_view,
 )
+from tracker.utils.run_orchestration import TaskBatch
 
 configure_logging()
 configure_observability("valkyrie-tracker", environment=ENVIRONMENT)
@@ -330,6 +333,7 @@ async def start_benchmark(
             run_starter.access_key_id,
         )
 
+    task_batch: list[str] | TaskBatch = verify_response.task_ids
     try:
         await copy_agent_to_benchmark(
             str(benchmark_row.id),
@@ -337,6 +341,12 @@ async def start_benchmark(
             request.harness_config.aws,
             request.harness_config.s3_bucket,
         )
+        if TOKENIZED_RETRY_BATCHES_ENABLED and verify_response.task_ids:
+            task_rows = create_task_rows(verify_response.task_ids, benchmark_row, session, run_starter.org)
+            task_batch = {
+                "kind": "start",
+                "attempts": {task_id: task.started_at.isoformat() for task_id, task in task_rows},
+            }
     except Exception as e:
         error_message = f"{str(e)}\n{traceback.format_exc()}"
         commit_benchmark_error(benchmark_row, session, error_message)
@@ -353,7 +363,7 @@ async def start_benchmark(
         .kiq(
             start_benchmark_request_json=request.model_dump(),
             benchmark_id_str=str(benchmark_row.id),
-            verified_task_ids=verify_response.task_ids,
+            verified_task_ids=task_batch,
         )
     )
 
@@ -726,7 +736,7 @@ async def retry_or_resume_benchmark(
         http_request.headers.get("x-api-key"),
     )
 
-    verified_task_ids = await reset_to_in_progress_status(
+    task_attempts = await reset_to_in_progress_status(
         benchmark_row=benchmark_row,
         session=session,
         benchmark_service=benchmark_row.benchmark_service(service_headers=effective_service_headers),
@@ -736,7 +746,7 @@ async def retry_or_resume_benchmark(
         org=org,
     )
 
-    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not verified_task_ids:
+    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not task_attempts:
         return RetryOrResumeBenchmarkResponse(
             status="success",
         )
@@ -757,6 +767,12 @@ async def retry_or_resume_benchmark(
     resume_request_json = benchmark_row.start_benchmark_request(
         harness_config, service_headers=effective_service_headers
     ).model_dump()
+    task_batch: list[str] | TaskBatch = list(task_attempts)
+    if TOKENIZED_RETRY_BATCHES_ENABLED and task_attempts:
+        task_batch = {
+            "kind": "retry",
+            "attempts": {task_id: started_at.isoformat() for task_id, started_at in task_attempts.items()},
+        }
 
     # start the benchmark with the same args used to create it
     # we will delegate inside what tasks we are running
@@ -766,7 +782,7 @@ async def retry_or_resume_benchmark(
         .kiq(
             start_benchmark_request_json=resume_request_json,
             benchmark_id_str=str(benchmark_row.id),
-            verified_task_ids=verified_task_ids,
+            verified_task_ids=task_batch,
         )
     )
 

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -39,6 +39,7 @@ AWS_S3_BUCKET = os.environ.get("AWS_S3_BUCKET", "agentic-harness")
 BROKER_ENVIRONMENT = os.environ.get("BROKER_ENVIRONMENT", "production")
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "development")
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
+TOKENIZED_RETRY_BATCHES_ENABLED = os.environ.get("TOKENIZED_RETRY_BATCHES_ENABLED", "false").lower() == "true"
 
 
 def _build_database_url() -> str:

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -154,7 +154,7 @@ async def reset_to_in_progress_status(
     retry_mode: RetryMode,
     rerun_task_ids: list[str],
     org: Org,
-) -> list[str]:
+) -> dict[str, datetime]:
     """
     Resets valid tasks to in progress and to allow for retrying or resuming the benchmark.
 
@@ -168,10 +168,19 @@ async def reset_to_in_progress_status(
     NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
     """
     try:
+        benchmark_row = session.exec(
+            select(Benchmark)
+            .where(Benchmark.id == benchmark_row.id)
+            .where(Benchmark.org_id == org.id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        ).one()
         existing_rows = session.exec(
             select(Task)
             .where(*_retry_task_filters(benchmark_row, retry, rerun_task_ids, org))
             .order_by(asc(Task.started_at))
+            .with_for_update()
+            .execution_options(populate_existing=True)
         ).all()
         existing_by_task_id: dict[str, Task] = {task.task_id: task for task in existing_rows}
 
@@ -187,7 +196,7 @@ async def reset_to_in_progress_status(
 
         # Allow re-running the end of the benchmark without running any tasks
         if not existing_rows and not new_task_ids:
-            return []
+            return {}
 
         # Verify the task ids are still valid before priming to resume
         # Raises if any task ids are invalid
@@ -200,7 +209,6 @@ async def reset_to_in_progress_status(
         if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
             benchmark_row.status = BenchmarkStatus.IN_PROGRESS
             session.add(benchmark_row)
-            session.commit()
 
         for task in existing_rows:
             task.status = (
@@ -214,12 +222,15 @@ async def reset_to_in_progress_status(
                 task.eval_resume_state = None
             session.add(task)
 
+        task_attempts = {task.task_id: task.started_at for task in existing_rows}
         for task_id in new_task_ids:
-            session.add(Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING))
+            task = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING)
+            session.add(task)
+            task_attempts[task_id] = task.started_at
 
         session.commit()
 
-        return verify_response.task_ids
+        return {task_id: task_attempts[task_id] for task_id in verify_response.task_ids}
     except (TrackerServiceError, BenchmarkServiceError):
         raise
     except Exception as e:

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -3,7 +3,8 @@
 import asyncio
 import traceback
 from asyncio import Semaphore, gather
-from typing import Any, Sequence, cast
+from datetime import datetime
+from typing import Any, Literal, Sequence, TypedDict, cast
 from uuid import UUID
 
 import logfire
@@ -45,12 +46,18 @@ from tracker.utils.resources import (
     fetch_sandbox_provider_config,
 )
 from tracker.utils.reporting import create_final_view, upload_final_view
-from tracker.utils.task_execution import TaskMonitor, TrackedTask, process_task
+from tracker.utils.task_execution import TaskMonitor, TrackedTask, is_expected_attempt, process_task
 
 logger = get_logger(__name__)
 
 _SANDBOX_CREATION_CAP: int = 10
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
+_TERMINAL_BENCHMARK_STATUSES = [BenchmarkStatus.FINISHED, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPED]
+
+
+class TaskBatch(TypedDict):
+    kind: Literal["start", "retry"]
+    attempts: dict[str, str]
 
 
 def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: Org) -> None:
@@ -191,6 +198,33 @@ def fetch_final_score_inputs(session: Session, benchmark_row: Benchmark, org: Or
     }
 
 
+def _fetch_benchmark_for_update(benchmark_id: UUID, session: Session, org: Org) -> Benchmark:
+    return session.exec(
+        select(Benchmark)
+        .where(Benchmark.id == benchmark_id)
+        .where(Benchmark.org_id == org.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).one()
+
+
+def _fetch_tasks_for_update(benchmark_id: UUID, session: Session, org: Org) -> Sequence[Task]:
+    return session.exec(
+        select(Task)
+        .where(Task.benchmark == benchmark_id)
+        .where(Task.org_id == org.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).all()
+
+
+def _generation_changed(task_rows: Sequence[Task], run_attempts: dict[str, datetime]) -> bool:
+    tasks_by_id = {task.task_id: task for task in task_rows}
+    return set(tasks_by_id) != set(run_attempts) or any(
+        not is_expected_attempt(tasks_by_id[task_id], started_at) for task_id, started_at in run_attempts.items()
+    )
+
+
 # Pin the Taskiq task name to its pre-refactor value so in-flight messages
 # enqueued as `tracker.utils:process_benchmark` still match after the module move.
 @broker.task("tracker.utils:process_benchmark")
@@ -198,7 +232,7 @@ def fetch_final_score_inputs(session: Session, benchmark_row: Benchmark, org: Or
 async def process_benchmark(
     start_benchmark_request_json: dict[str, Any],
     benchmark_id_str: str,
-    verified_task_ids: list[str],
+    verified_task_ids: list[str] | TaskBatch,
 ) -> None:
     # Was serialized to make it compatible with the broker
     start_benchmark_request: StartBenchmarkRequest = StartBenchmarkRequest(**start_benchmark_request_json)
@@ -218,7 +252,9 @@ async def process_benchmark(
             "benchmark_id": benchmark_id_str,
             "benchmark_name": start_benchmark_request.benchmark_name,
             "agent_name": start_benchmark_request.contract.name,
-            "task_count": len(verified_task_ids),
+            "task_count": len(
+                verified_task_ids if isinstance(verified_task_ids, list) else verified_task_ids["attempts"]
+            ),
         }
     )
 
@@ -239,7 +275,59 @@ async def process_benchmark(
         org = session.exec(select(Org).where(Org.id == benchmark_row.org_id)).one()
 
     finalization_deferred = False
+    execution_attempts: dict[str, datetime] = {}
+    run_attempts: dict[str, datetime] = {}
+
     try:
+        if isinstance(verified_task_ids, list):
+            execution_task_ids = verified_task_ids
+            with Session(bind=engine) as session:
+                benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+                task_rows: Sequence[tuple[str, Task]] = create_task_rows(
+                    execution_task_ids, benchmark_row, session, org
+                )
+                run_tasks = session.exec(
+                    select(Task).where(Task.benchmark == benchmark_id).where(Task.org_id == org.id)
+                ).all()
+                run_attempts = {task.task_id: task.started_at for task in run_tasks}
+                execution_attempts = {
+                    task_id: run_attempts[task_id] for task_id in execution_task_ids if task_id in run_attempts
+                }
+
+            missing_task_ids = [task_id for task_id in execution_task_ids if task_id not in execution_attempts]
+            if missing_task_ids:
+                raise TrackerServiceError(
+                    f"Race condition occured when resuming run {benchmark_id}. Missing task ids: {', '.join(missing_task_ids)}"
+                )
+        else:
+            batch_kind = cast(str, verified_task_ids["kind"])
+            match batch_kind:
+                case "start" | "retry":
+                    execution_attempts = {
+                        task_id: datetime.fromisoformat(started_at)
+                        for task_id, started_at in verified_task_ids["attempts"].items()
+                    }
+                case unknown_kind:
+                    raise TrackerServiceError(f"Unknown task batch kind: {unknown_kind}")
+
+            execution_task_ids = list(execution_attempts)
+            with Session(bind=engine) as session:
+                _fetch_benchmark_for_update(benchmark_id, session, org)
+                run_tasks = _fetch_tasks_for_update(benchmark_id, session, org)
+                run_attempts = {task.task_id: task.started_at for task in run_tasks}
+                tasks_by_id = {task.task_id: task for task in run_tasks}
+                if any(
+                    task_id not in tasks_by_id or not is_expected_attempt(tasks_by_id[task_id], expected_started_at)
+                    for task_id, expected_started_at in execution_attempts.items()
+                ):
+                    finalization_deferred = True
+                    return
+                task_rows = [
+                    (task_id, tasks_by_id[task_id])
+                    for task_id in execution_task_ids
+                    if tasks_by_id[task_id].status in [TaskStatus.PENDING, TaskStatus.EVALUATING]
+                ]
+
         # Copy the agent into the benchmarks S3 folder
         await copy_agent_to_benchmark(
             str(benchmark_id),
@@ -252,18 +340,6 @@ async def process_benchmark(
         create_benchmark_log_group(
             str(benchmark_id), harness_config.aws, harness_config.log_group, harness_config.log_retention_policy
         )
-
-        # Create tasks inside of the database for each task id
-        with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session, org)
-
-        task_row_ids: set[str] = {task_id for task_id, _ in task_rows}
-        missing_task_ids: list[str] = [task_id for task_id in verified_task_ids if task_id not in task_row_ids]
-        if missing_task_ids:
-            raise TrackerServiceError(
-                f"Race condition occured when resuming run {benchmark_id}. Missing task ids: {', '.join(missing_task_ids)}"
-            )
 
         # Semaphore to isolate concurrent sandboxes that are being made for the benchmark
         creation_semaphore = Semaphore(_SANDBOX_CREATION_CAP)
@@ -283,6 +359,7 @@ async def process_benchmark(
                     creation_semaphore=creation_semaphore,
                 ),
                 org,
+                task_row.started_at,
             )
             for task_id, task_row in task_rows
         }
@@ -298,31 +375,29 @@ async def process_benchmark(
         await monitor_task
 
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            if has_runnable_tasks(session, benchmark_row, org):
+            benchmark_row = _fetch_benchmark_for_update(benchmark_id, session, org)
+            score_task_rows = _fetch_tasks_for_update(benchmark_id, session, org)
+            if (benchmark_row.status in _TERMINAL_BENCHMARK_STATUSES and verified_task_ids) or any(
+                task.status in _RUNNABLE_TASK_STATUSES for task in score_task_rows
+            ):
                 finalization_deferred = True
                 return
+            score_snapshot = {task.task_id: (task.started_at, task.status) for task in score_task_rows}
             evaluation_results = fetch_final_score_inputs(session, benchmark_row, org)
 
+            if not any(result is not None for result in evaluation_results.values()) and any(
+                task.status == TaskStatus.STOPPED for task in score_task_rows
+            ):
+                set_benchmark_final_status(benchmark_row, session, org)
+                return
+
         if not any(result is not None for result in evaluation_results.values()):
-            with Session(bind=engine) as session:
-                benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-                if has_stopped_tasks(session, benchmark_row, org):
-                    set_benchmark_final_status(benchmark_row, session, org)
-                    return
             raise TrackerServiceError("No tasks were completed successfully")
 
         # Calculate the final score based off the tasks that were ran
         final_score_response = await benchmark_service.final_score(
             evaluation_results=evaluation_results, dataset=start_benchmark_request.dataset
         )
-
-        with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            # final_score is a network call; a concurrent retry can make tasks runnable before we write FinalEvaluation.
-            if has_runnable_tasks(session, benchmark_row, org):
-                finalization_deferred = True
-                return
 
         # Create the final evaluation row and add it to the database
         final_evaluation_row = FinalEvaluation(
@@ -331,23 +406,37 @@ async def process_benchmark(
             final_score=final_score_response.final_score,
             properties=final_score_response.metadata,
         )
-
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            benchmark_row = _fetch_benchmark_for_update(benchmark_id, session, org)
+            final_task_rows = _fetch_tasks_for_update(benchmark_id, session, org)
+            if (
+                (benchmark_row.status in _TERMINAL_BENCHMARK_STATUSES and verified_task_ids)
+                or {task.task_id for task in final_task_rows} != set(score_snapshot)
+                or any(
+                    task.status in _RUNNABLE_TASK_STATUSES
+                    or not is_expected_attempt(task, score_snapshot[task.task_id][0])
+                    or task.status != score_snapshot[task.task_id][1]
+                    for task in final_task_rows
+                )
+            ):
+                finalization_deferred = True
+                return
+
             # Delete existing final evaluation if re-running
             if benchmark_row.final_evaluation:
                 session.delete(benchmark_row.final_evaluation)
                 session.flush()
 
             session.add(final_evaluation_row)
-            session.commit()
-
             set_benchmark_final_status(benchmark_row, session, org)
 
             # Push the final benchmark view to the bucket
             final_view: FinalViewResponse = create_final_view(benchmark_row, session, org)
 
-            await upload_final_view(benchmark_row, final_view, harness_config)
+            try:
+                await upload_final_view(benchmark_row, final_view, harness_config)
+            except Exception:
+                logger.warning("Failed to upload final benchmark view", exc_info=True)
 
             # If the user has chosen to invoke a lambda function at the end of the benchmark
             # We run it but do not let a failure affect the benchmark status
@@ -357,32 +446,46 @@ async def process_benchmark(
                 lambda_payload: dict[str, Any] = arguments.model_dump()
                 lambda_payload["benchmark_id"] = str(benchmark_id)
 
-                invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
+                try:
+                    invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
+                except Exception:
+                    logger.warning("Failed to invoke final benchmark Lambda", exc_info=True)
 
     except BenchmarkServiceUnauthenticatedError as e:
         logfire.warn("process_benchmark failed due to benchmark service auth error")
+        error_message = f"{str(e)}\n{traceback.format_exc()}"
+        logger.warning(error_message)
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            error_message = f"{str(e)}\n{traceback.format_exc()}"
-            logger.warning(error_message)
-            commit_benchmark_error(benchmark_row, session, error_message)
+            finalization_deferred = not _commit_benchmark_attempt_error(
+                benchmark_row, session, org, execution_attempts, run_attempts, error_message
+            )
     except BenchmarkServiceError as e:
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            error_message = str(e)
-            commit_benchmark_error(benchmark_row, session, error_message)
+            finalization_deferred = not _commit_benchmark_attempt_error(
+                benchmark_row, session, org, execution_attempts, run_attempts, str(e)
+            )
     except Exception as e:
         logfire.exception("process_benchmark failed")
         sentry_sdk.capture_exception(e)
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-            error_message = f"{str(e)}\n{traceback.format_exc()}"
-            commit_benchmark_error(benchmark_row, session, error_message)
+            finalization_deferred = not _commit_benchmark_attempt_error(
+                benchmark_row,
+                session,
+                org,
+                execution_attempts,
+                run_attempts,
+                f"{str(e)}\n{traceback.format_exc()}",
+            )
     finally:
         if not finalization_deferred:
             with Session(bind=engine) as session:
                 # Handle any misalignments between the benchmark status and tasks
-                catch_errors_during_cleanup(benchmark_id, session, org)
+                finalization_deferred = not catch_errors_during_cleanup(
+                    benchmark_id, session, org, execution_attempts, run_attempts
+                )
 
         if notifier and not finalization_deferred:
             try:
@@ -409,7 +512,49 @@ def commit_benchmark_error(benchmark_row: Benchmark, session: Session, error_mes
     session.commit()
 
 
-def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) -> None:
+def _commit_benchmark_attempt_error(
+    benchmark_row: Benchmark,
+    session: Session,
+    org: Org,
+    execution_attempts: dict[str, datetime],
+    run_attempts: dict[str, datetime],
+    error_message: str,
+) -> bool:
+    benchmark_row = _fetch_benchmark_for_update(benchmark_row.id, session, org)
+    if benchmark_row.status == BenchmarkStatus.STOPPING:
+        return True
+    if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+        return False
+
+    task_rows = _fetch_tasks_for_update(benchmark_row.id, session, org)
+    owned_tasks = [
+        task
+        for task in task_rows
+        if task.task_id in execution_attempts and is_expected_attempt(task, execution_attempts[task.task_id])
+    ]
+    ownership_lost = len(owned_tasks) != len(execution_attempts) or _generation_changed(task_rows, run_attempts)
+    for task in owned_tasks:
+        if task.status not in _RUNNABLE_TASK_STATUSES:
+            continue
+        session.add(ErrorResult(org_id=org.id, task=task.id, error_message=error_message))
+        task.status = TaskStatus.ERROR
+        session.add(task)
+    session.flush()
+    if ownership_lost or any(task.status in _RUNNABLE_TASK_STATUSES for task in task_rows):
+        session.commit()
+        return False
+
+    commit_benchmark_error(benchmark_row, session, error_message)
+    return True
+
+
+def catch_errors_during_cleanup(
+    benchmark_id: UUID,
+    session: Session,
+    org: Org,
+    execution_attempts: dict[str, datetime],
+    run_attempts: dict[str, datetime],
+) -> bool:
     """
     On task exit we must clean up any edge cases so that it does not affect the users experience.
     There are sometimes fishy things that may occur with the sandboxes that if not dealt with could become an issue.
@@ -417,25 +562,49 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
     1. Benchmark status must be in a finished state
     2. All tasks must be in a finished state
     """
-    terminal_statuses = [BenchmarkStatus.FINISHED, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPED]
+    benchmark_row = _fetch_benchmark_for_update(benchmark_id, session, org)
+    task_rows = _fetch_tasks_for_update(benchmark_id, session, org)
+    owned_tasks = [
+        task
+        for task in task_rows
+        if task.task_id in execution_attempts and is_expected_attempt(task, execution_attempts[task.task_id])
+    ]
+    ownership_lost = len(owned_tasks) != len(execution_attempts) or _generation_changed(task_rows, run_attempts)
 
-    benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
-    if benchmark_row.status in terminal_statuses:
-        return
+    if benchmark_row.status in _TERMINAL_BENCHMARK_STATUSES:
+        return not ownership_lost
 
-    # Force non exited tasks to be ERROR
+    if benchmark_row.status == BenchmarkStatus.STOPPING:
+        for task in owned_tasks:
+            if task.status in _RUNNABLE_TASK_STATUSES:
+                task.status = TaskStatus.STOPPED
+                session.add(task)
+        session.flush()
+        if ownership_lost or any(task.status in _RUNNABLE_TASK_STATUSES for task in task_rows):
+            session.commit()
+            return False
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        benchmark_row.error_message = None
+        session.add(benchmark_row)
+        session.commit()
+        return True
+
+    # Force non exited tasks from this worker's attempts to be ERROR
     task_terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
-    undetected_exit_tasks = session.exec(
-        select(Task)
-        .where(col(Task.benchmark) == benchmark_id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).notin_(task_terminal_statuses))
-    ).all()
+    undetected_exit_tasks = [task for task in owned_tasks if task.status not in task_terminal_statuses]
     for task in undetected_exit_tasks:
         session.add(ErrorResult(org_id=org.id, task=task.id, error_message="Undetected exit of task"))
         task.status = TaskStatus.ERROR
         session.add(task)
-    session.commit()
+    session.flush()
+
+    if ownership_lost:
+        session.commit()
+        return False
+
+    if any(task.status in _RUNNABLE_TASK_STATUSES for task in task_rows):
+        session.commit()
+        return False
 
     # Sweep stale RUNNING analyzer invocations to ERROR. The invoke_analyzer
     # helper uses try/finally so this only fires when the worker process was
@@ -450,3 +619,4 @@ def catch_errors_during_cleanup(benchmark_id: UUID, session: Session, org: Org) 
         session,
         f"Run {benchmark_id} exited without finishing",
     )
+    return True

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -7,6 +7,7 @@ import traceback
 from asyncio import Semaphore
 from collections.abc import Coroutine
 from contextlib import suppress
+from datetime import datetime
 from enum import Enum
 from typing import Any
 from uuid import UUID
@@ -56,6 +57,11 @@ from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
 logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
+_TERMINAL_TASK_STATUSES = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+
+
+def is_expected_attempt(task: Task, expected_started_at: datetime) -> bool:
+    return task.started_at.replace(tzinfo=None) == expected_started_at.replace(tzinfo=None)
 
 
 class TrackedTaskStatus(str, Enum):
@@ -69,10 +75,12 @@ class TrackedTask:
     _status: str
     _task: asyncio.Task[Any] | None
     _org: Org
+    _expected_started_at: datetime
 
-    def __init__(self, coro: Coroutine[Any, Any, Any], org: Org):
+    def __init__(self, coro: Coroutine[Any, Any, Any], org: Org, expected_started_at: datetime):
         self._coro = coro
         self._org = org
+        self._expected_started_at = expected_started_at
         self._status = TrackedTaskStatus.WAITING
         self._task = None
 
@@ -83,6 +91,10 @@ class TrackedTask:
     @property
     def task(self) -> asyncio.Task[Any] | None:
         return self._task
+
+    @property
+    def expected_started_at(self) -> datetime:
+        return self._expected_started_at
 
     async def run(self, semaphore: asyncio.Semaphore, task_row: Task) -> dict[str, dict[str, Any] | None]:
         async def _wrap_coro():
@@ -108,7 +120,7 @@ class TrackedTask:
             sentry_sdk.capture_exception(e)
             with Session(bind=engine) as session:
                 task = fetch_task_row(task_row.id, session, self._org)
-                commit_task_error(task, session, error_message)
+                commit_task_error(task, session, self._expected_started_at, error_message)
 
             return {task_row.task_id: None}
         finally:
@@ -145,7 +157,7 @@ class TaskMonitor:
 
             return task_row
 
-    def _validate_task(self, task_id: str) -> bool:
+    def _validate_task(self, task_id: str, expected_started_at: datetime) -> bool:
         """
         If the task status has been set to stopped we return False to exit the task early.
 
@@ -158,7 +170,11 @@ class TaskMonitor:
             task_row = self._fetch_task_row(task_id)
 
             # If task has been stopped or benchmark has errored we need to exit
-            if task_row.status == TaskStatus.STOPPED or benchmark_row.status == BenchmarkStatus.ERROR:
+            if (
+                not is_expected_attempt(task_row, expected_started_at)
+                or task_row.status == TaskStatus.STOPPED
+                or benchmark_row.status == BenchmarkStatus.ERROR
+            ):
                 return False
 
         return True
@@ -189,7 +205,11 @@ class TaskMonitor:
                     del self._task_tracking[task_id]
                     continue
 
-                if not self._validate_task(task_id) and task.task is not None and not task.task.done():
+                if (
+                    not self._validate_task(task_id, task.expected_started_at)
+                    and task.task is not None
+                    and not task.task.done()
+                ):
                     task.task.cancel(f"Task {task_id} has been invalidated. Run has been requested to stop")
 
             await self._check_notifications()
@@ -200,8 +220,8 @@ class TaskMonitor:
             await asyncio.sleep(self._TRACK_INTERVAL)
 
 
-def handle_early_exit(task_row: Task, task_session: Session) -> None:
-    _commit_task_status(task_row, task_session, TaskStatus.STOPPED)
+def handle_early_exit(task_row: Task, task_session: Session, expected_started_at: datetime) -> None:
+    _commit_task_status(task_row, task_session, expected_started_at, TaskStatus.STOPPED)
 
 
 def buffer_logs(
@@ -222,21 +242,44 @@ def buffer_logs(
     loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws, log_group)
 
 
-def save_eval_resume_state(task_row_id: UUID, org: Org, eval_resume_state: dict[str, Any]) -> None:
+def save_eval_resume_state(
+    task_row_id: UUID, org: Org, expected_started_at: datetime, eval_resume_state: dict[str, Any]
+) -> None:
     with Session(bind=engine) as session:
-        task = fetch_task_row(task_row_id, session, org)
+        task = _fetch_attempt_task(task_row_id, session, org.id, expected_started_at)
+        if task is None or task.status in _TERMINAL_TASK_STATUSES:
+            return
         task.eval_resume_state = eval_resume_state
         session.commit()
+
+
+def _fetch_attempt_task(
+    task_row_id: UUID, session: Session, org_id: UUID, expected_started_at: datetime
+) -> Task | None:
+    task = session.exec(
+        select(Task)
+        .where(Task.id == task_row_id)
+        .where(Task.org_id == org_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).one()
+    if not is_expected_attempt(task, expected_started_at):
+        return None
+    return task
 
 
 def _commit_task_status(
     task: Task,
     session: Session,
+    expected_started_at: datetime,
     to_status: TaskStatus,
     *,
     error_message: str | None = None,
     extra: dict[str, Any] | None = None,
-) -> None:
+) -> bool:
+    if not is_expected_attempt(task, expected_started_at) or task.status in _TERMINAL_TASK_STATUSES:
+        return False
+
     from_status = task.status
     span_attributes = {
         "benchmark_id": str(task.benchmark),
@@ -252,12 +295,27 @@ def _commit_task_status(
         task.status = to_status
         session.add(task)
         session.commit()
+    return True
 
 
-def commit_task_status_transition(task_row_id: UUID, session: Session, org: Org, to_status: TaskStatus) -> None:
+def commit_task_status_transition(
+    task_row_id: UUID,
+    session: Session,
+    org: Org,
+    expected_started_at: datetime,
+    to_status: TaskStatus,
+) -> bool:
     fetch_start = time.monotonic()
-    task = fetch_task_row(task_row_id, session, org)
-    _commit_task_status(task, session, to_status, extra={"fetch_duration_ms": elapsed_ms(fetch_start)})
+    task = _fetch_attempt_task(task_row_id, session, org.id, expected_started_at)
+    if task is None:
+        return False
+    return _commit_task_status(
+        task,
+        session,
+        expected_started_at,
+        to_status,
+        extra={"fetch_duration_ms": elapsed_ms(fetch_start)},
+    )
 
 
 @logfire.instrument("process_task")
@@ -285,6 +343,7 @@ async def process_task(
     NOTE: When we close the sandbox the agent process will be killed and we will instantly go to evaluating,
     the evaluation will fail since the instance no longer exists. We handle this inside of the exception caught.
     """
+    expected_started_at = task_row.started_at
     task_id_var.set(task_id)
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
@@ -299,15 +358,19 @@ async def process_task(
 
     with Session(bind=engine) as task_session:
         benchmark_row = fetch_benchmark_row(benchmark_id, task_session, org)
-        task_row = task_session.merge(task_row)
+        task_in_session = _fetch_attempt_task(task_row.id, task_session, org.id, expected_started_at)
+        if task_in_session is None:
+            return {task_id: None}
 
         # If user has requested to stop the benchmark we exit before we process the task
-        if benchmark_row.status == BenchmarkStatus.STOPPING:
-            handle_early_exit(task_row, task_session)
+        if benchmark_row.status == BenchmarkStatus.STOPPING or task_in_session.status in _TERMINAL_TASK_STATUSES:
+            handle_early_exit(task_in_session, task_session, expected_started_at)
             return {task_id: None}
         benchmark_name = benchmark_row.name
         benchmark_agent_name = benchmark_row.arguments.contract.name
         benchmark_started_by_email = benchmark_row.started_by_email
+        task_status = task_in_session.status
+        eval_resume_state = task_in_session.eval_resume_state
 
     # Setup logging infrastructure before try block so it's always available
     # Suffix is required to version control streams, never delete between retries
@@ -335,23 +398,23 @@ async def process_task(
     flush_task = asyncio.create_task(auto_flush_logs())
 
     def on_eval_resume_state(state: dict[str, Any]) -> None:
-        save_eval_resume_state(task_row.id, org, state)
+        save_eval_resume_state(task_row.id, org, expected_started_at, state)
 
-    def task_is_stopped() -> bool:
+    def task_should_stop() -> bool:
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            return task.status == TaskStatus.STOPPED
+            return not is_expected_attempt(task, expected_started_at) or task.status == TaskStatus.STOPPED
 
     try:
-        if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
+        if task_status == TaskStatus.EVALUATING and eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
                 resume_eval_start_time = time.perf_counter()
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
                 evaluation_result = await benchmark_service.resume_evaluation(
-                    task_row.task_id,
-                    eval_resume_state=task_row.eval_resume_state,
+                    task_id,
+                    eval_resume_state=eval_resume_state,
                     on_message=log_output,
                     on_eval_resume_state=on_eval_resume_state,
                     dataset=start_benchmark_request.dataset,
@@ -366,19 +429,22 @@ async def process_task(
                 )
 
                 with Session(bind=engine) as task_session:
+                    task_in_session = _fetch_attempt_task(task_row.id, task_session, org.id, expected_started_at)
+                    if task_in_session is None:
+                        return {task_id: None}
                     task_session.add(evaluation_result_row)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
                     if task_in_session.task_breakdown:
                         existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
                         assert existing_breakdown is not None
                         existing_breakdown.evaluation_run_duration = resume_eval_duration
-                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.FINISHED)
+                    if not _commit_task_status(task_in_session, task_session, expected_started_at, TaskStatus.FINISHED):
+                        return {task_id: None}
 
                     return {task_id: evaluation_result_row.result}
             except Exception as e:
                 with Session(bind=engine) as task_session:
                     task = fetch_task_row(task_row.id, task_session, org)
-                    if task.status == TaskStatus.STOPPED:
+                    if not is_expected_attempt(task, expected_started_at) or task.status == TaskStatus.STOPPED:
                         return {task_id: None}
 
                 raise e from e
@@ -394,7 +460,10 @@ async def process_task(
         }
 
         with Session(bind=engine) as task_session:
-            commit_task_status_transition(task_row.id, task_session, org, TaskStatus.BUILDING)
+            if not commit_task_status_transition(
+                task_row.id, task_session, org, expected_started_at, TaskStatus.BUILDING
+            ):
+                return {task_id: None}
 
         identity = {
             "benchmark_name": benchmark_name,
@@ -434,7 +503,10 @@ async def process_task(
 
             try:
                 with Session(bind=engine) as task_session:
-                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.IN_PROGRESS)
+                    if not commit_task_status_transition(
+                        task_row.id, task_session, org, expected_started_at, TaskStatus.IN_PROGRESS
+                    ):
+                        return {task_id: None}
 
                 # Upload the contract to the sandbox after creating and install the dependencies
                 await upload_agent_artifacts(
@@ -489,10 +561,15 @@ async def process_task(
 
                 task_breakdown.agent_run_duration = agent_run_time
                 with Session(bind=engine) as task_session:
+                    task_in_session = _fetch_attempt_task(task_row.id, task_session, org.id, expected_started_at)
+                    if task_in_session is None:
+                        return {task_id: None}
                     task_session.add(task_breakdown)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
                     task_in_session.task_breakdown = task_breakdown.id
-                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.EVALUATING)
+                    if not _commit_task_status(
+                        task_in_session, task_session, expected_started_at, TaskStatus.EVALUATING
+                    ):
+                        return {task_id: None}
 
                 # Evaluate the instance
                 evaluation_start_time = time.perf_counter()
@@ -535,31 +612,34 @@ async def process_task(
                 )
 
                 with Session(bind=engine) as task_session:
+                    task_in_session = _fetch_attempt_task(task_row.id, task_session, org.id, expected_started_at)
+                    if task_in_session is None:
+                        return {task_id: None}
                     task_session.add(evaluation_result_row)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
                     existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
                     if existing_breakdown is None:
                         raise TrackerServiceError(f"Missing task breakdown for task {task_row.id}")
                     existing_breakdown.evaluation_run_duration = task_breakdown.evaluation_run_duration
                     existing_breakdown.sandbox_run_duration = task_breakdown.sandbox_run_duration
-                    commit_task_status_transition(task_row.id, task_session, org, TaskStatus.FINISHED)
+                    if not _commit_task_status(task_in_session, task_session, expected_started_at, TaskStatus.FINISHED):
+                        return {task_id: None}
 
                     return {task_id: evaluation_result_row.result}
             except Exception:
                 with Session(bind=engine) as task_session:
                     task = fetch_task_row(task_row.id, task_session, org)
-                    if task.status == TaskStatus.STOPPED:
+                    if not is_expected_attempt(task, expected_started_at) or task.status == TaskStatus.STOPPED:
                         return {task_id: None}
 
                 raise
 
     except SandboxSetupError as e:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         log_output(f"\n[ERROR] {e}")
         raise
     except OutputArtifactError as e:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         error_message = str(e)
         logger.warning(error_message)
@@ -567,11 +647,11 @@ async def process_task(
 
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(task, task_session, error_message)
+            commit_task_error(task, task_session, expected_started_at, error_message)
 
         return {task_id: None}
     except ConnectionClosedError:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         seconds = int(time.monotonic() - last_log_time)
         error_message = (
@@ -583,11 +663,11 @@ async def process_task(
 
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(task, task_session, error_message)
+            commit_task_error(task, task_session, expected_started_at, error_message)
 
         return {task_id: None}
     except ValidationError as e:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         field_names = ", ".join(".".join(str(loc) for loc in err["loc"]) for err in e.errors())
         error_message = (
@@ -597,33 +677,33 @@ async def process_task(
 
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(task, task_session, error_message)
+            commit_task_error(task, task_session, expected_started_at, error_message)
 
         return {task_id: None}
     except InvalidStatus as e:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         error_message = f"Benchmark service rejected the WebSocket connection (HTTP {e.response.status_code})"
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(task, task_session, error_message)
+            commit_task_error(task, task_session, expected_started_at, error_message)
 
         return {task_id: None}
     except BenchmarkServiceError as e:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         error_message = str(e)
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(task, task_session, error_message)
+            commit_task_error(task, task_session, expected_started_at, error_message)
 
         return {task_id: None}
     except Exception as e:
-        if task_is_stopped():
+        if task_should_stop():
             return {task_id: None}
         logfire.exception("process_task failed")
         error_message = str(e)
@@ -636,7 +716,7 @@ async def process_task(
 
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(task, task_session, error_message)
+            commit_task_error(task, task_session, expected_started_at, error_message)
 
         return {task_id: None}
     finally:
@@ -646,6 +726,14 @@ async def process_task(
         buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
 
-def commit_task_error(task_row: Task, session: Session, error_message: str) -> None:
-    session.add(ErrorResult(org_id=task_row.org_id, task=task_row.id, error_message=error_message))
-    _commit_task_status(task_row, session, TaskStatus.ERROR, error_message=error_message)
+def commit_task_error(task_row: Task, session: Session, expected_started_at: datetime, error_message: str) -> bool:
+    task = _fetch_attempt_task(
+        task_row.id,
+        session,
+        task_row.org_id,
+        expected_started_at,
+    )
+    if task is None or task.status in _TERMINAL_TASK_STATUSES:
+        return False
+    session.add(ErrorResult(org_id=task.org_id, task=task.id, error_message=error_message))
+    return _commit_task_status(task, session, expected_started_at, TaskStatus.ERROR, error_message=error_message)

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -493,7 +493,7 @@ class TestBenchmarkUtils:
         database_session.add(task_row)
         database_session.commit()
 
-        commit_task_error(task_row, database_session, "agent failed")
+        commit_task_error(task_row, database_session, task_row.started_at, "agent failed")
 
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR

--- a/services/tracker/tests/unit/test_docent_analysis.py
+++ b/services/tracker/tests/unit/test_docent_analysis.py
@@ -122,7 +122,7 @@ def test_cleanup_sweeps_running_docent_status_to_error(
     org = database_session.get(Org, TEST_ORG_ID)
     assert org is not None
 
-    catch_errors_during_cleanup(example_benchmark_object.id, database_session, org)
+    catch_errors_during_cleanup(example_benchmark_object.id, database_session, org, {}, {})
 
     database_session.refresh(example_benchmark_object)
     assert example_benchmark_object.docent_reading_status == DocentReadingStatus.ERROR

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -155,6 +155,47 @@ class TestFastapiServer:
         assert json_response["agent_name"] == request.contract.name
         assert json_response["concurrency"] == request.concurrency
 
+    async def test_start_benchmark_enqueues_attempt_tokens(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        harness_config: HarnessConfig,
+    ) -> None:
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=2,
+            task_ids=["task_0", "task_1"],
+            harness_config=harness_config,
+        )
+        captured_batches: list[dict[str, Any]] = []
+
+        async def verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=["task_0", "task_1"])
+
+        class Kicker:
+            def with_labels(self, **_kwargs: Any) -> "Kicker":
+                return self
+
+            async def kiq(self, **kwargs: Any) -> None:
+                captured_batches.append(kwargs["verified_task_ids"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_task_ids)
+        monkeypatch.setattr("main.TOKENIZED_RETRY_BATCHES_ENABLED", True)
+        monkeypatch.setattr("main.process_benchmark.kicker", lambda: Kicker())
+
+        response = client.post("/start-benchmark", json=request.model_dump())
+
+        assert response.status_code == 200
+        benchmark_id = UUID(response.json()["benchmark_id"])
+        tasks = database_session.exec(select(Task).where(Task.benchmark == benchmark_id)).all()
+        assert len(captured_batches) == 1
+        assert captured_batches[0] == {
+            "kind": "start",
+            "attempts": {task.task_id: task.started_at.isoformat() for task in tasks},
+        }
+
     async def test_start_benchmark_returns_502_when_benchmark_service_is_unreachable(
         self,
         contract: AgentContractRequest,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -39,9 +39,17 @@ from tracker.utils import (
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
 )
+from tracker.utils.run_orchestration import TaskBatch
 
 UTC = ZoneInfo("UTC")
 client = TestClient(app)
+
+
+def _retry_batch(attempts: dict[str, datetime]) -> TaskBatch:
+    return {
+        "kind": "retry",
+        "attempts": {task_id: value.isoformat() for task_id, value in attempts.items()},
+    }
 
 
 def _created_at(day: int) -> datetime:
@@ -149,7 +157,7 @@ class TestStopAndResume:
         database_session.add(benchmark_row)
         database_session.commit()
 
-        verified_task_ids = await reset_to_in_progress_status(
+        task_attempts = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
             session=database_session,
             benchmark_service=start_benchmark_request.benchmark_service,
@@ -159,14 +167,14 @@ class TestStopAndResume:
             org=self._test_org,
         )
         # Only 3 tasks should be verified for resume (the 3 tasks that are stopped)
-        assert len(verified_task_ids) == 3
-        assert set(verified_task_ids) == set(pending_task_ids)
+        assert len(task_attempts) == 3
+        assert set(task_attempts) == set(pending_task_ids)
 
         # Run process_benchmark to complete the remaining tasks (the 3 tasks that are pending)
         await process_benchmark(
             start_benchmark_request_json=benchmark_row.start_benchmark_request(harness_config).model_dump(),
             benchmark_id_str=str(benchmark_row.id),
-            verified_task_ids=verified_task_ids,
+            verified_task_ids=_retry_batch(task_attempts),
         )
 
         database_session.refresh(benchmark_row)
@@ -214,7 +222,7 @@ class TestStopAndResume:
 
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
 
-        verified_task_ids = await reset_to_in_progress_status(
+        task_attempts = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
             session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
@@ -225,7 +233,7 @@ class TestStopAndResume:
         )
 
         database_session.refresh(task_row)
-        assert verified_task_ids == [task_row.task_id]
+        assert list(task_attempts) == [task_row.task_id]
         assert task_row.status == expected_status
         assert task_row.eval_resume_state == expected_state
 
@@ -274,7 +282,7 @@ class TestStopAndResume:
 
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
 
-        verified_task_ids = await reset_to_in_progress_status(
+        task_attempts = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
             session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
@@ -284,7 +292,7 @@ class TestStopAndResume:
             org=self._test_org,
         )
 
-        assert verified_task_ids == ["task_error", "task_result"]
+        assert list(task_attempts) == ["task_error", "task_result"]
 
         for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all():
             task.status = TaskStatus.FINISHED
@@ -322,7 +330,7 @@ class TestStopAndResume:
         )
         database_session.commit()
 
-        verified_task_ids = await reset_to_in_progress_status(
+        task_attempts = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
             session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
@@ -337,7 +345,7 @@ class TestStopAndResume:
             for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         }
 
-        assert set(verified_task_ids) == {"task_0", "task_1", "task_2"}
+        assert set(task_attempts) == {"task_0", "task_1", "task_2"}
         assert task_statuses == {
             "task_0": TaskStatus.PENDING,
             "task_1": TaskStatus.PENDING,
@@ -367,7 +375,7 @@ class TestStopAndResume:
         )
         database_session.commit()
 
-        verified_task_ids = await reset_to_in_progress_status(
+        task_attempts = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
             session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
@@ -381,7 +389,7 @@ class TestStopAndResume:
             task.task_id: task.status
             for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         }
-        assert verified_task_ids == ["task_requested"]
+        assert list(task_attempts) == ["task_requested"]
         assert task_statuses == {"task_requested": TaskStatus.PENDING, "task_other": TaskStatus.ERROR}
 
     async def test_resume_runs_lazily_added_task_and_recomputes_final_score(
@@ -442,7 +450,7 @@ class TestStopAndResume:
         monkeypatch.setattr(BenchmarkServiceClient, "final_score", _capturing_final_score)
 
         # Resume with a new task id — should be lazily created as PENDING
-        verified_task_ids = await reset_to_in_progress_status(
+        task_attempts = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
             session=database_session,
             benchmark_service=start_benchmark_request.benchmark_service,
@@ -451,13 +459,13 @@ class TestStopAndResume:
             rerun_task_ids=[new_task_id],
             org=self._test_org,
         )
-        assert verified_task_ids == [new_task_id]
+        assert list(task_attempts) == [new_task_id]
 
         # Run the worker — the new task should make it through evaluation
         await process_benchmark(
             start_benchmark_request_json=benchmark_row.start_benchmark_request(harness_config).model_dump(),
             benchmark_id_str=str(benchmark_row.id),
-            verified_task_ids=verified_task_ids,
+            verified_task_ids=_retry_batch(task_attempts),
         )
 
         database_session.refresh(benchmark_row)
@@ -650,7 +658,7 @@ class TestStopAndResume:
             *_args: Any, benchmark_service: BenchmarkServiceClient, **_kwargs: Any
         ):
             observed_headers.update(benchmark_service._headers)
-            return ["task_0"]
+            return {"task_0": datetime.now(UTC)}
 
         class _MockKicker:
             def with_labels(self, **_kwargs: Any) -> "_MockKicker":
@@ -745,7 +753,7 @@ class TestStopAndResume:
         captured_request_json: dict[str, Any] = {}
 
         async def _mock_reset_to_in_progress_status(*_args: Any, **_kwargs: Any):
-            return ["task_0"]
+            return {"task_0": datetime.now(UTC)}
 
         class _MockKicker:
             def with_labels(self, **_kwargs: Any) -> "_MockKicker":
@@ -859,22 +867,24 @@ class TestStopAndResume:
         async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
             return VerifyTaskIdsResponse(task_ids=["task_error"])
 
-        captured_task_ids: list[str] = []
+        captured_batches: list[TaskBatch] = []
 
         class _MockKicker:
             def with_labels(self, **_kwargs: Any) -> "_MockKicker":
                 return self
 
             async def kiq(self, **kwargs: Any) -> None:
-                captured_task_ids.extend(kwargs["verified_task_ids"])
+                captured_batches.append(kwargs["verified_task_ids"])
 
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_request_verify_task_ids)
         monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+        monkeypatch.setattr("main.TOKENIZED_RETRY_BATCHES_ENABLED", True)
 
         response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true")
 
         assert response.status_code == 200
-        assert captured_task_ids == ["task_error"]
+        assert len(captured_batches) == 1
+        assert set(captured_batches[0]["attempts"]) == {"task_error"}
 
         task_statuses = {
             task.task_id: task.status
@@ -912,7 +922,7 @@ class TestStopAndResume:
         async def _mock_verify_task_ids(*_args: Any, task_ids: list[str], **_kwargs: Any) -> VerifyTaskIdsResponse:
             return VerifyTaskIdsResponse(task_ids=task_ids)
 
-        captured_retry_task_ids: list[str] = []
+        captured_retry_batches: list[TaskBatch] = []
         final_score_inputs: list[dict[str, Any]] = []
         sandbox_count = 0
 
@@ -921,7 +931,7 @@ class TestStopAndResume:
                 return self
 
             async def kiq(self, **kwargs: Any) -> None:
-                captured_retry_task_ids.extend(kwargs["verified_task_ids"])
+                captured_retry_batches.append(kwargs["verified_task_ids"])
 
         @asynccontextmanager
         async def _mock_create_sandbox(*_args: Any, **_kwargs: Any):
@@ -953,16 +963,18 @@ class TestStopAndResume:
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
         monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
         monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
+        monkeypatch.setattr("main.TOKENIZED_RETRY_BATCHES_ENABLED", True)
 
         response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true")
 
         assert response.status_code == 200
-        assert captured_retry_task_ids == ["task_retry"]
+        assert len(captured_retry_batches) == 1
+        assert set(captured_retry_batches[0]["attempts"]) == {"task_retry"}
 
         await process_benchmark(
             start_benchmark_request_json=request.model_dump(),
             benchmark_id_str=str(benchmark_row.id),
-            verified_task_ids=captured_retry_task_ids,
+            verified_task_ids=captured_retry_batches[0],
         )
 
         database_session.refresh(benchmark_row)
@@ -996,7 +1008,7 @@ class TestStopAndResume:
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
 
-        tracked_task = TrackedTask(asyncio.sleep(0), org=self._test_org)
+        tracked_task = TrackedTask(asyncio.sleep(0), org=self._test_org, expected_started_at=task_row.started_at)
         tracked_task._status = TrackedTaskStatus.WAITING  # type: ignore[attr-defined]
 
         cancel_mock = Mock()

--- a/services/tracker/tests/unit/test_task_attempt_guard.py
+++ b/services/tracker/tests/unit/test_task_attempt_guard.py
@@ -1,0 +1,418 @@
+import asyncio
+from datetime import datetime, timedelta
+from typing import Any, Literal
+from unittest.mock import AsyncMock, Mock
+from zoneinfo import ZoneInfo
+
+import pytest
+from benchmark_service.client import BenchmarkServiceClient
+from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
+from sqlmodel import Session, select
+
+from tests.conftest import TEST_ORG_ID
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkArguments,
+    BenchmarkStatus,
+    ErrorResult,
+    EvaluationResult,
+    Org,
+    RetryMode,
+    Task,
+    TaskStatus,
+)
+from tracker.types import HarnessConfig
+from tracker.utils import (
+    catch_errors_during_cleanup,
+    commit_task_error,
+    commit_task_status_transition,
+    process_benchmark,
+    reset_to_in_progress_status,
+    save_eval_resume_state,
+    TaskMonitor,
+    TrackedTask,
+    TrackedTaskStatus,
+)
+from tracker.utils.run_orchestration import TaskBatch
+
+UTC = ZoneInfo("UTC")
+OLD_ATTEMPT = datetime(2026, 7, 9, 1, tzinfo=UTC)
+NEW_ATTEMPT = OLD_ATTEMPT + timedelta(seconds=1)
+TEST_ORG = Org(id=TEST_ORG_ID, name="default")
+
+
+def _task_batch(kind: Literal["start", "retry"], task_id: str, started_at: datetime) -> TaskBatch:
+    return {"kind": kind, "attempts": {task_id: started_at.isoformat()}}
+
+
+def _create_task(
+    database_session: Session,
+    contract: AgentContractRequest,
+    *,
+    status: TaskStatus = TaskStatus.PENDING,
+) -> Task:
+    benchmark = Benchmark(
+        org_id=TEST_ORG_ID,
+        name="swebench",
+        status=BenchmarkStatus.IN_PROGRESS,
+        arguments=BenchmarkArguments(contract=contract, concurrency=1),
+    )
+    database_session.add(benchmark)
+    database_session.commit()
+    task = Task(
+        org_id=TEST_ORG_ID,
+        task_id="task_0",
+        benchmark=benchmark.id,
+        status=status,
+        started_at=OLD_ATTEMPT,
+    )
+    database_session.add(task)
+    database_session.commit()
+    return task
+
+
+def test_stale_attempt_writes_are_rejected(
+    database_session: Session,
+    contract: AgentContractRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract)
+    task.started_at = NEW_ATTEMPT
+    task.eval_resume_state = {"attempt": "new"}
+    database_session.add(task)
+    database_session.commit()
+    monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
+
+    assert not commit_task_error(task, database_session, OLD_ATTEMPT, "old attempt failed")
+    assert not commit_task_status_transition(task.id, database_session, TEST_ORG, OLD_ATTEMPT, TaskStatus.BUILDING)
+    save_eval_resume_state(task.id, TEST_ORG, OLD_ATTEMPT, {"attempt": "old"})
+
+    task.status = TaskStatus.STOPPED
+    database_session.add(task)
+    database_session.commit()
+    assert not commit_task_error(task, database_session, NEW_ATTEMPT, "late failure")
+    assert not commit_task_status_transition(task.id, database_session, TEST_ORG, NEW_ATTEMPT, TaskStatus.FINISHED)
+
+    database_session.refresh(task)
+    assert task.status == TaskStatus.STOPPED
+    assert task.eval_resume_state == {"attempt": "new"}
+    assert database_session.exec(select(ErrorResult).where(ErrorResult.task == task.id)).all() == []
+
+
+def test_stale_cleanup_only_errors_owned_current_attempts(
+    database_session: Session,
+    contract: AgentContractRequest,
+) -> None:
+    retried_task = _create_task(database_session, contract)
+    owned_task = Task(
+        org_id=TEST_ORG_ID,
+        task_id="task_1",
+        benchmark=retried_task.benchmark,
+        started_at=OLD_ATTEMPT,
+    )
+    database_session.add(owned_task)
+    database_session.commit()
+    retried_task.started_at = NEW_ATTEMPT
+    retried_task.status = TaskStatus.FINISHED
+    database_session.add(retried_task)
+    database_session.commit()
+
+    cleanup_owned = catch_errors_during_cleanup(
+        retried_task.benchmark,
+        database_session,
+        TEST_ORG,
+        {retried_task.task_id: OLD_ATTEMPT, owned_task.task_id: OLD_ATTEMPT},
+        {retried_task.task_id: OLD_ATTEMPT, owned_task.task_id: OLD_ATTEMPT},
+    )
+
+    database_session.refresh(retried_task)
+    database_session.refresh(owned_task)
+    benchmark = database_session.get(Benchmark, retried_task.benchmark)
+    assert benchmark is not None
+    assert not cleanup_owned
+    assert retried_task.status == TaskStatus.FINISHED
+    assert owned_task.status == TaskStatus.ERROR
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+    assert database_session.exec(select(ErrorResult.task)).all() == [owned_task.id]
+
+
+async def test_resume_commits_status_and_attempt_generation_atomically(
+    database_session: Session,
+    contract: AgentContractRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract, status=TaskStatus.STOPPED)
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+    benchmark.status = BenchmarkStatus.STOPPED
+    database_session.add(benchmark)
+    database_session.commit()
+    benchmark_service = benchmark.benchmark_service()
+    benchmark_service.verify_task_ids = AsyncMock(return_value=VerifyTaskIdsResponse(task_ids=[task.task_id]))
+    commits: list[tuple[BenchmarkStatus, TaskStatus, datetime]] = []
+    commit = database_session.commit
+
+    def record_commit() -> None:
+        commit()
+        commits.append((benchmark.status, task.status, task.started_at))
+
+    monkeypatch.setattr(database_session, "commit", record_commit)
+
+    verified_task_ids = await reset_to_in_progress_status(
+        benchmark,
+        database_session,
+        benchmark_service,
+        False,
+        RetryMode.AUTO,
+        [],
+        TEST_ORG,
+    )
+
+    assert list(verified_task_ids) == [task.task_id]
+    assert len(commits) == 1
+    assert commits[0][0:2] == (BenchmarkStatus.IN_PROGRESS, TaskStatus.PENDING)
+    assert commits[0][2] != OLD_ATTEMPT
+    await benchmark_service.close()
+
+
+async def test_stale_worker_exception_does_not_error_retry(
+    database_session: Session,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract)
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+
+    async def retry_then_fail(*_args: Any, **_kwargs: Any) -> None:
+        with Session(database_session.bind) as session:
+            current_task = session.get(Task, task.id)
+            assert current_task is not None
+            current_task.started_at = NEW_ATTEMPT
+            current_task.status = TaskStatus.PENDING
+            session.add(current_task)
+            session.commit()
+        raise RuntimeError("old worker failed")
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.copy_agent_to_benchmark", retry_then_fail)
+    await process_benchmark(
+        benchmark.start_benchmark_request(harness_config).model_dump(),
+        str(benchmark.id),
+        [task.task_id],
+    )
+
+    database_session.refresh(task)
+    database_session.refresh(benchmark)
+    assert task.status == TaskStatus.PENDING
+    assert task.started_at.replace(tzinfo=UTC) == NEW_ATTEMPT
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+    assert benchmark.error_message is None
+    assert database_session.exec(select(ErrorResult)).all() == []
+
+
+@pytest.mark.parametrize("kind", ["start", "retry"])
+async def test_delayed_message_cannot_adopt_new_attempt(
+    kind: Literal["start", "retry"],
+    database_session: Session,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract)
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+    task.started_at = NEW_ATTEMPT
+    database_session.add(task)
+    database_session.commit()
+    process_task = AsyncMock()
+    monkeypatch.setattr("tracker.utils.run_orchestration.process_task", process_task)
+
+    await process_benchmark(
+        benchmark.start_benchmark_request(harness_config).model_dump(),
+        str(benchmark.id),
+        _task_batch(kind, task.task_id, OLD_ATTEMPT),
+    )
+
+    database_session.refresh(task)
+    database_session.refresh(benchmark)
+    process_task.assert_not_called()
+    assert task.status == TaskStatus.PENDING
+    assert task.started_at.replace(tzinfo=UTC) == NEW_ATTEMPT
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+
+
+async def test_monitor_cancels_superseded_attempt(
+    database_session: Session,
+    contract: AgentContractRequest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract)
+    task.started_at = NEW_ATTEMPT
+    database_session.add(task)
+    database_session.commit()
+    monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
+    tracked_task = TrackedTask(asyncio.sleep(0), TEST_ORG, OLD_ATTEMPT)
+    tracked_task._status = TrackedTaskStatus.WAITING  # type: ignore[attr-defined]
+
+    def cancel(*_args: Any) -> None:
+        tracked_task._status = TrackedTaskStatus.DONE  # type: ignore[attr-defined]
+
+    cancel_mock = Mock(side_effect=cancel)
+    tracked_task._task = Mock(cancel=cancel_mock, done=lambda: False)  # type: ignore[assignment]
+    monitor = TaskMonitor(task.benchmark, {task.task_id: tracked_task}, TEST_ORG)
+    monitor._TRACK_INTERVAL = 0  # pyright: ignore[reportPrivateUsage]
+
+    await monitor.track_tasks()
+
+    cancel_mock.assert_called_once()
+    tracked_task._coro.close()  # pyright: ignore[reportPrivateUsage]
+
+
+async def test_terminal_redelivery_finalizes_without_rerunning_task(
+    database_session: Session,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract, status=TaskStatus.FINISHED)
+    database_session.add(EvaluationResult(org_id=TEST_ORG_ID, task=task.id, result={"score": 1.0}))
+    database_session.commit()
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+    process_task = AsyncMock(side_effect=AssertionError("terminal task must not execute again"))
+    monkeypatch.setattr("tracker.utils.run_orchestration.process_task", process_task)
+
+    await process_benchmark(
+        benchmark.start_benchmark_request(harness_config).model_dump(),
+        str(benchmark.id),
+        _task_batch("retry", task.task_id, task.started_at),
+    )
+
+    database_session.refresh(benchmark)
+    process_task.assert_not_called()
+    assert benchmark.status == BenchmarkStatus.FINISHED
+    assert benchmark.final_evaluation is not None
+
+
+async def test_final_score_revalidates_attempts_before_publication(
+    database_session: Session,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract, status=TaskStatus.FINISHED)
+    database_session.add(EvaluationResult(org_id=TEST_ORG_ID, task=task.id, result={"score": 1.0}))
+    database_session.commit()
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+
+    async def retry_during_score(*_args: Any, **_kwargs: Any) -> FinalScoreResponse:
+        with Session(database_session.bind) as session:
+            current_task = session.get(Task, task.id)
+            assert current_task is not None
+            current_task.started_at = NEW_ATTEMPT
+            current_task.status = TaskStatus.PENDING
+            session.add(current_task)
+            session.commit()
+        return FinalScoreResponse(tasks_evaluated=[task.task_id], final_score=1.0, metadata={})
+
+    monkeypatch.setattr(BenchmarkServiceClient, "final_score", retry_during_score)
+    await process_benchmark(
+        benchmark.start_benchmark_request(harness_config).model_dump(),
+        str(benchmark.id),
+        [task.task_id],
+    )
+
+    database_session.refresh(benchmark)
+    database_session.refresh(task)
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+    assert benchmark.final_evaluation is None
+    assert task.status == TaskStatus.PENDING
+    assert task.started_at.replace(tzinfo=UTC) == NEW_ATTEMPT
+
+
+async def test_late_lambda_error_does_not_poison_retry(
+    database_session: Session,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract, status=TaskStatus.FINISHED)
+    database_session.add(EvaluationResult(org_id=TEST_ORG_ID, task=task.id, result={"score": 1.0}))
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+    benchmark.arguments = benchmark.arguments.model_copy(update={"lambda_function": "final-view"})
+    database_session.add(benchmark)
+    database_session.commit()
+
+    def retry_then_fail(*_args: Any, **_kwargs: Any) -> None:
+        with Session(database_session.bind) as session:
+            current_benchmark = session.get(Benchmark, benchmark.id)
+            assert current_benchmark is not None
+            current_benchmark.status = BenchmarkStatus.IN_PROGRESS
+            new_task = Task(
+                org_id=TEST_ORG_ID,
+                task_id="task_1",
+                benchmark=benchmark.id,
+                status=TaskStatus.FINISHED,
+                started_at=NEW_ATTEMPT,
+            )
+            session.add(current_benchmark)
+            session.add(new_task)
+            session.flush()
+            session.add(EvaluationResult(org_id=TEST_ORG_ID, task=new_task.id, result={"score": 1.0}))
+            session.commit()
+        raise TimeoutError("old Lambda timed out")
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", retry_then_fail)
+    await process_benchmark(
+        benchmark.start_benchmark_request(harness_config).model_dump(),
+        str(benchmark.id),
+        [task.task_id],
+    )
+
+    database_session.refresh(benchmark)
+    database_session.refresh(task)
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+    assert benchmark.error_message is None
+    assert task.status == TaskStatus.FINISHED
+    added_task = database_session.exec(
+        select(Task).where(Task.benchmark == benchmark.id).where(Task.task_id == "task_1")
+    ).one()
+    assert added_task.status == TaskStatus.FINISHED
+    assert database_session.exec(select(ErrorResult)).all() == []
+
+
+async def test_terminal_redelivery_does_not_reopen_run(
+    database_session: Session,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    task = _create_task(database_session, contract, status=TaskStatus.FINISHED)
+    database_session.add(EvaluationResult(org_id=TEST_ORG_ID, task=task.id, result={"score": 1.0}))
+    benchmark = database_session.get(Benchmark, task.benchmark)
+    assert benchmark is not None
+    benchmark.status = BenchmarkStatus.FINISHED
+    database_session.add(benchmark)
+    database_session.commit()
+    score = AsyncMock()
+    monkeypatch.setattr(BenchmarkServiceClient, "final_score", score)
+
+    await process_benchmark(
+        benchmark.start_benchmark_request(harness_config).model_dump(),
+        str(benchmark.id),
+        [task.task_id],
+    )
+
+    database_session.refresh(benchmark)
+    score.assert_not_called()
+    assert benchmark.status == BenchmarkStatus.FINISHED

--- a/services/tracker/tests/unit/test_tracker.py
+++ b/services/tracker/tests/unit/test_tracker.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio import Semaphore, gather
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
@@ -54,13 +55,19 @@ class TestTracker:
         database_session.commit()
 
         tasks_to_track: list[str] = ["task_id_1"]
+        expected_attempts: dict[str, datetime] = {}
         for task_id in tasks_to_track:
             task_row = Task(org_id=TEST_ORG_ID, task_id=task_id, benchmark=benchmark_row.id)
             database_session.add(task_row)
             database_session.commit()
+            expected_attempts[task_id] = task_row.started_at
 
         task_tracking: dict[str, TrackedTask] = {
-            task_id: TrackedTask(coro=self._mock_coro(task_id=task_id), org=self._test_org)
+            task_id: TrackedTask(
+                coro=self._mock_coro(task_id=task_id),
+                org=self._test_org,
+                expected_started_at=expected_attempts[task_id],
+            )
             for task_id in tasks_to_track
         }
 
@@ -79,7 +86,7 @@ class TestTracker:
         task_tracking["task_id_1"]._task = Mock(cancel=cancel_mock, done=lambda: False)  # type: ignore
 
         # Test case 1. Validate task returns true if the task is not stopped
-        assert monitor._validate_task("task_id_1")  # type: ignore
+        assert monitor._validate_task("task_id_1", expected_attempts["task_id_1"])  # type: ignore
 
         # Change the task status to stopped to make sure that it gets invalidated inside of the validate task method
         task_row = monitor._fetch_task_row("task_id_1")  # type: ignore
@@ -91,7 +98,7 @@ class TestTracker:
 
         # Test case 2. Validate task returns false if the task status has been set to stopped
         # NOTE: ensures that the database change gets picked up by the session
-        assert not monitor._validate_task("task_id_1")  # type: ignore
+        assert not monitor._validate_task("task_id_1", expected_attempts["task_id_1"])  # type: ignore
 
         # Test case 3. Running tasks stay tracked until they are done
         await monitor.track_tasks()
@@ -124,7 +131,7 @@ class TestTracker:
         mock_task_row_2 = MagicMock(spec=Task)
         mock_task_row_2.task_id = "task_id_2"
 
-        tracked_task = TrackedTask(coro=mock_coro, org=self._test_org)
+        tracked_task = TrackedTask(coro=mock_coro, org=self._test_org, expected_started_at=datetime.now(UTC))
 
         # Test case 1. When first created, it is in the waiting state
         assert tracked_task.status == TrackedTaskStatus.WAITING
@@ -133,7 +140,9 @@ class TestTracker:
         # Create another task that tracks the status of the first task
         # Allows us to test that the task status changes to running once the semaphore is aquired.
         tracked_task_2 = TrackedTask(
-            coro=self._validate_task_state_before_run(tracked_task, "task_id_2"), org=self._test_org
+            coro=self._validate_task_state_before_run(tracked_task, "task_id_2"),
+            org=self._test_org,
+            expected_started_at=datetime.now(UTC),
         )
 
         mock_task_row_2 = MagicMock(spec=Task)
@@ -160,7 +169,11 @@ class TestTracker:
         mock_task_row_3 = MagicMock(spec=Task)
         mock_task_row_3.task_id = "task_id_3"
 
-        tracked_task = TrackedTask(coro=self._mock_coro(task_id="task_id_3"), org=self._test_org)
+        tracked_task = TrackedTask(
+            coro=self._mock_coro(task_id="task_id_3"),
+            org=self._test_org,
+            expected_started_at=datetime.now(UTC),
+        )
         semaphore = Semaphore(value=1)
         run_task = asyncio.create_task(tracked_task.run(semaphore, mock_task_row_3))
 
@@ -190,8 +203,16 @@ class TestTracker:
         mock_task_row_5 = MagicMock(spec=Task)
         mock_task_row_5.task_id = "task_id_5"
 
-        running_task = TrackedTask(coro=self._mock_coro(task_id="task_id_4"), org=self._test_org)
-        waiting_task = TrackedTask(coro=self._mock_coro(task_id="task_id_5"), org=self._test_org)
+        running_task = TrackedTask(
+            coro=self._mock_coro(task_id="task_id_4"),
+            org=self._test_org,
+            expected_started_at=datetime.now(UTC),
+        )
+        waiting_task = TrackedTask(
+            coro=self._mock_coro(task_id="task_id_5"),
+            org=self._test_org,
+            expected_started_at=datetime.now(UTC),
+        )
 
         semaphore = Semaphore(value=1)
 


### PR DESCRIPTION
## Summary

- attach exact task attempt timestamps to new start and retry queue messages
- reject delayed messages and stale task writes after a stop and retry
- cancel old task coroutines when their task generation changes
- revalidate the full task snapshot before committing a final score
- keep legacy list messages readable for a two-phase rollout
- expose the default-off producer flag through the tracker task definition and GitHub Actions variable

## Verification

- tracker unit suite: 223 passed
- focused tracker suite: 57 passed
- infra suite: 9 passed and 9 subtests passed
- targeted basedpyright: 0 errors
- Ruff, formatting, and git diff checks pass

## Required rollout

1. Deploy this reader-compatible code with TOKENIZED_RETRY_BATCHES_ENABLED=false.
2. Force-stop target runs and fully drain old worker revisions, legacy queue messages, sandboxes, and uploads.
3. Set the repository Actions variable TOKENIZED_RETRY_BATCHES_ENABLED=true and deploy again.
4. Only then enqueue Luna retries.

## Explicit boundaries

This PR prevents stale database state adoption. It does not add leases for hard worker death, and it does not make fixed S3 task artifacts or final-view Lambdas generation-safe. The FAB watcher must remain stopped until the previous finalizer is known quiescent. Durable artifact publication needs generation-scoped staging plus conditional promotion in a separate change.

No deployment is included in this PR.