### PR TITLE
feat: wire managed aws task roles

### DIFF
--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -44,6 +44,7 @@ from constants import (
     executor_release_launch_parameter,
 )
 from constructs import Construct
+from runtime_iam import create_executor_task_role, managed_runtime_environment
 from stage import Stage
 from stage_config import StageConfig, benchmark_service_base_url, config_for
 
@@ -117,6 +118,7 @@ class ExecutorStack(Stack):
             )
 
         benchmark_service_url = benchmark_service_base_url(stage)
+        bucket = aws_s3.Bucket.from_bucket_name(self, "ManagedRuntimeBucket", bucket_name)
         shared_env = {
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket_name,
@@ -124,6 +126,7 @@ class ExecutorStack(Stack):
             "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
             **({"BENCHMARK_SERVICE_BASE_URL": benchmark_service_url} if benchmark_service_url else {}),
+            **managed_runtime_environment(self, stage, bucket, stage_config.managed_aws),
         }
 
         db_env = {
@@ -146,13 +149,17 @@ class ExecutorStack(Stack):
             removal_policy=cdk.RemovalPolicy.RETAIN,
         )
 
+        self.executor_task_role = create_executor_task_role(self, stage, bucket, stage_config.managed_aws)
         executor_task_def = aws_ecs.FargateTaskDefinition(
             self,
             "ExecutorHostTaskDef",
             cpu=stage_config.worker.cpu,
             memory_limit_mib=stage_config.worker.memory_mib,
             runtime_platform=_ARM64_PLATFORM,
+            task_role=cast(aws_iam.IRole, self.executor_task_role),
         )
+
+        cdk.CfnOutput(self, "ExecutorTaskRoleArn", value=self.executor_task_role.role_arn)
         executor_task_def.add_container(
             "ExecutorHostContainer",
             image=executor_host_image,
@@ -177,13 +184,13 @@ class ExecutorStack(Stack):
             secrets=db_secrets,
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),
         )
