### PR TITLE
#patch Fix SkillsBench output artifact transfer

### DIFF
--- a/docs/LAMBDA_USAGE.md
+++ b/docs/LAMBDA_USAGE.md
@@ -13,7 +13,7 @@ The lambda is invoked once after all tasks finish and results are uploaded. If t
 
 ## Payload
 
-The tracker invokes your lambda with the full `BenchmarkArguments` plus the `benchmark_id`:
+The tracker invokes your lambda with the full `BenchmarkArguments` plus the persisted benchmark ID and name:
 
 ```json
 {
@@ -30,7 +30,8 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the `ben
   "task_ids": ["astropy__astropy-12907"],
   "slice_str": null,
   "lambda_function": "my-post-benchmark-handler",
-  "benchmark_id": "e532551e-d51b-4912-983d-47695bd24174"
+  "benchmark_id": "e532551e-d51b-4912-983d-47695bd24174",
+  "benchmark_name": "swebench"
 }
 ```
 
@@ -42,6 +43,7 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the `ben
 | `slice_str` | string or null | Dataset slice if provided |
 | `lambda_function` | string | Name of this lambda function |
 | `benchmark_id` | string | UUID of the completed run |
+| `benchmark_name` | string | Persisted name of the completed benchmark |
 
 ## Format required by AWS
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,5 @@
 """Sandbox management utilities for the tracker service."""
 
-import base64
 import shlex
 import time
 import uuid
@@ -594,12 +593,8 @@ async def upload_output_artifacts(
                 f"Output artifacts are too large: {total_bytes} bytes > {OUTPUT_ARTIFACTS_MAX_TOTAL_BYTES} bytes"
             )
 
-        b64_result = await _exec(sandbox, f"base64 {quoted_path}")
-        if b64_result.exit_code != _SUCCESS_EXIT_CODE:
-            raise OutputArtifactError(f"Failed to read output artifact: {sandbox_path}")
-
         s3_key = get_agent_result_s3_key(benchmark_id, task_id, artifact_path)
