### PR TITLE
#patch Bound agent setup dependency installs

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -72,6 +72,7 @@ logger = get_logger(__name__)
 bundle_path = PurePosixPath("/bundle")
 SANDBOX_AUTO_STOP_INTERVAL = 10 * 60
 SANDBOX_CREATE_TIMEOUT = 360
+AGENT_INSTALL_TIMEOUT_SECONDS = 10 * 60
 CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS = 24 * 60 * 60
 
 
@@ -330,8 +331,18 @@ async def install_agent_dependencies(
     log_output(f"Installing dependencies for contract: {contract.name}")
 
     contract_path = get_contract_path(contract.name)
+    install_cmd = f"timeout {AGENT_INSTALL_TIMEOUT_SECONDS:g} sh -c {shlex.quote(contract.install_cmd)}"
 
-    await stream_command_output(sandbox, f"cd {shlex.quote(str(contract_path))} && {contract.install_cmd}", log_output)
+    exit_reason, _duration = await stream_command_output(
+        sandbox,
+        f"cd {shlex.quote(str(contract_path))} && {install_cmd}",
+        log_output,
+    )
+    if exit_reason == AgentCausedExitReason.TIMEOUT:
+        raise SandboxError(
+            f"Dependency installation for contract {contract.name} timed out after "
+            f"{AGENT_INSTALL_TIMEOUT_SECONDS:g} seconds"
+        )
 
     log_output(f"Finished installing dependencies for contract: {contract.name}")
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -16,7 +16,12 @@ from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxComm
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 
 from tracker import sandbox as sandbox_module
-from tracker.database.models import AgentCausedExitReason, AgentContractRequest, MAX_OUTPUT_ARTIFACT_BYTES, OutputArtifact
+from tracker.database.models import (
+    AgentCausedExitReason,
+    AgentContractRequest,
+    MAX_OUTPUT_ARTIFACT_BYTES,
+    OutputArtifact,
+)
 from tracker.exceptions import (
     AgentRunFailedError,
     OutputArtifactError,

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -16,7 +16,7 @@ from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxComm
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 
 from tracker import sandbox as sandbox_module
-from tracker.database.models import AgentContractRequest, MAX_OUTPUT_ARTIFACT_BYTES, OutputArtifact
+from tracker.database.models import AgentCausedExitReason, AgentContractRequest, MAX_OUTPUT_ARTIFACT_BYTES, OutputArtifact
 from tracker.exceptions import (
     AgentRunFailedError,
     OutputArtifactError,
@@ -428,6 +428,45 @@ class TestAgentOutputTelemetry:
         assert deps_before_sleep is not None
         assert callable(upload_before_sleep)
         assert callable(deps_before_sleep)
+
+    async def test_install_agent_dependencies_retries_after_setup_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Dependency setup should be bounded and retried when it hangs.
+
+        Test cases:
+        - The install command is wrapped in the 10 minute shell timeout.
+        - A timed out setup attempt is retried by the existing dependency retry policy.
+        """
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="apt-get update -qq && echo done",
+            run_cmd="echo done",
+        )
+        observed_commands: list[str] = []
+        setup_results: deque[tuple[AgentCausedExitReason | None, float]] = deque(
+            [(AgentCausedExitReason.TIMEOUT, 600.0), (None, 2.0)]
+        )
+
+        async def fake_stream_command_output(
+            _sandbox: Any,
+            command: str,
+            _log_output: Any,
+        ) -> tuple[AgentCausedExitReason | None, float]:
+            observed_commands.append(command)
+
+            return setup_results.popleft()
+
+        def log_output(_message: str) -> None:
+            pass
+
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
+
+        await _install_agent_dependencies(Mock(), contract, log_output)
+
+        expected_command = "cd /bundle/test-agent && timeout 600 sh -c 'apt-get update -qq && echo done'"
+        assert observed_commands == [expected_command, expected_command]
 
     def test_metric_source_name_drops_high_cardinality_tag_and_digest(self) -> None:
         metric_source_name = getattr(sandbox_module, "_metric_source_name")


### PR DESCRIPTION
## Summary
Adds a 10 minute timeout around agent dependency setup so hung install commands fail and flow through the existing dependency retry policy instead of pinning a worker indefinitely.

## Changes
- Wrap `install_agent_dependencies` commands with `timeout 600 sh -c ...`.
- Convert setup timeout exits into `SandboxError` so the existing tenacity retry runs.
- Add a focused unit test proving a timed-out setup attempt is retried.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Checks run:
- `make style`
- `uv run pytest services/tracker/tests/unit/test_sandbox.py -k install_agent_dependencies_retries_after_setup_timeout`
- `uv run basedpyright services/tracker/src/tracker/sandbox.py services/tracker/tests/unit/test_sandbox.py`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed