### PR TITLE
Bump create-benchmark-service to v0.13.1

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.13.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.13.1" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -367,8 +367,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.13.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0#edd07c0186563eba4452851d4ebb4df2c962ccaa" }
+version = "0.13.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1#673dde74470594e3aa3f6931358e30ad60af06d5" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1923,7 +1923,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1" },
     { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.13.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0#edd07c0186563eba4452851d4ebb4df2c962ccaa" }
+version = "0.13.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1#673dde74470594e3aa3f6931358e30ad60af06d5" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2664,7 +2664,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1" },
     { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary

- pin `create-benchmark-service` v0.13.1 in Tracker
- refresh only the Tracker and root lock files
- carry the Daytona PTY durable-status completion fix from vals-ai/create-benchmark-service#88

No Valkyrie source code changes are included.

## Validation

- installed package reports `create-benchmark-service==0.13.1` and contains the PTY status-completion path
- Tracker unit tests — 13 passed
- CLI unit tests — 136 passed, with one pre-existing dotenv-warning failure reproduced unchanged on current `dev`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run basedpyright` — 0 errors, warnings, or notes
- CBS v0.13.1 upstream — 250 tests passed plus a live disposable Daytona canary

## Rollout

Deploy Tracker and Worker from the same SHA, then retry one stopped FAB task under its existing run ID at c1. Admit the preserved FAB, Legal, and SWE queues only after that task reaches a terminal state with its artifact and no residual PTY or sandbox.
