### PR TITLE
feat(cli): add API-key-only hosted onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,10 @@ Valkyrie is an orchestration platform for running agentic benchmarks.
 
 ## Hosting Modes
 
-Valkyrie supports **hosted** and **self-hosted** modes. 
-- **Self-hosted Mode** requires you to create AWS infrastructure using the IaC provided.
-- **Hosted Mode** allows you to use Vals-hosted infrastructure. Reach out to the Vals team for access (contact@vals.ai)
+Valkyrie supports **hosted** and **self-hosted** modes.
 
-Both modes require you to provide certain credentials and configuration:  
-- AWS API Key: Authentication for an AWS account with S3, CloudWatch, and Secrets Manager access (to store benchmarking logs and results)
-- S3 Bucket Name: The S3 bucket to be used for storing benchmark artifacts and agents
-- Sandbox provider config: named AWS Secrets Manager entries for sandbox providers. [Setup docs](docs/PROVIDER.md)
-- **Hosted mode only:** Vals API Key
+- **Hosted mode** requires only a personal Vals AI API key. Vals manages compute, storage, logs, sandbox credentials, and model access.
+- **Self-hosted mode** uses your AWS account, S3 bucket, CloudWatch logs, and sandbox-provider secrets. [Provider setup](docs/PROVIDER.md)
 
 See [Hosted vs Self-Hosted Mode](docs/HOSTED_MODE.md) for more details.
 
@@ -36,7 +31,7 @@ uv tool install git+https://github.com/vals-ai/Valkyrie@prod
 valkyrie config init
 ```
 
-This will prompt you to choose between **hosted** and **self-hosted** mode, then collect the required credentials. See [Hosted vs Self-Hosted Mode](docs/HOSTED_MODE.md) for detailed setup instructions.
+Hosted mode is the default and validates managed-runtime readiness before saving your API key. Self-hosted mode collects AWS configuration. See [Hosted vs Self-Hosted Mode](docs/HOSTED_MODE.md) for detailed setup instructions.
 
 To upsert a single key:
 
@@ -44,7 +39,7 @@ To upsert a single key:
 valkyrie config set <KEY> <VALUE>
 ```
 
-To configure sandbox providers:
+In self-hosted mode, configure sandbox providers with:
 
 ```bash
 valkyrie config provider set daytona DaytonaSecrets
@@ -56,7 +51,7 @@ The first configured provider is used by default unless you set one with `valkyr
 
 ## Agent Management
 
-Before running benchmarks, you need to install and upload agents to Valkyrie. These commands manage agent lifecycle. All agents are installed inside of the S3 bucket provided by `valkyrie config init` at `agents/`.
+Before running benchmarks, install or upload an agent to the configured runtime. Hosted agents are shared within the organization. Self-hosted agents use the configured S3 bucket.
 
 All agents will need to already be in the Valkyrie format. Please reference the [contract documentation](docs/CONTRACTS.md) to learn more.
 
@@ -69,20 +64,20 @@ valkyrie agent install https://github.com/user/my-agent
 valkyrie agent install https://github.com/user/my-agent --name my-custom-name
 ```
 
-Clones an agent repository from GitHub, bundles it, and pushes it to your S3 bucket.
+Clones an agent repository, bundles it, and uploads it to the configured runtime.
 
 | Option | Description |
 | --- | --- |
 | `--name, -n` | Agent name (defaults to repository name) |
 
-### Push a local agent to S3
+### Push a local agent
 
 ```bash
 valkyrie agent push ./agents/sweagent
 valkyrie agent push ./agents/sweagent --name my-agent
 ```
 
-Uploads an agent on your local machine to S3.
+Uploads an agent from your local machine.
 
 | Option | Description |
 | --- | --- |
@@ -102,7 +97,7 @@ View all installed agents with date and time last modified. Supports paginated n
 valkyrie agent remove sweagent
 ```
 
-Removes an agent from the S3 bucket. Cannot be reversed, will be requested to confirm before deleting.
+Removes an agent from the configured runtime.
 
 ### Download an agent
 
@@ -111,7 +106,7 @@ valkyrie agent download sweagent
 valkyrie agent download sweagent -o ./agents
 ```
 
-Downloads an agent from S3 to your local machine and unzips it.
+Downloads an agent to your local machine and unzips it.
 
 | Option | Description |
 | --- | --- |
@@ -128,7 +123,7 @@ valkyrie run start --agent <agent id> --benchmark <benchmark id>
 
 You can pass `--concurrency` to control the number of tasks that run in parallel, and `--task-ids` or `--slice` to run only a subset of tasks. Specific agents may take additional parameters as well, most commonly, a parameter to set the model. 
 
-To pass secrets to the agent environment, use `-s <ENVIRONMENT_VARIABLE> <AWS SECRET NAME>`. This will map the value stored in AWS SECRET NAME to ENVIRONMENT_VARIABLE inside the agent container.
+In self-hosted mode, pass AWS Secrets Manager references with `-s <ENVIRONMENT_VARIABLE> <AWS SECRET NAME>`. Hosted mode supplies model access through its managed gateway and does not accept arbitrary AWS secret references.
 
 Here is an example of how to run the first ten tasks of SWE-Bench Verified:
 ```bash
@@ -138,7 +133,6 @@ valkyrie run start \
   --model anthropic/claude-sonnet-4-6 \
   --concurrency 10 \
   --dataset default \
-  -s ANTHROPIC_API_KEY devEvalInfraAnthropicKey \
   -k temperature 1 \
   --slice "0:10" \
   --label swebench_sweagent
@@ -152,21 +146,22 @@ valkyrie run start --agent sweagent --benchmark swebench --connect
 
 | Flag | Description |
 | --- | --- |
-| `--agent` | Agent name from S3 or path to agent directory (e.g., `sweagent` or `./agents/sweagent`). Agents on users machine are automatically uploaded to S3 before the benchmark starts. |
+| `--agent` | Agent name or local agent directory (e.g., `sweagent` or `./agents/sweagent`). Local agents are uploaded before the run starts. |
 | `--benchmark` | Benchmark name (e.g. `swebench`) |
 | `--model` | Model key (e.g. `openai/gpt-4o`) |
 | `--concurrency` | Number of concurrent sandbox tasks (default: 5) |
-| `-s` / `--secret` | Secret pair as `ENV_VAR aws_secret_name`. Repeatable. Merged with contract defaults (CLI wins on conflict) |
+| `--provider` | Select a configured sandbox provider (self-hosted only) |
+| `-s` / `--secret` | Secret pair as `ENV_VAR aws_secret_name` (self-hosted only) |
 | `-k` / `--kwarg` | Key-value pair passed to the agent run command. Repeatable |
