### PR TITLE
change: security pass

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -124,7 +124,7 @@ def _operation_id(route: APIRoute) -> str:
     return route.name
 
 
-app = FastAPI(generate_unique_id_function=_operation_id)
+app = FastAPI(generate_unique_id_function=_operation_id, redirect_slashes=False)
 
 logfire.instrument_fastapi(app, excluded_urls="/health$")
 
@@ -167,19 +167,20 @@ def _taskiq_labels() -> dict[str, str]:
 async def tracker_service_error_handler(_request: Request, exc: TrackerServiceError):
     logger.error(exc, exc_info=True)
     sentry_sdk.capture_exception(exc)
-    raise HTTPException(status_code=500, detail=str(exc)) from exc
+    raise HTTPException(status_code=500, detail="Tracker service operation failed") from exc
 
 
 @app.exception_handler(BenchmarkServiceUnauthenticatedError)
 async def benchmark_service_unauth_error_handler(_request: Request, exc: BenchmarkServiceUnauthenticatedError):
-    raise HTTPException(status_code=502, detail=str(exc)) from exc
+    logger.warning("Benchmark service authentication failed: %s", exc)
+    raise HTTPException(status_code=502, detail="Benchmark service authentication failed") from exc
 
 
 @app.exception_handler(BenchmarkServiceError)
 async def benchmark_service_error_handler(_request: Request, exc: BenchmarkServiceError):
     logger.error(exc, exc_info=True)
     sentry_sdk.capture_exception(exc)
-    raise HTTPException(status_code=500, detail=str(exc)) from exc
+    raise HTTPException(status_code=500, detail="Benchmark service request failed") from exc
 
 
 @app.get("/health")
