### PR TITLE
Fix empty task error messages

### DIFF
--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -58,6 +58,10 @@ logger = get_logger(__name__)
 _PTY_TASK_RETRY_LIMIT: int = 1
 
 
+def _exception_message(exc: BaseException) -> str:
+    return str(exc).strip() or type(exc).__name__
+
+
 class TrackedTaskStatus(str, Enum):
     WAITING = "waiting"
     RUNNING = "running"
@@ -102,7 +106,7 @@ class TrackedTask:
             # When we cancel we return the task id still so that we can track the task when we create the final evaluation row
             return {task_row.task_id: None}
         except Exception as e:
-            error_message = f"Task error was not handled: {str(e)}\n{traceback.format_exc()}"
+            error_message = f"Task error was not handled: {_exception_message(e)}\n{traceback.format_exc()}"
             logger.error(error_message)
             logfire.exception("tracked_task_run failed")
             sentry_sdk.capture_exception(e)
@@ -558,12 +562,12 @@ async def process_task(
     except SandboxSetupError as e:
         if task_is_stopped():
             return {task_id: None}
-        log_output(f"\n[ERROR] {e}")
+        log_output(f"\n[ERROR] {_exception_message(e)}")
         raise
     except OutputArtifactError as e:
         if task_is_stopped():
             return {task_id: None}
-        error_message = str(e)
+        error_message = _exception_message(e)
         logger.warning(error_message)
         log_output(f"\n[ERROR] {error_message}")
 
@@ -616,7 +620,7 @@ async def process_task(
     except BenchmarkServiceError as e:
         if task_is_stopped():
             return {task_id: None}
-        error_message = str(e)
+        error_message = _exception_message(e)
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
@@ -628,7 +632,7 @@ async def process_task(
         if task_is_stopped():
             return {task_id: None}
         logfire.exception("process_task failed")
-        error_message = str(e)
+        error_message = _exception_message(e)
         logger.error(error_message, exc_info=True)
 
         sentry_sdk.capture_exception(e)

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -3,6 +3,7 @@ from asyncio import Semaphore
 from typing import Any
 from uuid import UUID
 
+import httpx
 import pytest
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from benchmark_service.schemas import RetrieveTaskResponse
@@ -233,6 +234,43 @@ class TestBenchmarkServiceDisconnect:
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
         assert "ProgramBench task container failed to start" in error_message
+
+    async def test_empty_network_error_stores_visible_message(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        process_benchmark_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """Network exceptions with empty strings must still produce visible task errors.
+
+        Test cases:
+        - Empty-string httpx.ConnectTimeout stores its exception type in the DB.
+        - The task log path receives the same visible exception type.
+        """
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
+        logged_messages: list[str] = []
+
+        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            raise httpx.ConnectTimeout("")
+
+        def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
+            logged_messages.append(message)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
+        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
+
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+        assert result == {"task_0": None}
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert self._latest_task_error(database_session, task_row) == "ConnectTimeout"
+        assert any("[ERROR] ConnectTimeout" in message for message in logged_messages)
 
     async def test_benchmark_service_error_in_process_benchmark(
         self,


### PR DESCRIPTION
## Summary
- format caught task exceptions with the exception class when the message string is empty