-| `--lambda` | AWS Lambda function to invoke after the run completes |
+| `--lambda` | AWS Lambda function to invoke after the run completes (self-hosted only) |
 | `--task-ids` | Comma-separated task IDs to run |
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
 | `--slice` | Slice the benchmark dataset (`start:stop:step`) |
 | `--dataset` | Dataset variant to run from the benchmark service. A single benchmark can expose multiple datasets (e.g. `default`, `test`, `validation`, `train`, `lite`) representing different task splits or difficulty levels. Defaults to `default` |
 | `-l` / `--label` | Label to attach to the run, can filter by when using `valk run list -l <LABEL>`. Can only set one label per run.  |
 | `-H` / `--header` | Custom header for benchmark service requests as `NAME VALUE`. Repeatable. See [Authentication & Custom Headers](#authentication--custom-headers) |
-| `-i` / `--interval` | Progress percentage threshold for Slack notification. Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
-| `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
+| `-i` / `--interval` | Progress percentage threshold for Slack notification (self-hosted only). Repeatable. Max 3, must be divisible by 5, range 5–100. See [Slack Notifications](#slack-notifications) |
+| `--ignore-custom-services` / `--ics` | Ignore configured custom benchmark services (self-hosted only) |
 | `--connect` | Stream run updates after the run starts |
 
 ### Monitor a run
@@ -265,7 +260,7 @@ valkyrie run resume <id> --connect
 # Stream updates after retry
 valkyrie run retry <id> --connect
 
-# Override agent secrets for resumed tasks
+# Override agent secrets for resumed tasks (self-hosted only)
 valkyrie run resume <id> -s ANTHROPIC_API_KEY newSecretName
 
 # Save every task ID in a benchmark dataset to a text file
@@ -278,10 +273,10 @@ valkyrie benchmark tasks swebench --dataset default --output tasks.txt
 | Option | Description |
 | --- | --- |
 | `--concurrency` | Override concurrency level |
-| `-s` / `--secret` | Secret pair as `ENV_VAR aws_secret_name`. Repeatable. Merged into the stored run contract before resumed/retried tasks are enqueued (CLI wins on conflict) |
+| `-s` / `--secret` | Secret pair as `ENV_VAR aws_secret_name` (self-hosted only) |
 | `--task-ids` | Comma-separated task IDs to resume/retry. Any id without an existing row is created as fresh `PENDING` if valid in the current dataset — lets you grow scope without starting a new run. |
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
-| `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
+| `--update-agent, -u` | Refresh the frozen agent copy before resuming (self-hosted only) |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
 | `--connect` | Stream run updates after resume/retry |
 
@@ -343,9 +338,9 @@ valkyrie run output <id> [subpath] [-o ./output-dir]
 | `-o` / `--output-dir` | Local destination directory (defaults to `./<benchmark_id>`) |
 
 
-## Adding Benchmarks
+## Adding Custom Benchmarks (self-hosted only)
 
-Vals provides a set of benchmarks out-of-the-box. If you want to add a new benchmark, you will need to add a new benchmark service. We provide a set of utilities that allow you to create and interact with benchmark services outside of the ones that are provided.
+Vals provides a set of benchmarks out-of-the-box. Self-hosted deployments can configure additional benchmark-service URLs.
 
 If hosting locally please use the [documentation](https://github.com/vals-ai/create-benchmark-service?tab=readme-ov-file#reverse-tunnel-setup) on the reverse tunnel that is needed.
 
@@ -376,9 +371,9 @@ Removes a custom benchmark service.
 
 ## Authentication & Custom Headers
 
-Benchmark services may require authentication. Valkyrie stores per-benchmark credentials and sends them as the `Authorization` header automatically. You can also pass arbitrary headers at runtime with `-H`.
+Self-hosted Valkyrie can store per-benchmark credentials and send them as the `Authorization` header automatically. Hosted runs ignore stored credentials; pass an explicit header with `-H` when needed.
 
-### Managing auth credentials
+### Managing auth credentials (self-hosted only)
 
 ```bash
 # Store a credential — sent as the Authorization header on every request to that benchmark
@@ -409,7 +404,7 @@ valkyrie run start --benchmark my-benchmark --agent sweagent \
   -H X-Another-Header another-value
 ```
 
-## Slack Notifications
+## Slack Notifications (self-hosted only)
 
 Valkyrie can send Slack webhook notifications as benchmark runs progress. Store an AWS Secrets Manager secret name (pointing to your Slack webhook URL) and get notified automatically when runs hit defined thresholds or reach a terminal state (finished, error, stopped).
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -30,9 +30,6 @@ egress_allowlist:
   - https://api.openai.com
   - https://github.com
 
-secrets:
-  ANTHROPIC_API_KEY: devEvalInfraAnthropicKey
-
 # Documentation only — these placeholders are always available and
 # substituted at runtime, changes will not be parsed
 provided:
@@ -67,6 +64,8 @@ kwargs:
     description: "Sampling temperature"
 ```
 
+Hosted runs inject `MODEL_GATEWAY_URL` and `MODEL_GATEWAY_API_KEY` for model access. Hosted contracts must omit `secrets`; Valkyrie adds the managed model-gateway origin to a non-empty egress allowlist automatically.
+
 ```bash
 # Run with required model and default temperature (0.7)
 valkyrie run start --agent agents/my_agent --model openai/gpt-4o --benchmark swebench
@@ -84,8 +83,6 @@ name: my_agent
 install_cmd: "bash setup.sh"
 run_cmd: "my_agent --task {problem_statement_path}"
 final_output: /logs/my_agent
-secrets:
-  API_KEY: myAwsSecretName
 ```
 
 ## Required Fields
@@ -187,7 +184,7 @@ egress_allowlist:
 
 Omit this field, or set it to an empty list, to keep unrestricted sandbox egress.
 
-### `secrets: dict`
+### `secrets: dict` (self-hosted only)
 
 Secrets required by the agent. Maps environment variable names to AWS Secrets Manager secret names. These are resolved at sandbox creation time - raw values are never stored.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -85,7 +85,7 @@ Then configure the CLI for hosted mode:
 
 ```bash
 valkyrie config init
-# Choose "hosted", provide your Vals AI API key and AWS credentials
+# Choose "hosted" and provide your personal Vals AI API key
 ```
 
 Without the env vars, the service runs in self-hosted mode (no auth, default org).

--- a/docs/HOSTED_MODE.md
+++ b/docs/HOSTED_MODE.md
@@ -1,17 +1,14 @@
 # Hosted vs Self-Hosted Mode
 
-Valkyrie supports two operational modes. Both require your own AWS credentials — hosted mode adds Vals AI API key authentication for multi-tenant data isolation.
+Valkyrie supports an API-key-only hosted runtime and a caller-owned self-hosted runtime.
 
 ## Hosted mode
 
-Use Vals-hosted compute infrastructure with your own AWS storage. Data is isolated per organization via Vals AI API key authentication.
+Use Vals-managed compute, storage, logging, sandbox credentials, and model access. Data is isolated by organization and authenticated with your personal Vals AI API key.
 
 ### Prerequisites
 
-- Vals AI API key (provided by Vals)
-- AWS account with the [required permissions](#required-aws-permissions)
-- S3 bucket for storing benchmark artifacts and agents. This will need to be unique for the region and created before defining it inside of the config.
-- API key for sandbox provider (Daytona). [Setup docs](PROVIDER.md)
+- Personal Vals AI API key linked to your user and organization
 
 ### Setup
 
@@ -19,28 +16,20 @@ Use Vals-hosted compute infrastructure with your own AWS storage. Data is isolat
 valkyrie config init
 ```
 
-Choose **hosted** when prompted. You'll be asked for:
-1. Your Vals AI API key — validates against the tracker and creates your organization
-2. AWS credentials — same as self-hosted (you supply your own S3, CloudWatch, Daytona)
+Hosted is the default. The CLI validates your key, organization, and managed-runtime readiness before saving it.
 
 ```
 $ valkyrie config init
-Setup mode (hosted, self-hosted) [self-hosted]: hosted
+Setup mode (hosted, self-hosted) [hosted]:
 API Key: <your-vals-ai-api-key>
 Organization 'your-org' configured successfully.
-
-AWS_ACCESS_KEY_ID: ...
-AWS_SECRET_ACCESS_KEY: ...
-...
 ```
 
-Your API key is sent with every request to authenticate and scope data to your organization. AWS credentials are sent via `X-Harness-*` headers.
+No AWS, S3, logging, provider, or model-provider key is requested. Existing self-hosted fields remain in the local config so historical legacy runs keep working and rollback is reversible; new starts use the managed runtime explicitly.
 
-You can also set the API key manually:
+Run `valkyrie config init` rather than setting `api_key` manually so readiness is checked. Hosted limitations are intentional: custom benchmark URLs, arbitrary AWS secret references, provider overrides, and Lambda hooks are rejected. Agent uploads are shared within the organization.
 
-```bash
-valkyrie config set api_key <your-vals-ai-api-key>
-```
+Each run records the runtime where it started. Managed runs continue to use managed storage after rollback; pre-cutover legacy runs continue to use the preserved self-hosted configuration.
 
 ## Self-hosted mode
 
@@ -65,7 +54,7 @@ Then run `config init` and choose **self-hosted**:
 
 ```
 $ valkyrie config init
-Setup mode (hosted, self-hosted) [self-hosted]: self-hosted
+Setup mode (hosted, self-hosted) [hosted]: self-hosted
 AWS_ACCESS_KEY_ID: ...
 AWS_SECRET_ACCESS_KEY: ...
 ...
@@ -73,7 +62,7 @@ AWS_SECRET_ACCESS_KEY: ...
 
 No API key or Descope authentication is used. All data belongs to a single default organization.
 
-## Required AWS permissions
+## Required AWS permissions (self-hosted only)
 
 Your AWS credentials must have the following permissions:
 

--- a/src/valkyrie/cli/agent/lifecycle.py
+++ b/src/valkyrie/cli/agent/lifecycle.py
@@ -8,10 +8,11 @@ from tracker.exceptions import S3Error
 from valkyrie.cli.agent.storage import download_agent, install_agent, list_agents, push_agent, remove_agent
 from valkyrie.cli.bundler import read_agent_name
 from valkyrie.cli.display import format_table, local_time, paginate_cli_pages
+from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.schemas import validate_agent_name
 
 
-@click.command(name="install", help="Installs agent from a github project to the users aws environment")
+@click.command(name="install", help="Install an agent from a GitHub project")
 @click.argument("github_url", type=str)
 @click.option(
     "--name",
@@ -34,13 +35,13 @@ def install(github_url: str, name: str | None):
     try:
         resolved_name = asyncio.run(install_agent(name, github_url))
         click.echo(click.style(f"✓ Agent '{resolved_name}' installed successfully!", fg="green", bold=True))
-    except (RuntimeError, S3Error) as e:
+    except (RuntimeError, S3Error, TrackerServiceError) as e:
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")
 
 
-@click.command(name="push", help="Pushes agent to the users aws environment from the local filesystem")
+@click.command(name="push", help="Push an agent from the local filesystem")
 @click.argument("agent_path", type=click.Path(exists=True, path_type=Path, file_okay=False, dir_okay=True))
 @click.option(
     "--name",
@@ -50,7 +51,7 @@ def install(github_url: str, name: str | None):
     help="Agent name (defaults to the contract name)",
 )
 def push(agent_path: Path, name: str | None):
-    """Push a local agent to S3.
+    """Push a local agent to the configured runtime.
 
     Example:
         valkyrie agent push ./agents/my-agent
@@ -60,7 +61,7 @@ def push(agent_path: Path, name: str | None):
         agent_name = validate_agent_name(name) if name else read_agent_name(agent_path)
         asyncio.run(push_agent(agent_name, agent_path))
         click.echo(click.style(f"✓ Agent '{agent_name}' pushed successfully!", fg="green", bold=True))
-    except S3Error as e:
+    except (S3Error, TrackerServiceError) as e:
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")
@@ -69,7 +70,7 @@ def push(agent_path: Path, name: str | None):
 @click.command(name="remove", help="Remove an installed agent")
 @click.argument("agent_name", type=str)
 def agent_remove(agent_name: str):
-    """Remove an agent from S3.
+    """Remove an agent from the configured runtime.
 
     Example:
         valkyrie agent remove my-agent
@@ -81,7 +82,7 @@ def agent_remove(agent_name: str):
 
         asyncio.run(remove_agent(agent_name))
         click.echo(click.style(f"✓ Agent '{agent_name}' removed successfully!", fg="green", bold=True))
-    except S3Error as e:
+    except (S3Error, TrackerServiceError) as e:
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")
@@ -98,7 +99,7 @@ def agent_remove(agent_name: str):
     help="Output directory for downloaded agent (default: current directory)",
 )
 def download(agent_name: str, output_dir: Path | None):
-    """Download an agent from S3.
+    """Download an agent from the configured runtime.
 
     Example:
         valkyrie agent download my-agent
@@ -106,7 +107,7 @@ def download(agent_name: str, output_dir: Path | None):
     try:
         asyncio.run(download_agent(agent_name, output_dir))
         click.echo(click.style(f"✓ Agent '{agent_name}' downloaded successfully!", fg="green", bold=True))
-    except S3Error as e:
+    except (S3Error, TrackerServiceError) as e:
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")
@@ -114,7 +115,7 @@ def download(agent_name: str, output_dir: Path | None):
 
 @click.command(name="list", help="List installed agents")
 def list_installed_agents():
-    """List all installed agents in S3.
+    """List all installed agents in the configured runtime.
 
     Use vim keys to navigate: [h] previous page, [l] next page, [q] quit.
 
@@ -129,7 +130,7 @@ def list_installed_agents():
             return
 
         paginate_agents(agents)
-    except S3Error as e:
+    except (S3Error, TrackerServiceError) as e:
         raise click.ClickException(str(e))
     except Exception as e:
         raise click.ClickException(f"Unexpected error: {str(e)}")

--- a/src/valkyrie/cli/agent/storage.py
+++ b/src/valkyrie/cli/agent/storage.py
@@ -10,6 +10,7 @@ from typing import Any, Coroutine, TypeVar, cast
 
 import aioboto3
 import click
+import httpx
 import yaml
 from botocore.exceptions import ClientError
 from tracker import handle_s3_error
@@ -26,6 +27,8 @@ from tracker.types import AWSCredentials
 
 from valkyrie.cli.bundler import get_agent_zip_stream, get_contract_from_zip_bytes, read_agent_name
 from valkyrie.cli.config.state import load_config
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.tracker_client import TrackerService
 from valkyrie.schemas import AgentConfig, validate_agent_name
 
 T = TypeVar("T")
@@ -72,6 +75,10 @@ def _fetch_bucket_name() -> str:
     return bucket_name
 
 
+def _is_hosted() -> bool:
+    return bool(load_config().get("api_key"))
+
+
 def _aws_credentials() -> AWSCredentials:
     """Build AWS credentials from the valkyrie config."""
     config = load_config()
@@ -91,6 +98,33 @@ def _s3_client():
         region_name=config.get("AWS_DEFAULT_REGION"),
     )
     return session.client("s3")
+
+
+async def _download_agent_zip(agent_name: str) -> bytes:
+    if _is_hosted():
+        tracker = TrackerService()
+        try:
+            download = tracker.get_agent_download_url(agent_name)
+        finally:
+            tracker.close()
+
+        try:
+            async with httpx.AsyncClient(timeout=None) as client:
+                response = await client.get(download.download_url)
+                response.raise_for_status()
+                return response.content
+        except httpx.HTTPError as error:
+            raise TrackerServiceError(f"Failed to download agent '{agent_name}': {error}") from error
+
+    bucket_name = _fetch_bucket_name()
+    async with _s3_client() as s3_client:
+        try:
+            response = await s3_client.get_object(Bucket=bucket_name, Key=get_contract_s3_key(agent_name))
+            return cast(bytes, await response["Body"].read())
+        except ClientError as error:
+            if error.response["Error"]["Code"] in ("404", "NoSuchKey"):
+                raise S3Error(f"Agent '{agent_name}' not found in S3.") from error
+            raise
 
 
 async def _run_git_command(repo_path: Path | None, *args: str) -> None:
@@ -182,16 +216,33 @@ async def install_agent(agent_name: str | None, github_url: str) -> str:
 @handle_s3_error(message="Failed to push agent to S3")
 async def push_agent(agent_name: str, agent_path: Path):
     """Zip and push an agent to S3 at agents/{agent_name}.zip"""
-
-    # fetch bucket name from config
-    bucket_name = _fetch_bucket_name()
+    agent_name = validate_agent_name(agent_name)
 
     with get_agent_zip_stream(agent_name=agent_name, agent_path=agent_path) as file_stream:
-        # Get file size for progress bar
-        file_stream.seek(0, 2)  # Seek to end
+        file_stream.seek(0, 2)
         file_size = file_stream.tell()
-        file_stream.seek(0)  # Seek back to start
+        file_stream.seek(0)
 
+        if _is_hosted():
+            tracker = TrackerService()
+            try:
+                upload = tracker.create_agent_upload_url(agent_name, file_size)
+            finally:
+                tracker.close()
+
+            try:
+                with httpx.Client(timeout=None) as client:
+                    response = client.post(
+                        upload.upload_url,
+                        data=upload.fields,
+                        files={"file": (f"{agent_name}.zip", file_stream, "application/zip")},
+                    )
+                    response.raise_for_status()
+                return
+            except httpx.HTTPError as error:
+                raise TrackerServiceError(f"Failed to upload agent '{agent_name}': {error}") from error
+
+        bucket_name = _fetch_bucket_name()
         async with _s3_client() as s3_client:
             # Initiate multipart upload
             key = get_contract_s3_key(agent_name)
@@ -256,6 +307,9 @@ async def push_agent(agent_name: str, agent_path: Path):
 
 async def update_benchmark_agent_version(agent_name: str, benchmark_id: str) -> None:
     """Overwrite the frozen benchmark agent copy from agents/<name>.zip in S3."""
+    if _is_hosted():
+        raise TrackerServiceError("Hosted mode does not support --update-agent yet")
+
     aws = _aws_credentials()
     bucket_name = _fetch_bucket_name()
     source_key = get_contract_s3_key(agent_name)
@@ -270,8 +324,15 @@ async def update_benchmark_agent_version(agent_name: str, benchmark_id: str) -> 
 @handle_s3_error(message="Failed to remove agent from S3")
 async def remove_agent(agent_name: str):
     """Remove an agent from S3. Raises an error if the agent doesn't exist"""
+    agent_name = validate_agent_name(agent_name)
+    if _is_hosted():
+        tracker = TrackerService()
+        try:
+            tracker.delete_agent(agent_name)
+        finally:
+            tracker.close()
+        return
 
-    # fetch bucket name from config
     bucket_name = _fetch_bucket_name()
 
     async with _s3_client() as s3_client:
@@ -291,6 +352,17 @@ async def remove_agent(agent_name: str):
 
 async def list_agents() -> list[tuple[str, datetime | None]]:
     """List all agents in the S3 bucket's agents/ folder with the dates that they were added."""
+    if _is_hosted():
+        tracker = TrackerService()
+        try:
+            response = tracker.list_agents()
+        finally:
+            tracker.close()
+        return [
+            (agent.name, datetime.fromisoformat(agent.last_modified) if agent.last_modified else None)
+            for agent in response.agents
+        ]
+
     bucket_name = _fetch_bucket_name()
 
     click.echo(f"\r\033[KListing agents from bucket '{bucket_name}'...", nl=False)
@@ -301,16 +373,7 @@ async def list_agents() -> list[tuple[str, datetime | None]]:
 @handle_s3_error(message="Failed to download agent from S3")
 async def download_agent(agent_name: str, output_dir: Path | None) -> None:
     """Download an agent zip from S3, extract it, and show progress"""
-    bucket_name = _fetch_bucket_name()
-
-    async with _s3_client() as s3_client:
-        try:
-            response = await s3_client.get_object(Bucket=bucket_name, Key=get_contract_s3_key(agent_name))
-            zip_bytes: bytes = cast(bytes, await response["Body"].read())
-        except ClientError as e:
-            if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
-                raise S3Error(f"Agent '{agent_name}' not found in S3.")
-            raise
+    zip_bytes = await _download_agent_zip(validate_agent_name(agent_name))
 
     # Extract to the specified output directory or current directory
     extract_dir = Path(output_dir) if output_dir else Path.cwd()
@@ -351,16 +414,8 @@ async def get_ingest_lambda_from_s3(agent_name: str) -> str | None:
 
     Reads the ``ingest_lambda`` field directly from the agent's ``contract.yaml``.
     """
-    bucket_name = _fetch_bucket_name()
-
-    async with _s3_client() as s3_client:
-        try:
-            response = await s3_client.get_object(Bucket=bucket_name, Key=get_contract_s3_key(agent_name))
-            zip_bytes: bytes = cast(bytes, await response["Body"].read())
-        except ClientError as e:
-            if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
-                raise S3Error(f"Agent '{agent_name}' not found in S3.")
-            raise
+    agent_name = validate_agent_name(agent_name)
+    zip_bytes = await _download_agent_zip(agent_name)
 
     with tempfile.TemporaryDirectory() as tmp:
         tmp_path = Path(tmp)
@@ -380,15 +435,7 @@ async def get_ingest_lambda_from_s3(agent_name: str) -> str | None:
 
 async def get_contract_from_s3(agent_name: str, agent_config: AgentConfig) -> AgentContractRequest:
     """Download agent zip from S3 and extract the contract into a temp dir, returning the contract request"""
-    bucket_name = _fetch_bucket_name()
-
-    async with _s3_client() as s3_client:
-        try:
-            response = await s3_client.get_object(Bucket=bucket_name, Key=get_contract_s3_key(agent_name))
-            zip_bytes: bytes = await response["Body"].read()
-        except ClientError as e:
-            if e.response["Error"]["Code"] in ("404", "NoSuchKey"):
-                raise S3Error(f"Agent '{agent_name}' not found in S3.")
-            raise
+    agent_name = validate_agent_name(agent_name)
+    zip_bytes = await _download_agent_zip(agent_name)
 
     return get_contract_from_zip_bytes(agent_name, zip_bytes, agent_config)  # type: ignore

--- a/src/valkyrie/cli/config/settings.py
+++ b/src/valkyrie/cli/config/settings.py
@@ -21,35 +21,27 @@ _REQUIRED_ENVIRONMENT_VARIABLES: dict[str, str | None | int] = {
 @click.command()
 def init() -> None:
     """
-    Initializes a config we can trust to have references to dependencies to run Valkyrie,
-    this becomes our source of truth for secrets required to run Valkyrie
+    Configure hosted Valkyrie with an API key or self-hosted Valkyrie with AWS resources.
     """
-
-    current_config: dict[str, Any] = {}
-    if CONFIG_LOCATION.exists():
-        try:
-            current_config = read_config_if_exists()
-        except Exception:
-            pass
+    current_config: dict[str, Any] = read_config_if_exists()
 
     mode = click.prompt(
         "Setup mode",
         type=click.Choice(["hosted", "self-hosted"]),
-        default="self-hosted",
+        default="hosted",
     )
 
     if mode == "hosted":
-        api_key = os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key")
-        current_config["api_key"] = api_key
-
-        # Validate the key and create/confirm org (uses default tracker URL)
+        api_key = os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key", hide_input=True)
         try:
             result = TrackerService.init_org(api_key)
         except TrackerServiceError as e:
             raise click.ClickException(str(e))
-        click.echo(f"Organization '{result['org_name']}' configured successfully.\n")
+        current_config["api_key"] = api_key
+        write_config(current_config)
+        click.echo(f"Organization '{result.org_name}' configured successfully.\n")
 
-        if result.get("email_claim_missing"):
+        if result.email_claim_missing:
             click.echo(
                 click.style(
                     "⚠  This access key is missing the 'email' custom claim. "
@@ -59,8 +51,9 @@ def init() -> None:
                     fg="yellow",
                 )
             )
+        click.echo(click.style(f"\nConfig written to {CONFIG_LOCATION}", fg="green", bold=True))
+        return
 
-    # Both modes require AWS credentials
     collected_keys: dict[str, str] = {}
     for key, default in _REQUIRED_ENVIRONMENT_VARIABLES.items():
         sourced = current_config.get(key) or os.environ.get(key)
@@ -86,8 +79,7 @@ def init() -> None:
 
     current_config.update(collected_keys)
 
-    if mode != "hosted":
-        current_config.pop("api_key", None)
+    current_config.pop("api_key", None)
 
     write_config(current_config)
 

--- a/src/valkyrie/cli/config/state.py
+++ b/src/valkyrie/cli/config/state.py
@@ -1,5 +1,6 @@
 """Config file state helpers for CLI commands."""
 
+import os
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -49,6 +50,9 @@ def load_config() -> dict[str, Any]:
 
 def write_config(config: dict[str, Any], *, sort_keys: bool = True) -> None:
     """Write the Valkyrie configuration to disk."""
-    CONFIG_LOCATION.parent.mkdir(parents=True, exist_ok=True)
-    with open(CONFIG_LOCATION, "w") as config_file:
+    CONFIG_LOCATION.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    CONFIG_LOCATION.parent.chmod(0o700)
+    descriptor = os.open(CONFIG_LOCATION, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(descriptor, 0o600)
+    with os.fdopen(descriptor, "w") as config_file:
         yaml.dump(config, config_file, default_flow_style=False, sort_keys=sort_keys)

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -13,8 +13,12 @@ import yaml
 from benchmark_service.schemas import VerifyTaskIdsResponse
 from dotenv import load_dotenv
 from httpx._models import Response
+from pydantic import ValidationError
 from tracker.database.models import AgentContractRequest, RetryMode
 from tracker.types import (
+    AgentDownloadURLResponse,
+    AgentsResponse,
+    AgentUploadURLResponse,
     BenchmarkServiceEntry,
     BenchmarkServicesRequest,
     BenchmarkServicesResponse,
@@ -26,10 +30,12 @@ from tracker.types import (
     FetchBenchmarksResponse,
     FinalViewResponse,
     HarnessConfig,
+    InitResponse,
     RetrieveResultsResponse,
     RetryOrResumeBenchmarkResponse,
     S3UploadResultsResponse,
-    StartBenchmarkRequest,
+    StartBenchmarkInput,
+    StatusResponse,
     StopBenchmarkResponse,
 )
 
@@ -62,6 +68,11 @@ def _sandbox_providers(config: dict[str, Any]) -> dict[str, str]:
         return {}
     providers = cast(dict[object, object], raw_providers)
     return {str(name): str(secret_name) for name, secret_name in providers.items()}
+
+
+def _harness_config_values(config: dict[str, Any]) -> dict[str, str]:
+    skipped = {"webhook", "api_key", "default_sandbox_provider"}
+    return {key: str(value) for key, value in config.items() if not isinstance(value, dict) and key not in skipped}
 
 
 def _response_error_detail(response: Response) -> Any:
@@ -134,8 +145,19 @@ class TrackerService:
         self._api_key = self._config.get("api_key")
         self._base_url = _resolve_tracker_url(base_url)
         self._timeout = timeout
-        self._config_values = self.parse_config_keys() if require_config else {}
+        self._config_values = self.parse_config_keys() if require_config and not self._api_key else {}
+        has_legacy_config = _REQUIRED_CONFIG_KEYS <= self._config.keys() and bool(
+            _sandbox_providers(self._config) or self._config.get("DAYTONA_SECRET_NAME")
+        )
+        self._legacy_config_values = _harness_config_values(self._config) if self._api_key and has_legacy_config else {}
         self._client = httpx.Client(timeout=timeout, headers=self._build_auth_headers())
+        run_headers = {
+            **self._build_auth_headers(),
+            **self._build_harness_headers(self._legacy_config_values),
+        }
+        self._run_client = (
+            httpx.Client(timeout=timeout, headers=run_headers) if self._legacy_config_values else self._client
+        )
 
     def __enter__(self) -> "TrackerService":
         """Context manager entry."""
@@ -148,6 +170,8 @@ class TrackerService:
 
     def close(self) -> None:
         """Close the HTTP client."""
+        if self._run_client is not self._client:
+            self._run_client.close()
         self._client.close()
 
     @staticmethod
@@ -161,10 +185,11 @@ class TrackerService:
             return yaml.safe_load(f) or {}
 
     def _build_auth_headers(self) -> dict[str, str]:
-        """Build request headers. Hosted mode adds X-Api-Key alongside X-Harness-* headers."""
-        headers = self._build_harness_headers()
+        """Build API-key headers for hosted mode or harness headers for self-hosted mode."""
+        headers = self._build_harness_headers(self._config_values)
         if self._api_key:
             headers["X-Api-Key"] = self._api_key
+            headers["X-Valkyrie-Runtime"] = "managed"
         return headers
 
     @staticmethod
@@ -188,8 +213,8 @@ class TrackerService:
         services = harness_config.get("custom_benchmark_services") or {}
         return services.get(benchmark_name)
 
-    @staticmethod
-    def get_benchmark_auth(benchmark_name: str) -> str | None:
+    @classmethod
+    def get_benchmark_auth(cls, benchmark_name: str) -> str | None:
         """
         Get benchmark auth credential from config if it exists.
 
@@ -199,39 +224,32 @@ class TrackerService:
         Returns:
             Auth credential if configured, None otherwise
         """
-        config_path = _CONFIG_LOCATION.expanduser()
-        if not config_path.exists():
+        config = cls._load_config()
+        if config.get("api_key"):
             return None
 
-        with open(config_path) as f:
-            harness_config = yaml.safe_load(f) or {}
-
-        auth = harness_config.get("benchmark_auth") or {}
+        auth = config.get("benchmark_auth") or {}
         return auth.get(benchmark_name)
 
-    @staticmethod
-    def get_webhook_secret() -> str | None:
+    @classmethod
+    def get_webhook_secret(cls) -> str | None:
         """
         Get Slack webhook secret name from config if it exists.
 
         Returns:
             Webhook secret name if configured, None otherwise
         """
-        config_path = _CONFIG_LOCATION.expanduser()
-        if not config_path.exists():
+        config = cls._load_config()
+        if config.get("api_key"):
             return None
 
-        with open(config_path) as f:
-            harness_config = yaml.safe_load(f) or {}
-
-        secret_name = harness_config.get("webhook")
+        secret_name = config.get("webhook")
         return secret_name if secret_name else None
 
     @staticmethod
     def parse_config_keys() -> dict[str, str]:
         """Parses expected config keys and handles edge cases"""
         config_path: Path = _CONFIG_LOCATION.expanduser()
-        config_keys: dict[str, str] = {}
         if not config_path.exists():
             raise TrackerServiceError(f"Could not find the config at {_CONFIG_LOCATION}, run `valkyrie config init`")
 
@@ -247,17 +265,7 @@ class TrackerService:
         if not (_sandbox_providers(harness_config) or "DAYTONA_SECRET_NAME" in harness_config):
             raise TrackerServiceError(f"Missing sandbox provider config. Run `{_PROVIDER_SETUP_COMMAND}`.")
 
-        # Keys that are managed separately and should not be sent as harness headers
-        _SKIP_HEADER_KEYS = {"webhook", "api_key", "default_sandbox_provider"}
-
-        # Skip custom_benchmark_services to avoid adding them inside of the header
-        for key, value in harness_config.items():
-            if isinstance(value, dict) or key in _SKIP_HEADER_KEYS:
-                continue
-
-            config_keys[key] = str(value)
-
-        return config_keys
+        return _harness_config_values(harness_config)
 
     @classmethod
     def validate_sandbox_provider(cls, provider: str | None = None) -> tuple[str, str]:
@@ -272,13 +280,25 @@ class TrackerService:
         Raises
         - TrackerServiceError: If provider config is missing or the provider is unknown.
         """
-        return _resolve_sandbox_provider_config(cls._load_config(), cls.parse_config_keys(), provider)
+        config = cls._load_config()
+        if config.get("api_key"):
+            if provider is not None:
+                raise TrackerServiceError("Hosted mode does not accept --provider")
+            return "daytona", ""
 
-    def _build_harness_headers(self) -> dict[str, str]:
+        return _resolve_sandbox_provider_config(config, cls.parse_config_keys(), provider)
+
+    @staticmethod
+    def _build_harness_headers(config_values: dict[str, str]) -> dict[str, str]:
         """Automate building the headers from the config keys"""
-        return {f"X-Harness-{re.sub(r'_', '-', key).title()}": value for key, value in self._config_values.items()}
+        return {f"X-Harness-{re.sub(r'_', '-', key).title()}": value for key, value in config_values.items()}
 
     def resolve_sandbox_provider(self, provider: str | None = None) -> tuple[str, str]:
+        if self._api_key:
+            if provider is not None:
+                raise TrackerServiceError("Hosted mode does not accept --provider")
+            return "daytona", ""
+
         return _resolve_sandbox_provider_config(self._config, self._config_values, provider)
 
     def _build_harness_config_payload(self, sandbox_provider_secret_name: str) -> dict[str, Any]:
@@ -357,15 +377,50 @@ class TrackerService:
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to check benchmark services: {e}") from e
 
+    def list_agents(self) -> AgentsResponse:
+        try:
+            response = self._client.get(f"{self._base_url}/agents")
+            return AgentsResponse.model_validate(_parse_response(response, "Failed to list agents"))
+        except httpx.HTTPError as error:
+            raise TrackerServiceError(f"Failed to list agents: {error}") from error
+
+    def create_agent_upload_url(self, name: str, size_bytes: int) -> AgentUploadURLResponse:
+        try:
+            response = self._client.post(
+                f"{self._base_url}/agents/{name}/upload-url",
+                params={"size_bytes": size_bytes},
+            )
+            return AgentUploadURLResponse.model_validate(_parse_response(response, f"Failed to upload agent '{name}'"))
+        except httpx.HTTPError as error:
+            raise TrackerServiceError(f"Failed to upload agent '{name}': {error}") from error
+
+    def get_agent_download_url(self, name: str) -> AgentDownloadURLResponse:
+        try:
+            response = self._client.get(f"{self._base_url}/agents/{name}/download-url")
+            return AgentDownloadURLResponse.model_validate(
+                _parse_response(response, f"Failed to download agent '{name}'")
+            )
+        except httpx.HTTPError as error:
+            raise TrackerServiceError(f"Failed to download agent '{name}': {error}") from error
+
+    def delete_agent(self, name: str) -> StatusResponse:
+        try:
+            response = self._client.delete(f"{self._base_url}/agents/{name}")
+            return StatusResponse.model_validate(_parse_response(response, f"Failed to remove agent '{name}'"))
+        except httpx.HTTPError as error:
+            raise TrackerServiceError(f"Failed to remove agent '{name}': {error}") from error
+
     @classmethod
-    def init_org(cls, api_key: str, base_url: str | None = None) -> dict[str, str | bool]:
+    def init_org(cls, api_key: str, base_url: str | None = None) -> InitResponse:
         """Validate a Descope API key and create/confirm the org. Does not require a full config."""
         tracker_url = _resolve_tracker_url(base_url)
         try:
             with httpx.Client(timeout=120, headers={"X-Api-Key": api_key}) as client:
                 response = client.post(f"{tracker_url}/init")
-
-                return _parse_response(response, "Failed to initialize org")
+                try:
+                    return InitResponse.model_validate(_parse_response(response, "Failed to initialize org"))
+                except ValidationError as error:
+                    raise TrackerServiceError("Managed runtime is not ready") from error
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to initialize org: {e}") from e
 
@@ -404,8 +459,18 @@ class TrackerService:
             TrackerServiceError: If start run fails
         """
         try:
-            provider_name, sandbox_provider_secret_name = self.resolve_sandbox_provider(provider)
-            payload = StartBenchmarkRequest(
+            if self._api_key and (contract.secrets or webhook_secret_name):
+                raise TrackerServiceError("Hosted mode does not accept AWS secret references")
+
+            provider_name, provider_secret_name = self.resolve_sandbox_provider(provider)
+            harness_config = None
+            custom_benchmark_service = None
+            if not self._api_key:
+                harness_config = HarnessConfig.model_validate(self._build_harness_config_payload(provider_secret_name))
+                if not ignore_custom_services:
+                    custom_benchmark_service = self.get_benchmark_service_url(benchmark_name)
+
+            payload = StartBenchmarkInput(
                 contract=contract,
                 benchmark_name=benchmark_name,
                 concurrency=concurrency,
@@ -414,19 +479,15 @@ class TrackerService:
                 slice_str=slice_str,
                 lambda_function=lambda_function,
                 dataset=dataset,
-                harness_config=HarnessConfig.model_validate(
-                    self._build_harness_config_payload(sandbox_provider_secret_name)
-                ),
-                custom_benchmark_service=self.get_benchmark_service_url(benchmark_name)
-                if not ignore_custom_services
-                else None,
+                harness_config=harness_config,
+                custom_benchmark_service=custom_benchmark_service,
                 service_headers=service_headers or {},
                 sandbox_provider=provider_name,
                 webhook_secret_name=webhook_secret_name,
                 webhook_intervals=webhook_intervals,
             )
 
-            body = payload.model_dump()
+            body = payload.model_dump(exclude_none=True)
 
             response = self._client.post(f"{self._base_url}/start-benchmark", json=body)
 
@@ -445,7 +506,9 @@ class TrackerService:
             FetchBenchmarkResponse with benchmark information
         """
         try:
-            response = self._client.get(f"{self._base_url}/fetch-benchmark", params={"benchmark_id": str(benchmark_id)})
+            response = self._run_client.get(
+                f"{self._base_url}/fetch-benchmark", params={"benchmark_id": str(benchmark_id)}
+            )
 
             return FetchBenchmarkResponse.model_validate(_parse_response(response, "Failed to fetch run"))
         except httpx.HTTPError as e:
@@ -464,7 +527,7 @@ class TrackerService:
         body = {"no_cache": no_cache, "lambda_function": lambda_function}
 
         try:
-            with self._client.stream("POST", url, json=body, timeout=None) as response:
+            with self._run_client.stream("POST", url, json=body, timeout=None) as response:
                 if response.status_code != 200:
                     response.read()
                     details = _response_error_detail(response)
@@ -511,7 +574,7 @@ class TrackerService:
             Generator[str, None, None]
         """
         try:
-            with self._client.stream(
+            with self._run_client.stream(
                 "GET",
                 f"{self._base_url}/fetch-benchmark",
                 params={"benchmark_id": str(benchmark_id), "connect": "true"},
@@ -545,7 +608,7 @@ class TrackerService:
             if task_ids:
                 params["task_ids"] = task_ids
 
-            response = self._client.get(f"{self._base_url}/retrieve-results", params=params)
+            response = self._run_client.get(f"{self._base_url}/retrieve-results", params=params)
 
             response_data = _parse_response(response, "Failed to retrieve results")
             if not s3:
@@ -571,7 +634,7 @@ class TrackerService:
                 benchmark_name=benchmark_name,
                 dataset=dataset,
                 custom_benchmark_service=self.get_benchmark_service_url(benchmark_name)
-                if not ignore_custom_services
+                if not self._api_key and not ignore_custom_services
                 else None,
                 service_headers=service_headers or {},
             )
@@ -595,7 +658,7 @@ class TrackerService:
             TrackerServiceError if request fails
         """
         try:
-            response = self._client.get(
+            response = self._run_client.get(
                 f"{self._base_url}/check-results-exist", params={"benchmark_id": str(benchmark_id)}
             )
 
@@ -614,7 +677,7 @@ class TrackerService:
             StopBenchmarkResponse with status and message
         """
         try:
-            response = self._client.post(f"{self._base_url}/stop-benchmark/{benchmark_id}", params={"force": force})
+            response = self._run_client.post(f"{self._base_url}/stop-benchmark/{benchmark_id}", params={"force": force})
 
             return StopBenchmarkResponse.model_validate(_parse_response(response, "Failed to stop run"))
         except httpx.HTTPError as e:
@@ -646,6 +709,9 @@ class TrackerService:
             RetryOrResumeBenchmarkResponse with status and message
         """
         try:
+            if self._api_key and secrets:
+                raise TrackerServiceError("Hosted mode does not accept AWS secret references")
+
             params: dict[str, Any] = {"retry": retry, "retry_mode": retry_mode.value}
 
             # NOTE: 0 is not acceptable
@@ -656,7 +722,7 @@ class TrackerService:
             if secrets:
                 body["secrets"] = secrets
 
-            response = self._client.post(
+            response = self._run_client.post(
                 f"{self._base_url}/retry-or-resume-benchmark/{benchmark_id}",
                 params=params,
                 json=body,
@@ -711,7 +777,7 @@ class TrackerService:
             params: dict[str, Any] = {}
             if task_ids:
                 params["task_ids"] = task_ids
-            response = self._client.get(f"{self._base_url}/fetch-run-outputs/{benchmark_id}", params=params)
+            response = self._run_client.get(f"{self._base_url}/fetch-run-outputs/{benchmark_id}", params=params)
             if response.status_code != 200:
                 details = _response_error_detail(response)
                 raise TrackerServiceError(f"Failed to fetch run outputs: {details}")

--- a/tests/unit/test_agent_storage.py
+++ b/tests/unit/test_agent_storage.py
@@ -1,0 +1,153 @@
+import io
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+import pytest
+from tracker.types import (
+    AgentDownloadURLResponse,
+    AgentEntry,
+    AgentsResponse,
+    AgentUploadURLResponse,
+    StatusResponse,
+)
+
+import valkyrie.cli.agent.storage as storage
+from valkyrie.schemas import AgentConfig
+
+
+def _agent_zip(name: str = "agent") -> bytes:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr(
+            f"{name}/contract.yaml",
+            f"name: {name}\ninstall_cmd: echo install\nrun_cmd: echo {{problem_statement_path}}\n",
+        )
+        archive.writestr(f"{name}/README.md", "agent docs")
+    return stream.getvalue()
+
+
+class _Tracker:
+    deleted: list[str] = []
+    upload_sizes: list[int] = []
+
+    def __init__(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def create_agent_upload_url(self, name: str, size_bytes: int) -> AgentUploadURLResponse:
+        self.upload_sizes.append(size_bytes)
+        return AgentUploadURLResponse(
+            name=name,
+            upload_url="https://s3.test/upload",
+            fields={"policy": "signed"},
+            expires_in=300,
+        )
+
+    def get_agent_download_url(self, name: str) -> AgentDownloadURLResponse:
+        return AgentDownloadURLResponse(name=name, download_url="https://s3.test/download", expires_in=300)
+
+    def list_agents(self) -> AgentsResponse:
+        return AgentsResponse(agents=[AgentEntry(name="agent", last_modified="2026-01-02T00:00:00+00:00")])
+
+    def delete_agent(self, name: str) -> StatusResponse:
+        self.deleted.append(name)
+        return StatusResponse(status="success")
+
+
+def _hosted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(storage, "load_config", lambda: {"api_key": "personal-key"})
+    monkeypatch.setattr(storage, "TrackerService", _Tracker)
+
+
+async def test_hosted_push_streams_zip_through_presigned_post(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _hosted(monkeypatch)
+    agent_path = tmp_path / "agent"
+    agent_path.mkdir()
+    (agent_path / "contract.yaml").write_text(
+        "name: agent\ninstall_cmd: echo install\nrun_cmd: echo {problem_statement_path}\n"
+    )
+    uploaded: list[bytes] = []
+
+    class Client:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> "Client":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+        def post(self, url: str, *, data: dict[str, str], files: dict[str, tuple[str, object, str]]) -> httpx.Response:
+            assert url == "https://s3.test/upload"
+            assert data == {"policy": "signed"}
+            uploaded.append(files["file"][1].read())  # type: ignore[union-attr]
+            return httpx.Response(204, request=httpx.Request("POST", url))
+
+    monkeypatch.setattr(storage.httpx, "Client", Client)
+    _Tracker.upload_sizes = []
+
+    await storage.push_agent("agent", agent_path)
+
+    assert _Tracker.upload_sizes == [len(uploaded[0])]
+    with zipfile.ZipFile(io.BytesIO(uploaded[0])) as archive:
+        assert "agent/contract.yaml" in archive.namelist()
+
+
+async def test_hosted_list_and_remove_use_tracker(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hosted(monkeypatch)
+    _Tracker.deleted = []
+
+    agents = await storage.list_agents()
+    await storage.remove_agent("agent")
+
+    assert agents == [("agent", datetime(2026, 1, 2, tzinfo=timezone.utc))]
+    assert _Tracker.deleted == ["agent"]
+
+
+async def test_hosted_download_and_start_contract_use_tracker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _hosted(monkeypatch)
+    zip_bytes = _agent_zip()
+
+    class AsyncClient:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> "AsyncClient":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def get(self, url: str) -> httpx.Response:
+            return httpx.Response(200, content=zip_bytes, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(storage.httpx, "AsyncClient", AsyncClient)
+
+    await storage.download_agent("agent", tmp_path / "download")
+    contract = await storage.get_contract_from_s3("agent", AgentConfig())
+
+    assert (tmp_path / "download" / "agent" / "README.md").read_text() == "agent docs"
+    assert contract.name == "agent"
+    assert contract.run_cmd == "echo {problem_statement_path}"
+
+
+async def test_legacy_list_keeps_direct_s3_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(storage, "load_config", lambda: {"AWS_ACCESS_KEY_ID": "key"})
+    monkeypatch.setattr(storage, "_fetch_bucket_name", lambda: "legacy-bucket")
+    expected = [("legacy-agent", datetime(2026, 1, 2, tzinfo=timezone.utc))]
+    captured: list[str] = []
+
+    async def list_agents(_aws: object, bucket: str) -> list[tuple[str, datetime]]:
+        captured.append(bucket)
+        return expected
+
+    monkeypatch.setattr(storage, "_aws_credentials", lambda: object())
+    monkeypatch.setattr(storage, "list_s3_agents", list_agents)
+
+    assert await storage.list_agents() == expected
+    assert captured == ["legacy-bucket"]

--- a/tests/unit/test_config_settings.py
+++ b/tests/unit/test_config_settings.py
@@ -1,0 +1,107 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+from tracker.types import InitResponse, ManagedRuntimeReadiness
+
+import valkyrie.cli.config.settings as settings
+import valkyrie.cli.config.state as config_state
+from valkyrie.cli.exceptions import TrackerServiceError
+
+
+def _config(tmp_path: Path) -> Path:
+    path = tmp_path / "valkyrie.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "AWS_ACCESS_KEY_ID": "legacy-key",
+                "AWS_SECRET_ACCESS_KEY": "legacy-secret",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                "S3_BUCKET": "legacy-bucket",
+                "LOG_GROUP": "legacy-logs",
+                "LOG_RETENTION_POLICY": 30,
+                "DAYTONA_SECRET_NAME": "legacy-provider",
+            }
+        )
+    )
+    return path
+
+
+def _patch_config_path(monkeypatch: pytest.MonkeyPatch, path: Path) -> None:
+    monkeypatch.setattr(settings, "CONFIG_LOCATION", path)
+    monkeypatch.setattr(config_state, "CONFIG_LOCATION", path)
+
+
+def test_hosted_init_is_default_and_preserves_legacy_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _config(tmp_path)
+    _patch_config_path(monkeypatch, path)
+    monkeypatch.delenv("VALKYRIE_API_KEY", raising=False)
+    observed_keys: list[str] = []
+
+    def init_org(api_key: str) -> InitResponse:
+        observed_keys.append(api_key)
+        return InitResponse(
+            org_name="vals",
+            created=False,
+            email_claim_missing=False,
+            runtime=ManagedRuntimeReadiness(),
+        )
+
+    monkeypatch.setattr(settings.TrackerService, "init_org", init_org)
+
+    result = CliRunner().invoke(settings.init, input="\npersonal-key\n")
+
+    assert result.exit_code == 0
+    assert observed_keys == ["personal-key"]
+    assert yaml.safe_load(path.read_text()) == {
+        "AWS_ACCESS_KEY_ID": "legacy-key",
+        "AWS_SECRET_ACCESS_KEY": "legacy-secret",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "S3_BUCKET": "legacy-bucket",
+        "LOG_GROUP": "legacy-logs",
+        "LOG_RETENTION_POLICY": 30,
+        "DAYTONA_SECRET_NAME": "legacy-provider",
+        "api_key": "personal-key",
+    }
+    assert "AWS_ACCESS_KEY_ID" not in result.output
+    assert "personal-key" not in result.output
+    assert "Organization 'vals' configured successfully" in result.output
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o777 == 0o700
+
+
+def test_hosted_init_does_not_write_when_runtime_is_not_ready(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _config(tmp_path)
+    original = path.read_text()
+    _patch_config_path(monkeypatch, path)
+    monkeypatch.setenv("VALKYRIE_API_KEY", "personal-key")
+
+    def fail_init(_api_key: str) -> InitResponse:
+        raise TrackerServiceError("Managed runtime is not ready")
+
+    monkeypatch.setattr(settings.TrackerService, "init_org", fail_init)
+
+    result = CliRunner().invoke(settings.init, input="\n")
+
+    assert result.exit_code != 0
+    assert "Managed runtime is not ready" in result.output
+    assert path.read_text() == original
+
+
+def test_self_hosted_init_removes_api_key_without_changing_aws_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _config(tmp_path)
+    config = yaml.safe_load(path.read_text())
+    config["api_key"] = "personal-key"
+    path.write_text(yaml.safe_dump(config))
+    _patch_config_path(monkeypatch, path)
+
+    result = CliRunner().invoke(settings.init, input="self-hosted\n")
+
+    assert result.exit_code == 0
+    saved = yaml.safe_load(path.read_text())
+    assert "api_key" not in saved
+    assert saved["AWS_ACCESS_KEY_ID"] == "legacy-key"
+    assert saved["S3_BUCKET"] == "legacy-bucket"

--- a/tests/unit/test_tracker_client.py
+++ b/tests/unit/test_tracker_client.py
@@ -68,6 +68,150 @@ def _handle_catalog_service_request(requests: list[httpx.Request], request: http
     )
 
 
+def test_hosted_start_uses_managed_payload_and_legacy_headers_only_for_existing_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path.startswith("/fetch-run-outputs/"):
+            return httpx.Response(200, content=b"tar")
+        if request.url.path == "/fetch-benchmark-tasks":
+            return httpx.Response(200, json={"task_ids": ["task"]})
+        return httpx.Response(200, json={"status": "success"})
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.Client
+
+    monkeypatch.setattr(
+        TrackerService,
+        "_load_config",
+        staticmethod(
+            lambda: {
+                "api_key": "personal-key",
+                "AWS_ACCESS_KEY_ID": "legacy-key",
+                "AWS_SECRET_ACCESS_KEY": "legacy-secret",
+                "AWS_DEFAULT_REGION": "us-east-1",
+                "S3_BUCKET": "legacy-bucket",
+                "LOG_GROUP": "legacy-logs",
+                "LOG_RETENTION_POLICY": 30,
+                "DAYTONA_SECRET_NAME": "legacy-provider",
+                "custom_benchmark_services": {"swebench": "https://custom.invalid"},
+            }
+        ),
+    )
+    monkeypatch.setattr("valkyrie.cli.tracker_client.httpx.Client", partial(original_client, transport=transport))
+
+    tracker = TrackerService(base_url="http://tracker")
+    tracker.start_benchmark(
+        contract=AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run"),
+        benchmark_name="swebench",
+        concurrency=1,
+        ignore_custom_services=False,
+        task_ids=None,
+        slice_str=None,
+    )
+    tracker.fetch_benchmark_tasks("swebench")
+    tracker.fetch_run_outputs(uuid4())
+    tracker.close()
+
+    start_request, tasks_request, outputs_request = requests
+    assert start_request.headers["X-Api-Key"] == "personal-key"
+    assert start_request.headers["X-Valkyrie-Runtime"] == "managed"
+    assert not [name for name in start_request.headers if name.lower().startswith("x-harness-")]
+    start_body = json.loads(start_request.content)
+    assert "harness_config" not in start_body
+    assert "sandbox_provider_secret_name" not in start_body
+    assert "custom_benchmark_service" not in start_body
+    assert json.loads(tasks_request.content)["custom_benchmark_service"] is None
+    assert outputs_request.headers["X-Api-Key"] == "personal-key"
+    assert outputs_request.headers["X-Harness-Aws-Access-Key-Id"] == "legacy-key"
+
+
+def test_hosted_start_ignores_legacy_service_auth_and_webhook(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        TrackerService,
+        "_load_config",
+        staticmethod(
+            lambda: {
+                "api_key": "personal-key",
+                "benchmark_auth": {"swebench": "legacy-auth"},
+                "webhook": "legacy-webhook",
+            }
+        ),
+    )
+
+    assert TrackerService.get_benchmark_auth("swebench") is None
+    assert TrackerService.get_webhook_secret() is None
+
+
+def test_init_org_rejects_unready_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_client = httpx.Client
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(
+            200,
+            json={
+                "org_name": "vals",
+                "created": False,
+                "email_claim_missing": False,
+                "runtime": {"kind": "managed", "ready": False},
+            },
+        )
+    )
+    monkeypatch.setattr("valkyrie.cli.tracker_client.httpx.Client", partial(original_client, transport=transport))
+
+    with pytest.raises(TrackerServiceError, match="Managed runtime is not ready"):
+        TrackerService.init_org("personal-key", base_url="http://tracker")
+
+
+def test_hosted_agent_client_uses_tracker_lifecycle_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:
+    requests: list[httpx.Request] = []
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/agents":
+            return httpx.Response(200, json={"agents": [{"name": "agent", "last_modified": None}]})
+        if request.url.path.endswith("/upload-url"):
+            return httpx.Response(
+                200,
+                json={
+                    "name": "agent",
+                    "upload_url": "https://s3.test/upload",
+                    "fields": {"policy": "signed"},
+                    "expires_in": 300,
+                },
+            )
+        if request.url.path.endswith("/download-url"):
+            return httpx.Response(
+                200,
+                json={"name": "agent", "download_url": "https://s3.test/download", "expires_in": 300},
+            )
+        return httpx.Response(200, json={"status": "success"})
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.Client
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(lambda: {"api_key": "personal-key"}))
+    monkeypatch.setattr("valkyrie.cli.tracker_client.httpx.Client", partial(original_client, transport=transport))
+
+    tracker = TrackerService(base_url="http://tracker")
+    assert [agent.name for agent in tracker.list_agents().agents] == ["agent"]
+    assert tracker.create_agent_upload_url("agent", 42).fields == {"policy": "signed"}
+    assert tracker.get_agent_download_url("agent").download_url == "https://s3.test/download"
+    assert tracker.delete_agent("agent").status == "success"
+    tracker.close()
+
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/agents"),
+        ("POST", "/agents/agent/upload-url"),
+        ("GET", "/agents/agent/download-url"),
+        ("DELETE", "/agents/agent"),
+    ]
+    assert requests[1].url.params["size_bytes"] == "42"
+    assert all(request.headers["X-Api-Key"] == "personal-key" for request in requests)
+
+
 def test_tracker_client_lists_catalog_services_through_tracker(monkeypatch: pytest.MonkeyPatch) -> None:
     """Catalog service listing should use tracker-owned catalog lookup and health checks.
 


### PR DESCRIPTION
## Summary
- Make hosted setup the default and require only a personal Vals AI API key.
- Validate managed-runtime readiness before saving a key and protect the local config with owner-only permissions.
- Send new starts to the managed runtime while retaining legacy AWS headers only for historical-run operations.
- Ignore preserved legacy service credentials and webhooks on hosted starts.
- Route hosted agent lifecycle through organization-shared tracker endpoints and document self-hosted-only flags.

## Demo
valkyrie config init
Setup mode (hosted, self-hosted) [hosted]:
API Key: hidden
Organization configured successfully.

No AWS, S3, sandbox-provider, or model-provider credential is requested.

## Verification
- 129 CLI and root unit tests pass from a clean path.
- Ruff passes.
- Basedpyright reports 0 errors for changed production modules.
- Diff checks pass.

## Transition
Existing self-hosted fields remain in local config for historical runs and reversible rollback. New starts are explicitly managed. Hosted update-agent remains intentionally unsupported.