### PR TITLE
feat(tracker): add runtime locator compatibility

### DIFF
--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,11 +1,12 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import BaseModel, Field as PydanticField, field_serializer, field_validator
+from pydantic.json_schema import SkipJsonSchema
 from sqlalchemy import Connection, Dialect, Index, event, text
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -153,6 +154,29 @@ class AgentContractRequest(BaseModel):
         return normalized_artifacts
 
 
+class _RunRuntimeLocator(BaseModel):
+    aws_default_region: str
+    s3_bucket: str
+    s3_prefix: str
+    log_group: str
+    log_retention_policy: int
+    sandbox_provider_secret_name: str
+
+
+class LegacyRunRuntimeLocator(_RunRuntimeLocator):
+    kind: Literal["legacy"] = "legacy"
+
+
+class ManagedRunRuntimeLocator(_RunRuntimeLocator):
+    kind: Literal["managed"] = "managed"
+
+
+RunRuntimeLocator = Annotated[
+    LegacyRunRuntimeLocator | ManagedRunRuntimeLocator,
+    PydanticField(discriminator="kind"),
+]
+
+
 class BenchmarkArguments(BaseModel):
     model_config = {"extra": "forbid"}
 
@@ -164,6 +188,7 @@ class BenchmarkArguments(BaseModel):
     dataset: str | None = None
     sandbox_provider: str = "daytona"
     sandbox_provider_secret_name: str | None = None
+    runtime: SkipJsonSchema[RunRuntimeLocator | None] = PydanticField(default=None, exclude=True)
 
 
 class FinalEvaluation(SQLModel, table=True):
@@ -201,7 +226,10 @@ class BenchmarkArgumentsType(TypeDecorator[BenchmarkArguments]):
         """Runs when we save the value to the database."""
         if value is None:
             return None
-        return value.model_dump()
+        arguments = value.model_dump()
+        if value.runtime:
+            arguments["runtime"] = value.runtime.model_dump()
+        return arguments
 
     def process_result_value(self, value: dict[str, Any] | None, dialect: Dialect) -> BenchmarkArguments | None:
         """Runs when we fetch the value from the database."""

--- a/services/tracker/tests/unit/test_runtime_locator_compat.py
+++ b/services/tracker/tests/unit/test_runtime_locator_compat.py
@@ -1,0 +1,49 @@
+from sqlmodel import Session
+
+from main import app
+from tests.conftest import TEST_ORG_ID
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkArguments,
+    ManagedRunRuntimeLocator,
+)
+
+
+def test_runtime_locator_is_nullable_and_round_trips(database_session: Session) -> None:
+    legacy_row = Benchmark(
+        org_id=TEST_ORG_ID,
+        name="legacy",
+        arguments=BenchmarkArguments(contract=AgentContractRequest(name="agent"), concurrency=1),
+    )
+    managed_row = Benchmark(
+        org_id=TEST_ORG_ID,
+        name="managed",
+        arguments=BenchmarkArguments(
+            contract=AgentContractRequest(name="agent"),
+            concurrency=1,
+            runtime=ManagedRunRuntimeLocator(
+                aws_default_region="us-east-1",
+                s3_bucket="bucket",
+                s3_prefix="orgs/org-id",
+                log_group="logs",
+                log_retention_policy=30,
+                sandbox_provider_secret_name="provider",
+            ),
+        ),
+    )
+    database_session.add(legacy_row)
+    database_session.add(managed_row)
+    database_session.commit()
+    database_session.expire_all()
+
+    stored_legacy = database_session.get(Benchmark, legacy_row.id)
+    stored_managed = database_session.get(Benchmark, managed_row.id)
+
+    assert stored_legacy is not None
+    assert stored_legacy.arguments.runtime is None
+    assert stored_managed is not None
+    assert stored_managed.arguments.runtime == managed_row.arguments.runtime
+    assert "runtime" not in stored_managed.arguments.model_dump()
+    assert "runtime" not in BenchmarkArguments.model_json_schema()["properties"]
+    assert "runtime" not in app.openapi()["components"]["schemas"]["BenchmarkArguments"]["properties"]


### PR DESCRIPTION
## Summary
- Add an optional managed-runtime locator to stored benchmark arguments.
- Keep the locator out of public serialization, JSON schema, and OpenAPI.
- Preserve legacy rows without a migration or production writer.

## Verification
- Runtime-locator database roundtrip and public-boundary test passes.
- Ruff and diff checks pass.

## Rollout
This is parse-only compatibility. Deploy it before worker readiness; it does not activate managed starts.