### PR TITLE
Add focused run error inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ valkyrie run fetch <id> --connect --format jsonl
 
 # Lightweight status for several known run IDs
 valkyrie run status --ids <id-1>,<id-2> --format json
+
+# Show stored run and current task error messages
+valkyrie run errors <id>
+
+# Machine-readable error messages
+valkyrie run errors <id> --format json
 ```
 
 Connected text fetches display the benchmark, agent, model, dataset, run ID, and other run metadata before streaming
@@ -209,15 +215,22 @@ The version 1 machine document shapes are:
 - Run list document: `schema_version`, `kind: "run_list"`, `observed_at`, `returned_count`, and allowlisted `runs`.
 - Batch status document: `schema_version`, `kind: "run_status"`, `observed_at`, request/return counts,
   `missing_run_ids`, and lightweight `runs` containing status and task counts.
+- Run errors document: `schema_version`, `kind: "run_errors"`, `observed_at`, run identity and status, the stored
+  run-level `error_message`, and a complete task-ID-to-error mapping for tasks currently in `ERROR`.
 
 Batch status preserves the requested ID order, ignores duplicate IDs, and requests up to 50 IDs at a time. A missing
 or inaccessible ID is listed in `missing_run_ids` and makes the command exit nonzero after emitting the JSON document.
 Its `finished_tasks` count includes terminal `FINISHED`, `ERROR`, and `STOPPED` tasks. Use `run list --format json --all`
 when benchmark, agent, model, or dataset identity is also needed.
 
+Text error output groups tasks only when their complete stored messages are identical and shows a short task-ID sample
+for repeated messages. JSON always includes every current task error. A successful command exits zero even when the run
+itself failed. Error messages can contain sensitive provider- or user-generated data, so review the output before
+sharing it or sending it to logs.
+
 ### Download results
 
-To view results, you should use the following command to download results to disk:
+Use `run errors` for focused inline diagnostics. To download the complete scores, evaluations, and result metadata, use:
 ```bash
 # default path: ./<benchmark>.json)
 valkyrie run results <id> --path ./results.json

--- a/README.md
+++ b/README.md
@@ -215,22 +215,15 @@ The version 1 machine document shapes are:
 - Run list document: `schema_version`, `kind: "run_list"`, `observed_at`, `returned_count`, and allowlisted `runs`.
 - Batch status document: `schema_version`, `kind: "run_status"`, `observed_at`, request/return counts,
   `missing_run_ids`, and lightweight `runs` containing status and task counts.
-- Run errors document: `schema_version`, `kind: "run_errors"`, `observed_at`, run identity and status, the stored
-  run-level `error_message`, and a complete task-ID-to-error mapping for tasks currently in `ERROR`.
 
 Batch status preserves the requested ID order, ignores duplicate IDs, and requests up to 50 IDs at a time. A missing
 or inaccessible ID is listed in `missing_run_ids` and makes the command exit nonzero after emitting the JSON document.
 Its `finished_tasks` count includes terminal `FINISHED`, `ERROR`, and `STOPPED` tasks. Use `run list --format json --all`
 when benchmark, agent, model, or dataset identity is also needed.
 
-Text error output groups tasks only when their complete stored messages are identical and shows a short task-ID sample
-for repeated messages. JSON always includes every current task error. A successful command exits zero even when the run
-itself failed. Error messages can contain sensitive provider- or user-generated data, so review the output before
-sharing it or sending it to logs.
-
 ### Download results
 