-        file_content = base64.b64decode(b64_result.stdout)
+        file_content = await sandbox.download_file(sandbox_path)
         await upload_to_s3(file_content, s3_key, aws, s3_bucket)
 
         logger.info(

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -353,9 +353,10 @@ async def process_benchmark(
             # We run it but do not let a failure affect the benchmark status
             arguments = benchmark_row.arguments
             if arguments.lambda_function:
-                # Expose the benchmark arguments and the benchmark id inside of the lambda
+                # Expose the benchmark arguments, id, and name inside of the lambda
                 lambda_payload: dict[str, Any] = arguments.model_dump()
                 lambda_payload["benchmark_id"] = str(benchmark_id)
+                lambda_payload["benchmark_name"] = benchmark_row.name
 
                 invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
 

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -349,8 +349,7 @@ async def process_benchmark(
 
             await upload_final_view(benchmark_row, final_view, harness_config)
 
-            # If the user has chosen to invoke a lambda function at the end of the benchmark
-            # We run it but do not let a failure affect the benchmark status
+            # Invoke the configured lambda after the benchmark's final view is uploaded.
             arguments = benchmark_row.arguments
             if arguments.lambda_function:
                 # Expose the benchmark arguments, id, and name inside of the lambda

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -42,21 +42,27 @@ _upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
 
 
 class TestOutputArtifacts:
-    async def test_upload_output_artifacts_uploads_declared_file_to_task_prefix(
+    async def test_upload_output_artifacts_downloads_file_without_exec_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
         harness_config: Any,
     ) -> None:
+        """
+        Verify artifact contents use the sandbox file-transfer API instead of command output.
+
+        Test cases:
+        - A 288,928-byte SkillsBench sidecar is downloaded without a base64 exec call.
+        - The exact bytes are uploaded to the task-scoped S3 key.
+        """
         artifact = "artifacts/turns.jsonl"
+        artifact_content = b"x" * 288_928
         uploaded: list[tuple[bytes, str]] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
             if command == "test -f /tmp/valkyrie/artifacts/turns.jsonl":
                 return ExecResult(exit_code=0, output="")
             if command == "stat -c%s /tmp/valkyrie/artifacts/turns.jsonl":
-                return ExecResult(exit_code=0, output="12")
-            if command == "base64 /tmp/valkyrie/artifacts/turns.jsonl":
-                return ExecResult(exit_code=0, output="eyJ0dXJuIjoxfQo=")
+                return ExecResult(exit_code=0, output=str(len(artifact_content)))
             raise AssertionError(f"unexpected command: {command}")
 
         async def fake_upload_to_s3(file_content: bytes, s3_key: str, _aws: Any, _s3_bucket: str) -> None:
@@ -68,6 +74,7 @@ class TestOutputArtifacts:
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.download_file = AsyncMock(return_value=artifact_content)
 
         await upload_output_artifacts(
             mock_sandbox,
@@ -78,7 +85,7 @@ class TestOutputArtifacts:
             harness_config.s3_bucket,
         )
 
-        assert uploaded == [(b'{"turn":1}\n', "benchmarks/benchmark-123/task_0/artifacts/turns.jsonl")]
+        assert uploaded == [(artifact_content, "benchmarks/benchmark-123/task_0/artifacts/turns.jsonl")]
 
     async def test_upload_output_artifacts_can_upload_explicit_glob_sources(
         self,
@@ -92,14 +99,10 @@ class TestOutputArtifacts:
                 return ExecResult(exit_code=0, output="/logs/task/turns/init/config.json\n")
             if command == "stat -c%s /logs/task/turns/init/config.json":
                 return ExecResult(exit_code=0, output="11")
-            if command == "base64 /logs/task/turns/init/config.json":
-                return ExecResult(exit_code=0, output="eyJsbG0iOnt9fQo=")
             if command == "find /logs -type f -path '/logs/*/result.json' | sort | head -n 1":
                 return ExecResult(exit_code=0, output="/logs/task/result.json\n")
             if command == "stat -c%s /logs/task/result.json":
                 return ExecResult(exit_code=0, output="13")
-            if command == "base64 /logs/task/result.json":
-                return ExecResult(exit_code=0, output="eyJ0dXJucyI6W119Cg==")
             raise AssertionError(f"unexpected command: {command}")
 
         async def fake_upload_to_s3(file_content: bytes, s3_key: str, _aws: Any, _s3_bucket: str) -> None:
@@ -111,6 +114,7 @@ class TestOutputArtifacts:
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.download_file = AsyncMock(side_effect=[b'{"llm":{}}\n', b'{"turns":[]}\n'])
 
         await upload_output_artifacts(
             mock_sandbox,
@@ -141,8 +145,6 @@ class TestOutputArtifacts:
                 return ExecResult(exit_code=0, output="")
             if command == "stat -c%s /logs/model-library-run/result.json":
                 return ExecResult(exit_code=0, output="13")
-            if command == "base64 /logs/model-library-run/result.json":
-                return ExecResult(exit_code=0, output="eyJ0dXJucyI6W119Cg==")
             raise AssertionError(f"unexpected command: {command}")
 
         async def fake_upload_to_s3(file_content: bytes, s3_key: str, _aws: Any, _s3_bucket: str) -> None:
@@ -154,6 +156,7 @@ class TestOutputArtifacts:
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.download_file = AsyncMock(return_value=b'{"turns":[]}\n')
 
         await upload_output_artifacts(
             mock_sandbox,

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -73,6 +73,7 @@ class TestStopAndResume:
         database_session: Session,
         process_benchmark_env: None,
         harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
     ):
         """
         Tests stop and resume when some tasks have already completed.
@@ -83,6 +84,7 @@ class TestStopAndResume:
             - Stop benchmark - 3 tasks are stopped (pending -> stopped)
             - Resume benchmark - only the 3 tasks that are stopped should be resumed
             - Retry or resume benchmark - all 5 tasks should have evaluation results after completion
+            - The finalization lambda receives the persisted benchmark name
         """
         task_ids: list[str] = [
             "astropy__astropy-12907",
@@ -91,12 +93,21 @@ class TestStopAndResume:
             "django__django-12325",
             "django__django-12858",
         ]
+        captured_lambda_payload: dict[str, Any] | None = None
+
+        def _capture_lambda_payload(_client: Any, _function_name: str, payload: dict[str, Any]) -> None:
+            nonlocal captured_lambda_payload
+            captured_lambda_payload = payload
+
+        monkeypatch.setattr("tracker.utils.run_orchestration.lambda_client", Mock(return_value=object()))
+        monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", _capture_lambda_payload)
 
         start_benchmark_request = StartBenchmarkRequest(
             benchmark_name="swebench",
             contract=contract,
             concurrency=2,
             task_ids=task_ids,
+            lambda_function="vals-format-lambda",
             harness_config=harness_config,
         )
 
@@ -171,6 +182,8 @@ class TestStopAndResume:
 
         database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.FINISHED, benchmark_row.error_message
+        assert captured_lambda_payload is not None
+        assert captured_lambda_payload["benchmark_name"] == "swebench"
 
     @pytest.mark.parametrize(
         ("retry_mode", "eval_resume_state", "expected_status", "expected_state"),


### PR DESCRIPTION
## Summary

- stream declared output artifacts through the sandbox file-transfer API instead of base64 command output
- pass the persisted benchmark name to end-of-run Lambdas so benchmark-specific result files are selected deterministically

## Why

A one-task SkillsBench run archived its agent output, uploaded the 383-byte config sidecar, then stalled for more than four hours while sending a 288,928-byte turns sidecar through Daytona command stdout. The turns payload expands to about 385 KB when base64 encoded. The existing file-transfer API already handles this artifact shape without command-output buffering.

SkillsBench also writes both a model JSON and `skillsbench.json`; without `benchmark_name`, `vals-format-lambda` cannot deterministically select the final benchmark view.

## Checks

- exact 288,928-byte regression
- tracker unit suite: 219 passed
- Ruff check and format check
- BasedPyright: 0 errors
- `git diff --check`

Merging to `dev` deploys Valkyrie; no live deploy or smoke was performed from this branch.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->