### PR TITLE
Strip whitespace from `valk config init` inputs

### DIFF
--- a/src/valkyrie/cli/config/settings.py
+++ b/src/valkyrie/cli/config/settings.py
@@ -39,7 +39,7 @@ def init() -> None:
     )
 
     if mode == "hosted":
-        api_key = os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key")
+        api_key = (os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key")).strip()
         current_config["api_key"] = api_key
 
         # Validate the key and create/confirm org (uses default tracker URL)
@@ -74,13 +74,13 @@ def init() -> None:
                 f"  {key} (required, Enter to cancel)",
                 default="",
                 show_default=False,
-            )
+            ).strip()
 
-            if not value.strip():
+            if not value:
                 click.echo(click.style(f"\n  {key} is required. Aborting.", fg="red"))
                 raise click.Abort()
         else:
-            value = click.prompt(f"  {key}", default=str(default))
+            value = click.prompt(f"  {key}", default=str(default)).strip()
 
         collected_keys[key] = value
 

--- a/tests/unit/test_config_init.py
+++ b/tests/unit/test_config_init.py
@@ -1,0 +1,100 @@
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+settings = import_module("valkyrie.cli.config.settings")
+state = import_module("valkyrie.cli.config.state")
+
+
+@pytest.fixture
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "valkyrie.yaml"
+    monkeypatch.setattr(state, "CONFIG_LOCATION", path)
+    monkeypatch.setattr(settings, "CONFIG_LOCATION", path)
+    return path
+
+
+def test_init_self_hosted_strips_whitespace(config_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in settings._REQUIRED_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(key, raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        settings.init,
+        input="\n".join(
+            [
+                "self-hosted",
+                "  aws-key  ",
+                " aws-secret\t",
+                " us-east-1 ",
+                " bucket ",
+                "  benchmarks  ",
+                " 365 ",
+            ]
+        )
+        + "\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    config = yaml.safe_load(config_path.read_text())
+    assert config == {
+        "AWS_ACCESS_KEY_ID": "aws-key",
+        "AWS_SECRET_ACCESS_KEY": "aws-secret",
+        "AWS_DEFAULT_REGION": "us-east-1",
+        "S3_BUCKET": "bucket",
+        "LOG_GROUP": "benchmarks",
+        "LOG_RETENTION_POLICY": "365",
+    }
+
+
+def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in settings._REQUIRED_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.delenv("VALKYRIE_API_KEY", raising=False)
+
+    init_org_calls: list[str] = []
+
+    class FakeTrackerService:
+        @staticmethod
+        def init_org(api_key: str) -> dict[str, object]:
+            init_org_calls.append(api_key)
+            return {"org_name": "test-org"}
+
+    monkeypatch.setattr(settings, "TrackerService", FakeTrackerService)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        settings.init,
+        input="\n".join(
+            [
+                "hosted",
+                "  secret-key  ",
+                "aws-key",
+                "aws-secret",
+                "us-east-1",
+                "bucket",
+                "benchmarks",
+                "365",
+            ]
+        )
+        + "\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert init_org_calls == ["secret-key"]
+    config = yaml.safe_load(config_path.read_text())
+    assert config["api_key"] == "secret-key"
+
+
+def test_init_whitespace_only_required_value_aborts(config_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in settings._REQUIRED_ENVIRONMENT_VARIABLES:
+        monkeypatch.delenv(key, raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(settings.init, input="self-hosted\n   \n")
+
+    assert result.exit_code != 0
+    assert "AWS_ACCESS_KEY_ID is required" in result.output


### PR DESCRIPTION
## Summary
`valk config init` accepted values with leading/trailing whitespace (e.g. pasted API keys or bucket names with a trailing newline/space), which then got written verbatim into the config and broke later requests. This strips whitespace from all interactive inputs.

## Changes
- `.strip()` the hosted-mode API key (env var or prompt) before validating/storing it
- `.strip()` prompted required values before the empty-check and defaulted values before storing
- Add unit tests covering self-hosted/hosted init stripping and whitespace-only required value abort

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested (`make lint`, `make typecheck` pass)

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/7ed0a643d09a4ec88c40562b6e6583c1
Requested by: @lgnashold