-Use `run errors` for focused inline diagnostics. To download the complete scores, evaluations, and result metadata, use:
+To view results, you should use the following command to download results to disk:
 ```bash
 # default path: ./<benchmark>.json)
 valkyrie run results <id> --path ./results.json

--- a/src/valkyrie/cli/run/__init__.py
+++ b/src/valkyrie/cli/run/__init__.py
@@ -1,6 +1,7 @@
 import click
 
 from valkyrie.cli.run.analyze import analyze
+from valkyrie.cli.run.errors import errors
 from valkyrie.cli.run.fetch import fetch
 from valkyrie.cli.run.list_runs import list_runs
 from valkyrie.cli.run.outputs import output_path, outputs
@@ -18,6 +19,7 @@ def run():
 
 
 run.add_command(analyze)
+run.add_command(errors)
 run.add_command(fetch)
 run.add_command(list_runs)
 run.add_command(output_path)

--- a/src/valkyrie/cli/run/errors.py
+++ b/src/valkyrie/cli/run/errors.py
@@ -1,0 +1,165 @@
+"""Inspect stored run errors without downloading a results file."""
+
+import json
+from collections import defaultdict
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from uuid import UUID
+
+import click
+from tracker.types import FinalViewResponse
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.tracker_client import TrackerService
+
+_TASK_ID_PREVIEW_LIMIT = 5
+
+
+def _utc_isoformat(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _terminal_safe(value: str, *, preserve_newlines: bool) -> str:
+    """Escape controls in untrusted text before writing it to a terminal."""
+    escaped: list[str] = []
+    for character in value:
+        if character == "\n" and preserve_newlines:
+            escaped.append(character)
+        elif character == "\t":
+            escaped.append("    ")
+        elif character.isprintable():
+            escaped.append(character)
+        else:
+            escaped.append(character.encode("unicode_escape").decode("ascii"))
+    return "".join(escaped)
+
+
+def _display_error_message(message: str) -> str:
+    if message == "":
+        return "(empty error message)"
+    return _terminal_safe(message, preserve_newlines=True)
+
+
+def _indent_message(message: str) -> str:
+    return "\n".join(f"  {line}" for line in message.split("\n"))
+
+
+def _count_label(count: int, singular: str) -> str:
+    return f"{count} {singular if count == 1 else f'{singular}s'}"
+
+
+def _format_task_id_preview(task_ids: tuple[str, ...]) -> str:
+    visible_ids = task_ids[:_TASK_ID_PREVIEW_LIMIT]
+    preview = ", ".join(_terminal_safe(task_id, preserve_newlines=False) for task_id in visible_ids)
+    omitted_count = len(task_ids) - len(visible_ids)
+    return f"{preview} (+{omitted_count} more)" if omitted_count else preview
+
+
+def group_task_errors(task_errors: Mapping[str, str]) -> list[tuple[str, tuple[str, ...]]]:
+    """Group task IDs by identical raw messages in deterministic display order."""
+    grouped: defaultdict[str, list[str]] = defaultdict(list)
+    for task_id, message in task_errors.items():
+        grouped[message].append(task_id)
+
+    groups = [(message, tuple(sorted(task_ids))) for message, task_ids in grouped.items()]
+    return sorted(groups, key=lambda group: (-len(group[1]), group[1][0]))
+
+
+def build_run_errors_payload(
+    response: FinalViewResponse,
+    *,
+    observed_at: datetime | None = None,
+) -> dict[str, object]:
+    """Build a versioned allowlist containing only run-error diagnostics."""
+    task_errors = dict(sorted((response.task_errors or {}).items()))
+    return {
+        "schema_version": 1,
+        "kind": "run_errors",
+        "observed_at": _utc_isoformat(observed_at or datetime.now(timezone.utc)),
+        "run_id": str(response.benchmark_id),
+        "benchmark_name": response.benchmark_name,
+        "status": response.status.value,
+        "error_message": response.error_message,
+        "task_error_count": len(task_errors),
+        "task_errors": task_errors,
+    }
+
+
+def format_run_errors_json(response: FinalViewResponse) -> str:
+    """Serialize one compact, machine-readable run-errors document."""
+    return json.dumps(
+        build_run_errors_payload(response),
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def format_run_errors_text(response: FinalViewResponse) -> None:
+    """Render stored run and current task errors for a human reader."""
+    task_errors = response.task_errors or {}
+    groups = group_task_errors(task_errors)
+
+    click.echo(click.style("Run Errors", bold=True))
+    click.echo(f"{'Run ID:':<12}{response.benchmark_id}")
+    click.echo(f"{'Benchmark:':<12}{_terminal_safe(response.benchmark_name, preserve_newlines=False)}")
+    click.echo(f"{'Status:':<12}{response.status.value.replace('_', ' ').title()}")
+
+    if response.error_message is not None:
+        click.echo()
+        click.echo(click.style("Stored run error", bold=True))
+        click.echo(_indent_message(_display_error_message(response.error_message)))
+
+    if groups:
+        click.echo()
+        click.echo(
+            click.style(
+                f"Task errors ({_count_label(len(task_errors), 'task')}, "
+                f"{_count_label(len(groups), 'distinct message')})",
+                bold=True,
+            )
+        )
+
+        for message, task_ids in groups:
+            click.echo()
+            click.echo(f"[{_count_label(len(task_ids), 'task')}] {_format_task_id_preview(task_ids)}")
+            click.echo(_indent_message(_display_error_message(message)))
+    elif response.error_message is None:
+        click.echo()
+        click.echo("No current error messages recorded.")
+
+
+@click.command(
+    name="errors",
+    help=(
+        "Show stored run and current task error messages.\n\n"
+        "Example:\n"
+        "valkyrie run errors 123e4567-e89b-12d3-a456-426614174000"
+    ),
+)
+@click.argument("run_id", type=UUID)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["text", "json"], case_sensitive=False),
+    default="text",
+    show_default=True,
+    help="Output format.",
+)
+def errors(run_id: UUID, output_format: str) -> None:
+    """Show stored run and current task error messages."""
+    try:
+        with TrackerService() as tracker:
+            response = tracker.retrieve_results(run_id, s3=False)
+        if not isinstance(response, FinalViewResponse):
+            raise TrackerServiceError("Tracker returned an unexpected response while fetching run errors")
+    except TrackerServiceError as error:
+        safe_error = _terminal_safe(str(error), preserve_newlines=False)
+        raise click.ClickException(safe_error) from error
+
+    if output_format == "json":
+        click.echo(format_run_errors_json(response))
+    else:
+        format_run_errors_text(response)

--- a/src/valkyrie/cli/run/errors.py
+++ b/src/valkyrie/cli/run/errors.py
@@ -132,7 +132,6 @@ def format_run_errors_text(response: FinalViewResponse) -> None:
 
 
 @click.command(
-    name="errors",
     help=(
         "Show stored run and current task error messages.\n\n"
         "Example:\n"

--- a/tests/unit/test_run_errors_output.py
+++ b/tests/unit/test_run_errors_output.py
@@ -1,0 +1,310 @@
+import json
+from datetime import datetime, timezone
+from importlib import import_module
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+from click.testing import CliRunner, Result
+from tracker.database.models import AgentContractRequest, BenchmarkArguments, BenchmarkStatus
+from tracker.types import FinalViewResponse, RetrieveResultsResponse, S3UploadResultsResponse
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run import run
+from valkyrie.cli.run.errors import build_run_errors_payload, errors, group_task_errors
+
+errors_module = import_module("valkyrie.cli.run.errors")
+
+
+def make_response(
+    run_id: UUID,
+    *,
+    status: BenchmarkStatus = BenchmarkStatus.ERROR,
+    error_message: str | None = "No tasks were completed successfully",
+    task_errors: dict[str, str] | None = None,
+) -> FinalViewResponse:
+    return FinalViewResponse(
+        benchmark_id=run_id,
+        benchmark_name="demo-bench",
+        started_at=datetime(2026, 7, 10, 12, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 7, 10, 12, 5, tzinfo=timezone.utc),
+        status=status,
+        error_message=error_message,
+        benchmark_arguments=BenchmarkArguments(
+            contract=AgentContractRequest(
+                name="demo-agent",
+                secrets={"SYNTHETIC_KEY": "excluded-secret-name"},
+                kwargs={"private-option": "excluded-kwarg-value"},
+            ),
+            concurrency=10,
+        ),
+        tasks_stopped=None,
+        final_evaluation=None,
+        average_task_breakdown=None,
+        evaluation_results={"successful-task": {"private": "excluded-evaluation-value"}},
+        task_errors=task_errors,
+    )
+
+
+class StubErrorsTracker:
+    def __init__(self, response: RetrieveResultsResponse | TrackerServiceError) -> None:
+        self.response = response
+        self.calls: list[tuple[UUID, bool, list[str] | None]] = []
+
+    def __enter__(self) -> "StubErrorsTracker":
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def retrieve_results(
+        self,
+        run_id: UUID,
+        s3: bool,
+        task_ids: list[str] | None = None,
+    ) -> RetrieveResultsResponse:
+        self.calls.append((run_id, s3, task_ids))
+        if isinstance(self.response, TrackerServiceError):
+            raise self.response
+        return self.response
+
+
+def invoke_with_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+    tracker: StubErrorsTracker,
+    run_id: UUID,
+    *args: str,
+) -> Result:
+    monkeypatch.setattr(errors_module, "TrackerService", lambda: tracker)
+    return CliRunner().invoke(errors, [str(run_id), *args])
+
+
+def test_errors_text_groups_identical_messages_without_writing_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    shared_message = "Required output artifact was not produced."
+    task_errors = {f"task-{index:03}": shared_message for index in range(100)}
+    task_errors["other-task"] = "Evaluator returned an invalid response."
+    tracker = StubErrorsTracker(make_response(run_id, task_errors=task_errors))
+    runner = CliRunner()
+    monkeypatch.setattr(errors_module, "TrackerService", lambda: tracker)
+
+    with runner.isolated_filesystem():
+        result = runner.invoke(errors, [str(run_id)])
+        assert list(Path.cwd().iterdir()) == []
+
+    assert result.exit_code == 0, result.output
+    assert "Run Errors" in result.stdout
+    assert "Stored run error" in result.stdout
+    assert "Task errors (101 tasks, 2 distinct messages)" in result.stdout
+    assert "[100 tasks]" in result.stdout
+    assert result.stdout.count(shared_message) == 1
+    assert "task-000" in result.stdout
+    assert "task-004" in result.stdout
+    assert "task-005" not in result.stdout
+    assert "task-099" not in result.stdout
+    assert "(+95 more)" in result.stdout
+    assert tracker.calls == [(run_id, False, None)]
+    assert "Results saved" not in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("error_message", "task_errors", "status", "expected", "unexpected"),
+    [
+        ("Run failed before task execution.", None, BenchmarkStatus.ERROR, "Stored run error", "Task errors ("),
+        ("Previous attempt failed.", None, BenchmarkStatus.IN_PROGRESS, "Stored run error", "Task errors ("),
+        (None, {"task-a": "Task failed."}, BenchmarkStatus.FINISHED, "Task errors (1 task", "Stored run error"),
+        (None, None, BenchmarkStatus.ERROR, "No current error messages recorded.", "Stored run error"),
+    ],
+)
+def test_errors_text_handles_run_task_and_empty_states(
+    monkeypatch: pytest.MonkeyPatch,
+    error_message: str | None,
+    task_errors: dict[str, str] | None,
+    status: BenchmarkStatus,
+    expected: str,
+    unexpected: str,
+) -> None:
+    run_id = uuid4()
+    tracker = StubErrorsTracker(
+        make_response(run_id, status=status, error_message=error_message, task_errors=task_errors)
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, run_id)
+
+    assert result.exit_code == 0, result.output
+    assert expected in result.stdout
+    assert unexpected not in result.stdout
+    assert status.value.replace("_", " ").title() in result.stdout
+
+
+def test_errors_text_preserves_empty_messages(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubErrorsTracker(make_response(run_id, error_message="", task_errors={"task-a": ""}))
+
+    result = invoke_with_tracker(monkeypatch, tracker, run_id)
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout.count("(empty error message)") == 2
+
+
+def test_errors_text_sanitizes_terminal_controls(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    unsafe_message = "\x1b]8;;https://example.invalid\x07click\x1b]8;;\x07\rrewritten\nnext\tline\u202e"
+    tracker = StubErrorsTracker(
+        make_response(
+            run_id,
+            error_message=unsafe_message,
+            task_errors={"task\x1b[31m": "boom\b"},
+        )
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, run_id)
+
+    assert result.exit_code == 0, result.output
+    for control in ("\x1b", "\x07", "\r", "\b", "\t", "\u202e"):
+        assert control not in result.stdout
+    assert "\\x1b" in result.stdout
+    assert "\\x07" in result.stdout
+    assert "\\r" in result.stdout
+    assert "\\u202e" in result.stdout
+    assert "next    line" in result.stdout
+
+
+def test_errors_json_is_versioned_allowlisted_and_deterministic(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    raw_error = "task failed\n\x1b[31mred"
+    response = make_response(
+        run_id,
+        error_message=None,
+        task_errors={"task-b": raw_error, "task-a": "another failure"},
+    )
+    tracker = StubErrorsTracker(response)
+
+    result = invoke_with_tracker(monkeypatch, tracker, run_id, "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    assert len(result.stdout.splitlines()) == 1
+    assert "\x1b" not in result.stdout
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "schema_version",
+        "kind",
+        "observed_at",
+        "run_id",
+        "benchmark_name",
+        "status",
+        "error_message",
+        "task_error_count",
+        "task_errors",
+    }
+    assert payload["schema_version"] == 1
+    assert payload["kind"] == "run_errors"
+    assert payload["observed_at"].endswith("Z")
+    assert payload["run_id"] == str(run_id)
+    assert payload["benchmark_name"] == "demo-bench"
+    assert payload["status"] == "ERROR"
+    assert payload["error_message"] is None
+    assert payload["task_error_count"] == 2
+    assert list(payload["task_errors"]) == ["task-a", "task-b"]
+    assert payload["task_errors"]["task-b"] == raw_error
+    assert not any(
+        marker in result.stdout
+        for marker in ["excluded-secret-name", "excluded-kwarg-value", "excluded-evaluation-value"]
+    )
+
+    fixed_payload = build_run_errors_payload(
+        response,
+        observed_at=datetime(2026, 7, 10, 20, 15),
+    )
+    assert fixed_payload["observed_at"] == "2026-07-10T20:15:00Z"
+
+
+def test_errors_json_normalizes_empty_error_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubErrorsTracker(
+        make_response(
+            run_id,
+            status=BenchmarkStatus.FINISHED,
+            error_message=None,
+            task_errors=None,
+        )
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, run_id, "--format", "json")
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "FINISHED"
+    assert payload["error_message"] is None
+    assert payload["task_error_count"] == 0
+    assert payload["task_errors"] == {}
+
+
+def test_group_task_errors_uses_raw_messages_and_stable_order() -> None:
+    groups = group_task_errors(
+        {
+            "task-c": "same",
+            "task-b": "different\x1b",
+            "task-a": "same",
+            "task-d": "different\\x1b",
+        }
+    )
+
+    assert groups == [
+        ("same", ("task-a", "task-c")),
+        ("different\x1b", ("task-b",)),
+        ("different\\x1b", ("task-d",)),
+    ]
+
+
+def test_errors_tracker_failure_has_no_partial_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    unsafe_error = "tracker unavailable\x1b]8;;https://example.invalid\x07link\x1b]8;;\x07\rrewritten\u202e"
+    tracker = StubErrorsTracker(TrackerServiceError(unsafe_error))
+    monkeypatch.setattr(errors_module, "TrackerService", lambda: tracker)
+
+    result = CliRunner().invoke(errors, [str(run_id), "--format", "json"], color=True)
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "tracker unavailable" in result.stderr
+    assert "\x1b]8;" not in result.stderr
+    assert "\x07" not in result.stderr
+    assert "\r" not in result.stderr
+    assert "\u202e" not in result.stderr
+    assert "\\x1b" in result.stderr
+    assert "\\x07" in result.stderr
+    assert "\\r" in result.stderr
+    assert "\\u202e" in result.stderr
+
+
+def test_errors_rejects_unexpected_s3_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    run_id = uuid4()
+    tracker = StubErrorsTracker(
+        S3UploadResultsResponse(
+            s3_url="s3://example/results.json",
+            presigned_url="https://example.invalid/download",
+            console_url="https://example.invalid/console",
+        )
+    )
+
+    result = invoke_with_tracker(monkeypatch, tracker, run_id, "--format", "json")
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "unexpected response" in result.stderr
+
+
+def test_errors_command_is_registered_and_rejects_invalid_uuid(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert "errors" in run.commands
+    help_result = CliRunner().invoke(errors, ["--help"])
+    assert help_result.exit_code == 0
+    assert "--format [text|json]" in help_result.stdout
+    assert "--all" not in help_result.stdout
+
+    def unexpected_tracker() -> None:
+        pytest.fail("invalid UUID should fail before constructing a tracker")
+
+    monkeypatch.setattr(errors_module, "TrackerService", unexpected_tracker)
+    invalid_result = CliRunner().invoke(errors, ["not-a-uuid"])
+    assert invalid_result.exit_code == 2

--- a/tests/unit/test_run_errors_output.py
+++ b/tests/unit/test_run_errors_output.py
@@ -101,10 +101,8 @@ def test_errors_text_groups_identical_messages_without_writing_files(monkeypatch
     assert "task-000" in result.stdout
     assert "task-004" in result.stdout
     assert "task-005" not in result.stdout
-    assert "task-099" not in result.stdout
     assert "(+95 more)" in result.stdout
     assert tracker.calls == [(run_id, False, None)]
-    assert "Results saved" not in result.stdout
 
 
 @pytest.mark.parametrize(
@@ -300,7 +298,6 @@ def test_errors_command_is_registered_and_rejects_invalid_uuid(monkeypatch: pyte
     help_result = CliRunner().invoke(errors, ["--help"])
     assert help_result.exit_code == 0
     assert "--format [text|json]" in help_result.stdout
-    assert "--all" not in help_result.stdout
 
     def unexpected_tracker() -> None:
         pytest.fail("invalid UUID should fail before constructing a tracker")


### PR DESCRIPTION
## Summary

Adds a focused valk run errors RUN_ID command so humans and agents can inspect failures inline without downloading a results file first.

The command deliberately reuses the existing typed, read-only results endpoint with s3 disabled and no task filter. This keeps the change additive: no tracker API, SDK, persistence, scoring, or migration changes.

## Examples

Human-readable:

    valk run errors <run-id>

Machine-readable JSON:

    valk run errors <run-id> --format json

## Related Issues

Addresses vals-ai/valkyrie-ticket-library#122