### PR TITLE
Add run identity and machine-readable run workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ valkyrie run list \
   --order-by DESC \
   --started-by alice@vals.ai,bob@vals.ai \
   --label swebench_claude_code
+
+# Dump every matching run as one machine-readable JSON document
+valkyrie run list --format json --all \
+  --model openai/gpt-5 \
+  --status IN_PROGRESS
 ```
 
 | Option | Description |
@@ -283,8 +288,12 @@ valkyrie run list \
 | `--status` | Filter by status: `IN_PROGRESS`, `STOPPING`, `STOPPED`, `FINISHED`, `ERROR` |
 | `--order-by` | Order results (`desc` or `asc`) |
 | `--started-by` | Comma-separated list of starter emails (case-insensitive) |
+| `--format json` | Emit one versioned, allowlisted JSON document instead of a table (requires `--all`) |
+| `--all` | Fetch every matching run without interactive paging (requires `--format json`) |
 
 Supports paginated navigation ([h] previous, [l] next, [q] quit).
+Machine output exhausts cursor pagination before writing stdout and excludes stored agent secrets, kwargs, and raw
+error messages.
 
 ### Download run outputs
 

--- a/README.md
+++ b/README.md
@@ -179,10 +179,18 @@ valkyrie run fetch <id> --connect
 
 # One-time status check
 valkyrie run fetch <id>
+
+# One-time machine-readable snapshot
+valkyrie run fetch <id> --format json
+
+# Machine-readable stream (one JSON object per line)
+valkyrie run fetch <id> --connect --format jsonl
 ```
 
 Connected fetches display the benchmark, agent, model, dataset, run ID, and other run metadata before streaming
-progress updates.
+progress updates. Machine-readable output uses a versioned, allowlisted schema and does not include stored agent
+secrets or kwargs. JSONL records use `snapshot`, `update`, `complete`, `error`, `stopped`, `disconnect`, or
+`interrupted` events. Terminal consumers should inspect both `event` and `status`.
 
 ### Download results
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ valkyrie run fetch <id> --connect
 valkyrie run fetch <id>
 ```
 
+Connected fetches display the benchmark, agent, model, dataset, run ID, and other run metadata before streaming
+progress updates.
+
 ### Download results
 
 To view results, you should use the following command to download results to disk:

--- a/README.md
+++ b/README.md
@@ -192,10 +192,23 @@ valkyrie run status --ids <id-1>,<id-2> --format json
 
 Connected text fetches display the benchmark, agent, model, dataset, run ID, and other run metadata before streaming
 progress updates. Machine-readable output uses a versioned, allowlisted schema and does not include stored agent
-secrets or kwargs. JSONL begins with a `snapshot` record, followed by `update` records and a final `complete`, `error`,
-`stopped`, `disconnect`, or `interrupted` event. Identity fields can be null when `metadata_available` is false;
-timestamps are UTC ISO 8601 strings. Agents should parse stdout as JSON/JSONL and always inspect the process exit
-code; unexpected stream exhaustion emits `disconnect` and exits nonzero.
+secrets or kwargs. JSONL begins with a `snapshot` record, followed by zero or more `update` records. Recognized stream
+termination emits `complete`, `error`, `stopped`, `disconnect`, or `interrupted`; unexpected clean exhaustion emits
+`disconnect` and exits nonzero. Transport or malformed-protocol failures can exit nonzero without a final record, so
+stderr and the process exit code remain authoritative for command failures.
+
+Exit code 0 means the CLI handled the response or stream event; it does not mean the benchmark itself succeeded.
+Agents must inspect each run's `status` and each JSONL record's `event`. Optional values such as model, starter, label,
+finish time, and score can be null. In fetch output, `metadata_available: false` specifically means identity metadata
+could not be loaded. All timestamps are UTC ISO 8601 strings, and non-finite scores are normalized to null.
+
+The version 1 machine document shapes are:
+
+- Fetch JSON/JSONL record: `schema_version`, `event`, `observed_at`, run identity, status/progress counts, score, and
+  metadata availability.
+- Run list document: `schema_version`, `kind: "run_list"`, `observed_at`, `returned_count`, and allowlisted `runs`.
+- Batch status document: `schema_version`, `kind: "run_status"`, `observed_at`, request/return counts,
+  `missing_run_ids`, and lightweight `runs` containing status and task counts.
 
 Batch status preserves the requested ID order, ignores duplicate IDs, and requests up to 50 IDs at a time. A missing
 or inaccessible ID is listed in `missing_run_ids` and makes the command exit nonzero after emitting the JSON document.

--- a/README.md
+++ b/README.md
@@ -185,12 +185,22 @@ valkyrie run fetch <id> --format json
 
 # Machine-readable stream (one JSON object per line)
 valkyrie run fetch <id> --connect --format jsonl
+
+# Lightweight status for several known run IDs
+valkyrie run status --ids <id-1>,<id-2> --format json
 ```
 
-Connected fetches display the benchmark, agent, model, dataset, run ID, and other run metadata before streaming
+Connected text fetches display the benchmark, agent, model, dataset, run ID, and other run metadata before streaming
 progress updates. Machine-readable output uses a versioned, allowlisted schema and does not include stored agent
-secrets or kwargs. JSONL records use `snapshot`, `update`, `complete`, `error`, `stopped`, `disconnect`, or
-`interrupted` events. Terminal consumers should inspect both `event` and `status`.
+secrets or kwargs. JSONL begins with a `snapshot` record, followed by `update` records and a final `complete`, `error`,
+`stopped`, `disconnect`, or `interrupted` event. Identity fields can be null when `metadata_available` is false;
+timestamps are UTC ISO 8601 strings. Agents should parse stdout as JSON/JSONL and always inspect the process exit
+code; unexpected stream exhaustion emits `disconnect` and exits nonzero.
+
+Batch status preserves the requested ID order, ignores duplicate IDs, and requests up to 50 IDs at a time. A missing
+or inaccessible ID is listed in `missing_run_ids` and makes the command exit nonzero after emitting the JSON document.
+Its `finished_tasks` count includes terminal `FINISHED`, `ERROR`, and `STOPPED` tasks. Use `run list --format json --all`
+when benchmark, agent, model, or dataset identity is also needed.
 
 ### Download results
 

--- a/src/valkyrie/cli/main.py
+++ b/src/valkyrie/cli/main.py
@@ -1,6 +1,7 @@
 """CLI views/commands for Valkyrie."""
 
 import click
+from dotenv import load_dotenv
 
 from valkyrie.cli.agent import agent
 from valkyrie.cli.benchmark import benchmark
@@ -12,6 +13,8 @@ from valkyrie.cli.run import run
 @click.group()
 def cli():
     """Valkyrie CLI."""
+    configure_cli_logging()
+    load_dotenv()
     configure_cli_logging()
 
 

--- a/src/valkyrie/cli/run/__init__.py
+++ b/src/valkyrie/cli/run/__init__.py
@@ -7,6 +7,7 @@ from valkyrie.cli.run.outputs import output_path, outputs
 from valkyrie.cli.run.results import results
 from valkyrie.cli.run.resume import resume, retry_command
 from valkyrie.cli.run.start import start
+from valkyrie.cli.run.status import status_runs
 from valkyrie.cli.run.stop import stop
 
 
@@ -25,10 +26,12 @@ run.add_command(results)
 run.add_command(resume)
 run.add_command(retry_command)
 run.add_command(start)
+run.add_command(status_runs)
 run.add_command(stop)
 
 __all__ = [
     "list_runs",
     "run",
     "start",
+    "status_runs",
 ]

--- a/src/valkyrie/cli/run/fetch.py
+++ b/src/valkyrie/cli/run/fetch.py
@@ -28,7 +28,7 @@ def fetch(run_id: UUID, connect: bool):
     try:
         with TrackerService() as tracker:
             if connect:
-                stream_benchmark_status(tracker, run_id)
+                stream_benchmark_status(tracker, run_id, show_identity=True)
             else:
                 response = tracker.fetch_benchmark(run_id)
                 format_benchmark_status(response)

--- a/src/valkyrie/cli/run/fetch.py
+++ b/src/valkyrie/cli/run/fetch.py
@@ -4,6 +4,7 @@ import click
 
 from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.run.progress import format_benchmark_status, stream_benchmark_status
+from valkyrie.cli.run.snapshot import fetch_run_metadata, format_run_snapshot_json
 from valkyrie.cli.tracker_client import TrackerService
 
 
@@ -17,7 +18,15 @@ from valkyrie.cli.tracker_client import TrackerService
     required=False,
     help="Connect to the tracker service to stream run updates",
 )
-def fetch(run_id: UUID, connect: bool):
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json", "jsonl"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format. Use json for a snapshot or jsonl with --connect.",
+)
+def fetch(run_id: UUID, connect: bool, output_format: str):
     """
     Fetch a run by its run id.
 
@@ -25,12 +34,24 @@ def fetch(run_id: UUID, connect: bool):
         valkyrie run fetch 123e4567-e89b-12d3-a456-426614174000 --connect
     """
 
+    if connect and output_format == "json":
+        raise click.UsageError("--format json cannot be used with --connect; use --format jsonl.")
+    if not connect and output_format == "jsonl":
+        raise click.UsageError("--format jsonl requires --connect.")
+
     try:
         with TrackerService() as tracker:
             if connect:
-                stream_benchmark_status(tracker, run_id, show_identity=True)
+                if output_format == "jsonl":
+                    stream_benchmark_status(tracker, run_id, output_format="jsonl")
+                else:
+                    stream_benchmark_status(tracker, run_id, show_identity=True)
             else:
                 response = tracker.fetch_benchmark(run_id)
-                format_benchmark_status(response)
+                if output_format == "json":
+                    metadata = fetch_run_metadata(tracker, run_id)
+                    click.echo(format_run_snapshot_json(response, metadata, event="snapshot"))
+                else:
+                    format_benchmark_status(response)
     except TrackerServiceError as e:
         raise click.ClickException(str(e))

