### PR TITLE
Bump create-benchmark-service to v0.13.1 (Daytona PTY reconnect fix)

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.13.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.13.1" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -367,8 +367,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.13.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0#edd07c0186563eba4452851d4ebb4df2c962ccaa" }
+version = "0.13.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1#673dde74470594e3aa3f6931358e30ad60af06d5" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1923,7 +1923,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1" },
     { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -574,8 +574,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.13.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0#edd07c0186563eba4452851d4ebb4df2c962ccaa" }
+version = "0.13.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1#673dde74470594e3aa3f6931358e30ad60af06d5" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2664,7 +2664,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1" },
     { name = "daytona", specifier = ">=0.189.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },


### PR DESCRIPTION
## Summary
Bumps the pinned `create-benchmark-service` tag from v0.13.0 to v0.13.1 to pick up upstream fix #88 ("complete Daytona PTY commands from status").

This addresses two recurring worker-side errors seen in Sentry during benchmark runs (e.g. VALKYRIE-6Y / VALKYRIE-9R, plus `ConnectionError('Connection lost')` "Future exception was never retrieved" log noise):

- The old `_exec_pty` reconnect loop reconnected the PTY every second without disconnecting the previous handle, leaking websockets whose deaths emit unretrieved `ConnectionError('Connection lost')` drain futures.
- v0.13.1 only reconnects when the websocket actually closed, disconnects the old handle first, and completes commands from the on-disk status file instead of the PTY close frame — reducing `Daytona PTY session no longer exists` failures after transient websocket drops.

## Changes
- `services/tracker/pyproject.toml`: `create-benchmark-service` tag v0.13.0 → v0.13.1
- `services/tracker/uv.lock`, `uv.lock`: lockfile updates for the new tag (no other dependency changes)

## Related Issues
Sentry: VALKYRIE-6Y, VALKYRIE-9R

## Type of Change
- [x] Bug fix

## Testing
- [x] Manually tested — `make lint` and `make typecheck` green at root and in `services/tracker` after `uv sync`

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/479ebacd72cd402d8a72a47e348dfd6e
Requested by: @lgnashold