### PR TITLE
Print "Track progress:" inside the Run Details box

### DIFF
--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -91,9 +91,7 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ {'S3 Bucket:':<17} {start_benchmark_response.s3_bucket_url}")
     click.echo("├" + "─" * 79)
     if not connect:
-        click.echo(
-            f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan")
-        )
+        click.echo(f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan"))
     click.echo(
         f"│ {'Get results:':<17} "
         + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")

--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -75,7 +75,7 @@ def format_agent_start_details(
     click.echo()
 
 
-def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResponse) -> None:
+def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResponse, connect: bool = False) -> None:
     """Format and display the start run response."""
     run_id = start_benchmark_response.benchmark_id
 
@@ -90,6 +90,10 @@ def format_start_benchmark_response(start_benchmark_response: StartBenchmarkResp
     click.echo(f"│ {'CloudWatch:':<17} {start_benchmark_response.cloudwatch_url}")
     click.echo(f"│ {'S3 Bucket:':<17} {start_benchmark_response.s3_bucket_url}")
     click.echo("├" + "─" * 79)
+    if not connect:
+        click.echo(
+            f"│ {'Track progress:':<17} " + click.style(f"valkyrie run fetch {run_id} --connect", fg="cyan")
+        )
     click.echo(
         f"│ {'Get results:':<17} "
         + click.style(f"valkyrie run results {run_id} --path ./results-{run_id}.json", fg="cyan")
@@ -375,13 +379,8 @@ def start(
                 return
 
             start_response = StartBenchmarkResponse.model_validate(response.json())
-            format_start_benchmark_response(start_response)
+            format_start_benchmark_response(start_response, connect)
             if connect:
                 stream_benchmark_status(tracker, start_response.benchmark_id)
-            else:
-                click.echo(
-                    f"{'Track progress:':<17} "
-                    + click.style(f"valkyrie run fetch {start_response.benchmark_id} --connect", fg="cyan")
-                )
     except (BundlerError, TrackerServiceError, ContractValidationError) as e:
         raise click.ClickException(str(e))


### PR DESCRIPTION
## Summary
`valkyrie run start` printed the `Track progress:` hint after the closing `└─` line of the Run Details box. It now renders as a `│`-prefixed row inside the box, right after the `├─` divider (matching `run resume`), and is skipped when `--connect` is used.

## Changes
- `format_start_benchmark_response` takes a `connect` flag and prints the `Track progress:` row inside the box when not connecting
- Removed the stray post-box echo in the start command

## Related Issues
N/A

## Type of Change
- [x] Bug fix

## Testing
- [x] Manually tested (`make lint`, `make typecheck`, `uv run pytest tests/unit/test_tracker_client.py` all pass)

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/cfec33aab4314cbaa10a6a8390da3cc6
Requested by: @lgnashold