--- a/src/valkyrie/cli/run/list_runs.py
+++ b/src/valkyrie/cli/run/list_runs.py
@@ -1,11 +1,14 @@
 import click
 from tracker.database.models import BenchmarkStatus
-from tracker.types import FetchBenchmarksRequest, FetchBenchmarksResponse, Order
+from tracker.types import BenchmarkTableRow, FetchBenchmarksRequest, FetchBenchmarksResponse, Order
 
 from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.display import format_table, paginate_cli_pages, short_local_time
 from valkyrie.cli.run.progress import BenchmarkFormatter
+from valkyrie.cli.run.snapshot import format_run_list_json
 from valkyrie.cli.tracker_client import TrackerService
+
+_MACHINE_PAGE_LIMIT = 500
 
 
 @click.command(
@@ -64,6 +67,20 @@ from valkyrie.cli.tracker_client import TrackerService
     default=None,
     help="Comma-separated list of starter emails (e.g., alice@vals.ai,bob@vals.ai). Case-insensitive.",
 )
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format. Machine-readable JSON requires --all.",
+)
+@click.option(
+    "--all",
+    "all_runs",
+    is_flag=True,
+    help="Fetch every matching run without interactive paging. Requires --format json.",
+)
 def list_runs(
     agent_name: str | None,
     benchmark_name: str | None,
@@ -73,6 +90,8 @@ def list_runs(
     status: str | None,
     order_by: str = "desc",
     started_by: str | None = None,
+    output_format: str = "text",
+    all_runs: bool = False,
 ):
     """
     List runs based on the request parameters.
@@ -84,21 +103,89 @@ def list_runs(
     """
     started_by_list: list[str] = [s.strip() for s in started_by.split(",") if s.strip()] if started_by else []
 
+    if output_format == "json" and not all_runs:
+        raise click.UsageError("--format json requires --all.")
+    if all_runs and output_format != "json":
+        raise click.UsageError("--all requires --format json.")
+
     try:
         with TrackerService() as tracker:
-            paginate_benchmarks(
-                tracker,
-                agent_name,
-                benchmark_name,
-                model,
-                dataset,
-                label,
-                status,
-                order_by,
-                started_by=started_by_list or None,
-            )
+            if output_format == "json":
+                request = _build_fetch_benchmarks_request(
+                    agent_name,
+                    benchmark_name,
+                    model,
+                    dataset,
+                    label,
+                    status,
+                    order_by,
+                    started_by_list or None,
+                    cursor="",
+                    limit=_MACHINE_PAGE_LIMIT,
+                )
+                click.echo(format_run_list_json(fetch_all_benchmarks(tracker, request)))
+            else:
+                paginate_benchmarks(
+                    tracker,
+                    agent_name,
+                    benchmark_name,
+                    model,
+                    dataset,
+                    label,
+                    status,
+                    order_by,
+                    started_by=started_by_list or None,
+                )
     except TrackerServiceError as e:
         raise click.ClickException(str(e))
+
+
+def _build_fetch_benchmarks_request(
+    agent_name: str | None,
+    benchmark_name: str | None,
+    model: str | None,
+    dataset: str | None,
+    label: str | None,
+    status: str | None,
+    order_by: str,
+    started_by: list[str] | None,
+    *,
+    cursor: str | None = None,
+    limit: int = 5,
+    offset: int = 0,
+) -> FetchBenchmarksRequest:
+    """Build a list request shared by human and machine output modes."""
+    return FetchBenchmarksRequest(
+        agent_name=[agent_name] if agent_name else None,
+        benchmark_name=[benchmark_name] if benchmark_name else None,
+        model=model,
+        dataset=dataset,
+        label=label,
+        status=[BenchmarkStatus(status)] if status else None,
+        started_by=started_by,
+        order_by=Order(order_by),
+        cursor=cursor,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def fetch_all_benchmarks(tracker: TrackerService, request: FetchBenchmarksRequest) -> list[BenchmarkTableRow]:
+    """Exhaust cursor pagination before writing any machine-readable output."""
+    benchmarks: list[BenchmarkTableRow] = []
+    cursor = request.cursor
+    seen_cursors: set[str] = set()
+
+    while cursor is not None:
+        if cursor in seen_cursors:
+            raise TrackerServiceError("Tracker returned a repeated run-list cursor.")
+        seen_cursors.add(cursor)
+
+        response = tracker.fetch_benchmarks(request.model_copy(update={"cursor": cursor}))
+        benchmarks.extend(response.benchmarks)
+        cursor = response.next_cursor
+
+    return benchmarks
 
 
 def format_fetch_benchmarks_response(
@@ -207,15 +294,15 @@ def paginate_benchmarks(
     """Interactively page through runs."""
 
     def load_page(offset: int, page_limit: int) -> tuple[int, FetchBenchmarksResponse]:
-        request = FetchBenchmarksRequest(
-            agent_name=[agent_name] if agent_name else None,
-            benchmark_name=[benchmark_name] if benchmark_name else None,
-            model=model,
-            dataset=dataset,
-            label=label,
-            status=[BenchmarkStatus(status)] if status else None,
-            started_by=started_by,
-            order_by=Order(order_by),
+        request = _build_fetch_benchmarks_request(
+            agent_name,
+            benchmark_name,
+            model,
+            dataset,
+            label,
+            status,
+            order_by,
+            started_by,
             limit=page_limit,
             offset=offset,
         )

--- a/src/valkyrie/cli/run/progress.py
+++ b/src/valkyrie/cli/run/progress.py
@@ -4,8 +4,9 @@ from uuid import UUID
 
 import click
 from tracker.database.models import DocentReadingStatus, TaskStatus
-from tracker.types import BenchmarkDetails, FetchBenchmarkResponse
+from tracker.types import BenchmarkDetails, FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
 
+from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.display import local_time
 from valkyrie.cli.tracker_client import TrackerService
 
@@ -85,6 +86,31 @@ def format_benchmark_status(benchmark_response: FetchBenchmarkResponse) -> None:
     click.echo("└" + "─" * 79)
 
 
+def format_run_identity(
+    benchmark_response: FetchBenchmarkResponse,
+    metadata: FetchBenchmarkMetadataResponse | None,
+) -> None:
+    """Display stable run identity before connected progress updates."""
+    click.echo("┌─ Run Details " + "─" * 65)
+    click.echo(f"│ {'Benchmark:':<17} {benchmark_response.benchmark_name}")
+    if metadata is not None:
+        arguments = metadata.benchmark_arguments
+        click.echo(f"│ {'Agent:':<17} {arguments.contract.name}")
+        click.echo(f"│ {'Model:':<17} {arguments.contract.model or '-'}")
+        click.echo(f"│ {'Dataset:':<17} {arguments.dataset or 'default'}")
+    click.echo(f"│ {'Run ID:':<17} {benchmark_response.benchmark_id}")
+    if benchmark_response.label:
+        click.echo(f"│ {'Label:':<17} {benchmark_response.label}")
+    if metadata is not None:
+        if metadata.started_by_email:
+            click.echo(f"│ {'Started by:':<17} {metadata.started_by_email}")
+        click.echo(f"│ {'Max concurrency:':<17} {metadata.benchmark_arguments.concurrency}")
+    else:
+        click.echo(f"│ {'Metadata:':<17} unavailable")
+    click.echo(f"│ {'Started at:':<17} {local_time(benchmark_response.details.started_at)}")
+    click.echo("└" + "─" * 79)
+
+
 def _format_docent_analysis(details: BenchmarkDetails, run_id: UUID) -> str | None:
     status = details.docent_reading_status
     if status == DocentReadingStatus.DONE and details.docent_reading_url:
@@ -109,10 +135,16 @@ def _stream_next_steps(benchmark_id: UUID, s3_url: str | None = None) -> None:
     click.echo("└" + "─" * 79)
 
 
-def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID) -> None:
+def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID, *, show_identity: bool = False) -> None:
     """Stream and display live run status updates."""
     initial = tracker.fetch_benchmark(benchmark_id)
     s3_url = initial.s3_bucket_url
+    if show_identity:
+        try:
+            metadata = tracker.fetch_benchmark_metadata(benchmark_id)
+        except TrackerServiceError:
+            metadata = None
+        format_run_identity(initial, metadata)
     click.echo(click.style("Streaming run updates (Ctrl+C to stop)...", fg="cyan"))
 
     initial_details = initial.details

--- a/src/valkyrie/cli/run/progress.py
+++ b/src/valkyrie/cli/run/progress.py
@@ -1,13 +1,14 @@
 """Run progress rendering and streaming helpers."""
 
+from typing import Literal
 from uuid import UUID
 
 import click
-from tracker.database.models import DocentReadingStatus, TaskStatus
+from tracker.database.models import BenchmarkStatus, DocentReadingStatus, TaskStatus
 from tracker.types import BenchmarkDetails, FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
 
-from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.display import local_time
+from valkyrie.cli.run.snapshot import fetch_run_metadata, format_run_snapshot_json
 from valkyrie.cli.tracker_client import TrackerService
 
 
@@ -135,28 +136,44 @@ def _stream_next_steps(benchmark_id: UUID, s3_url: str | None = None) -> None:
     click.echo("└" + "─" * 79)
 
 
-def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID, *, show_identity: bool = False) -> None:
+def _completion_event(response: FetchBenchmarkResponse) -> Literal["complete", "error", "stopped"]:
+    if response.details.status == BenchmarkStatus.ERROR:
+        return "error"
+    if response.details.status == BenchmarkStatus.STOPPED:
+        return "stopped"
+    return "complete"
+
+
+def stream_benchmark_status(
+    tracker: TrackerService,
+    benchmark_id: UUID,
+    *,
+    show_identity: bool = False,
+    output_format: Literal["text", "jsonl"] = "text",
+) -> None:
     """Stream and display live run status updates."""
     initial = tracker.fetch_benchmark(benchmark_id)
     s3_url = initial.s3_bucket_url
-    if show_identity:
-        try:
-            metadata = tracker.fetch_benchmark_metadata(benchmark_id)
-        except TrackerServiceError:
-            metadata = None
-        format_run_identity(initial, metadata)
-    click.echo(click.style("Streaming run updates (Ctrl+C to stop)...", fg="cyan"))
+    metadata = fetch_run_metadata(tracker, benchmark_id) if show_identity or output_format == "jsonl" else None
+    if output_format == "jsonl":
+        click.echo(format_run_snapshot_json(initial, metadata, event="snapshot"))
+    else:
+        if show_identity:
+            format_run_identity(initial, metadata)
+        click.echo(click.style("Streaming run updates (Ctrl+C to stop)...", fg="cyan"))
 
-    initial_details = initial.details
-    bar, progress_pct = BenchmarkFormatter.create_progress_bar(
-        initial_details.finished_tasks, initial_details.total_tasks
-    )
-    status_color = BenchmarkFormatter.STATUS_COLORS[initial_details.status.value]
-    status_text = click.style(initial_details.status.value.replace("_", " ").title(), fg=status_color, bold=True)
-    click.echo(
-        f"[{bar}] {initial_details.finished_tasks}/{initial_details.total_tasks} ({progress_pct:.1f}%) • {status_text}"
-    )
-    click.echo(BenchmarkFormatter.format_task_breakdown(initial_details.task_breakdown), nl=False)
+        initial_details = initial.details
+        bar, progress_pct = BenchmarkFormatter.create_progress_bar(
+            initial_details.finished_tasks, initial_details.total_tasks
+        )
+        status_color = BenchmarkFormatter.STATUS_COLORS[initial_details.status.value]
+        status_text = click.style(initial_details.status.value.replace("_", " ").title(), fg=status_color, bold=True)
+        click.echo(
+            f"[{bar}] {initial_details.finished_tasks}/{initial_details.total_tasks} ({progress_pct:.1f}%) • {status_text}"
+        )
+        click.echo(BenchmarkFormatter.format_task_breakdown(initial_details.task_breakdown), nl=False)
+
+    latest = initial
 
     try:
         for event in tracker.stream_benchmark(benchmark_id):
@@ -166,6 +183,11 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID, *, show
                     continue
 
                 response = FetchBenchmarkResponse.model_validate_json(data_json)
+                latest = response
+                if output_format == "jsonl":
+                    click.echo(format_run_snapshot_json(response, metadata, event="update"))
+                    continue
+
                 details = response.details
 
                 bar, progress_pct = BenchmarkFormatter.create_progress_bar(details.finished_tasks, details.total_tasks)
@@ -180,26 +202,38 @@ def stream_benchmark_status(tracker: TrackerService, benchmark_id: UUID, *, show
                 click.echo(f"\033[F\033[K{progress_line}\n\033[K{breakdown_text}", nl=False)
 
             elif event.startswith("event: complete"):
-                click.echo("\n")
-                click.echo(click.style("✓ Run completed!", fg="green", bold=True))
-                click.echo("┌─ Next Steps " + "─" * 66)
-                _stream_next_steps(benchmark_id, s3_url)
+                if output_format == "jsonl":
+                    click.echo(format_run_snapshot_json(latest, metadata, event=_completion_event(latest)))
+                else:
+                    click.echo("\n")
+                    click.echo(click.style("✓ Run completed!", fg="green", bold=True))
+                    click.echo("┌─ Next Steps " + "─" * 66)
+                    _stream_next_steps(benchmark_id, s3_url)
                 break
 
             elif event.startswith("event: error"):
-                click.echo("\n")
-                click.echo(click.style("✗ Run errored.", fg="red", bold=True))
-                click.echo("┌─ Next Steps " + "─" * 66)
-                _stream_next_steps(benchmark_id, s3_url)
+                if output_format == "jsonl":
+                    click.echo(format_run_snapshot_json(latest, metadata, event="error"))
+                else:
+                    click.echo("\n")
+                    click.echo(click.style("✗ Run errored.", fg="red", bold=True))
+                    click.echo("┌─ Next Steps " + "─" * 66)
+                    _stream_next_steps(benchmark_id, s3_url)
                 break
 
             elif event.startswith("event: disconnect"):
-                click.echo("\n")
-                click.echo(click.style("Disconnected from stream.", fg="yellow"))
+                if output_format == "jsonl":
+                    click.echo(format_run_snapshot_json(latest, metadata, event="disconnect"))
+                else:
+                    click.echo("\n")
+                    click.echo(click.style("Disconnected from stream.", fg="yellow"))
                 break
 
     except KeyboardInterrupt:
-        click.echo("\n")
-        click.echo(click.style("Streaming stopped.", fg="yellow"))
-        click.echo("┌─ Next Steps " + "─" * 66)
-        _stream_next_steps(benchmark_id, s3_url)
+        if output_format == "jsonl":
+            click.echo(format_run_snapshot_json(latest, metadata, event="interrupted"))
+        else:
+            click.echo("\n")
+            click.echo(click.style("Streaming stopped.", fg="yellow"))
+            click.echo("┌─ Next Steps " + "─" * 66)
+            _stream_next_steps(benchmark_id, s3_url)

--- a/src/valkyrie/cli/run/progress.py
+++ b/src/valkyrie/cli/run/progress.py
@@ -228,6 +228,13 @@ def stream_benchmark_status(
                     click.echo("\n")
                     click.echo(click.style("Disconnected from stream.", fg="yellow"))
                 break
+        else:
+            if output_format == "jsonl":
+                click.echo(format_run_snapshot_json(latest, metadata, event="disconnect"))
+            else:
+                click.echo("\n")
+                click.echo(click.style("Disconnected from stream.", fg="yellow"))
+            raise click.ClickException("Run stream ended without a terminal event.")
 
     except KeyboardInterrupt:
         if output_format == "jsonl":

--- a/src/valkyrie/cli/run/snapshot.py
+++ b/src/valkyrie/cli/run/snapshot.py
@@ -6,7 +6,12 @@ from typing import Literal
 from uuid import UUID
 
 from tracker.database.models import TaskStatus
-from tracker.types import BenchmarkTableRow, FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
+from tracker.types import (
+    BenchmarkStatusEntry,
+    BenchmarkTableRow,
+    FetchBenchmarkMetadataResponse,
+    FetchBenchmarkResponse,
+)
 
 from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.tracker_client import TrackerService
@@ -111,5 +116,41 @@ def format_run_list_json(runs: list[BenchmarkTableRow], *, observed_at: datetime
         "observed_at": _utc_isoformat(observed_at or datetime.now(timezone.utc)),
         "returned_count": len(runs),
         "runs": [build_run_summary(run) for run in runs],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def build_run_status(entry: BenchmarkStatusEntry) -> dict[str, object]:
+    """Build a stable allowlisted batch-status record."""
+    progress_percent = (entry.finished_tasks / entry.total_tasks * 100) if entry.total_tasks else 0.0
+    return {
+        "run_id": str(entry.id),
+        "status": entry.status.value,
+        "finished_at": _utc_isoformat(entry.finished_at) if entry.finished_at is not None else None,
+        "total_tasks": entry.total_tasks,
+        "finished_tasks": entry.finished_tasks,
+        "task_state_counts": {
+            task_status.value: entry.task_state_counts.get(task_status.value, 0) for task_status in TaskStatus
+        },
+        "progress_percent": round(progress_percent, 4),
+    }
+
+
+def format_run_status_json(
+    entries: list[BenchmarkStatusEntry],
+    missing_run_ids: list[UUID],
+    *,
+    requested_count: int,
+    observed_at: datetime | None = None,
+) -> str:
+    """Serialize deterministic multi-run status output as one compact JSON document."""
+    payload = {
+        "schema_version": 1,
+        "kind": "run_status",
+        "observed_at": _utc_isoformat(observed_at or datetime.now(timezone.utc)),
+        "requested_count": requested_count,
+        "returned_count": len(entries),
+        "missing_run_ids": [str(run_id) for run_id in missing_run_ids],
+        "runs": [build_run_status(entry) for entry in entries],
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/src/valkyrie/cli/run/snapshot.py
+++ b/src/valkyrie/cli/run/snapshot.py
@@ -1,7 +1,9 @@
 """Safe machine-readable snapshots for benchmark runs."""
 
 import json
+from collections.abc import Mapping
 from datetime import datetime, timezone
+from math import isfinite
 from typing import Literal
 from uuid import UUID
 
@@ -31,6 +33,15 @@ def _utc_isoformat(value: datetime) -> str:
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _finite_score_or_none(value: float | None) -> float | None:
+    return value if value is None or isfinite(value) else None
+
+
+def _format_json(payload: Mapping[str, object]) -> str:
+    """Serialize strict compact JSON; NaN and Infinity are never valid machine output."""
+    return json.dumps(payload, allow_nan=False, sort_keys=True, separators=(",", ":"))
 
 
 def build_run_snapshot(
@@ -66,7 +77,7 @@ def build_run_snapshot(
         },
         "progress_percent": round(progress_percent, 4),
         "max_concurrency": arguments.concurrency if arguments is not None else None,
-        "final_score": response.final_score,
+        "final_score": _finite_score_or_none(response.final_score),
         "s3_bucket_url": response.s3_bucket_url,
         "docent_reading_status": details.docent_reading_status.value,
         "docent_reading_url": details.docent_reading_url,
@@ -81,7 +92,7 @@ def format_run_snapshot_json(
     event: RunEvent,
 ) -> str:
     """Serialize one compact JSON or JSONL record."""
-    return json.dumps(build_run_snapshot(response, metadata, event=event), sort_keys=True, separators=(",", ":"))
+    return _format_json(build_run_snapshot(response, metadata, event=event))
 
 
 def build_run_summary(run: BenchmarkTableRow) -> dict[str, object]:
@@ -104,7 +115,7 @@ def build_run_summary(run: BenchmarkTableRow) -> dict[str, object]:
             task_status.value: run.task_state_counts.get(task_status.value, 0) for task_status in TaskStatus
         },
         "progress_percent": round(progress_percent, 4),
-        "final_score": run.final_score,
+        "final_score": _finite_score_or_none(run.final_score),
     }
 
 
@@ -117,7 +128,7 @@ def format_run_list_json(runs: list[BenchmarkTableRow], *, observed_at: datetime
         "returned_count": len(runs),
         "runs": [build_run_summary(run) for run in runs],
     }
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return _format_json(payload)
 
 
 def build_run_status(entry: BenchmarkStatusEntry) -> dict[str, object]:
@@ -153,4 +164,4 @@ def format_run_status_json(
         "missing_run_ids": [str(run_id) for run_id in missing_run_ids],
         "runs": [build_run_status(entry) for entry in entries],
     }
-    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return _format_json(payload)

--- a/src/valkyrie/cli/run/snapshot.py
+++ b/src/valkyrie/cli/run/snapshot.py
@@ -6,7 +6,7 @@ from typing import Literal
 from uuid import UUID
 
 from tracker.database.models import TaskStatus
-from tracker.types import FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
+from tracker.types import BenchmarkTableRow, FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
 
 from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.tracker_client import TrackerService
@@ -77,3 +77,39 @@ def format_run_snapshot_json(
 ) -> str:
     """Serialize one compact JSON or JSONL record."""
     return json.dumps(build_run_snapshot(response, metadata, event=event), sort_keys=True, separators=(",", ":"))
+
+
+def build_run_summary(run: BenchmarkTableRow) -> dict[str, object]:
+    """Build a stable allowlisted run summary for list output."""
+    progress_percent = (run.finished_tasks / run.total_tasks * 100) if run.total_tasks else 0.0
+    return {
+        "run_id": str(run.id),
+        "benchmark_name": run.name,
+        "agent_name": run.agent_name,
+        "model": run.model,
+        "dataset": run.dataset or "default",
+        "label": run.label,
+        "started_by_email": run.started_by_email,
+        "started_at": _utc_isoformat(run.started_at),
+        "finished_at": _utc_isoformat(run.finished_at) if run.finished_at is not None else None,
+        "status": run.status.value,
+        "total_tasks": run.total_tasks,
+        "finished_tasks": run.finished_tasks,
+        "task_state_counts": {
+            task_status.value: run.task_state_counts.get(task_status.value, 0) for task_status in TaskStatus
+        },
+        "progress_percent": round(progress_percent, 4),
+        "final_score": run.final_score,
+    }
+
+
+def format_run_list_json(runs: list[BenchmarkTableRow], *, observed_at: datetime | None = None) -> str:
+    """Serialize a complete set of matching runs as one compact JSON document."""
+    payload = {
+        "schema_version": 1,
+        "kind": "run_list",
+        "observed_at": _utc_isoformat(observed_at or datetime.now(timezone.utc)),
+        "returned_count": len(runs),
+        "runs": [build_run_summary(run) for run in runs],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/src/valkyrie/cli/run/snapshot.py
+++ b/src/valkyrie/cli/run/snapshot.py
@@ -1,0 +1,79 @@
+"""Safe machine-readable snapshots for benchmark runs."""
+
+import json
+from datetime import datetime, timezone
+from typing import Literal
+from uuid import UUID
+
+from tracker.database.models import TaskStatus
+from tracker.types import FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.tracker_client import TrackerService
+
+RunEvent = Literal["snapshot", "update", "complete", "error", "stopped", "disconnect", "interrupted"]
+
+
+def fetch_run_metadata(tracker: TrackerService, run_id: UUID) -> FetchBenchmarkMetadataResponse | None:
+    """Fetch optional identity metadata without making status monitoring fail."""
+    try:
+        return tracker.fetch_benchmark_metadata(run_id)
+    except TrackerServiceError:
+        return None
+
+
+def _utc_isoformat(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def build_run_snapshot(
+    response: FetchBenchmarkResponse,
+    metadata: FetchBenchmarkMetadataResponse | None,
+    *,
+    event: RunEvent,
+    observed_at: datetime | None = None,
+) -> dict[str, object]:
+    """Build a versioned allowlisted view that excludes stored contract secrets and kwargs."""
+    details = response.details
+    arguments = metadata.benchmark_arguments if metadata is not None else None
+    contract = arguments.contract if arguments is not None else None
+    progress_percent = (details.finished_tasks / details.total_tasks * 100) if details.total_tasks else 0.0
+
+    return {
+        "schema_version": 1,
+        "event": event,
+        "observed_at": _utc_isoformat(observed_at or datetime.now(timezone.utc)),
+        "run_id": str(response.benchmark_id),
+        "benchmark_name": response.benchmark_name,
+        "agent_name": contract.name if contract is not None else None,
+        "model": contract.model if contract is not None else None,
+        "dataset": (arguments.dataset or "default") if arguments is not None else None,
+        "label": response.label,
+        "started_by_email": metadata.started_by_email if metadata is not None else None,
+        "started_at": _utc_isoformat(details.started_at),
+        "status": details.status.value,
+        "total_tasks": details.total_tasks,
+        "finished_tasks": details.finished_tasks,
+        "task_state_counts": {
+            task_status.value: details.task_breakdown.get(task_status, 0) for task_status in TaskStatus
+        },
+        "progress_percent": round(progress_percent, 4),
+        "max_concurrency": arguments.concurrency if arguments is not None else None,
+        "final_score": response.final_score,
+        "s3_bucket_url": response.s3_bucket_url,
+        "docent_reading_status": details.docent_reading_status.value,
+        "docent_reading_url": details.docent_reading_url,
+        "metadata_available": metadata is not None,
+    }
+
+
+def format_run_snapshot_json(
+    response: FetchBenchmarkResponse,
+    metadata: FetchBenchmarkMetadataResponse | None,
+    *,
+    event: RunEvent,
+) -> str:
+    """Serialize one compact JSON or JSONL record."""
+    return json.dumps(build_run_snapshot(response, metadata, event=event), sort_keys=True, separators=(",", ":"))

--- a/src/valkyrie/cli/run/status.py
+++ b/src/valkyrie/cli/run/status.py
@@ -1,0 +1,110 @@
+from uuid import UUID
+
+import click
+from tracker.types import BenchmarkStatusEntry
+
+from valkyrie.cli.display import format_table
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run.progress import BenchmarkFormatter
+from valkyrie.cli.run.snapshot import format_run_status_json
+from valkyrie.cli.tracker_client import TrackerService
+
+_STATUS_BATCH_SIZE = 50
+
+
+@click.command(
+    name="status",
+    help=(
+        "Fetch lightweight status for multiple run IDs.\n\n"
+        "Example:\n"
+        "valkyrie run status --ids "
+        "123e4567-e89b-12d3-a456-426614174000,123e4567-e89b-12d3-a456-426614174001 --format json"
+    ),
+)
+@click.option(
+    "--ids",
+    "run_ids_value",
+    required=True,
+    help="Comma-separated run UUIDs. Duplicates are ignored while preserving order.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+def status_runs(run_ids_value: str, output_format: str) -> None:
+    """Fetch lightweight progress for a deterministic set of run IDs."""
+    run_ids = parse_run_ids(run_ids_value)
+
+    try:
+        with TrackerService() as tracker:
+            entries = fetch_status_entries(tracker, run_ids)
+    except TrackerServiceError as e:
+        raise click.ClickException(str(e))
+
+    entries_by_id = {entry.id: entry for entry in entries}
+    ordered_entries = [entries_by_id[run_id] for run_id in run_ids if run_id in entries_by_id]
+    missing_run_ids = [run_id for run_id in run_ids if run_id not in entries_by_id]
+
+    if output_format == "json":
+        click.echo(
+            format_run_status_json(
+                ordered_entries,
+                missing_run_ids,
+                requested_count=len(run_ids),
+            )
+        )
+    else:
+        format_status_table(ordered_entries)
+
+    if missing_run_ids:
+        raise click.ClickException(f"{len(missing_run_ids)} requested run ID(s) were not found or are not accessible.")
+
+
+def parse_run_ids(value: str) -> list[UUID]:
+    """Parse comma-separated UUIDs and de-duplicate them in input order."""
+    raw_ids = [part.strip() for part in value.split(",") if part.strip()]
+    if not raw_ids:
+        raise click.BadParameter("provide at least one run UUID", param_hint="--ids")
+
+    run_ids: list[UUID] = []
+    seen: set[UUID] = set()
+    for raw_id in raw_ids:
+        try:
+            run_id = UUID(raw_id)
+        except ValueError as e:
+            raise click.BadParameter(f"invalid run UUID: {raw_id}", param_hint="--ids") from e
+        if run_id not in seen:
+            seen.add(run_id)
+            run_ids.append(run_id)
+    return run_ids
+
+
+def fetch_status_entries(tracker: TrackerService, run_ids: list[UUID]) -> list[BenchmarkStatusEntry]:
+    """Fetch status entries in URL-safe batches without writing partial output."""
+    entries: list[BenchmarkStatusEntry] = []
+    for start in range(0, len(run_ids), _STATUS_BATCH_SIZE):
+        response = tracker.fetch_benchmark_statuses(run_ids[start : start + _STATUS_BATCH_SIZE])
+        entries.extend(response.entries)
+    return entries
+
+
+def format_status_table(entries: list[BenchmarkStatusEntry]) -> None:
+    """Render lightweight multi-run status for humans."""
+    rows: list[dict[str, str]] = []
+    for entry in entries:
+        _, progress_percent = BenchmarkFormatter.create_progress_bar(entry.finished_tasks, entry.total_tasks)
+        rows.append(
+            {
+                "ID": str(entry.id),
+                "Status": click.style(
+                    entry.status.value.replace("_", " ").title(),
+                    fg=BenchmarkFormatter.STATUS_COLORS[entry.status.value],
+                ),
+                "Progress": f"{entry.finished_tasks}/{entry.total_tasks} ({progress_percent:.1f}%)",
+            }
+        )
+    format_table(rows, ["ID", "Status", "Progress"], total_count=len(entries), item_name="run")

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -18,6 +18,7 @@ from tracker.types import (
     BenchmarkServiceEntry,
     BenchmarkServicesRequest,
     BenchmarkServicesResponse,
+    BenchmarkStatusResponse,
     FetchBenchmarkMetadataResponse,
     FetchBenchmarkResponse,
     FetchBenchmarkTasksRequest,
@@ -683,6 +684,17 @@ class TrackerService:
             return FetchBenchmarksResponse.model_validate(_parse_response(response, "Failed to fetch runs"))
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to fetch runs: {e}") from e
+
+    def fetch_benchmark_statuses(self, benchmark_ids: list[UUID]) -> BenchmarkStatusResponse:
+        """Fetch lightweight status and task counts for multiple runs."""
+        try:
+            response = self._client.get(
+                f"{self._base_url}/benchmarks/status",
+                params={"ids": ",".join(str(benchmark_id) for benchmark_id in benchmark_ids)},
+            )
+            return BenchmarkStatusResponse.model_validate(_parse_response(response, "Failed to fetch run statuses"))
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to fetch run statuses: {e}") from e
 
     def fetch_run_outputs(self, benchmark_id: UUID, task_ids: list[str] | None = None) -> Response:
         """

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -34,8 +34,6 @@ from tracker.types import (
 
 from valkyrie.cli.exceptions import TrackerNotFoundError, TrackerServiceError
 
-load_dotenv()
-
 TRACKER_URL = os.environ.get("TRACKER_SERVICE_URL", "https://benchmark-tracker.vals.ai")
 _CONFIG_LOCATION = Path("~/.config/valkyrie/valkyrie.yaml")
 _REQUIRED_CONFIG_KEYS = {
@@ -45,6 +43,16 @@ _REQUIRED_CONFIG_KEYS = {
     "S3_BUCKET",
 }
 _PROVIDER_SETUP_COMMAND = "valkyrie config provider set <provider> <secret-name>"
+
+
+def _resolve_tracker_url(base_url: str | None) -> str:
+    """Load local environment values after CLI logging has been configured."""
+    if base_url is not None:
+        return base_url.rstrip("/")
+
+    load_dotenv()
+    resolved_url = os.environ.get("TRACKER_SERVICE_URL", TRACKER_URL)
+    return resolved_url.rstrip("/")
 
 
 def _sandbox_providers(config: dict[str, Any]) -> dict[str, str]:
@@ -109,7 +117,7 @@ class TrackerService:
 
     def __init__(
         self,
-        base_url: str = TRACKER_URL,
+        base_url: str | None = None,
         timeout: int = 120,
         require_config: bool = True,
     ):
@@ -123,7 +131,7 @@ class TrackerService:
         """
         self._config = self._load_config()
         self._api_key = self._config.get("api_key")
-        self._base_url = base_url.rstrip("/")
+        self._base_url = _resolve_tracker_url(base_url)
         self._timeout = timeout
         self._config_values = self.parse_config_keys() if require_config else {}
         self._client = httpx.Client(timeout=timeout, headers=self._build_auth_headers())
@@ -349,11 +357,12 @@ class TrackerService:
             raise TrackerServiceError(f"Failed to check benchmark services: {e}") from e
 
     @classmethod
-    def init_org(cls, api_key: str, base_url: str = TRACKER_URL) -> dict[str, str | bool]:
+    def init_org(cls, api_key: str, base_url: str | None = None) -> dict[str, str | bool]:
         """Validate a Descope API key and create/confirm the org. Does not require a full config."""
+        tracker_url = _resolve_tracker_url(base_url)
         try:
             with httpx.Client(timeout=120, headers={"X-Api-Key": api_key}) as client:
-                response = client.post(f"{base_url.rstrip('/')}/init")
+                response = client.post(f"{tracker_url}/init")
 
                 return _parse_response(response, "Failed to initialize org")
         except httpx.HTTPError as e:

--- a/tests/unit/test_cli_logging.py
+++ b/tests/unit/test_cli_logging.py
@@ -1,5 +1,15 @@
 import io
+import json
 import logging
+import os
+import shutil
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import urlparse
+from uuid import uuid4
 
 import pytest
 
@@ -54,3 +64,111 @@ def test_configure_cli_logging_suppresses_logs_for_non_true_values(value: str, m
     configure_cli_logging()
 
     assert _emit_info_log() == ""
+
+
+def test_machine_json_subprocess_suppresses_import_time_dotenv_warnings(tmp_path: Path) -> None:
+    """A real CLI process must emit exactly one JSON document even when dotenv parsing warns."""
+    run_id = uuid4()
+
+    class TrackerHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            path = urlparse(self.path).path
+            if path == "/health":
+                payload: object = {"status": "healthy"}
+            elif path == "/fetch-benchmark":
+                payload = {
+                    "benchmark_name": "swebench",
+                    "benchmark_id": str(run_id),
+                    "details": {
+                        "status": "IN_PROGRESS",
+                        "started_at": "2026-07-09T12:30:00Z",
+                        "total_tasks": 1,
+                        "finished_tasks": 0,
+                        "task_breakdown": {"PENDING": 1},
+                        "docent_reading_status": "IDLE",
+                    },
+                    "s3_bucket_url": "s3://example/run",
+                }
+            elif path == f"/fetch-benchmark-metadata/{run_id}":
+                payload = {
+                    "benchmark_id": str(run_id),
+                    "benchmark_name": "swebench",
+                    "benchmark_arguments": {
+                        "contract": {"name": "agent", "model": "openai/gpt-5"},
+                        "concurrency": 1,
+                        "dataset": "default",
+                    },
+                }
+            else:
+                self.send_error(404)
+                return
+
+            body = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return None
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), TrackerHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        project_root = Path(__file__).parents[2]
+        tool_root = tmp_path / "tool-root"
+        site_packages = tool_root / "lib" / "python3.12" / "site-packages"
+        shutil.copytree(project_root / "src" / "valkyrie", site_packages / "valkyrie")
+        (tool_root / ".env").write_text("this is not valid dotenv syntax = 'unterminated\n")
+        runner = tmp_path / "run_valkyrie.py"
+        runner.write_text("from valkyrie.cli.entry import main\n\nmain()\n")
+
+        home = tmp_path / "home"
+        config_dir = home / ".config" / "valkyrie"
+        config_dir.mkdir(parents=True)
+        (config_dir / "valkyrie.yaml").write_text(
+            "AWS_ACCESS_KEY_ID: test\n"
+            "AWS_SECRET_ACCESS_KEY: test\n"
+            "AWS_DEFAULT_REGION: us-east-1\n"
+            "S3_BUCKET: test\n"
+            "LOG_GROUP: test\n"
+            "LOG_RETENTION_POLICY: 1\n"
+            "DAYTONA_SECRET_NAME: test\n"
+        )
+
+        env = os.environ.copy()
+        env["HOME"] = str(home)
+        env["PYTHONPATH"] = os.pathsep.join([str(site_packages), *filter(None, [env.get("PYTHONPATH")])])
+        env["TRACKER_SERVICE_URL"] = f"http://127.0.0.1:{server.server_port}"
+        env.pop("VALKYRIE_CLI_LOGS", None)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(runner),
+                "run",
+                "fetch",
+                str(run_id),
+                "--format",
+                "json",
+            ],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+    lines = result.stdout.splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["run_id"] == str(run_id)

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,18 +1,90 @@
 import io
 import tarfile
 from datetime import datetime, timezone
+from importlib import import_module
 from pathlib import Path
-from uuid import uuid4
+from typing import cast
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
-from tracker.database.models import BenchmarkStatus, DocentReadingStatus, TaskStatus
-from tracker.types import BenchmarkDetails, FetchBenchmarkResponse, StartBenchmarkResponse
+from click.testing import CliRunner
+from tracker.database.models import (
+    AgentContractRequest,
+    BenchmarkArguments,
+    BenchmarkStatus,
+    DocentReadingStatus,
+    TaskStatus,
+)
+from tracker.types import (
+    BenchmarkDetails,
+    FetchBenchmarkMetadataResponse,
+    FetchBenchmarkResponse,
+    StartBenchmarkResponse,
+)
 
 from valkyrie.cli.display import paginate_cli_pages
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run.fetch import fetch
 from valkyrie.cli.run.outputs import download_run_outputs
+from valkyrie.cli.run.progress import _stream_next_steps, format_benchmark_status, stream_benchmark_status
 from valkyrie.cli.run.start import format_start_benchmark_response
-from valkyrie.cli.run.progress import _stream_next_steps, format_benchmark_status
+from valkyrie.cli.tracker_client import TrackerService
+
+fetch_module = import_module("valkyrie.cli.run.fetch")
+
+
+class StubProgressTracker:
+    def __init__(
+        self,
+        response: FetchBenchmarkResponse,
+        metadata: FetchBenchmarkMetadataResponse | TrackerServiceError,
+    ) -> None:
+        self.response = response
+        self.metadata = metadata
+        self.metadata_calls = 0
+
+    def fetch_benchmark(self, _run_id: UUID) -> FetchBenchmarkResponse:
+        return self.response
+
+    def fetch_benchmark_metadata(self, _run_id: UUID) -> FetchBenchmarkMetadataResponse:
+        self.metadata_calls += 1
+        if isinstance(self.metadata, TrackerServiceError):
+            raise self.metadata
+        return self.metadata
+
+    def stream_benchmark(self, _run_id: UUID):
+        yield "event: disconnect"
+
+
+def make_fetch_response(run_id: UUID) -> FetchBenchmarkResponse:
+    return FetchBenchmarkResponse(
+        benchmark_name="swebench",
+        benchmark_id=run_id,
+        details=BenchmarkDetails(
+            status=BenchmarkStatus.IN_PROGRESS,
+            started_at=datetime(2026, 6, 24, tzinfo=timezone.utc),
+            total_tasks=4,
+            finished_tasks=1,
+            task_breakdown={TaskStatus.IN_PROGRESS: 3, TaskStatus.FINISHED: 1},
+            docent_reading_status=DocentReadingStatus.IDLE,
+        ),
+        s3_bucket_url="https://example.com/run",
+        label="release-candidate",
+    )
+
+
+def make_fetch_metadata(run_id: UUID) -> FetchBenchmarkMetadataResponse:
+    return FetchBenchmarkMetadataResponse(
+        benchmark_id=run_id,
+        benchmark_name="swebench",
+        benchmark_arguments=BenchmarkArguments(
+            contract=AgentContractRequest(name="mini_sweagent", model="openai/gpt-5", secrets={"API_KEY": "secret"}),
+            concurrency=20,
+            dataset="verified",
+        ),
+        started_by_email="runner@vals.ai",
+    )
 
 
 def test_format_benchmark_status_prints_final_score(capsys: pytest.CaptureFixture[str]) -> None:
@@ -43,6 +115,75 @@ def test_format_benchmark_status_prints_final_score(capsys: pytest.CaptureFixtur
     assert "Final score:" in output
     assert "83.2%" in output
     assert "3/4 (75.0%)" in output
+
+
+def test_connected_fetch_prints_rich_identity(capsys: pytest.CaptureFixture[str]) -> None:
+    run_id = uuid4()
+    tracker = StubProgressTracker(make_fetch_response(run_id), make_fetch_metadata(run_id))
+
+    stream_benchmark_status(cast(TrackerService, tracker), run_id, show_identity=True)
+
+    output = capsys.readouterr().out
+    assert "Run Details" in output
+    assert "swebench" in output
+    assert "mini_sweagent" in output
+    assert "openai/gpt-5" in output
+    assert "verified" in output
+    assert str(run_id) in output
+    assert "release-candidate" in output
+    assert "runner@vals.ai" in output
+    assert "20" in output
+    assert "Streaming run updates" in output
+    assert "API_KEY" not in output
+    assert "secret" not in output
+    assert tracker.metadata_calls == 1
+
+
+def test_connected_fetch_continues_when_metadata_is_unavailable(capsys: pytest.CaptureFixture[str]) -> None:
+    run_id = uuid4()
+    tracker = StubProgressTracker(make_fetch_response(run_id), TrackerServiceError("metadata unavailable"))
+
+    stream_benchmark_status(cast(TrackerService, tracker), run_id, show_identity=True)
+
+    output = capsys.readouterr().out
+    assert "Run Details" in output
+    assert "Metadata:" in output
+    assert "unavailable" in output
+    assert "Streaming run updates" in output
+
+
+def test_shared_connected_stream_omits_identity_by_default(capsys: pytest.CaptureFixture[str]) -> None:
+    run_id = uuid4()
+    tracker = StubProgressTracker(make_fetch_response(run_id), make_fetch_metadata(run_id))
+
+    stream_benchmark_status(cast(TrackerService, tracker), run_id)
+
+    output = capsys.readouterr().out
+    assert "Run Details" not in output
+    assert tracker.metadata_calls == 0
+
+
+def test_fetch_connect_enables_identity_header(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    stream_calls: list[tuple[UUID, bool]] = []
+
+    class StubFetchTrackerService:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+    def record_stream(_tracker: StubFetchTrackerService, actual_run_id: UUID, *, show_identity: bool = False) -> None:
+        stream_calls.append((actual_run_id, show_identity))
+
+    monkeypatch.setattr(fetch_module, "TrackerService", StubFetchTrackerService)
+    monkeypatch.setattr(fetch_module, "stream_benchmark_status", record_stream)
+
+    result = CliRunner().invoke(fetch, [str(run_id), "--connect"])
+
+    assert result.exit_code == 0, result.output
+    assert stream_calls == [(run_id, True)]
 
 
 def test_format_start_benchmark_response_prints_run_outputs_command(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/test_run_fetch_output.py
+++ b/tests/unit/test_run_fetch_output.py
@@ -1,0 +1,283 @@
+import json
+from datetime import datetime, timezone
+from importlib import import_module
+from uuid import UUID, uuid4
+
+import pytest
+from click.testing import CliRunner
+from tracker.database.models import (
+    AgentContractRequest,
+    BenchmarkArguments,
+    BenchmarkStatus,
+    DocentReadingStatus,
+    TaskStatus,
+)
+from tracker.types import BenchmarkDetails, FetchBenchmarkMetadataResponse, FetchBenchmarkResponse
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run.fetch import fetch
+from valkyrie.cli.run.snapshot import build_run_snapshot, format_run_snapshot_json
+
+fetch_module = import_module("valkyrie.cli.run.fetch")
+
+
+def make_response(
+    run_id: UUID,
+    *,
+    status: BenchmarkStatus = BenchmarkStatus.IN_PROGRESS,
+    finished_tasks: int = 1,
+    final_score: float | None = None,
+) -> FetchBenchmarkResponse:
+    task_breakdown = {
+        TaskStatus.FINISHED: finished_tasks,
+        TaskStatus.IN_PROGRESS: 4 - finished_tasks,
+    }
+    return FetchBenchmarkResponse(
+        benchmark_name="swebench",
+        benchmark_id=run_id,
+        details=BenchmarkDetails(
+            status=status,
+            started_at=datetime(2026, 7, 9, 12, 30, tzinfo=timezone.utc),
+            total_tasks=4,
+            finished_tasks=finished_tasks,
+            task_breakdown=task_breakdown,
+            docent_reading_status=DocentReadingStatus.IDLE,
+        ),
+        s3_bucket_url="s3://example/run",
+        label="release-candidate",
+        final_score=final_score,
+    )
+
+
+def make_metadata(run_id: UUID) -> FetchBenchmarkMetadataResponse:
+    return FetchBenchmarkMetadataResponse(
+        benchmark_id=run_id,
+        benchmark_name="swebench",
+        benchmark_arguments=BenchmarkArguments(
+            contract=AgentContractRequest(
+                name="mini_sweagent",
+                model="openai/gpt-5",
+                secrets={"MODEL_API_KEY": "classified-secret-name"},
+                kwargs={"temperature": "0"},
+            ),
+            concurrency=20,
+            dataset="verified",
+        ),
+        started_by_email="runner@vals.ai",
+    )
+
+
+class StubFetchTracker:
+    def __init__(
+        self,
+        response: FetchBenchmarkResponse,
+        metadata: FetchBenchmarkMetadataResponse | TrackerServiceError,
+        events: list[str] | None = None,
+        *,
+        interrupt: bool = False,
+    ) -> None:
+        self.response = response
+        self.metadata = metadata
+        self.events = events or []
+        self.interrupt = interrupt
+        self.metadata_calls = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def fetch_benchmark(self, _run_id: UUID) -> FetchBenchmarkResponse:
+        return self.response
+
+    def fetch_benchmark_metadata(self, _run_id: UUID) -> FetchBenchmarkMetadataResponse:
+        self.metadata_calls += 1
+        if isinstance(self.metadata, TrackerServiceError):
+            raise self.metadata
+        return self.metadata
+
+    def stream_benchmark(self, _run_id: UUID):
+        if self.interrupt:
+            raise KeyboardInterrupt
+        yield from self.events
+
+
+def invoke_with_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker: StubFetchTracker,
+    args: list[str],
+):
+    monkeypatch.setattr(fetch_module, "TrackerService", lambda: tracker)
+    return CliRunner().invoke(fetch, args)
+
+
+def test_run_snapshot_is_versioned_allowlisted_and_stable() -> None:
+    run_id = uuid4()
+    response = make_response(run_id)
+    metadata = make_metadata(run_id)
+    observed_at = datetime(2026, 7, 9, 13, 0, tzinfo=timezone.utc)
+
+    snapshot = build_run_snapshot(response, metadata, event="snapshot", observed_at=observed_at)
+    serialized = format_run_snapshot_json(response, metadata, event="snapshot")
+
+    assert snapshot["schema_version"] == 1
+    assert snapshot["event"] == "snapshot"
+    assert snapshot["observed_at"] == "2026-07-09T13:00:00Z"
+    assert snapshot["run_id"] == str(run_id)
+    assert snapshot["benchmark_name"] == "swebench"
+    assert snapshot["agent_name"] == "mini_sweagent"
+    assert snapshot["model"] == "openai/gpt-5"
+    assert snapshot["dataset"] == "verified"
+    assert snapshot["progress_percent"] == 25.0
+    assert snapshot["task_state_counts"] == {
+        "PENDING": 0,
+        "BUILDING": 0,
+        "IN_PROGRESS": 3,
+        "EVALUATING": 0,
+        "STOPPED": 0,
+        "FINISHED": 1,
+        "ERROR": 0,
+    }
+    assert "MODEL_API_KEY" not in serialized
+    assert "classified-secret-name" not in serialized
+    assert "temperature" not in serialized
+
+
+def test_fetch_json_outputs_one_clean_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubFetchTracker(make_response(run_id), make_metadata(run_id))
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert len(result.output.splitlines()) == 1
+    assert "\x1b" not in result.output
+    assert "Run Status" not in result.output
+    payload = json.loads(result.output)
+    assert payload["event"] == "snapshot"
+    assert payload["run_id"] == str(run_id)
+    assert payload["agent_name"] == "mini_sweagent"
+    assert tracker.metadata_calls == 1
+
+
+def test_fetch_json_uses_null_identity_when_metadata_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubFetchTracker(make_response(run_id), TrackerServiceError("metadata unavailable"))
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["metadata_available"] is False
+    assert payload["agent_name"] is None
+    assert payload["model"] is None
+    assert payload["dataset"] is None
+
+
+def test_fetch_jsonl_outputs_only_snapshot_update_and_terminal_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    finished = make_response(run_id, status=BenchmarkStatus.FINISHED, finished_tasks=4, final_score=75.0)
+    tracker = StubFetchTracker(
+        make_response(run_id),
+        make_metadata(run_id),
+        events=[f"data: {finished.model_dump_json()}", "event: complete"],
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--connect", "--format", "jsonl"])
+
+    assert result.exit_code == 0, result.output
+    assert "\x1b" not in result.output
+    assert "Streaming run updates" not in result.output
+    assert "Next Steps" not in result.output
+    assert "MODEL_API_KEY" not in result.output
+    records = [json.loads(line) for line in result.output.splitlines()]
+    assert [record["event"] for record in records] == ["snapshot", "update", "complete"]
+    assert all(record["schema_version"] == 1 for record in records)
+    assert all(record["run_id"] == str(run_id) for record in records)
+    assert records[-1]["status"] == "FINISHED"
+    assert records[-1]["final_score"] == 75.0
+    assert tracker.metadata_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_event"),
+    [
+        (BenchmarkStatus.ERROR, "error"),
+        (BenchmarkStatus.STOPPED, "stopped"),
+    ],
+)
+def test_fetch_jsonl_maps_completed_stream_to_terminal_run_status(
+    monkeypatch: pytest.MonkeyPatch,
+    status: BenchmarkStatus,
+    expected_event: str,
+) -> None:
+    run_id = uuid4()
+    terminal = make_response(run_id, status=status, finished_tasks=4)
+    tracker = StubFetchTracker(
+        make_response(run_id),
+        make_metadata(run_id),
+        events=[f"data: {terminal.model_dump_json()}", "event: complete"],
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--connect", "--format", "jsonl"])
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.output.splitlines()]
+    assert records[-1]["event"] == expected_event
+    assert records[-1]["status"] == status.value
+
+
+@pytest.mark.parametrize("terminal_event", ["error", "disconnect"])
+def test_fetch_jsonl_preserves_other_terminal_events(
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_event: str,
+) -> None:
+    run_id = uuid4()
+    tracker = StubFetchTracker(
+        make_response(run_id),
+        make_metadata(run_id),
+        events=[f"event: {terminal_event}"],
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--connect", "--format", "jsonl"])
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.output.splitlines()]
+    assert [record["event"] for record in records] == ["snapshot", terminal_event]
+
+
+def test_fetch_jsonl_reports_keyboard_interrupt_as_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubFetchTracker(make_response(run_id), make_metadata(run_id), interrupt=True)
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--connect", "--format", "jsonl"])
+
+    assert result.exit_code == 0, result.output
+    records = [json.loads(line) for line in result.output.splitlines()]
+    assert [record["event"] for record in records] == ["snapshot", "interrupted"]
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_error"),
+    [
+        (["--connect", "--format", "json"], "use --format jsonl"),
+        (["--format", "jsonl"], "requires --connect"),
+    ],
+)
+def test_fetch_rejects_mismatched_machine_format(
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+    expected_error: str,
+) -> None:
+    run_id = uuid4()
+
+    def unexpected_tracker():
+        raise AssertionError("format validation should happen before constructing the tracker")
+
+    monkeypatch.setattr(fetch_module, "TrackerService", unexpected_tracker)
+
+    result = CliRunner().invoke(fetch, [str(run_id), *args])
+
+    assert result.exit_code == 2
+    assert expected_error in result.output

--- a/tests/unit/test_run_fetch_output.py
+++ b/tests/unit/test_run_fetch_output.py
@@ -258,6 +258,18 @@ def test_fetch_jsonl_reports_keyboard_interrupt_as_json(monkeypatch: pytest.Monk
     assert [record["event"] for record in records] == ["snapshot", "interrupted"]
 
 
+def test_fetch_jsonl_reports_clean_stream_exhaustion_as_disconnect(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubFetchTracker(make_response(run_id), make_metadata(run_id))
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--connect", "--format", "jsonl"])
+
+    assert result.exit_code != 0
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [record["event"] for record in records] == ["snapshot", "disconnect"]
+    assert "ended without a terminal event" in result.stderr
+
+
 @pytest.mark.parametrize(
     ("args", "expected_error"),
     [

--- a/tests/unit/test_run_fetch_output.py
+++ b/tests/unit/test_run_fetch_output.py
@@ -161,6 +161,21 @@ def test_fetch_json_outputs_one_clean_object(monkeypatch: pytest.MonkeyPatch) ->
     assert tracker.metadata_calls == 1
 
 
+@pytest.mark.parametrize("final_score", [float("nan"), float("inf"), float("-inf")])
+def test_fetch_json_normalizes_non_finite_scores(
+    monkeypatch: pytest.MonkeyPatch,
+    final_score: float,
+) -> None:
+    run_id = uuid4()
+    tracker = StubFetchTracker(make_response(run_id, final_score=final_score), make_metadata(run_id))
+
+    result = invoke_with_tracker(monkeypatch, tracker, [str(run_id), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["final_score"] is None
+    assert not any(token in result.stdout for token in ["NaN", "Infinity"])
+
+
 def test_fetch_json_uses_null_identity_when_metadata_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     run_id = uuid4()
     tracker = StubFetchTracker(make_response(run_id), TrackerServiceError("metadata unavailable"))

--- a/tests/unit/test_run_list_output.py
+++ b/tests/unit/test_run_list_output.py
@@ -1,0 +1,187 @@
+import json
+from datetime import datetime, timezone
+from importlib import import_module
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+from tracker.database.models import BenchmarkStatus
+from tracker.types import BenchmarkTableRow, FetchBenchmarksRequest, FetchBenchmarksResponse, Order
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run.list_runs import list_runs
+
+list_runs_module = import_module("valkyrie.cli.run.list_runs")
+
+
+def make_row(index: int) -> BenchmarkTableRow:
+    return BenchmarkTableRow(
+        id=UUID(int=index + 1),
+        name="swebench",
+        agent_name="mini_sweagent",
+        model="openai/gpt-5",
+        dataset="verified",
+        label="release-candidate",
+        started_by_email="runner@vals.ai",
+        started_at=datetime(2026, 7, 9, 12, 30, tzinfo=timezone.utc),
+        finished_at=None,
+        status=BenchmarkStatus.IN_PROGRESS,
+        total_tasks=4,
+        finished_tasks=1,
+        task_state_counts={"FINISHED": 1, "IN_PROGRESS": 3},
+        final_score=None,
+        error_message="provider response contained sensitive raw detail",
+    )
+
+
+class StubListTracker:
+    def __init__(self, pages: dict[str, FetchBenchmarksResponse | TrackerServiceError]) -> None:
+        self.pages = pages
+        self.requests: list[FetchBenchmarksRequest] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def fetch_benchmarks(self, request: FetchBenchmarksRequest) -> FetchBenchmarksResponse:
+        self.requests.append(request)
+        page = self.pages[request.cursor or ""]
+        if isinstance(page, TrackerServiceError):
+            raise page
+        return page
+
+
+def invoke_with_tracker(monkeypatch: pytest.MonkeyPatch, tracker: StubListTracker, args: list[str]):
+    monkeypatch.setattr(list_runs_module, "TrackerService", lambda: tracker)
+    return CliRunner().invoke(list_runs, args)
+
+
+def test_list_json_all_exhausts_cursor_pages_and_preserves_filters(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_page = [make_row(index) for index in range(500)]
+    final_row = make_row(500)
+    tracker = StubListTracker(
+        {
+            "": FetchBenchmarksResponse(benchmarks=first_page, next_cursor="page-2"),
+            "page-2": FetchBenchmarksResponse(benchmarks=[final_row], next_cursor=None),
+        }
+    )
+    monkeypatch.setattr(
+        list_runs_module,
+        "paginate_benchmarks",
+        lambda *_args, **_kwargs: pytest.fail("machine output must not invoke the interactive pager"),
+    )
+
+    result = invoke_with_tracker(
+        monkeypatch,
+        tracker,
+        [
+            "--format",
+            "json",
+            "--all",
+            "--agent-name",
+            "mini_sweagent",
+            "--benchmark-name",
+            "swebench",
+            "--model",
+            "openai/gpt-5",
+            "--dataset",
+            "verified",
+            "--label",
+            "release-candidate",
+            "--status",
+            "IN_PROGRESS",
+            "--order-by",
+            "ASC",
+            "--started-by",
+            "runner@vals.ai",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(result.stdout.splitlines()) == 1
+    assert "\x1b" not in result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == 1
+    assert payload["kind"] == "run_list"
+    assert payload["returned_count"] == 501
+    assert [run["run_id"] for run in payload["runs"]] == [str(row.id) for row in [*first_page, final_row]]
+    assert "error_message" not in payload["runs"][0]
+    assert "sensitive raw detail" not in result.stdout
+
+    assert [request.cursor for request in tracker.requests] == ["", "page-2"]
+    assert all(request.limit == 500 for request in tracker.requests)
+    assert all(request.agent_name == ["mini_sweagent"] for request in tracker.requests)
+    assert all(request.benchmark_name == ["swebench"] for request in tracker.requests)
+    assert all(request.model == "openai/gpt-5" for request in tracker.requests)
+    assert all(request.dataset == "verified" for request in tracker.requests)
+    assert all(request.label == "release-candidate" for request in tracker.requests)
+    assert all(request.status == [BenchmarkStatus.IN_PROGRESS] for request in tracker.requests)
+    assert all(request.order_by == Order.ASC for request in tracker.requests)
+    assert all(request.started_by == ["runner@vals.ai"] for request in tracker.requests)
+
+
+def test_list_json_all_emits_empty_document(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracker = StubListTracker({"": FetchBenchmarksResponse(benchmarks=[], next_cursor=None)})
+
+    result = invoke_with_tracker(monkeypatch, tracker, ["--format", "json", "--all"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["returned_count"] == 0
+    assert payload["runs"] == []
+
+
+def test_list_json_all_does_not_emit_partial_output_after_later_page_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tracker = StubListTracker(
+        {
+            "": FetchBenchmarksResponse(benchmarks=[make_row(0)], next_cursor="page-2"),
+            "page-2": TrackerServiceError("second page failed"),
+        }
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, ["--format", "json", "--all"])
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+    assert "second page failed" in result.stderr
+
+
+def test_list_json_all_rejects_repeated_cursor(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracker = StubListTracker(
+        {
+            "": FetchBenchmarksResponse(benchmarks=[make_row(0)], next_cursor=""),
+        }
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, ["--format", "json", "--all"])
+
+    assert result.exit_code != 0
+    assert result.stdout == ""
+    assert "repeated run-list cursor" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_error"),
+    [
+        (["--format", "json"], "requires --all"),
+        (["--all"], "requires --format json"),
+    ],
+)
+def test_list_machine_flags_validate_before_tracker_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+    expected_error: str,
+) -> None:
+    def unexpected_tracker():
+        raise AssertionError("flag validation should happen before constructing the tracker")
+
+    monkeypatch.setattr(list_runs_module, "TrackerService", unexpected_tracker)
+
+    result = CliRunner().invoke(list_runs, args)
+
+    assert result.exit_code == 2
+    assert expected_error in result.output

--- a/tests/unit/test_run_list_output.py
+++ b/tests/unit/test_run_list_output.py
@@ -133,6 +133,21 @@ def test_list_json_all_emits_empty_document(monkeypatch: pytest.MonkeyPatch) -> 
     assert payload["runs"] == []
 
 
+@pytest.mark.parametrize("final_score", [float("nan"), float("inf"), float("-inf")])
+def test_list_json_all_normalizes_non_finite_scores(
+    monkeypatch: pytest.MonkeyPatch,
+    final_score: float,
+) -> None:
+    row = make_row(0).model_copy(update={"final_score": final_score})
+    tracker = StubListTracker({"": FetchBenchmarksResponse(benchmarks=[row], next_cursor=None)})
+
+    result = invoke_with_tracker(monkeypatch, tracker, ["--format", "json", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout)["runs"][0]["final_score"] is None
+    assert not any(token in result.stdout for token in ["NaN", "Infinity"])
+
+
 def test_list_json_all_does_not_emit_partial_output_after_later_page_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_run_status_output.py
+++ b/tests/unit/test_run_status_output.py
@@ -1,0 +1,171 @@
+import json
+from datetime import datetime, timezone
+from importlib import import_module
+from uuid import UUID
+
+import httpx
+import pytest
+from click.testing import CliRunner
+from tracker.database.models import BenchmarkStatus
+from tracker.types import BenchmarkStatusEntry, BenchmarkStatusResponse
+
+from valkyrie.cli.run import run
+from valkyrie.cli.run.status import status_runs
+from valkyrie.cli.tracker_client import TrackerService
+
+status_module = import_module("valkyrie.cli.run.status")
+
+
+def make_entry(index: int, *, status: BenchmarkStatus = BenchmarkStatus.IN_PROGRESS) -> BenchmarkStatusEntry:
+    return BenchmarkStatusEntry(
+        id=UUID(int=index + 1),
+        status=status,
+        finished_at=datetime(2026, 7, 9, 13, 0, tzinfo=timezone.utc) if status == BenchmarkStatus.FINISHED else None,
+        total_tasks=4,
+        finished_tasks=1,
+        task_state_counts={"FINISHED": 1, "IN_PROGRESS": 3},
+    )
+
+
+class StubStatusTracker:
+    def __init__(self, entries: list[BenchmarkStatusEntry]) -> None:
+        self.entries = entries
+        self.calls: list[list[UUID]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def fetch_benchmark_statuses(self, run_ids: list[UUID]) -> BenchmarkStatusResponse:
+        self.calls.append(run_ids)
+        requested = set(run_ids)
+        return BenchmarkStatusResponse(entries=[entry for entry in self.entries if entry.id in requested])
+
+
+def invoke_with_tracker(monkeypatch: pytest.MonkeyPatch, tracker: StubStatusTracker, args: list[str]):
+    monkeypatch.setattr(status_module, "TrackerService", lambda: tracker)
+    return CliRunner().invoke(status_runs, args)
+
+
+def test_status_json_deduplicates_and_restores_requested_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    first = make_entry(0)
+    second = make_entry(1, status=BenchmarkStatus.FINISHED)
+    tracker = StubStatusTracker([second, first])
+
+    result = invoke_with_tracker(
+        monkeypatch,
+        tracker,
+        ["--ids", f" {first.id}, {second.id}, {first.id} ", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(result.stdout.splitlines()) == 1
+    assert "\x1b" not in result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == 1
+    assert payload["kind"] == "run_status"
+    assert payload["requested_count"] == 2
+    assert payload["returned_count"] == 2
+    assert payload["missing_run_ids"] == []
+    assert [entry["run_id"] for entry in payload["runs"]] == [str(first.id), str(second.id)]
+    assert payload["runs"][0]["progress_percent"] == 25.0
+    assert payload["runs"][1]["finished_at"] == "2026-07-09T13:00:00Z"
+    assert tracker.calls == [[first.id, second.id]]
+
+
+def test_status_json_reports_missing_ids_and_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    found = make_entry(0)
+    missing = UUID(int=2)
+    tracker = StubStatusTracker([found])
+
+    result = invoke_with_tracker(
+        monkeypatch,
+        tracker,
+        ["--ids", f"{found.id},{missing}", "--format", "json"],
+    )
+
+    assert result.exit_code != 0
+    payload = json.loads(result.stdout)
+    assert payload["returned_count"] == 1
+    assert payload["missing_run_ids"] == [str(missing)]
+    assert "not found or are not accessible" in result.stderr
+
+
+def test_status_json_chunks_large_id_sets(monkeypatch: pytest.MonkeyPatch) -> None:
+    entries = [make_entry(index) for index in range(51)]
+    tracker = StubStatusTracker(entries)
+
+    result = invoke_with_tracker(
+        monkeypatch,
+        tracker,
+        ["--ids", ",".join(str(entry.id) for entry in entries), "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert [len(call) for call in tracker.calls] == [50, 1]
+    assert json.loads(result.stdout)["returned_count"] == 51
+
+
+@pytest.mark.parametrize("ids_value", ["", " , ", "not-a-uuid"])
+def test_status_rejects_invalid_ids_before_tracker_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    ids_value: str,
+) -> None:
+    def unexpected_tracker():
+        raise AssertionError("ID validation should happen before constructing the tracker")
+
+    monkeypatch.setattr(status_module, "TrackerService", unexpected_tracker)
+
+    result = CliRunner().invoke(status_runs, ["--ids", ids_value, "--format", "json"])
+
+    assert result.exit_code == 2
+    assert "--ids" in result.output
+
+
+def test_tracker_client_fetches_batch_status_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = UUID(int=1)
+
+    class FakeStatusClient:
+        def __init__(self) -> None:
+            self.url: str | None = None
+            self.params: dict[str, str] | None = None
+
+        def get(self, url: str, *, params: dict[str, str]) -> httpx.Response:
+            self.url = url
+            self.params = params
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": str(run_id),
+                            "status": "IN_PROGRESS",
+                            "finished_at": None,
+                            "total_tasks": 1,
+                            "finished_tasks": 0,
+                            "task_state_counts": {"PENDING": 1},
+                        }
+                    ]
+                },
+            )
+
+        def close(self) -> None:
+            return None
+
+    client = FakeStatusClient()
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(lambda: {}))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", lambda _self: {})
+    monkeypatch.setattr("valkyrie.cli.tracker_client.httpx.Client", lambda **_kwargs: client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    response = tracker.fetch_benchmark_statuses([run_id])
+
+    assert client.url == "http://tracker/benchmarks/status"
+    assert client.params == {"ids": str(run_id)}
+    assert [entry.id for entry in response.entries] == [run_id]
+
+
+def test_status_command_is_registered() -> None:
+    assert "status" in run.commands


### PR DESCRIPTION
## Summary

Adds human-readable identity context to connected run fetches and safe, noninteractive run interfaces for agents.

## Changes

- Show benchmark, agent, model, dataset, run ID, label, starter, concurrency, and start time before connected text fetch progress.
- Add `run fetch --format json` snapshots and connected `--format jsonl` streams.
- Add `run list --format json --all`, preserving existing model, benchmark, status, dataset, label, agent, and starter filters while exhausting cursor pagination without the interactive pager.
- Add `run status --ids <id-1>,<id-2> --format json` using the existing lightweight batch endpoint, with deterministic ordering, de-duplication, batching, and explicit missing-ID reporting.
- Emit versioned allowlisted schemas that exclude stored contract secrets, kwargs, and raw error messages.
- Keep machine stdout strict JSON: dotenv warnings are delayed until after logging setup, clean stream exhaustion emits disconnect and exits nonzero, and non-finite scores normalize to null.
- Keep metadata enrichment best-effort and document output shapes, nullability, and exit semantics.
- Reuse existing tracker APIs; no backend, schema, migration, or deployment change is required.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing

- [x] Added/updated unit tests
- [ ] Manually tested against a live tracker

Checks run:

- `make unit-test` — 118 passed
- `make typecheck` — 0 errors
- `make format-check`
- `uv run ruff check .`
- `make build`
- CLI help smoke checks for fetch, list, and status
- CI installed-tool smoke test

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated

## Commit structure

1. `feat: show run identity for connected fetch`
2. `feat: add machine-readable run fetch output`
3. `fix: harden machine-readable fetch output`
4. `feat: add machine-readable run listing`
5. `feat: add batch run status command`
6. `fix: tighten machine output contract`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->