-        cast(aws_iam.Role, executor_task_def.task_role).add_to_policy(
+        self.executor_task_role.add_to_policy(
             aws_iam.PolicyStatement(
                 actions=["ecs:UpdateTaskProtection"],
                 resources=["*"],
             )
         )
-        cast(aws_iam.Role, executor_task_def.task_role).add_to_policy(
+        self.executor_task_role.add_to_policy(
             aws_iam.PolicyStatement(
                 actions=["s3:GetObject"],
                 resources=[self.executor_release_bucket.arn_for_objects(f"{EXECUTOR_RELEASE_PREFIX}/*")],

--- a/infra/runtime_iam.py
+++ b/infra/runtime_iam.py
@@ -1,0 +1,181 @@
+"""Managed AWS runtime environment and ECS task-role policies."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import aws_cdk as cdk
+from aws_cdk import aws_iam, aws_s3
+from constructs import Construct
+
+from stage import Stage
+from stage_config import ManagedAWSRuntimeConfig
+
+_S3_PREFIXES = ("agents/*", "benchmarks/*")
+
+
+def managed_runtime_environment(
+    scope: Construct,
+    stage: Stage,
+    bucket: aws_s3.IBucket,
+    config: ManagedAWSRuntimeConfig,
+) -> dict[str, str]:
+    """Build the deployment-owned runtime configuration for an ECS container."""
+    return {
+        "AWS_DEPLOYMENT_ROLE_ORG_IDS": ",".join(config.deployment_role_org_ids),
+        "AWS_DEPLOYMENT_REGION": cdk.Stack.of(scope).region,
+        "AWS_DEPLOYMENT_S3_BUCKET": bucket.bucket_name,
+        "AWS_DEPLOYMENT_LOG_GROUP": stage.phys(config.benchmark_log_group_prefix),
+        "AWS_DEPLOYMENT_LOG_RETENTION_DAYS": str(config.benchmark_log_retention_days),
+        "AWS_MANAGED_SUBMISSIONS_ENABLED": str(config.submissions_enabled).lower(),
+    }
+
+
+def create_tracker_task_role(
+    scope: Construct,
+    stage: Stage,
+    bucket: aws_s3.IBucket,
+    config: ManagedAWSRuntimeConfig,
+) -> aws_iam.Role:
+    """Create the tracker application task role."""
+    role = _task_role(scope, "TrackerTaskRole", stage.phys("ValkyrieTrackerTaskRole"))
+    _add_s3_runtime_access(role, bucket)
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["s3:DeleteObject", "s3:DeleteObjectVersion"],
+            resources=[bucket.arn_for_objects("benchmarks/*")],
+        )
+    )
+    _add_secret_access(role, config.tracker_secret_name_prefixes)
+    _add_lambda_access(role, config.tracker_lambda_function_name_patterns)
+    _add_kms_access(role, config.kms_key_arns)
+    return role
+
+
+def create_executor_task_role(
+    scope: Construct,
+    stage: Stage,
+    bucket: aws_s3.IBucket,
+    config: ManagedAWSRuntimeConfig,
+) -> aws_iam.Role:
+    """Create the executor host application task role."""
+    role = _task_role(scope, "ExecutorTaskRole", stage.phys("ValkyrieExecutorTaskRole"))
+    _add_s3_runtime_access(role, bucket)
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["s3:AbortMultipartUpload"],
+            resources=[bucket.arn_for_objects("benchmarks/*")],
+        )
+    )
+    _add_benchmark_log_access(role, stage, config.benchmark_log_group_prefix)
+    _add_secret_access(role, config.executor_secret_name_prefixes)
+    _add_lambda_access(role, config.executor_lambda_function_name_patterns)
+    _add_kms_access(role, config.kms_key_arns)
+    return role
+
+
+def _task_role(scope: Construct, construct_id: str, role_name: str) -> aws_iam.Role:
+    return aws_iam.Role(
+        scope,
+        construct_id,
+        role_name=role_name,
+        assumed_by=cast(aws_iam.IPrincipal, aws_iam.ServicePrincipal("ecs-tasks.amazonaws.com")),
+    )
+
+
+def _add_s3_runtime_access(role: aws_iam.Role, bucket: aws_s3.IBucket) -> None:
+    # ListBucket must be unconditioned: S3 reports a missing object as 404 instead of
+    # 403 only when the caller holds ListBucket, and HeadObject's request context has
+    # no s3:prefix key for a prefix condition to match.
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["s3:ListBucket"],
+            resources=[bucket.bucket_arn],
+        )
+    )
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["s3:GetObject"],
+            resources=[bucket.arn_for_objects(prefix) for prefix in _S3_PREFIXES],
+        )
+    )
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["s3:PutObject"],
+            resources=[bucket.arn_for_objects("benchmarks/*")],
+        )
+    )
+
+
+def _add_benchmark_log_access(role: aws_iam.Role, stage: Stage, log_group_prefix: str) -> None:
+    stack = cdk.Stack.of(role)
+    log_group_arn = stack.format_arn(
+        service="logs",
+        resource="log-group",
+        resource_name=f"{stage.phys(log_group_prefix)}/*",
+        arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
+    )
+    # Executors create per-run log groups and apply the deployment-owned retention policy.
+    # CreateLogStream authorizes against the log-group ARN (whose IAM form ends in
+    # `:*`), which a `...:log-stream:*` pattern never matches; the group wildcard
+    # already covers both the groups and their streams.
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["logs:CreateLogGroup", "logs:PutRetentionPolicy", "logs:CreateLogStream", "logs:PutLogEvents"],
+            resources=[log_group_arn],
+        )
+    )
+
+
+def _add_secret_access(role: aws_iam.Role, secret_name_prefixes: tuple[str, ...]) -> None:
+    if not secret_name_prefixes:
+        return
+
+    stack = cdk.Stack.of(role)
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["secretsmanager:GetSecretValue"],
+            resources=[
+                stack.format_arn(
+                    service="secretsmanager",
+                    resource="secret",
+                    resource_name=f"{prefix}*",
+                    arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
+                )
+                for prefix in secret_name_prefixes
+            ],
+        )
+    )
+
+
+def _add_lambda_access(role: aws_iam.Role, function_name_patterns: tuple[str, ...]) -> None:
+    if not function_name_patterns:
+        return
+
+    stack = cdk.Stack.of(role)
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["lambda:InvokeFunction"],
+            resources=[
+                stack.format_arn(
+                    service="lambda",
+                    resource="function",
+                    resource_name=pattern,
+                    arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
+                )
+                for pattern in function_name_patterns
+            ],
+        )
+    )
+
+
+def _add_kms_access(role: aws_iam.Role, key_arns: tuple[str, ...]) -> None:
+    if not key_arns:
+        return
+
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["kms:Decrypt", "kms:GenerateDataKey"],
+            resources=list(key_arns),
+        )
+    )

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -122,6 +122,9 @@ class SharedStack(Stack):
             enforce_ssl=None if self.stage.is_prod else True,
             object_ownership=None if self.stage.is_prod else aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
             versioned=None if self.stage.is_prod else True,
+            lifecycle_rules=[
+                aws_s3.LifecycleRule(abort_incomplete_multipart_upload_after=cdk.Duration.days(1)),
+            ],
         )
 
         self.tracker_repository: aws_ecr.Repository | None = None

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from uuid import UUID
 
 from aws_cdk import aws_logs
 from stage import DEV, PROD, RELEASE_TEST, Stage
+
+
+_SECRET_NAME_PREFIX_PATTERN = re.compile(r"[A-Za-z0-9/_+=.@-]+")
+_LAMBDA_FUNCTION_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\*?")
+_KMS_KEY_ARN_PATTERN = re.compile(r"arn:[^:]+:kms:[^:]+:[0-9]{12}:key/[A-Za-z0-9-]+")
 
 
 @dataclass(frozen=True)
@@ -25,12 +32,55 @@ class DatabaseConfig:
 
 
 @dataclass(frozen=True)
+class ManagedAWSRuntimeConfig:
+    benchmark_log_group_prefix: str
+    benchmark_log_retention_days: int
+    deployment_role_org_ids: tuple[str, ...] = ()
+    submissions_enabled: bool = False
+    tracker_secret_name_prefixes: tuple[str, ...] = ()
+    executor_secret_name_prefixes: tuple[str, ...] = ()
+    tracker_lambda_function_name_patterns: tuple[str, ...] = ()
+    executor_lambda_function_name_patterns: tuple[str, ...] = ()
+    kms_key_arns: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.benchmark_log_retention_days <= 0:
+            raise ValueError("benchmark_log_retention_days must be positive")
+
+        for org_id in self.deployment_role_org_ids:
+            try:
+                UUID(org_id.strip())
+            except ValueError:
+                raise ValueError(f"deployment_role_org_ids contains an invalid UUID: {org_id!r}") from None
+
+        for field_name, prefixes in (
+            ("tracker_secret_name_prefixes", self.tracker_secret_name_prefixes),
+            ("executor_secret_name_prefixes", self.executor_secret_name_prefixes),
+        ):
+            if any(_SECRET_NAME_PREFIX_PATTERN.fullmatch(prefix) is None for prefix in prefixes):
+                raise ValueError(f"{field_name} must contain literal, non-empty Secrets Manager name prefixes")
+
+        for field_name, patterns in (
+            ("tracker_lambda_function_name_patterns", self.tracker_lambda_function_name_patterns),
+            ("executor_lambda_function_name_patterns", self.executor_lambda_function_name_patterns),
+        ):
+            if any(_LAMBDA_FUNCTION_NAME_PATTERN.fullmatch(pattern) is None for pattern in patterns):
+                raise ValueError(
+                    f"{field_name} must contain anchored Lambda function names or trailing-wildcard patterns"
+                )
+
+        if any(_KMS_KEY_ARN_PATTERN.fullmatch(arn) is None or "*" in arn or "?" in arn for arn in self.kms_key_arns):
+            raise ValueError("kms_key_arns must contain concrete KMS key ARNs")
+
+
+@dataclass(frozen=True)
 class StageConfig:
     runtime_environment: str
     tracker: ServiceConfig
     worker: ServiceConfig
     database: DatabaseConfig
     service_log_retention: aws_logs.RetentionDays
+    managed_aws: ManagedAWSRuntimeConfig
 
 
 PROD_CONFIG = StageConfig(
@@ -44,6 +94,10 @@ PROD_CONFIG = StageConfig(
         connection_alarm_threshold=135,
     ),
     service_log_retention=aws_logs.RetentionDays.ONE_YEAR,
+    managed_aws=ManagedAWSRuntimeConfig(
+        benchmark_log_group_prefix="/valkyrie/benchmarks",
+        benchmark_log_retention_days=365,
+    ),
 )
 
 DEV_CONFIG = StageConfig(
@@ -57,6 +111,10 @@ DEV_CONFIG = StageConfig(
         connection_alarm_threshold=65,
     ),
     service_log_retention=aws_logs.RetentionDays.ONE_WEEK,
+    managed_aws=ManagedAWSRuntimeConfig(
+        benchmark_log_group_prefix="/valkyrie/benchmarks",
+        benchmark_log_retention_days=7,
+    ),
 )
 
 RELEASE_TEST_CONFIG = StageConfig(
@@ -65,6 +123,7 @@ RELEASE_TEST_CONFIG = StageConfig(
     worker=DEV_CONFIG.worker,
     database=DEV_CONFIG.database,
     service_log_retention=DEV_CONFIG.service_log_retention,
+    managed_aws=DEV_CONFIG.managed_aws,
 )
 
 RELEASE_TEST_BENCHMARK_SERVICE_BASE_URL = "benchmarks.vals.ai"

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -184,6 +184,11 @@ class DevAccountInfrastructureTest(unittest.TestCase):
                 {"ServerSideEncryptionConfiguration": [{"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]},
             )
 
+        self.assertEqual(
+            bucket["Properties"]["LifecycleConfiguration"],
+            {"Rules": [{"AbortIncompleteMultipartUpload": {"DaysAfterInitiation": 1}, "Status": "Enabled"}]},
+        )
+
         conditional_write_statements = [
             statement
             for policy in executor_template.find_resources("AWS::S3::BucketPolicy").values()
@@ -218,8 +223,15 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         hosted_zone_parameter = ssm_parameter_id(template, DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER)
         rendered = json.dumps(template)
         iam_policies = tracker_template.find_resources("AWS::IAM::Policy")
-        rendered_policies = json.dumps(iam_policies)
-        self.assertNotIn("s3:DeleteObject", rendered_policies)
+        delete_statements = [
+            statement
+            for policy in iam_policies.values()
+            for statement in policy["Properties"]["PolicyDocument"]["Statement"]
+            if set(statement["Action"]) == {"s3:DeleteObject", "s3:DeleteObjectVersion"}
+        ]
+        self.assertEqual(len(delete_statements), 1)
+        self.assertIn("benchmarks/*", json.dumps(delete_statements[0]["Resource"]))
+        self.assertNotIn("agents/*", json.dumps(delete_statements[0]["Resource"]))
         self.assertIn(DESCOPE_MANAGEMENT_KEY_SECRET_NAME, rendered)
         self.assertNotIn("/vals/dev/descope/project-id", rendered)
         self.assertNotIn("SENTRY_DSN", rendered)

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -1,7 +1,7 @@
 import json
 import os
 import unittest
-from typing import cast
+from typing import Any, cast
 from unittest import mock
 
 import aws_cdk as cdk
@@ -64,6 +64,7 @@ SHARED_STACK_CONTEXT = {
         "Name": "vals.ai.",
     },
 }
+JsonObject = dict[str, Any]
 
 
 def _has_resource_property(
@@ -152,7 +153,7 @@ def _shared_template(stage_name: str = PROD) -> assertions.Template:
     return assertions.Template.from_stack(shared)
 
 
-def _service_templates(
+def service_templates(
     stage_name: str,
 ) -> tuple[assertions.Template, assertions.Template, assertions.Template]:
     app = cdk.App(context=SHARED_STACK_CONTEXT)
@@ -236,7 +237,7 @@ class MonitoringStackTest(unittest.TestCase):
             (RELEASE_TEST, TEST_RELEASE_TEST_ENV),
         ):
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
-                tracker_templates[stage_name] = _service_templates(stage_name)[0]
+                tracker_templates[stage_name] = service_templates(stage_name)[0]
 
         for stage_name in (PROD, DEV):
             listeners = {
@@ -288,7 +289,7 @@ class MonitoringStackTest(unittest.TestCase):
                 self.assertNotIn("SecurityGroupIngress", redis_security_group["Properties"])
                 self.assertFalse(shared_template.find_resources("AWS::EC2::SecurityGroupIngress"))
 
-                tracker_template, executor_template, _ = _service_templates(stage_name)
+                tracker_template, executor_template, _ = service_templates(stage_name)
                 tracker_security_groups = tracker_template.find_resources("AWS::EC2::SecurityGroup")
                 tracker_security_group_id = next(
                     logical_id
@@ -398,7 +399,7 @@ class MonitoringStackTest(unittest.TestCase):
             with self.subTest(stage=stage):
                 env = TEST_DEV_ENV if stage == DEV else TEST_PROD_ENV
                 with mock.patch.dict(os.environ, env, clear=False):
-                    _, executor_template, _ = _service_templates(stage)
+                    _, executor_template, _ = service_templates(stage)
                 roles = executor_template.find_resources("AWS::IAM::Role")
                 release_role = next(role for role in roles.values() if role["Properties"].get("RoleName") == role_name)
                 trust = json.dumps(release_role["Properties"]["AssumeRolePolicyDocument"])
@@ -407,7 +408,7 @@ class MonitoringStackTest(unittest.TestCase):
                 self.assertNotIn("refs/heads/prod", trust)
 
         with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=False):
-            synthesized = json.dumps(_service_templates(PROD)[1].to_json())
+            synthesized = json.dumps(service_templates(PROD)[1].to_json())
         self.assertIn("tracker.executor.release_entrypoint", synthesized)
         self.assertIn("ecs:UpdateTaskProtection", synthesized)
         self.assertIn("ecs:StopTask", synthesized)
@@ -419,7 +420,7 @@ class MonitoringStackTest(unittest.TestCase):
             TEST_RELEASE_TEST_ENV,
             clear=False,
         ):
-            tracker_template, executor_template, _ = _service_templates(RELEASE_TEST)
+            tracker_template, executor_template, _ = service_templates(RELEASE_TEST)
 
         parameter_names = [
             resource["Properties"]["Name"]
@@ -457,7 +458,7 @@ class MonitoringStackTest(unittest.TestCase):
 
     def test_executor_stack_owns_the_host_and_release_control(self) -> None:
         with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=False):
-            _, executor_template, monitoring_template = _service_templates(PROD)
+            _, executor_template, monitoring_template = service_templates(PROD)
         services = executor_template.find_resources("AWS::ECS::Service")
         task_definitions = executor_template.find_resources("AWS::ECS::TaskDefinition")
         scalable_targets = executor_template.find_resources("AWS::ApplicationAutoScaling::ScalableTarget")
@@ -591,7 +592,7 @@ class MonitoringStackTest(unittest.TestCase):
 
     def test_dev_stage_wires_stage_config_to_resources(self) -> None:
         with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
-            tracker_template, worker_template, _ = _service_templates(DEV)
+            tracker_template, executor_template, _ = service_templates(DEV)
         with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
             monitoring_template = _monitoring_template(DEV)
 
@@ -607,26 +608,26 @@ class MonitoringStackTest(unittest.TestCase):
             "AWS::ApplicationAutoScaling::ScalableTarget",
             {"MinCapacity": DEV_CONFIG.tracker.min_tasks, "MaxCapacity": DEV_CONFIG.tracker.max_tasks},
         )
-        worker_template.has_resource_properties(
+        executor_template.has_resource_properties(
             "AWS::ECS::Service",
             {"DesiredCount": DEV_CONFIG.worker.min_tasks},
         )
-        worker_template.has_resource_properties(
+        executor_template.has_resource_properties(
             "AWS::ApplicationAutoScaling::ScalableTarget",
             {"MinCapacity": DEV_CONFIG.worker.min_tasks, "MaxCapacity": DEV_CONFIG.worker.max_tasks},
         )
-        worker_template.has_resource_properties(
+        executor_template.has_resource_properties(
             "AWS::Logs::LogGroup",
             {"LogGroupName": f"{WORKER_LOG_GROUP_NAME}-dev", "RetentionInDays": 7},
         )
-        worker_log_group = worker_template.to_json()["Resources"]["WorkerLogGroup31FDBE4A"]
+        worker_log_group = executor_template.to_json()["Resources"]["WorkerLogGroup31FDBE4A"]
         self.assertEqual(worker_log_group["DeletionPolicy"], "Retain")
         self.assertEqual(worker_log_group["UpdateReplacePolicy"], "Retain")
-        worker_policies = worker_template.find_resources("AWS::IAM::Policy")
+        worker_policies = executor_template.find_resources("AWS::IAM::Policy")
         executor_host_policies = [
             policy
             for logical_id, policy in worker_policies.items()
-            if logical_id.startswith("ExecutorHostTaskDefTaskRoleDefaultPolicy")
+            if logical_id.startswith("ExecutorTaskRoleDefaultPolicy")
         ]
         self.assertEqual(len(executor_host_policies), 1)
         executor_host_policy = json.dumps(executor_host_policies[0])
@@ -646,7 +647,7 @@ class MonitoringStackTest(unittest.TestCase):
         ):
             environment = TEST_DEV_ENV if stage_name == DEV else TEST_PROD_ENV
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
-                tracker_template, worker_template, _ = _service_templates(stage_name)
+                tracker_template, executor_template, _ = service_templates(stage_name)
 
                 expected_env = assertions.Match.array_with(
                     [
@@ -663,7 +664,7 @@ class MonitoringStackTest(unittest.TestCase):
                         )
                     },
                 )
-                worker_template.has_resource_properties(
+                executor_template.has_resource_properties(
                     "AWS::ECS::TaskDefinition",
                     {
                         "ContainerDefinitions": assertions.Match.array_with(
@@ -681,21 +682,21 @@ class MonitoringStackTest(unittest.TestCase):
             },
             clear=True,
         ):
-            _, worker_template, _ = _service_templates(DEV)
+            _, executor_template, _ = service_templates(DEV)
 
-        worker_template.resource_count_is("AWS::Scheduler::Schedule", 0)
-        worker_template.resource_count_is("AWS::Lambda::Function", 0)
-        worker_template.resource_count_is("AWS::SQS::Queue", 0)
+        executor_template.resource_count_is("AWS::Scheduler::Schedule", 0)
+        executor_template.resource_count_is("AWS::Lambda::Function", 0)
+        executor_template.resource_count_is("AWS::SQS::Queue", 0)
 
     def test_prod_sandbox_cleanup_is_disabled_and_bounded_by_default(self) -> None:
         with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=True):
-            _, worker_template, _ = _service_templates(PROD)
+            _, executor_template, _ = service_templates(PROD)
 
-        worker_template.resource_count_is("AWS::Scheduler::Schedule", 1)
-        worker_template.resource_count_is("AWS::Lambda::Function", 1)
-        worker_template.resource_count_is("AWS::Lambda::EventInvokeConfig", 1)
-        worker_template.resource_count_is("AWS::SQS::Queue", 1)
-        worker_template.has_resource_properties(
+        executor_template.resource_count_is("AWS::Scheduler::Schedule", 1)
+        executor_template.resource_count_is("AWS::Lambda::Function", 1)
+        executor_template.resource_count_is("AWS::Lambda::EventInvokeConfig", 1)
+        executor_template.resource_count_is("AWS::SQS::Queue", 1)
+        executor_template.has_resource_properties(
             "AWS::Scheduler::Schedule",
             {
                 "Name": SANDBOX_CLEANUP_SCHEDULE_NAME,
@@ -704,7 +705,7 @@ class MonitoringStackTest(unittest.TestCase):
                 "Target": assertions.Match.object_like({"DeadLetterConfig": assertions.Match.any_value()}),
             },
         )
-        worker_template.has_resource_properties(
+        executor_template.has_resource_properties(
             "AWS::Lambda::Function",
             {
                 "FunctionName": SANDBOX_CLEANUP_FUNCTION_NAME,
@@ -720,7 +721,7 @@ class MonitoringStackTest(unittest.TestCase):
                 },
             },
         )
-        worker_template.has_resource_properties(
+        executor_template.has_resource_properties(
             "AWS::Lambda::EventInvokeConfig",
             {
                 "DestinationConfig": {
@@ -728,7 +729,7 @@ class MonitoringStackTest(unittest.TestCase):
                 },
             },
         )
-        worker_template.has_resource_properties(
+        executor_template.has_resource_properties(
             "AWS::SQS::Queue",
             {
                 "QueueName": SANDBOX_CLEANUP_DLQ_NAME,
@@ -737,7 +738,7 @@ class MonitoringStackTest(unittest.TestCase):
         )
         secret_statements = [
             statement
-            for policy in worker_template.find_resources("AWS::IAM::Policy").values()
+            for policy in executor_template.find_resources("AWS::IAM::Policy").values()
             for statement in policy["Properties"]["PolicyDocument"]["Statement"]
             if statement.get("Action") == ["secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret"]
             and SANDBOX_CLEANUP_SECRET_NAME in str(statement.get("Resource"))
@@ -760,13 +761,13 @@ class MonitoringStackTest(unittest.TestCase):
                     clear=True,
                 ),
             ):
-                _, worker_template, _ = _service_templates(PROD)
+                _, executor_template, _ = service_templates(PROD)
 
-            worker_template.has_resource_properties(
+            executor_template.has_resource_properties(
                 "AWS::Scheduler::Schedule",
                 {"State": expected_state},
             )
-            worker_template.has_resource_properties(
+            executor_template.has_resource_properties(
                 "AWS::Lambda::Function",
                 {
                     "Environment": {
@@ -783,10 +784,10 @@ class MonitoringStackTest(unittest.TestCase):
 
     def test_dev_sentry_secret_is_optional(self) -> None:
         with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
-            tracker_template, worker_template, _ = _service_templates(DEV)
+            tracker_template, executor_template, _ = service_templates(DEV)
 
         self.assertNotIn("SENTRY_DSN", str(tracker_template.to_json()))
-        self.assertNotIn("SENTRY_DSN", str(worker_template.to_json()))
+        self.assertNotIn("SENTRY_DSN", str(executor_template.to_json()))
 
         custom_sentry_secret_name = "custom/dev-sentry-dsn"
         sentry_environment = {
@@ -794,7 +795,7 @@ class MonitoringStackTest(unittest.TestCase):
             "SENTRY_DSN_SECRET_NAME": custom_sentry_secret_name,
         }
         with mock.patch.dict(os.environ, sentry_environment, clear=True):
-            tracker_template, worker_template, _ = _service_templates(DEV)
+            tracker_template, executor_template, _ = service_templates(DEV)
 
         tracker_template.has_resource_properties(
             "AWS::ECS::TaskDefinition",
@@ -821,7 +822,7 @@ class MonitoringStackTest(unittest.TestCase):
         ]
         self.assertEqual(len(sentry_value_from), 1)
         self.assertIn(custom_sentry_secret_name, str(sentry_value_from[0]))
-        self.assertNotIn("SENTRY_DSN", str(worker_template.to_json()))
+        self.assertNotIn("SENTRY_DSN", str(executor_template.to_json()))
 
 
 if __name__ == "__main__":

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -1,0 +1,281 @@
+import json
+import os
+import unittest
+from dataclasses import replace
+from typing import cast
+from unittest import mock
+
+import aws_cdk as cdk
+from aws_cdk import assertions, aws_s3
+
+from runtime_iam import create_executor_task_role, create_tracker_task_role
+from stage import DEV, Stage
+from stage_config import ManagedAWSRuntimeConfig
+from test_monitoring_stack import (
+    TEST_AWS_ACCOUNT,
+    TEST_AWS_REGION,
+    TEST_DEV_ENV,
+    JsonObject,
+    service_templates,
+)
+
+
+def _named_role(template: assertions.Template, role_name: str) -> tuple[str, JsonObject]:
+    resources = cast(dict[str, JsonObject], template.find_resources("AWS::IAM::Role"))
+    matches = [
+        (logical_id, resource)
+        for logical_id, resource in resources.items()
+        if cast(JsonObject, resource.get("Properties", {})).get("RoleName") == role_name
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one role named {role_name!r}, found {len(matches)}")
+    return matches[0]
+
+
+def _role_policy_statements(template: assertions.Template, role_logical_id: str) -> list[JsonObject]:
+    statements: list[JsonObject] = []
+    policies = cast(dict[str, JsonObject], template.find_resources("AWS::IAM::Policy"))
+    for policy in policies.values():
+        properties = cast(JsonObject, policy.get("Properties", {}))
+        if {"Ref": role_logical_id} not in cast(list[JsonObject], properties.get("Roles", [])):
+            continue
+        policy_document = cast(JsonObject, properties["PolicyDocument"])
+        policy_statements = policy_document["Statement"]
+        if isinstance(policy_statements, list):
+            statements.extend(cast(list[JsonObject], policy_statements))
+        else:
+            statements.append(cast(JsonObject, policy_statements))
+    return statements
+
+
+def _statement_actions(statement: JsonObject) -> set[str]:
+    actions = cast(str | list[str], statement["Action"])
+    return set(actions) if isinstance(actions, list) else {actions}
+
+
+class RuntimeIamTest(unittest.TestCase):
+    def test_managed_runtime_rejects_invalid_authority_configuration(self) -> None:
+        config = ManagedAWSRuntimeConfig(
+            benchmark_log_group_prefix="/valkyrie/benchmarks",
+            benchmark_log_retention_days=7,
+        )
+        lambda_arn = f"arn:aws:lambda:{TEST_AWS_REGION}:{TEST_AWS_ACCOUNT}:function:example"
+        invalid_values: list[tuple[str, object]] = [
+            ("benchmark_log_retention_days", 0),
+            ("benchmark_log_retention_days", -1),
+            ("deployment_role_org_ids", ("not-a-uuid",)),
+            ("tracker_secret_name_prefixes", ("",)),
+            ("tracker_secret_name_prefixes", ("*",)),
+            ("tracker_secret_name_prefixes", ("valkyrie/*",)),
+            ("executor_secret_name_prefixes", ("",)),
+            ("executor_secret_name_prefixes", ("*",)),
+            ("executor_secret_name_prefixes", ("valkyrie/*",)),
+            ("tracker_lambda_function_name_patterns", ("",)),
+            ("tracker_lambda_function_name_patterns", ("*",)),
+            ("tracker_lambda_function_name_patterns", ("?suffix",)),
+            ("tracker_lambda_function_name_patterns", ("name:qualifier",)),
+            ("tracker_lambda_function_name_patterns", (lambda_arn,)),
+            ("executor_lambda_function_name_patterns", ("",)),
+            ("executor_lambda_function_name_patterns", ("*",)),
+            ("executor_lambda_function_name_patterns", ("?suffix",)),
+            ("executor_lambda_function_name_patterns", (lambda_arn,)),
+            ("kms_key_arns", ("*",)),
+            ("kms_key_arns", (f"arn:aws:s3:{TEST_AWS_REGION}:{TEST_AWS_ACCOUNT}:bucket/example",)),
+            ("kms_key_arns", (f"arn:aws:kms:*:{TEST_AWS_ACCOUNT}:key/example",)),
+            ("kms_key_arns", (f"arn:aws:kms:{TEST_AWS_REGION}:*:key/example",)),
+            ("kms_key_arns", (f"arn:aws:kms:{TEST_AWS_REGION}:{TEST_AWS_ACCOUNT}:alias/example",)),
+        ]
+
+        for field_name, value in invalid_values:
+            with self.subTest(field=field_name, value=value):
+                with self.assertRaisesRegex(ValueError, field_name):
+                    replace(config, **{field_name: value})
+
+    def test_managed_runtime_task_roles_are_scoped_and_closed_by_default(self) -> None:
+        with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
+            tracker_template, executor_template, _ = service_templates(DEV)
+
+        expected_environment = assertions.Match.array_with(
+            [
+                {"Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS", "Value": ""},
+                {"Name": "AWS_DEPLOYMENT_REGION", "Value": TEST_AWS_REGION},
+                assertions.Match.object_like({"Name": "AWS_DEPLOYMENT_S3_BUCKET"}),
+                {"Name": "AWS_DEPLOYMENT_LOG_GROUP", "Value": "/valkyrie/benchmarks-dev"},
+                {"Name": "AWS_DEPLOYMENT_LOG_RETENTION_DAYS", "Value": "7"},
+                {"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "false"},
+            ]
+        )
+
+        expected_actions = {
+            "s3:ListBucket",
+            "s3:GetObject",
+            "s3:PutObject",
+        }
+        for template, role_name, output_name, service_actions in (
+            (
+                tracker_template,
+                "ValkyrieTrackerTaskRole-dev",
+                "TrackerTaskRoleArn",
+                expected_actions | {"s3:DeleteObject", "s3:DeleteObjectVersion"},
+            ),
+            (
+                executor_template,
+                "ValkyrieExecutorTaskRole-dev",
+                "ExecutorTaskRoleArn",
+                expected_actions
+                | {
+                    "s3:AbortMultipartUpload",
+                    "logs:CreateLogGroup",
+                    "logs:PutRetentionPolicy",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "ecs:UpdateTaskProtection",
+                },
+            ),
+        ):
+            with self.subTest(role=role_name):
+                role_logical_id, _ = _named_role(template, role_name)
+                task_definitions = cast(
+                    dict[str, JsonObject],
+                    template.find_resources("AWS::ECS::TaskDefinition"),
+                )
+                role_task_definitions = [
+                    task_definition
+                    for task_definition in task_definitions.values()
+                    if cast(JsonObject, task_definition["Properties"]).get("TaskRoleArn")
+                    == {"Fn::GetAtt": [role_logical_id, "Arn"]}
+                ]
+                self.assertEqual(len(role_task_definitions), 1)
+                task_properties = cast(JsonObject, role_task_definitions[0]["Properties"])
+                self.assertEqual(task_properties["TaskRoleArn"], {"Fn::GetAtt": [role_logical_id, "Arn"]})
+                self.assertIn("ExecutionRoleArn", task_properties)
+                self.assertNotEqual(task_properties["TaskRoleArn"], task_properties["ExecutionRoleArn"])
+                self.assertEqual(
+                    template.to_json()["Outputs"][output_name]["Value"],
+                    {"Fn::GetAtt": [role_logical_id, "Arn"]},
+                )
+                template.has_resource_properties(
+                    "AWS::ECS::TaskDefinition",
+                    {
+                        "ContainerDefinitions": assertions.Match.array_with(
+                            [assertions.Match.object_like({"Environment": expected_environment})]
+                        )
+                    },
+                )
+
+                statements = _role_policy_statements(template, role_logical_id)
+                actions = set[str]().union(*(_statement_actions(statement) for statement in statements))
+                self.assertEqual(actions, service_actions)
+
+                list_statement = next(
+                    statement for statement in statements if _statement_actions(statement) == {"s3:ListBucket"}
+                )
+                self.assertNotIn("Condition", list_statement)
+                get_statement = next(
+                    statement for statement in statements if _statement_actions(statement) == {"s3:GetObject"}
+                )
+                self.assertIn("agents/*", json.dumps(get_statement["Resource"]))
+                self.assertIn("benchmarks/*", json.dumps(get_statement["Resource"]))
+                put_statement = next(
+                    statement for statement in statements if _statement_actions(statement) == {"s3:PutObject"}
+                )
+                self.assertIn("benchmarks/*", json.dumps(put_statement["Resource"]))
+                self.assertNotIn("agents/*", json.dumps(put_statement["Resource"]))
+
+                delete_statements = [
+                    statement
+                    for statement in statements
+                    if _statement_actions(statement) == {"s3:DeleteObject", "s3:DeleteObjectVersion"}
+                ]
+                if role_name.startswith("ValkyrieTracker"):
+                    self.assertEqual(len(delete_statements), 1)
+                    self.assertIn("benchmarks/*", json.dumps(delete_statements[0]["Resource"]))
+                    self.assertNotIn("agents/*", json.dumps(delete_statements[0]["Resource"]))
+                else:
+                    self.assertEqual(delete_statements, [])
+
+                abort_statements = [
+                    statement
+                    for statement in statements
+                    if _statement_actions(statement) == {"s3:AbortMultipartUpload"}
+                ]
+                if role_name.startswith("ValkyrieExecutor"):
+                    self.assertEqual(len(abort_statements), 1)
+                    self.assertIn("benchmarks/*", json.dumps(abort_statements[0]["Resource"]))
+                    self.assertNotIn("agents/*", json.dumps(abort_statements[0]["Resource"]))
+                else:
+                    self.assertEqual(abort_statements, [])
+
+                for statement in statements:
+                    resources = statement["Resource"]
+                    if resources == "*" or (isinstance(resources, list) and "*" in resources):
+                        self.assertEqual(_statement_actions(statement), {"ecs:UpdateTaskProtection"})
+
+                if role_name.startswith("ValkyrieExecutor"):
+                    log_statement = next(
+                        statement for statement in statements if "logs:CreateLogStream" in _statement_actions(statement)
+                    )
+                    self.assertEqual(
+                        _statement_actions(log_statement),
+                        {"logs:CreateLogGroup", "logs:PutRetentionPolicy", "logs:CreateLogStream", "logs:PutLogEvents"},
+                    )
+                    self.assertIn("/valkyrie/benchmarks-dev/*", json.dumps(log_statement["Resource"]))
+                    self.assertNotIn(":log-stream:", json.dumps(log_statement["Resource"]))
+
+    def test_managed_runtime_optional_grants_are_limited_to_configured_resources(self) -> None:
+        app = cdk.App()
+        stack = cdk.Stack(
+            app,
+            "RuntimeIamStack",
+            env=cdk.Environment(account=TEST_AWS_ACCOUNT, region=TEST_AWS_REGION),
+        )
+        bucket = aws_s3.Bucket.from_bucket_name(stack, "ManagedRuntimeBucket", "managed-runtime-bucket")
+        kms_key_arn = f"arn:aws:kms:{TEST_AWS_REGION}:{TEST_AWS_ACCOUNT}:key/test-key"
+        config = ManagedAWSRuntimeConfig(
+            benchmark_log_group_prefix="/valkyrie/benchmarks",
+            benchmark_log_retention_days=7,
+            tracker_secret_name_prefixes=("valkyrie/tracker/",),
+            executor_secret_name_prefixes=("valkyrie/executor/",),
+            tracker_lambda_function_name_patterns=("valkyrie-analyzer-*",),
+            executor_lambda_function_name_patterns=("valkyrie-post-run-*",),
+            kms_key_arns=(kms_key_arn,),
+        )
+        create_tracker_task_role(stack, Stage(DEV), bucket, config)
+        create_executor_task_role(stack, Stage(DEV), bucket, config)
+        template = assertions.Template.from_stack(stack)
+
+        for role_name, secret_prefix, lambda_pattern in (
+            ("ValkyrieTrackerTaskRole-dev", "valkyrie/tracker/", "valkyrie-analyzer-*"),
+            ("ValkyrieExecutorTaskRole-dev", "valkyrie/executor/", "valkyrie-post-run-*"),
+        ):
+            with self.subTest(role=role_name):
+                role_logical_id, _ = _named_role(template, role_name)
+                statements = _role_policy_statements(template, role_logical_id)
+
+                secret_statement = next(
+                    statement
+                    for statement in statements
+                    if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
+                )
+                self.assertIn(f"secret:{secret_prefix}*", json.dumps(secret_statement["Resource"]))
+
+                lambda_statement = next(
+                    statement for statement in statements if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                )
+                self.assertIn(f"function:{lambda_pattern}", json.dumps(lambda_statement["Resource"]))
+
+                kms_statement = next(
+                    statement for statement in statements if "kms:Decrypt" in _statement_actions(statement)
+                )
+                self.assertEqual(
+                    _statement_actions(kms_statement),
+                    {"kms:Decrypt", "kms:GenerateDataKey"},
+                )
+                self.assertEqual(kms_statement["Resource"], kms_key_arn)
+
+                for statement in (secret_statement, lambda_statement, kms_statement):
+                    self.assertNotEqual(statement["Resource"], "*")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -13,9 +13,11 @@ from aws_cdk import (
     aws_ecs,
     aws_ecs_patterns,
     aws_elasticloadbalancingv2,
+    aws_iam,
     aws_logs,
     aws_rds,
     aws_route53,
+    aws_s3,
     aws_secretsmanager,
     aws_servicediscovery,
     aws_ssm,
@@ -45,6 +47,7 @@ from constants import (
     stage_parameter_name,
 )
 from constructs import Construct
+from runtime_iam import create_tracker_task_role, managed_runtime_environment
 from stage import Stage
 from stage_config import benchmark_service_base_url, config_for
 
@@ -79,6 +82,7 @@ class TrackerStack(Stack):
     ):
         super().__init__(scope, id, **kwargs)
         stage_config = config_for(stage)
+        bucket = aws_s3.Bucket.from_bucket_name(self, "ManagedRuntimeBucket", bucket_name)
 
         # Release-test writes images only to its stage-qualified repository;
         # other stages retain the established CDK asset path.
@@ -105,6 +109,7 @@ class TrackerStack(Stack):
             "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
             **({"BENCHMARK_SERVICE_BASE_URL": benchmark_service_url} if benchmark_service_url else {}),
+            **managed_runtime_environment(self, stage, bucket, stage_config.managed_aws),
         }
 
         # ── RDS ──────────────────────────────────────────────────────────
@@ -190,13 +195,17 @@ class TrackerStack(Stack):
 
         # ── Tracker API service ──────────────────────────────────────────
 
+        self.tracker_task_role = create_tracker_task_role(self, stage, bucket, stage_config.managed_aws)
         tracker_task_def = aws_ecs.FargateTaskDefinition(
             self,
             "TrackerTaskDef",
             cpu=stage_config.tracker.cpu,
             memory_limit_mib=stage_config.tracker.memory_mib,
             runtime_platform=_ARM64_PLATFORM,
+            task_role=cast(aws_iam.IRole, self.tracker_task_role),
         )
+
+        cdk.CfnOutput(self, "TrackerTaskRoleArn", value=self.tracker_task_role.role_arn)
 
         tracker_task_def.add_container(
             "TrackerContainer",
@@ -344,7 +353,7 @@ class TrackerStack(Stack):
             description="Allow Tracker and ExecutorHost to connect to Redis",
         )
 
-        # Allow VPC services (tracker + worker) to reach RDS.
+        # Allow VPC services (Tracker and ExecutorHost) to reach RDS.
         db_security_group.add_ingress_rule(
             peer=aws_ec2.Peer.ipv4(VPC_CIDR),
             connection=aws_ec2.Port.tcp(POSTGRES_PORT),


### PR DESCRIPTION
## Human Description

### Why

Valkyrie currently needs AWS access keys from whoever starts a run: the CLI stores them in `valkyrie.yaml`, sends them to the tracker, and they ride the queue to the worker. The keys must be long-lived, because anything short-lived would expire mid-run. This stack adds **managed mode**: the tracker and worker use the IAM roles on their own ECS tasks, and AWS rotates those credentials automatically — the caller never hands over a secret. Only allowlisted organizations can use it. Access-key mode keeps working unchanged.

Managed mode has nothing to run on yet. The ECS tasks roles don't have the complete deployment-managed permissions required for managed mode. This PR creates the task roles with the permissions managed mode needs, and gives both services the deployment-owned settings (region, bucket, log group, org allowlist, submission gate) that access-key mode used to take from the caller.

---

Tracker and ExecutorHost containers now receive separate application task roles and deployment-owned AWS settings. Managed submissions remain disabled with an empty organization allowlist until an operator explicitly enables them.

## Stack

1. [#532 — aws client providers](https://github.com/vals-ai/Valkyrie/pull/532)
2. [#543 — persist managed aws runtime](https://github.com/vals-ai/Valkyrie/pull/543)
3. [#544 — managed taskiq execution](https://github.com/vals-ai/Valkyrie/pull/544)
4. **[#545 — managed aws task roles](https://github.com/vals-ai/Valkyrie/pull/545) ← this PR**

## What changed

**Task roles**

- `ValkyrieTrackerTaskRole` and `ValkyrieExecutorTaskRole` are separate from their ECS execution roles.
- Both roles can read `agents/*` and `benchmarks/*`, write `benchmarks/*`, and list the shared bucket.
- Tracker can delete the version-identified benchmark agent copy when start admission rolls back.
- Executor can abort benchmark multipart uploads and write to the benchmark CloudWatch Logs prefix. It retains `ecs:UpdateTaskProtection`.
- Secrets Manager, Lambda, and KMS access is added only for configured resources. Stage configuration rejects empty or wildcard-only authority that could expand those grants unexpectedly.

**Deployment configuration**

- `ManagedAWSRuntimeConfig` supplies region, bucket, log group, retention, organization allowlist, submission gate, and optional AWS resource scope to both services.
- Organization IDs and retention values fail during synthesis when invalid.
- Development and production default to no eligible organizations and managed submissions disabled.
- The shared bucket aborts incomplete multipart uploads after one day. This removes abandoned upload fragments from interrupted CLI and Executor uploads; it never deletes completed objects.

## How to review

Start with `infra/runtime_iam.py` and `infra/stage_config.py`, then confirm how `tracker_stack.py` and `executor_stack.py` attach the task roles and environment.

`infra/shared.py` contains the bucket lifecycle rule. It is bucket-wide because both `agents/*` CLI uploads and `benchmarks/*` Executor uploads can leave unfinished multipart sessions after process termination.

The intentionally broad resources are limited to bucket-level `s3:ListBucket`, the CloudWatch log-group prefix needed by `CreateLogStream`, and `ecs:UpdateTaskProtection`. Optional Secrets Manager, Lambda, and KMS grants cannot synthesize from empty or global wildcard configuration.

```mermaid
flowchart LR
    ECS[ECS task launch] -->|execution role| Image[Container image and startup logs]
    ECS --> Tracker[Tracker container]
    ECS --> Host[ExecutorHost container]
    Config[Deployment-owned configuration] --> Tracker
    Config --> Host
    Tracker -->|ValkyrieTrackerTaskRole| AWS[S3, optional Secrets Manager, Lambda, and KMS]
    Host -->|ValkyrieExecutorTaskRole| WorkerAWS[S3, CloudWatch Logs, optional Secrets Manager, Lambda, and KMS]
```

## Testing

Live-tested on dev in the combined stack at `17a16fd6`. Tracker ran as `ValkyrieTrackerTaskRole-dev` and ExecutorHost ran as `ValkyrieExecutorTaskRole-dev`. An allowlisted managed `legal-research` task finished through real S3, CloudWatch Logs, Secrets Manager, and Daytona. The explicit-header access-key control also finished. Afterward, both services were redeployed with an empty organization allowlist, managed submissions disabled, and no executor secret-prefix configuration; both ECS services reached a stable state.

At `b3aaabff`, the dev CDK plan authenticated to AWS account `533328366429` and produced zero differences across the Shared, Tracker, Worker, and Monitoring stacks. This confirms the stricter Lambda-name validation still accepts the deployed configuration without changing generated infrastructure.

Design: architectural (changes ECS application-role ownership and the deployment configuration boundary for managed AWS access)