@@ -314,10 +315,12 @@ async def start_benchmark(
         verify_response = await benchmark_service.verify_task_ids(
             task_ids=request.task_ids, slice_str=request.slice_str, dataset=request.dataset
         )
-    except BenchmarkServiceUnauthenticatedError as e:
-        raise HTTPException(status_code=502, detail=f"Benchmark service auth failed: {e}") from e
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"Failed to verify task ids: {e}") from e
+    except BenchmarkServiceUnauthenticatedError as exc:
+        logger.warning("Benchmark service authentication failed for %s: %s", request.benchmark_name, exc)
+        raise HTTPException(status_code=502, detail="Benchmark service authentication failed") from exc
+    except Exception as exc:
+        logger.error("Failed to verify task ids for %s", request.benchmark_name, exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to verify task ids") from exc
 
     # Create benchmark row only after pre-flight checks pass.
     benchmark_row = start_benchmark_request_to_benchmark(request, run_starter)
@@ -398,10 +401,8 @@ async def fetch_benchmark_tasks(
         finally:
             await benchmark_service.close()
     except (BenchmarkServiceError, httpx.HTTPError) as exc:
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to fetch task ids from benchmark service '{request.benchmark_name}': {exc}",
-        ) from exc
+        logger.warning("Failed to fetch task ids from benchmark service %s: %s", request.benchmark_name, exc)
+        raise HTTPException(status_code=502, detail="Failed to fetch task ids from benchmark service") from exc
 
 
 @app.get("/fetch-benchmark", response_model=None)
@@ -882,6 +883,25 @@ async def fetch_benchmark_metadata(
     return benchmark_row.benchmark_metadata
 
 
+def _safe_output_tar_member(s3_key: str, benchmark_prefix: str) -> str | None:
+    """Return a safe relative tar member name for an object under a benchmark prefix."""
+    if not s3_key.startswith(benchmark_prefix):
+        return None
+
+    relative_path = s3_key[len(benchmark_prefix) :]
+    parts = relative_path.split("/")
+    if (
+        not relative_path
+        or "\x00" in relative_path
+        or "\\" in relative_path
+        or any(part in {"", ".", ".."} for part in parts)
+        or (len(parts[0]) >= 2 and parts[0][1] == ":")
+    ):
+        return None
+
+    return relative_path
+
+
 @app.get("/fetch-run-outputs/{benchmark_id}", response_model=None)
 async def fetch_run_outputs(
     benchmark_id: TrackedBenchmarkId,
@@ -907,6 +927,9 @@ async def fetch_run_outputs(
         prefixes = [f"{benchmark_prefix}{task_id}/" for task_id in task_ids] if task_ids else [benchmark_prefix]
         for prefix in prefixes:
             async for key in list_s3_objects(prefix, harness_config.aws, harness_config.s3_bucket):
+                if _safe_output_tar_member(key, benchmark_prefix) is None:
+                    logger.warning("Skipping unsafe output archive member for benchmark %s", benchmark_id)
+                    continue
                 yield key
 
     # Peek a single key so an empty result still returns 404 before the stream starts.
@@ -927,8 +950,7 @@ async def fetch_run_outputs(
         # and reads one object into memory at a time (bounded by the largest object).
         with tarfile.open(fileobj=writer, mode="w|") as tar:
             async for s3_key, data in download_many_from_s3(all_keys(), harness_config.aws, harness_config.s3_bucket):
-                relative_path: str = s3_key.removeprefix(benchmark_prefix)
-
+                relative_path = s3_key.removeprefix(benchmark_prefix)
                 tarinfo = tarfile.TarInfo(name=relative_path)
                 tarinfo.size = len(data)
                 tar.addfile(tarinfo, fileobj=io.BytesIO(data))

--- a/services/tracker/src/tracker/api/benchmark_services.py
+++ b/services/tracker/src/tracker/api/benchmark_services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -13,7 +14,6 @@ from tracker.config import BENCHMARK_CATALOG_URL
 from tracker.database.models import Org
 from tracker.types import (
     BenchmarkServiceCatalogResponse,
-    BenchmarkServiceEntry,
     BenchmarkServiceHealth,
     BenchmarkServicesRequest,
     BenchmarkServicesResponse,
@@ -22,6 +22,7 @@ from tracker.types import (
 CATALOG_REQUEST_TIMEOUT_SECONDS = 10.0
 HEALTH_CHECK_TIMEOUT_SECONDS = 1.0
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/benchmark-services")
 
 
@@ -39,8 +40,15 @@ async def _ping_service(client: httpx.AsyncClient, name: str, url: str) -> Bench
             latency_ms=latency_ms,
             error=None if resp.status_code == 200 else f"HTTP {resp.status_code}",
         )
-    except (httpx.TimeoutException, httpx.RequestError) as e:
-        return BenchmarkServiceHealth(name=name, url=url, healthy=False, latency_ms=None, error=str(e))
+    except (httpx.TimeoutException, httpx.RequestError) as exc:
+        logger.warning("Benchmark service health check failed for %s: %s", name, exc)
+        return BenchmarkServiceHealth(
+            name=name,
+            url=url,
+            healthy=False,
+            latency_ms=None,
+            error="Benchmark service request failed",
+        )
 
 
 @router.get("", response_model=BenchmarkServiceCatalogResponse)
@@ -59,20 +67,24 @@ async def catalog_benchmark_services(
     try:
         async with httpx.AsyncClient(timeout=CATALOG_REQUEST_TIMEOUT_SECONDS) as client:
             response = await client.get(f"{BENCHMARK_CATALOG_URL}/benchmark-services", headers=headers)
-    except httpx.HTTPError as e:
-        raise HTTPException(status_code=502, detail=f"Failed to list benchmark services: {e}") from e
+    except httpx.HTTPError as exc:
+        logger.warning("Benchmark catalog request failed: %s", exc)
+        raise HTTPException(status_code=502, detail="Failed to list benchmark services") from exc
 
     if response.status_code != 200:
-        try:
-            body = response.json()
-            detail = body.get("detail", response.text) if isinstance(body, dict) else response.text
-        except ValueError:
-            detail = response.text
-        raise HTTPException(status_code=response.status_code, detail=detail)
+        logger.warning("Benchmark catalog returned HTTP %s", response.status_code)
+        raise HTTPException(status_code=response.status_code, detail="Failed to list benchmark services")
 
-    return BenchmarkServiceCatalogResponse(
-        services=[BenchmarkServiceEntry.model_validate(service) for service in response.json().get("services", [])]
-    )
+    try:
+        payload: object = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Benchmark catalog response must be an object")
+        if "services" not in payload:
+            return BenchmarkServiceCatalogResponse(services=[])
+        return BenchmarkServiceCatalogResponse.model_validate(payload)
+    except ValueError as exc:
+        logger.warning("Benchmark catalog returned an invalid response", exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to list benchmark services") from exc
 
 
 @router.post("", response_model=BenchmarkServicesResponse)

--- a/services/tracker/src/tracker/auth.py
+++ b/services/tracker/src/tracker/auth.py
@@ -17,6 +17,7 @@ from tracker.config import AUTH_REQUIRED, DESCOPE_MANAGEMENT_KEY, DESCOPE_PROJEC
 from tracker.database.models import DEFAULT_ORG_NAME, Org
 from tracker.database.session import get_session
 from tracker.logging import get_logger
+from tracker.outbound_security import validate_service_headers
 
 logger = get_logger(__name__)
 
@@ -186,10 +187,12 @@ def resolve_descope_identity(api_key: str, *, include_user_profile: bool = False
         raise RuntimeError("Descope client not initialized — check DESCOPE_PROJECT_ID and AUTH_REQUIRED")
     try:
         jwt_response = _exchange_access_key(api_key, _descope_client)
-    except AuthException as e:
-        raise HTTPException(status_code=401, detail=f"Invalid API key: {e.error_message}") from e
-    except Exception as e:
-        raise HTTPException(status_code=503, detail="Auth service unavailable") from e
+    except AuthException as exc:
+        logger.warning("Descope API key validation failed: %s", exc.error_message)
+        raise HTTPException(status_code=401, detail="Invalid API key") from exc
+    except Exception as exc:
+        logger.exception("Descope API key validation failed")
+        raise HTTPException(status_code=503, detail="Auth service unavailable") from exc
 
     tenants = list(jwt_response.get("tenants", {}).keys())
     if len(tenants) != 1:
@@ -231,6 +234,10 @@ def forward_tracker_api_key(
     header is already reserved for Daytona sandbox credentials.
     """
     forwarded_headers = dict(service_headers or {})
+    try:
+        validate_service_headers(forwarded_headers)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail="Unsupported benchmark service header") from exc
     if not tracker_api_key:
         return forwarded_headers
 
@@ -258,8 +265,9 @@ def resolve_bearer_session(jwt: str, session: Session) -> Org:
 
     try:
         jwt_response = _descope_client.validate_session(jwt)
-    except AuthException as e:
-        raise HTTPException(status_code=401, detail=f"Invalid session: {e.error_message}") from e
+    except AuthException as exc:
+        logger.warning("Descope session validation failed: %s", exc.error_message)
+        raise HTTPException(status_code=401, detail="Invalid session") from exc
 
     tenants = list(jwt_response.get("tenants", {}).keys())
     if not tenants:

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -11,6 +11,7 @@ from taskiq_redis.redis_backend import RedisAsyncResultBackend
 from tracker.logging import configure_logging
 from tracker.middleware import LoggingContextMiddleware, TaskProtectionMiddleware, TracingContextMiddleware
 from tracker.observability import configure_observability
+from tracker.outbound_security import validate_benchmark_name
 
 load_dotenv()
 configure_logging()
@@ -29,6 +30,8 @@ def create_benchmark_service_url(benchmark_name: str) -> str:
     NOTE: If BENCHMARK_SERVICE_BASE_URL is set (e.g. benchmarks.vals.ai), use HTTPS subdomains.
     Otherwise fall back to CloudMap internal DNS (only works inside the VPC).
     """
+    benchmark_name = validate_benchmark_name(benchmark_name)
+
     if _BENCHMARK_SERVICE_BASE_URL:
         return f"https://{benchmark_name}.{_BENCHMARK_SERVICE_BASE_URL}"
 

--- a/services/tracker/src/tracker/outbound_security.py
+++ b/services/tracker/src/tracker/outbound_security.py
@@ -1,4 +1,9 @@
-"""Validation for caller-controlled benchmark-service destinations and headers."""
+"""Validation for caller-controlled benchmark-service destinations and headers.
+
+This module intentionally implements Tracker's reject-only policy before HTTP
+transport. Generic URL and header containers normalize or accept inputs forbidden
+here, which would change persisted/API values or defer failures until request time.
+"""
 
 from __future__ import annotations
 

--- a/services/tracker/src/tracker/outbound_security.py
+++ b/services/tracker/src/tracker/outbound_security.py
@@ -1,0 +1,68 @@
+"""Validation for caller-controlled benchmark-service destinations and headers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+import re
+from urllib.parse import urlsplit
+
+_BENCHMARK_NAME_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
+_HEADER_NAME_RE = re.compile(r"[-!#$%&'*+.^_`|~0-9A-Za-z]+")
+_HEADER_VALUE_RE = re.compile(r"(?:[\x21-\x7e]+(?:[ \t]+[\x21-\x7e]+)*)?")
+_FORBIDDEN_HEADER_NAMES = {
+    "connection",
+    "content-length",
+    "host",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "x-api-key",
+    "x-real-ip",
+}
+_FORBIDDEN_HEADER_PREFIXES = ("forwarded", "proxy-", "sec-websocket-", "x-forwarded-")
+
+
+def validate_benchmark_name(value: str) -> str:
+    """Require the DNS-label grammar used to derive hosted benchmark-service URLs."""
+    if not _BENCHMARK_NAME_RE.fullmatch(value):
+        raise ValueError("Invalid benchmark name")
+    return value
+
+
+def validate_service_headers(headers: Mapping[str, str]) -> None:
+    """Reject malformed headers and names that alter HTTP routing or protocol handling."""
+    for name, value in headers.items():
+        normalized = name.lower()
+        if (
+            not _HEADER_NAME_RE.fullmatch(name)
+            or not _HEADER_VALUE_RE.fullmatch(value)
+            or normalized in _FORBIDDEN_HEADER_NAMES
+            or normalized.startswith(_FORBIDDEN_HEADER_PREFIXES)
+        ):
+            raise ValueError("Unsupported benchmark service header")
+
+
+def validate_service_url_syntax(value: str) -> str:
+    """Validate and normalize a caller-provided benchmark-service base URL."""
+    if (
+        any(character.isspace() or ord(character) < 0x20 or ord(character) == 0x7F for character in value)
+        or "\\" in value
+    ):
+        raise ValueError("Invalid benchmark service URL")
+
+    parsed = urlsplit(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("Invalid benchmark service URL")
+    if parsed.username is not None or parsed.password is not None or parsed.query or parsed.fragment:
+        raise ValueError("Invalid benchmark service URL")
+
+    try:
+        parsed.port
+    except ValueError as exc:
+        raise ValueError("Invalid benchmark service URL") from exc
+
+    return value.rstrip("/")

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -19,6 +19,7 @@ from tracker.database.models import (
     FinalEvaluation,
     TaskStatus,
 )
+from tracker.outbound_security import validate_benchmark_name, validate_service_url_syntax
 
 
 def _serialize_utc(value: datetime | None) -> str | None:
@@ -74,6 +75,16 @@ class StartBenchmarkRequest(BaseModel):
     webhook_secret_name: str | None = None
     webhook_intervals: list[int] | None = None
 
+    @field_validator("benchmark_name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return validate_benchmark_name(value)
+
+    @field_validator("custom_benchmark_service")
+    @classmethod
+    def validate_custom_service(cls, value: str | None) -> str | None:
+        return validate_service_url_syntax(value) if value is not None else None
+
     @property
     def benchmark_service(self) -> BenchmarkServiceClient:
         from tracker.utils import create_benchmark_service_client
@@ -91,6 +102,16 @@ class FetchBenchmarkTasksRequest(BaseModel):
     dataset: str | None = None
     custom_benchmark_service: str | None = None
     service_headers: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("benchmark_name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        return validate_benchmark_name(value)
+
+    @field_validator("custom_benchmark_service")
+    @classmethod
+    def validate_custom_service(cls, value: str | None) -> str | None:
+        return validate_service_url_syntax(value) if value is not None else None
 
 
 class StartBenchmarkErrorResponse(BaseModel):
@@ -243,7 +264,7 @@ class BenchmarkServiceEntry(BaseModel):
     @field_validator("url")
     @classmethod
     def remove_trailing_slashes(cls, value: str) -> str:
-        return value.rstrip("/")
+        return validate_service_url_syntax(value)
 
 
 class BenchmarkServiceHealth(BaseModel):

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -19,6 +19,7 @@ from tracker.database.models import (
     Task,
 )
 from tracker.exceptions import TrackerServiceError
+from tracker.outbound_security import validate_service_headers, validate_service_url_syntax
 from tracker.types import (
     AWSCredentials,
     StartBenchmarkRequest,
@@ -39,9 +40,10 @@ def create_benchmark_service_client(
     service_headers: dict[str, str] | None = None,
 ) -> BenchmarkServiceClient:
     """Create a BenchmarkServiceClient with benchmark-service headers."""
-    headers: dict[str, str] = {}
-    if service_headers:
-        headers.update(service_headers)
+    url = validate_service_url_syntax(url)
+    headers = dict(service_headers or {})
+    validate_service_headers(headers)
+
     return BenchmarkServiceClient(url=url, headers=headers)
 
 

--- a/services/tracker/tests/unit/test_api_review_endpoints.py
+++ b/services/tracker/tests/unit/test_api_review_endpoints.py
@@ -1,9 +1,14 @@
+"""Tests for Tracker API review endpoints.
+
+Run: uv run pytest tests/unit/test_api_review_endpoints.py
+"""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 from uuid import uuid4
 
 import httpx
@@ -49,7 +54,7 @@ def test_benchmark_services_endpoint_fetches_catalog(monkeypatch: pytest.MonkeyP
         return original_client(transport=transport, timeout=timeout)
 
     monkeypatch.setattr(benchmark_services_api, "BENCHMARK_CATALOG_URL", "https://catalog.example")
-    monkeypatch.setattr(benchmark_services_api.httpx, "AsyncClient", build_client)
+    monkeypatch.setattr(httpx, "AsyncClient", build_client)
 
     response = client.get("/benchmark-services", headers={"X-Api-Key": "tenant-key"})
 
@@ -66,6 +71,119 @@ def test_benchmark_services_endpoint_fetches_catalog(monkeypatch: pytest.MonkeyP
             }
         ]
     }
+
+
+def test_benchmark_services_endpoint_defaults_missing_services_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preserve the empty catalog response when the services key is absent."""
+
+    async def handle_request(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={})
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.AsyncClient
+
+    def build_client(*, timeout: float) -> httpx.AsyncClient:
+        return original_client(transport=transport, timeout=timeout)
+
+    monkeypatch.setattr(benchmark_services_api, "BENCHMARK_CATALOG_URL", "https://catalog.example")
+    monkeypatch.setattr(httpx, "AsyncClient", build_client)
+
+    response = client.get("/benchmark-services", headers={"X-Api-Key": "tenant-key"})
+
+    assert response.status_code == 200
+    assert response.json() == {"services": []}
+
+
+def test_benchmark_services_endpoint_hides_catalog_error_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Verify downstream catalog failures retain only a stable public error.
+
+    Test cases:
+    - The downstream status remains available to the caller.
+    - The downstream response body is not reflected.
+    """
+    sensitive_detail = "sensitive-catalog-provider-detail"
+
+    async def handle_request(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"detail": sensitive_detail})
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.AsyncClient
+
+    def build_client(*, timeout: float) -> httpx.AsyncClient:
+        return original_client(transport=transport, timeout=timeout)
+
+    monkeypatch.setattr(benchmark_services_api, "BENCHMARK_CATALOG_URL", "https://catalog.example")
+    monkeypatch.setattr(httpx, "AsyncClient", build_client)
+
+    response = client.get("/benchmark-services", headers={"X-Api-Key": "tenant-key"})
+
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Failed to list benchmark services"}
+    assert sensitive_detail not in response.text
+
+
+def test_benchmark_services_endpoint_hides_catalog_transport_error_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Return a stable 502 without reflecting catalog transport exception text."""
+    sensitive_detail = "sensitive-catalog-transport-detail"
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(sensitive_detail, request=request)
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.AsyncClient
+
+    def build_client(*, timeout: float) -> httpx.AsyncClient:
+        return original_client(transport=transport, timeout=timeout)
+
+    monkeypatch.setattr(benchmark_services_api, "BENCHMARK_CATALOG_URL", "https://catalog.example")
+    monkeypatch.setattr(httpx, "AsyncClient", build_client)
+
+    response = client.get("/benchmark-services", headers={"X-Api-Key": "tenant-key"})
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "Failed to list benchmark services"}
+    assert sensitive_detail not in response.text
+
+
+@pytest.mark.parametrize(
+    "catalog_response",
+    [
+        pytest.param(httpx.Response(200, content=b"sensitive-not-json"), id="invalid-json"),
+        pytest.param(httpx.Response(200, json=[]), id="non-object-json"),
+        pytest.param(
+            httpx.Response(200, json={"services": [{"name": "swebench", "url": "not-a-url"}]}),
+            id="invalid-service-entry",
+        ),
+        pytest.param(httpx.Response(200, json={"services": None}), id="non-list-services"),
+    ],
+)
+def test_benchmark_services_endpoint_hides_malformed_catalog_response_detail(
+    monkeypatch: pytest.MonkeyPatch,
+    catalog_response: httpx.Response,
+) -> None:
+    """Return a stable 502 for malformed successful catalog responses."""
+
+    async def handle_request(_request: httpx.Request) -> httpx.Response:
+        return catalog_response
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.AsyncClient
+
+    def build_client(*, timeout: float) -> httpx.AsyncClient:
+        return original_client(transport=transport, timeout=timeout)
+
+    monkeypatch.setattr(benchmark_services_api, "BENCHMARK_CATALOG_URL", "https://catalog.example")
+    monkeypatch.setattr(httpx, "AsyncClient", build_client)
+
+    response = client.get("/benchmark-services", headers={"X-Api-Key": "tenant-key"})
+
+    assert response.status_code == 502
+    assert response.json() == {"detail": "Failed to list benchmark services"}
 
 
 def test_list_agents_uses_harness_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -142,11 +260,19 @@ async def test_ping_service_appends_health_path() -> None:
     assert result.error is None
 
 
-async def test_ping_service_reports_request_errors() -> None:
-    async def fake_get(url: str) -> httpx.Response:
-        raise httpx.ConnectError("boom", request=httpx.Request("GET", url))
+async def test_ping_service_hides_request_errors_and_logs_detail(monkeypatch: pytest.MonkeyPatch) -> None:
+    sensitive_detail = "sensitive-benchmark-service-transport-detail"
+    error = httpx.ConnectError(
+        sensitive_detail,
+        request=httpx.Request("GET", "http://benchmark-service/health"),
+    )
+
+    async def fake_get(_url: str) -> httpx.Response:
+        raise error
 
     fake_client = SimpleNamespace(get=fake_get)
+    warning = Mock()
+    monkeypatch.setattr(benchmark_services_api.logger, "warning", warning)
 
     result = await benchmark_services_api._ping_service(
         cast(httpx.AsyncClient, fake_client),
@@ -156,7 +282,48 @@ async def test_ping_service_reports_request_errors() -> None:
 
     assert result.healthy is False
     assert result.latency_ms is None
-    assert result.error == "boom"
+    assert result.error == "Benchmark service request failed"
+    warning.assert_called_once_with(
+        "Benchmark service health check failed for %s: %s",
+        "swebench",
+        error,
+    )
+
+
+def test_benchmark_services_endpoint_hides_health_transport_error_detail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sensitive_detail = "sensitive-benchmark-service-transport-detail"
+
+    async def handle_request(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(sensitive_detail, request=request)
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.AsyncClient
+
+    def build_client(*, timeout: float) -> httpx.AsyncClient:
+        return original_client(transport=transport, timeout=timeout)
+
+    monkeypatch.setattr(httpx, "AsyncClient", build_client)
+
+    response = client.post(
+        "/benchmark-services",
+        json={"services": [{"name": "swebench", "url": "http://swebench"}]},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "services": [
+            {
+                "name": "swebench",
+                "url": "http://swebench",
+                "healthy": False,
+                "latency_ms": None,
+                "error": "Benchmark service request failed",
+            }
+        ]
+    }
+    assert sensitive_detail not in response.text
 
 
 def test_benchmark_services_endpoint_reuses_ping_client(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -203,7 +370,7 @@ def test_benchmark_services_endpoint_uses_short_health_timeout(monkeypatch: pyte
     async def fake_ping(_client: httpx.AsyncClient, name: str, url: str):
         return {"name": name, "url": url, "healthy": True, "latency_ms": 1, "error": None}
 
-    monkeypatch.setattr(benchmark_services_api.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
     monkeypatch.setattr(benchmark_services_api, "_ping_service", AsyncMock(side_effect=fake_ping))
 
     response = client.post(

--- a/services/tracker/tests/unit/test_auth.py
+++ b/services/tracker/tests/unit/test_auth.py
@@ -1,7 +1,14 @@
+"""Tests for Tracker authentication and outbound header forwarding.
+
+Run: uv run pytest tests/unit/test_auth.py
+"""
+
 import pytest
+from fastapi import HTTPException
 from sqlmodel import Session, SQLModel, create_engine
 
 from tests.conftest import TEST_ORG_ID
+from tracker.auth import forward_tracker_api_key
 from tracker.database.models import DEFAULT_ORG_NAME, Org
 
 
@@ -35,11 +42,50 @@ def test_get_default_org_raises_if_missing(session: Session):
 
 
 def test_forward_tracker_api_key_preserves_explicit_override_case_insensitive():
-    from tracker.auth import forward_tracker_api_key
-
     original_headers = {"x-descope-api-key": "override-key"}
 
     headers = forward_tracker_api_key(original_headers, "tracker-api-key")
 
     assert headers == original_headers
     assert headers is not original_headers
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "Host",
+        "Connection",
+        "Upgrade",
+        "Transfer-Encoding",
+        "Forwarded",
+        "X-Forwarded-For",
+        "Sec-WebSocket-Key",
+        "X-Api-Key",
+    ],
+)
+def test_forward_tracker_api_key_rejects_protocol_and_routing_headers(header_name: str) -> None:
+    """Reject caller headers that can alter HTTP routing or protocol handling."""
+    with pytest.raises(HTTPException) as exc_info:
+        forward_tracker_api_key({header_name: "attacker-controlled"}, "tracker-api-key")
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Unsupported benchmark service header"
+
+
+@pytest.mark.parametrize(
+    ("header_name", "header_value"),
+    [
+        (":authority", "attacker.example"),
+        ("bad header", "attacker-controlled"),
+        ("Authorization", "Bearer token\r\nHost: attacker.example"),
+        ("Authorization", "Bearer token\x00suffix"),
+        ("Authorization", "non-ascii-é"),
+    ],
+)
+def test_forward_tracker_api_key_rejects_malformed_headers(header_name: str, header_value: str) -> None:
+    """Reject headers that the outbound HTTP transport cannot encode or send."""
+    with pytest.raises(HTTPException) as exc_info:
+        forward_tracker_api_key({header_name: header_value}, "tracker-api-key")
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Unsupported benchmark service header"

--- a/services/tracker/tests/unit/test_auth_descope.py
+++ b/services/tracker/tests/unit/test_auth_descope.py
@@ -1,3 +1,8 @@
+"""Tests for Tracker Descope authentication boundaries.
+
+Run: uv run pytest tests/unit/test_auth_descope.py
+"""
+
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -12,6 +17,7 @@ from tracker.auth import (
     find_org_by_tenant,
     get_current_org,
     get_current_starter,
+    resolve_bearer_session,
     resolve_descope_identity,
 )
 from tracker.database.models import DEFAULT_ORG_NAME, Org
@@ -88,7 +94,23 @@ def test_resolve_descope_identity_invalid_api_key_raises_401(mock_descope):
 
     with pytest.raises(HTTPException) as exc_info:
         resolve_descope_identity("bad-key")
+
     assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid API key"
+    assert "Invalid key" not in str(exc_info.value.detail)
+
+
+def test_resolve_bearer_session_invalid_token_raises_safe_401(mock_descope, session: Session) -> None:
+    mock_descope.validate_session.side_effect = AuthException(
+        status_code=401, error_message="Sensitive provider detail"
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_bearer_session("bad-session", session)
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Invalid session"
+    assert "Sensitive provider detail" not in str(exc_info.value.detail)
 
 
 def test_org_not_in_db_returns_none(mock_descope, session):
@@ -188,14 +210,18 @@ def test_resolve_descope_identity_retries_read_timeout(mock_descope):
     assert mock_descope.exchange_access_key.call_count == 2
 
 
-def test_resolve_descope_identity_returns_503_when_retries_exhausted(mock_descope):
+def test_resolve_descope_identity_returns_503_when_retries_exhausted(mock_descope) -> None:
     mock_descope.exchange_access_key.side_effect = ReadTimeout(
         "HTTPSConnectionPool(host='api.descope.com', port=443): Read timed out. (read timeout=60)"
     )
 
-    with pytest.raises(HTTPException) as exc_info:
-        resolve_descope_identity("some-key")
+    with patch("tracker.auth.logger.exception") as log_exception:
+        with pytest.raises(HTTPException) as exc_info:
+            resolve_descope_identity("some-key")
+
     assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Auth service unavailable"
+    log_exception.assert_called_once_with("Descope API key validation failed")
     assert mock_descope.exchange_access_key.call_count == 3
 
 

--- a/services/tracker/tests/unit/test_benchmark_utils.py
+++ b/services/tracker/tests/unit/test_benchmark_utils.py
@@ -264,7 +264,7 @@ class TestBenchmarkUtils:
         Test Cases:
             - Running benchmark retry with no error tasks is a no-op
             - Cannot resume a benchmark where all tasks have already finished
-            - Errors are raised and returned to the client
+            - Downstream errors return a stable generic client detail
             - Can recreate the same environment the benchmark was started in
             - Can force resume a task and validate the task ids passed in
         """
@@ -338,7 +338,7 @@ class TestBenchmarkUtils:
             json={"task_ids": ["task_5"]},
         )
         assert response.status_code == 500
-        assert "task_5" in response.json()["detail"]
+        assert response.json() == {"detail": "Benchmark service request failed"}
 
         # Assert all tasks but 0 are in finished state
         task_rows = database_session.exec(

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -1,3 +1,8 @@
+"""Tests for Tracker FastAPI route behavior.
+
+Run: uv run pytest tests/unit/test_fastapi_server.py
+"""
+
 from collections.abc import AsyncIterator
 import io
 import logging
@@ -9,15 +14,20 @@ from uuid import UUID, uuid4
 
 import httpx
 import pytest
-from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceUnauthenticatedError
+from benchmark_service.client import (
+    BenchmarkServiceClient,
+    BenchmarkServiceError,
+    BenchmarkServiceUnauthenticatedError,
+)
 from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
 from dateutil.parser import isoparse
 from descope import DescopeClient
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 from sqlmodel import Session, select
 
-from main import app
+from main import app, tracker_service_error_handler
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity, get_current_starter
 from tracker.database.models import (
@@ -32,6 +42,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
+from tracker.exceptions import TrackerServiceError
 from tracker.types import (
     AWSCredentials,
     BenchmarkTableRow,
@@ -65,6 +76,73 @@ class TestFastapiServer:
         assert response.status_code == 200
 
         assert response.json() == {"status": "ok"}
+
+    def test_trailing_slash_does_not_redirect(self, monkeypatch: MonkeyPatch) -> None:
+        """
+        Verify non-canonical route paths cannot construct redirects from forwarded request data.
+
+        Test cases:
+        - The canonical health path remains available.
+        - The trailing-slash variant returns not found without a Location header.
+        """
+        monkeypatch.setattr("main.check_database_connection", lambda: True)
+
+        canonical_response = client.get("/health")
+        slash_response = client.get(
+            "/health/",
+            headers={"Host": "example.invalid", "X-Forwarded-Proto": "https"},
+            follow_redirects=False,
+        )
+
+        assert canonical_response.status_code == 200
+        assert slash_response.status_code == 404
+        assert "location" not in slash_response.headers
+
+    async def test_tracker_service_error_hides_internal_detail(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """
+        Verify internal Tracker errors retain diagnostics only in server logs.
+
+        Test cases:
+        - The client receives a stable generic detail.
+        - The full exception remains available to operators in logs.
+        """
+        sensitive_detail = "sensitive-internal-tracker-detail"
+        monkeypatch.setattr("sentry_sdk.capture_exception", lambda _exc: None)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await tracker_service_error_handler(MagicMock(), TrackerServiceError(sensitive_detail))
+
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.detail == "Tracker service operation failed"
+        assert sensitive_detail in caplog.text
+
+    async def test_fetch_benchmark_tasks_hides_downstream_error(self, monkeypatch: MonkeyPatch) -> None:
+        """
+        Verify downstream benchmark-service diagnostics are not reflected to callers.
+
+        Test cases:
+        - The endpoint retains its gateway-error status.
+        - The downstream sentinel is absent from the stable response detail.
+        """
+        sensitive_detail = "sensitive-downstream-provider-detail"
+
+        async def _raise_downstream_error(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            raise BenchmarkServiceError(sensitive_detail)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _raise_downstream_error)
+
+        response = client.post(
+            "/fetch-benchmark-tasks",
+            json={"benchmark_name": "swebench", "dataset": "verified"},
+        )
+
+        assert response.status_code == 502
+        assert response.json() == {"detail": "Failed to fetch task ids from benchmark service"}
+        assert sensitive_detail not in response.text
 
     async def test_fetch_benchmark_tasks(
         self,
@@ -607,9 +685,10 @@ class TestFastapiServer:
 
         response = client.post("/start-benchmark", json=request.model_dump())
 
-        # Test case 1. Verify failure returns 502 with the error message
+        # Test case 1. Verify failure returns a stable 502 without internal detail
         assert response.status_code == 502
-        assert "Error verifying task ids" in response.json()["detail"]
+        assert response.json() == {"detail": "Failed to verify task ids"}
+        assert "Error verifying task ids" not in response.text
 
         # Test case 2. No benchmark row is created when pre-flight checks fail
         row_count_after = len(database_session.exec(select(Benchmark)).all())
@@ -1145,6 +1224,63 @@ class TestFastapiServer:
             assert task_file is not None
             assert task_file.read() == b"output contents"
 
+    async def test_fetch_run_outputs_omits_unsafe_tar_members(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        """Never copy unsafe S3 key suffixes into a downloaded tar."""
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        async def _mock_list_s3_objects(prefix: str, *_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            yield f"{prefix}task/../../outside.txt"
+            yield f"{prefix}task/..\\outside.txt"
+            yield f"{prefix}C:/outside.txt"
+            yield f"{prefix}task//outside.txt"
+            yield f"{prefix}task/hidden\x00.txt"
+            yield f"{prefix}task/output.txt"
+
+        async def _mock_download_many_from_s3(
+            keys: AsyncIterator[str], *_args: Any, **_kwargs: Any
+        ) -> AsyncIterator[tuple[str, bytes]]:
+            async for key in keys:
+                yield key, b"output contents"
+
+        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
+        monkeypatch.setattr("main.download_many_from_s3", _mock_download_many_from_s3)
+
+        response = client.get(f"/fetch-run-outputs/{example_benchmark_object.id}")
+
+        assert response.status_code == 200
+        with tarfile.open(fileobj=io.BytesIO(response.content), mode="r:") as tar:
+            assert tar.getnames() == ["task/output.txt"]
+
+    async def test_fetch_run_outputs_returns_404_when_all_members_are_unsafe(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        """Do not download outputs when every listed tar member name is unsafe."""
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        async def _mock_list_s3_objects(prefix: str, *_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            yield f"{prefix}task/../../outside.txt"
+            yield f"{prefix}task/hidden\x00.txt"
+
+        download_many_from_s3 = MagicMock()
+        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
+        monkeypatch.setattr("main.download_many_from_s3", download_many_from_s3)
+
+        response = client.get(f"/fetch-run-outputs/{example_benchmark_object.id}")
+
+        assert response.status_code == 404
+        assert response.json() == {"detail": f"No outputs found for run '{example_benchmark_object.id}'"}
+        download_many_from_s3.assert_not_called()
+
     async def test_fetch_run_outputs_returns_404_when_empty(
         self,
         monkeypatch: MonkeyPatch,
@@ -1201,6 +1337,8 @@ class TestFastapiServer:
 
         response = no_raise_client.post("/start-benchmark", json=request.model_dump())
         assert response.status_code == 502
+        assert response.json() == {"detail": "Benchmark service authentication failed"}
+        assert "401 Unauthorized" not in response.text
 
         # Case 2: /fetch-benchmark-tasks
         response = no_raise_client.post(
@@ -1208,6 +1346,8 @@ class TestFastapiServer:
             json={"benchmark_name": "swebench"},
         )
         assert response.status_code == 502
+        assert response.json() == {"detail": "Failed to fetch task ids from benchmark service"}
+        assert "401 Unauthorized" not in response.text
 
         # Case 3: /retry-or-resume-benchmark — needs at least one task so verify_task_ids is reached
         benchmark = Benchmark(
@@ -1229,6 +1369,8 @@ class TestFastapiServer:
             params={"retry": "true"},
         )
         assert response.status_code == 502
+        assert response.json() == {"detail": "Benchmark service authentication failed"}
+        assert "401 Unauthorized" not in response.text
 
         # None of the three cases should have reached Sentry
         assert captured == []

--- a/services/tracker/tests/unit/test_outbound_security.py
+++ b/services/tracker/tests/unit/test_outbound_security.py
@@ -1,0 +1,131 @@
+"""Tests for Tracker outbound benchmark-service trust boundaries.
+
+Run: uv run pytest tests/unit/test_outbound_security.py
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from tracker.config import create_benchmark_service_url
+from tracker.database.models import AgentContractRequest
+from tracker.types import (
+    AWSCredentials,
+    BenchmarkServiceEntry,
+    FetchBenchmarkTasksRequest,
+    HarnessConfig,
+    StartBenchmarkRequest,
+)
+from tracker.utils.resources import create_benchmark_service_client
+
+_ASCII_CONTROL_URLS = [
+    pytest.param(
+        f"http://service.example/{chr(codepoint)}path",
+        id=f"control-u{codepoint:04x}",
+    )
+    for codepoint in (*range(0x20), 0x7F)
+]
+
+
+def _start_benchmark_request(**overrides: object) -> StartBenchmarkRequest:
+    values: dict[str, object] = {
+        "contract": AgentContractRequest(name="agent"),
+        "benchmark_name": "swebench",
+        "harness_config": HarnessConfig(
+            aws=AWSCredentials(
+                aws_access_key_id="test-access-key",
+                aws_secret_access_key="test-secret-key",
+                aws_default_region="us-east-1",
+            ),
+            s3_bucket="test-bucket",
+            log_group="test-log-group",
+            log_retention_policy=1,
+            sandbox_provider_secret_name="test-provider-secret",
+        ),
+    }
+    values.update(overrides)
+    return StartBenchmarkRequest.model_validate(values)
+
+
+@pytest.mark.parametrize(
+    "benchmark_name",
+    [
+        "127.0.0.1/",
+        "service/path",
+        "service#fragment",
+        "service@example.invalid",
+        "../service",
+        "-service",
+        "service-",
+        "service..other",
+    ],
+)
+def test_benchmark_name_rejects_url_parser_control(benchmark_name: str) -> None:
+    """Reject names that can alter the derived benchmark-service destination."""
+    with pytest.raises(ValueError, match="Invalid benchmark name"):
+        create_benchmark_service_url(benchmark_name)
+
+    with pytest.raises(ValidationError):
+        FetchBenchmarkTasksRequest(benchmark_name=benchmark_name)
+
+    with pytest.raises(ValidationError):
+        _start_benchmark_request(benchmark_name=benchmark_name)
+
+
+def test_benchmark_name_preserves_supported_dns_label() -> None:
+    """Keep a normal hosted benchmark name unchanged in the derived URL."""
+    assert create_benchmark_service_url("swebench") == "http://swebench.local:8001"
+    assert FetchBenchmarkTasksRequest(benchmark_name="swebench").benchmark_name == "swebench"
+    assert _start_benchmark_request().benchmark_name == "swebench"
+
+
+@pytest.mark.parametrize(
+    "service_url",
+    [
+        "ftp://service.example",
+        "http://user:password@service.example",
+        "http://service.example?target=other",
+        "http://service.example#fragment",
+        "http://service.example\\@other.example",
+        "http://service.example/ bad",
+        "http://serv\x00ice.example",
+        "http://serv\x7fice.example",
+        *_ASCII_CONTROL_URLS,
+    ],
+)
+def test_custom_service_url_rejects_parser_and_credential_controls(service_url: str) -> None:
+    """Reject custom service URLs whose syntax can obscure routing or credentials."""
+    with pytest.raises(ValidationError):
+        FetchBenchmarkTasksRequest(benchmark_name="swebench", custom_benchmark_service=service_url)
+
+    with pytest.raises(ValidationError):
+        _start_benchmark_request(custom_benchmark_service=service_url)
+
+    with pytest.raises(ValidationError):
+        BenchmarkServiceEntry(name="swebench", url=service_url)
+
+
+@pytest.mark.parametrize("service_url", _ASCII_CONTROL_URLS)
+def test_client_factory_rejects_url_controls(service_url: str) -> None:
+    """Reject URL controls when constructing a client outside request-model validation."""
+    with pytest.raises(ValueError, match="Invalid benchmark service URL"):
+        create_benchmark_service_client(service_url)
+
+
+def test_custom_service_url_preserves_intentional_internal_http_service() -> None:
+    """Preserve the documented custom/internal benchmark-service capability."""
+    request = FetchBenchmarkTasksRequest(
+        benchmark_name="swebench",
+        custom_benchmark_service="http://internal-swebench.example.com:8001/",
+    )
+
+    start_request = _start_benchmark_request(
+        custom_benchmark_service="http://internal-swebench.example.com:8001/",
+    )
+    service_entry = BenchmarkServiceEntry(
+        name="swebench",
+        url="http://internal-swebench.example.com:8001/",
+    )
+
+    assert request.custom_benchmark_service == "http://internal-swebench.example.com:8001"
+    assert start_request.custom_benchmark_service == "http://internal-swebench.example.com:8001"
+    assert service_entry.url == "http://internal-swebench.example.com:8001"


### PR DESCRIPTION
## Summary

Hardens Tracker's externally reachable and outbound-request boundaries based on a full security review. The change rejects parser/routing ambiguity before transport, prevents internal exception details from reaching API clients, and makes streamed result archives safe to construct from S3 keys.

## Changes

- Added a centralized, reject-only outbound policy for:
  - benchmark names used to derive service hosts;
  - caller-provided benchmark-service URLs;
  - custom service headers that could alter routing, framing, forwarding, or protocol behavior.
- Preserved intentional internal/custom HTTP(S) benchmark-service support while rejecting credentials, queries, fragments, malformed ports, backslashes, whitespace, ASCII controls, and DEL.
- Replaced Tracker, Descope, catalog, and benchmark-service exception text with stable public errors while retaining diagnostic server logs.
- Disabled implicit slash redirects so non-canonical paths return `404` without constructing Host- or scheme-derived `Location` headers.
- Filtered unsafe S3 keys before constructing streamed run-output archives, including traversal components, backslashes, empty segments, drive prefixes, and NUL bytes.

## Security findings fixed

These are internal security-review IDs, not published CVEs.

- `VULN-000042` — restricted benchmark names to the DNS-label grammar before deriving service URLs, rejecting malformed labels and parser-control payloads.
- `VULN-000045` — rejected malformed, routing-sensitive, hop-by-hop, proxy/forwarding, WebSocket-upgrade, and reserved authentication headers before transport.
- `VULN-000046` — disabled implicit slash redirects that could construct scheme- or Host-derived `Location` headers from request metadata.
- `VULN-000054` — replaced internal Tracker, Descope, catalog, and benchmark-service exception details with stable public errors while retaining server-side diagnostics.
- `VULN-000066` — rejected slash and fragment payload variants through the same benchmark-name validation source of truth.
- `VULN-000067` — stopped `/fetch-benchmark-tasks` and related benchmark-service authentication/error paths from reflecting downstream exception strings.
- Additional unnumbered finding — rejected traversal-capable or ambiguous S3 keys before using their suffixes as streamed tar member names.

## Reviewer guidance

- Start with `services/tracker/src/tracker/outbound_security.py`, then its bindings in `types.py`, `config.py`, `auth.py`, and `utils/resources.py`.
- The explicit outbound policy is intentional: installed HTTPX and Pydantic URL/header containers normalize or accept values that Tracker must reject, and would change persisted/API string representations or fail only at transport time.
- Error-redaction paths are concentrated in `main.py`, `auth.py`, and `api/benchmark_services.py`.

## Related Issues

- No public CVE identifiers or linked GitHub issues; the internal findings are listed above.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] Manually tested
- `uv run pytest tests/unit -q`: `334 passed`; one upstream Starlette TestClient deprecation warning.
- Ruff format/lint passed for the changed security files.
- Scoped basedpyright and targeted LSP diagnostics passed with zero findings.
- Container smoke test returned `200` for `/health` and `404` without `Location` for `/health/`.
- Whole-repository basedpyright was not completed because its Node process exhausted both 4 GB and 8 GB heaps; changed `main.py` and `auth.py` retain pre-existing diagnostics.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/547" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
