### PR TITLE
Add task-scoped model gateway capabilities and secure resume cleanup

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -175,7 +175,7 @@ benchmarks/run_id/task_0/artifacts/result.json
 
 ### `egress_allowlist: list`
 
-URLs the agent may reach while `run_cmd` is running. Use this to allow model provider requests while denying other outbound requests from the agent sandbox; the sandbox provider resolves each host into its network rules at run time.
+URLs the agent may reach while `run_cmd` is running. Use this to allow model provider requests while denying other outbound requests from the agent sandbox; the sandbox provider resolves each host into its network rules at run time. Dependency installation runs before these rules are applied and retains unrestricted egress.
 
 These rules only apply while the agent command runs. They help keep evaluations clean, but they are not a hard block against data leaks: egress is restored after `run_cmd`, root agents can change sandbox host files, and CDN hosts can share allowed edge IPs with other services.
 
@@ -189,7 +189,9 @@ Omit this field, or set it to an empty list, to keep unrestricted sandbox egress
 
 ### `secrets: dict`
 
-Secrets required by the agent. Maps environment variable names to AWS Secrets Manager secret names. These are resolved at sandbox creation time - raw values are never stored.
+Secrets required by the agent. Maps environment variable names to AWS Secrets Manager secret names. Values are resolved immediately before agent installation and are passed only to the `install_cmd` and `run_cmd` processes; they are not added to the persistent sandbox environment. Valkyrie clears the resolved values from its task frame after the agent command finishes.
+
+This process scope limits accidental persistence; it is not a containment boundary for arbitrary privileged agent code. A root agent can copy, transform, or move a secret into another process or file. Use short-lived, task-scoped credentials for untrusted agents, revoke them when `run_cmd` ends, and rely on sandbox deletion as the final boundary.
 
 ```yaml
 secrets:

--- a/infra/README.md
+++ b/infra/README.md
@@ -12,6 +12,7 @@ AWS CDK infrastructure for the Agentic Harness benchmark platform.
 - AWS CLI configured with appropriate credentials
 - Python 3.12+
 - [uv](https://github.com/astral-sh/uv) package manager
+- The matching model-proxy stage stack, which exports its capability admin secret ARN. Worker deployment fails closed when that export is missing.
 
 ## Setup
 

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -27,6 +27,8 @@ class DatabaseConfig:
 @dataclass(frozen=True)
 class StageConfig:
     runtime_environment: str
+    model_gateway_url: str
+    model_gateway_admin_secret_export: str
     tracker: ServiceConfig
     worker: ServiceConfig
     database: DatabaseConfig
@@ -35,6 +37,8 @@ class StageConfig:
 
 PROD_CONFIG = StageConfig(
     runtime_environment="production",
+    model_gateway_url="https://model-gateway.vals.ai",
+    model_gateway_admin_secret_export="ProdGateway-ProdGatewayService:CapabilityAdminKeySecretArn",
     tracker=ServiceConfig(cpu=1024, memory_mib=2048, min_tasks=1, max_tasks=2),
     worker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=2, max_tasks=4),
     database=DatabaseConfig(
@@ -48,6 +52,8 @@ PROD_CONFIG = StageConfig(
 
 DEV_CONFIG = StageConfig(
     runtime_environment="dev",
+    model_gateway_url="https://dev.model-gateway.vals.ai",
+    model_gateway_admin_secret_export="DevGateway-DevGatewayService:CapabilityAdminKeySecretArn",
     tracker=ServiceConfig(cpu=1024, memory_mib=2048, min_tasks=1, max_tasks=1),
     worker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=1, max_tasks=2),
     database=DatabaseConfig(

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -341,6 +341,80 @@ class MonitoringStackTest(unittest.TestCase):
                     },
                 )
 
+    def test_model_gateway_admin_secret_is_worker_only(self) -> None:
+        for stage_name, gateway_url, secret_export in (
+            (
+                PROD,
+                "https://model-gateway.vals.ai",
+                "ProdGateway-ProdGatewayService:CapabilityAdminKeySecretArn",
+            ),
+            (
+                DEV,
+                "https://dev.model-gateway.vals.ai",
+                "DevGateway-DevGatewayService:CapabilityAdminKeySecretArn",
+            ),
+        ):
+            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, {}, clear=True):
+                tracker_template, worker_template = _service_templates(stage_name)
+
+                worker_template.has_resource_properties(
+                    "AWS::ECS::TaskDefinition",
+                    {
+                        "ContainerDefinitions": assertions.Match.array_with(
+                            [
+                                assertions.Match.object_like(
+                                    {
+                                        "Name": "WorkerContainer",
+                                        "Environment": assertions.Match.array_with(
+                                            [{"Name": "MODEL_GATEWAY_URL", "Value": gateway_url}]
+                                        ),
+                                        "Secrets": assertions.Match.array_with(
+                                            [
+                                                {
+                                                    "Name": "MODEL_GATEWAY_ADMIN_API_KEY",
+                                                    "ValueFrom": {"Fn::ImportValue": secret_export},
+                                                }
+                                            ]
+                                        ),
+                                    }
+                                )
+                            ]
+                        )
+                    },
+                )
+                worker_template.has_resource_properties(
+                    "AWS::IAM::Policy",
+                    {
+                        "PolicyDocument": assertions.Match.object_like(
+                            {
+                                "Statement": assertions.Match.array_with(
+                                    [
+                                        assertions.Match.object_like(
+                                            {
+                                                "Action": assertions.Match.array_with(
+                                                    ["secretsmanager:GetSecretValue"]
+                                                ),
+                                                "Effect": "Allow",
+                                                "Resource": {"Fn::ImportValue": secret_export},
+                                            }
+                                        )
+                                    ]
+                                )
+                            }
+                        )
+                    },
+                )
+
+                tracker_task = next(iter(tracker_template.find_resources("AWS::ECS::TaskDefinition").values()))
+                tracker_names = {
+                    item["Name"]
+                    for container in tracker_task["Properties"]["ContainerDefinitions"]
+                    for field in ("Environment", "Secrets")
+                    for item in container.get(field, [])
+                }
+                self.assertNotIn("MODEL_GATEWAY_URL", tracker_names)
+                self.assertNotIn("MODEL_GATEWAY_ADMIN_API_KEY", tracker_names)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -103,6 +103,12 @@ class WorkerStack(Stack):
             "SENTRY_DSN": aws_ecs.Secret.from_secrets_manager(sentry_secret),
         }
 
+        model_gateway_admin_secret = aws_secretsmanager.Secret.from_secret_complete_arn(
+            self,
+            "ModelGatewayAdminSecret",
+            cdk.Fn.import_value(stage_config.model_gateway_admin_secret_export),
+        )
+
         # ── Worker service ────────────────────────────────────────────────
 
         worker_task_def = aws_ecs.FargateTaskDefinition(
@@ -130,11 +136,13 @@ class WorkerStack(Stack):
                 **shared_env,
                 **db_env,
                 "REDIS_URL": redis_url,
+                "MODEL_GATEWAY_URL": stage_config.model_gateway_url,
                 "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
             },
             secrets={
                 **db_secrets,
                 **sentry_secrets,
+                "MODEL_GATEWAY_ADMIN_API_KEY": aws_ecs.Secret.from_secrets_manager(model_gateway_admin_secret),
             },
             command=[
                 "uv",

--- a/packages/valkyrie-sdk/pyproject.toml
+++ b/packages/valkyrie-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "valkyrie-sdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Async Python SDK for managing Valkyrie benchmark runs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/models/agents.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/models/agents.py
@@ -1,8 +1,17 @@
 """Agent contract models used by SDK run requests."""
 
 from pathlib import PurePosixPath
+from typing import Literal, cast
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    FiniteFloat,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 MAX_OUTPUT_ARTIFACT_COUNT = 10
 
@@ -43,6 +52,53 @@ class OutputArtifact(BaseModel):
 OutputArtifactSpec = str | OutputArtifact
 
 
+ModelGatewayConfigValue = bool | float | int | str
+
+
+class ModelGatewayPolicyConfig(BaseModel):
+    """Closed model settings allowed in a task-scoped gateway capability."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    client_scope: Literal["shared"]
+    max_tokens: int | None = Field(default=None, gt=0)
+    temperature: FiniteFloat | None = None
+    top_p: FiniteFloat | None = None
+    top_k: int | None = Field(default=None, gt=0)
+    reasoning: bool | None = None
+    reasoning_effort: str | bool | None = None
+    compute_effort: str | int | None = None
+
+    @model_serializer(mode="plain")
+    def serialize_config(self) -> dict[str, ModelGatewayConfigValue]:
+        """Preserve only the immutable settings authored in the contract row."""
+        return {
+            name: cast(ModelGatewayConfigValue, getattr(self, name))
+            for name in type(self).model_fields
+            if name in self.model_fields_set and getattr(self, name) is not None
+        }
+
+
+class ModelGatewayTaskCapabilityPolicy(BaseModel):
+    """One selected model policy carried on a resolved agent contract."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    kind: Literal["task_capability"]
+    model: str
+    config: ModelGatewayPolicyConfig
+    max_queries: int = Field(ge=1, le=2000)
+    max_sessions: int = Field(ge=1, le=16)
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        """Require the exact non-blank registry key selected by the contract."""
+        if not value or value != value.strip():
+            raise ValueError("model must be a non-blank exact model key")
+        return value
+
+
 class AgentContractRequest(BaseModel):
     """Agent definition submitted when starting a run."""
 
@@ -55,6 +111,7 @@ class AgentContractRequest(BaseModel):
     egress_allowlist: list[str] = Field(default_factory=list)
     secrets: dict[str, str] = Field(default_factory=dict)
     kwargs: dict[str, str] = Field(default_factory=dict)
+    model_gateway_policy: ModelGatewayTaskCapabilityPolicy | None = None
 
     @field_validator("output_artifacts")
     @classmethod
@@ -75,3 +132,10 @@ class AgentContractRequest(BaseModel):
                 str(path) if isinstance(artifact, str) else artifact.model_copy(update={"path": str(path)})
             )
         return normalized_artifacts
+
+    @model_validator(mode="after")
+    def validate_model_gateway_policy(self) -> "AgentContractRequest":
+        """Bind the selected capability policy to the request's exact model."""
+        if self.model_gateway_policy is not None and self.model_gateway_policy.model != self.model:
+            raise ValueError("model_gateway_policy.model must exactly match contract.model")
+        return self

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]==2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service>=0.11.0",
+    "create-benchmark-service>=0.15.0",
     "aioboto3>=7.0.0",
 ]
 
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.13.1" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.15.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/agent/contract.py
+++ b/services/tracker/src/tracker/agent/contract.py
@@ -22,7 +22,7 @@ def read_agent_name(agent_dir: Path) -> str:
             if not isinstance(data, dict):
                 raise BundlerError(f"Invalid contract file '{contract_file}': expected a mapping")
             try:
-                return AgentContract(**data).name
+                return AgentContract.model_validate(data).name
             except PydanticValidationError as e:
                 raise BundlerError(f"Invalid contract file '{contract_file}': {e}") from e
 
@@ -70,6 +70,7 @@ def _parse_yaml_contract(contract_path: Path, agent_config: AgentConfig) -> Agen
             user_values["model"] = agent_config.model
 
         validated_kwargs = agent_contract.validate_kwargs(all_schema, user_values)
+        model_gateway_policy = agent_contract.select_model_gateway_policy(agent_config.model)
 
         return AgentContractRequest(
             name=agent_contract.name,
@@ -80,6 +81,7 @@ def _parse_yaml_contract(contract_path: Path, agent_config: AgentConfig) -> Agen
             output_artifacts=agent_contract.output_artifacts,
             egress_allowlist=agent_contract.egress_allowlist,
             secrets=agent_contract.secrets,
+            model_gateway_policy=model_gateway_policy,
         )
     except ContractValidationError:
         raise

--- a/services/tracker/src/tracker/agent/schemas.py
+++ b/services/tracker/src/tracker/agent/schemas.py
@@ -5,9 +5,14 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Literal
 
-from pydantic import BaseModel, ValidationError, create_model, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, create_model, field_validator
 
-from tracker.database.models import OutputArtifact, OutputArtifactSpec
+from tracker.database.models import (
+    ModelGatewayPolicyConfig,
+    ModelGatewayTaskCapabilityPolicy,
+    OutputArtifact,
+    OutputArtifactSpec,
+)
 from tracker.exceptions import ContractValidationError
 
 
@@ -52,6 +57,14 @@ class Parameter(BaseModel):
     description: str | None = None
 
 
+class ModelGatewayPolicyRow(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    config: ModelGatewayPolicyConfig
+    max_queries: int = Field(ge=1, le=2000)
+    max_sessions: int = Field(ge=1, le=16)
+
+
 class AgentContract(BaseModel):
     """Declarative YAML agent contract."""
 
@@ -64,6 +77,7 @@ class AgentContract(BaseModel):
     ingest_lambda: str | None = None
     defaults: dict[str, Parameter] = {}
     kwargs: dict[str, Parameter] = {}
+    model_gateway_policies: dict[str, ModelGatewayPolicyRow] = {}
     run_cmd: str
 
     @field_validator("name")
@@ -88,6 +102,23 @@ class AgentContract(BaseModel):
             reference = reference.replace(f"{{{name}}}", str(value))
 
         return reference
+
+    def select_model_gateway_policy(self, model: str | None) -> ModelGatewayTaskCapabilityPolicy | None:
+        if not self.model_gateway_policies:
+            return None
+        if model is None:
+            raise ValueError("agent_config.model is required by model_gateway_policies")
+        try:
+            policy = self.model_gateway_policies[model]
+        except KeyError as e:
+            raise ValueError(f"model_gateway_policies has no policy for exact model {model!r}") from e
+        return ModelGatewayTaskCapabilityPolicy(
+            kind="task_capability",
+            model=model,
+            config=policy.config,
+            max_queries=policy.max_queries,
+            max_sessions=policy.max_sessions,
+        )
 
     def validate_kwargs(self, schema: dict[str, Parameter], values: dict[str, Any]) -> dict[str, Any]:
         if not schema:

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,11 +1,20 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field as PydanticField,
+    FiniteFloat,
+    field_serializer,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 from sqlalchemy import Connection, Dialect, Index, event, text
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -120,6 +129,47 @@ class OutputArtifact(BaseModel):
 OutputArtifactSpec = str | OutputArtifact
 
 
+ModelGatewayConfigValue = bool | float | int | str
+
+
+class ModelGatewayPolicyConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    client_scope: Literal["shared"]
+    max_tokens: int | None = PydanticField(default=None, gt=0)
+    temperature: FiniteFloat | None = None
+    top_p: FiniteFloat | None = None
+    top_k: int | None = PydanticField(default=None, gt=0)
+    reasoning: bool | None = None
+    reasoning_effort: str | bool | None = None
+    compute_effort: str | int | None = None
+
+    @model_serializer(mode="plain")
+    def serialize_config(self) -> dict[str, ModelGatewayConfigValue]:
+        return {
+            name: cast(ModelGatewayConfigValue, getattr(self, name))
+            for name in type(self).model_fields
+            if name in self.model_fields_set and getattr(self, name) is not None
+        }
+
+
+class ModelGatewayTaskCapabilityPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    kind: Literal["task_capability"]
+    model: str
+    config: ModelGatewayPolicyConfig
+    max_queries: int = PydanticField(ge=1, le=2000)
+    max_sessions: int = PydanticField(ge=1, le=16)
+
+    @field_validator("model")
+    @classmethod
+    def validate_model(cls, value: str) -> str:
+        if not value or value != value.strip():
+            raise ValueError("model must be a non-blank exact model key")
+        return value
+
+
 class AgentContractRequest(BaseModel):
     name: str
     model: str | None = None
@@ -130,6 +180,7 @@ class AgentContractRequest(BaseModel):
     egress_allowlist: list[str] = []
     secrets: dict[str, str] = {}
     kwargs: dict[str, str] = {}
+    model_gateway_policy: ModelGatewayTaskCapabilityPolicy | None = None
 
     @field_validator("output_artifacts")
     @classmethod
@@ -151,6 +202,12 @@ class AgentContractRequest(BaseModel):
                 normalized_artifacts.append(artifact.model_copy(update={"path": str(path)}))
 
         return normalized_artifacts
+
+    @model_validator(mode="after")
+    def validate_model_gateway_policy(self) -> "AgentContractRequest":
+        if self.model_gateway_policy is not None and self.model_gateway_policy.model != self.model:
+            raise ValueError("model_gateway_policy.model must exactly match contract.model")
+        return self
 
 
 class BenchmarkArguments(BaseModel):

--- a/services/tracker/src/tracker/model_gateway.py
+++ b/services/tracker/src/tracker/model_gateway.py
@@ -1,0 +1,250 @@
+"""Administrative client for task-scoped model gateway capabilities."""
+
+import asyncio
+import math
+import os
+from collections.abc import Awaitable, Callable
+from decimal import Decimal
+from typing import Any, Literal
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from tracker.exceptions import TrackerServiceError
+
+
+CAPABILITY_FINALIZATION_GRACE_SECONDS = 5 * 60
+MAX_CAPABILITY_LIFETIME_SECONDS = 24 * 60 * 60
+CAPABILITY_DRAIN_TIMEOUT_SECONDS = 60.0
+CAPABILITY_ACTION_TIMEOUT_SECONDS = 140.0
+CAPABILITY_ACTION_MAX_ATTEMPTS = 2
+CAPABILITY_ACTION_RETRY_SECONDS = 1.0
+
+assert 2 * CAPABILITY_ACTION_TIMEOUT_SECONDS < CAPABILITY_FINALIZATION_GRACE_SECONDS
+
+
+class ModelGatewayError(TrackerServiceError):
+    """A task capability could not be safely created or finalized."""
+
+
+class CapabilityMintRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    run_id: str
+    task_id: str
+    model: str
+    config: dict[str, bool | float | int | str]
+    sandbox_id: str
+    identity: dict[str, object]
+    expires_at: int
+    max_queries: int = Field(ge=1, le=2000)
+    max_sessions: int = Field(ge=1, le=16)
+
+
+class CapabilityMintResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    capability_id: str
+    token: str = Field(repr=False)
+    state: Literal["active"]
+    expires_at: int
+
+    @field_validator("capability_id")
+    @classmethod
+    def validate_capability_id(cls, value: str) -> str:
+        if not value.startswith("cap_"):
+            raise ValueError("invalid capability id")
+        return value
+
+    @field_validator("token")
+    @classmethod
+    def validate_token(cls, value: str) -> str:
+        if not value.startswith("mgc_"):
+            raise ValueError("invalid capability token")
+        return value
+
+
+class CapabilityUsageSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    capability_id: str
+    state: Literal["sealed", "revoked"]
+    drained: bool
+    session_count: int = Field(ge=0)
+    query_count: int = Field(ge=0)
+    completed_queries: int = Field(ge=0)
+    total_input_tokens: int = Field(ge=0)
+    total_output_tokens: int = Field(ge=0)
+    cost_usd: Decimal = Field(ge=0)
+
+
+class CapabilityEvalResumeState(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    kind: Literal["model_gateway_eval_resume"]
+    capability_id: str = Field(pattern=r"^cap_[A-Za-z0-9_-]+$")
+    benchmark_state: dict[str, Any]
+
+
+def capability_expires_at(agent_timeout: float, now: float) -> int:
+    if not math.isfinite(agent_timeout) or agent_timeout <= 0:
+        raise ModelGatewayError("Task capability requires a finite positive agent_timeout")
+
+    lifetime = math.ceil(agent_timeout) + CAPABILITY_FINALIZATION_GRACE_SECONDS
+    if lifetime > MAX_CAPABILITY_LIFETIME_SECONDS:
+        raise ModelGatewayError("Task capability agent_timeout exceeds the 24-hour capability lifetime")
+    return math.floor(now) + lifetime
+
+
+class ModelGatewayAdminClient:
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    @classmethod
+    def from_environment(cls) -> "ModelGatewayAdminClient":
+        gateway_url = os.environ.get("MODEL_GATEWAY_URL", "").rstrip("/")
+        admin_key = os.environ.get("MODEL_GATEWAY_ADMIN_API_KEY", "")
+        parsed_url = httpx.URL(gateway_url)
+        if (
+            parsed_url.scheme != "https"
+            or not parsed_url.host
+            or parsed_url.userinfo
+            or parsed_url.path != "/"
+            or parsed_url.query
+            or parsed_url.fragment
+        ):
+            raise ModelGatewayError("MODEL_GATEWAY_URL must be an absolute HTTPS URL")
+        if not admin_key or admin_key != admin_key.strip():
+            raise ModelGatewayError("MODEL_GATEWAY_ADMIN_API_KEY is required for task capabilities")
+
+        client = httpx.AsyncClient(
+            base_url=gateway_url,
+            headers={"Authorization": f"Bearer {admin_key}"},
+            timeout=65.0,
+        )
+        return cls(client)
+
+    @property
+    def gateway_url(self) -> str:
+        return str(self._client.base_url).rstrip("/")
+
+    async def __aenter__(self) -> "ModelGatewayAdminClient":
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        await self._client.aclose()
+
+    async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+        response = await self._post("/capabilities/mint", request.model_dump(mode="json"))
+        try:
+            minted = CapabilityMintResponse.model_validate_json(response.content)
+        except ValidationError:
+            raise ModelGatewayError("Model gateway returned an invalid mint response") from None
+        return minted
+
+    async def finalize(self, capability_id: str) -> CapabilityUsageSummary:
+        try:
+            await self._action("seal", capability_id, "sealed")
+        except ModelGatewayError:
+            pass
+
+        revoked = await self._action("revoke", capability_id, "revoked")
+        if not revoked.drained:
+            raise ModelGatewayError("Task capability did not drain before revocation")
+        return revoked
+
+    async def _action(
+        self,
+        action: Literal["seal", "revoke"],
+        capability_id: str,
+        expected_state: Literal["sealed", "revoked"],
+    ) -> CapabilityUsageSummary:
+        try:
+            async with asyncio.timeout(CAPABILITY_ACTION_TIMEOUT_SECONDS):
+                for attempt in range(CAPABILITY_ACTION_MAX_ATTEMPTS):
+                    try:
+                        response = await self._client.post(
+                            f"/capabilities/{action}",
+                            json={
+                                "capability_id": capability_id,
+                                "wait_timeout_seconds": CAPABILITY_DRAIN_TIMEOUT_SECONDS,
+                            },
+                        )
+                    except httpx.TransportError:
+                        if attempt + 1 == CAPABILITY_ACTION_MAX_ATTEMPTS:
+                            raise ModelGatewayError(f"Model gateway {action} request failed after retries") from None
+                    else:
+                        if response.status_code == 200:
+                            try:
+                                summary = CapabilityUsageSummary.model_validate_json(response.content)
+                            except ValidationError:
+                                raise ModelGatewayError(
+                                    f"Model gateway returned an invalid {action} response"
+                                ) from None
+                            if summary.capability_id != capability_id or summary.state != expected_state:
+                                raise ModelGatewayError(f"Model gateway returned a mismatched {action} response")
+                            return summary
+                        if response.status_code != 503 or attempt + 1 == CAPABILITY_ACTION_MAX_ATTEMPTS:
+                            raise ModelGatewayError(
+                                f"Model gateway administrative request failed with HTTP {response.status_code}"
+                            )
+
+                    await asyncio.sleep(CAPABILITY_ACTION_RETRY_SECONDS)
+        except TimeoutError:
+            raise ModelGatewayError(f"Model gateway {action} exceeded its finalization deadline") from None
+
+        raise AssertionError("unreachable")
+
+    async def _post(self, path: str, body: dict[str, object]) -> httpx.Response:
+        try:
+            response = await self._client.post(path, json=body)
+        except httpx.HTTPError:
+            raise ModelGatewayError("Model gateway administrative request failed") from None
+        if response.status_code == 200:
+            return response
+
+        raise ModelGatewayError(f"Model gateway administrative request failed with HTTP {response.status_code}")
+
+
+async def finalize_capability_uninterruptibly(
+    client: ModelGatewayAdminClient,
+    capability_id: str,
+    write_usage: Callable[[CapabilityUsageSummary], Awaitable[None]],
+) -> CapabilityUsageSummary:
+    async def finalize_and_write() -> CapabilityUsageSummary:
+        summary = await client.finalize(capability_id)
+        await write_usage(summary)
+        return summary
+
+    task = asyncio.create_task(finalize_and_write())
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+
+    summary = task.result()
+    if cancellation is not None:
+        raise cancellation
+    return summary
+
+
+async def mint_capability_uninterruptibly(
+    client: ModelGatewayAdminClient,
+    request: CapabilityMintRequest,
+    write_usage: Callable[[CapabilityUsageSummary], Awaitable[None]],
+) -> CapabilityMintResponse:
+    task = asyncio.create_task(client.mint(request))
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+
+    minted = task.result()
+    if cancellation is not None:
+        await finalize_capability_uninterruptibly(client, minted.capability_id, write_usage)
+        raise cancellation
+    return minted

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -70,6 +70,7 @@ def init_sentry(service_name: str, environment: str) -> None:
             instrumenter=INSTRUMENTER.OTEL,
             enable_logs=True,
             send_default_pii=False,
+            include_local_variables=False,
             before_send=_before_send,
             before_send_log=_before_send_log,
             integrations=[

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,11 +1,13 @@
 """Sandbox management utilities for the tracker service."""
 
+import asyncio
+import json
 import shlex
 import time
 import uuid
 from asyncio import Semaphore
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Collection, Coroutine, Mapping
 from contextlib import asynccontextmanager
 from pathlib import PurePosixPath
 from typing import Any, AsyncGenerator
@@ -74,6 +76,154 @@ SANDBOX_AUTO_STOP_INTERVAL = 10 * 60
 SANDBOX_CREATE_TIMEOUT = 360
 AGENT_INSTALL_TIMEOUT_SECONDS = 10 * 60
 CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS = 24 * 60 * 60
+_REDACTED = "[REDACTED]"
+_AGENT_SCOPE_ENV = "VALKYRIE_AGENT_SECRET_SCOPE"
+_SECRET_NAMES_ENV = "VALKYRIE_AGENT_SECRET_NAMES"
+_AGENT_SECRET_CLEANUP_SOURCE = r"""
+import json
+import os
+import signal
+import time
+from pathlib import Path
+
+scope_name = "VALKYRIE_AGENT_SECRET_SCOPE"
+names = json.loads(os.environ["VALKYRIE_AGENT_SECRET_NAMES"])
+scope_entry = f"{scope_name}={os.environ[scope_name]}".encode()
+secret_entries = {
+    f"{name}={os.environ[name]}".encode()
+    for name in names
+    if os.environ[name]
+}
+uid = os.getuid()
+
+
+def process_fields(path):
+    fields = (path / "stat").read_text().rsplit(")", 1)[1].split()
+    return fields[0], int(fields[1]), int(fields[19])
+
+
+ancestors = set()
+pid = os.getpid()
+while pid > 1:
+    ancestors.add(pid)
+    try:
+        _state, pid, _start_time = process_fields(Path("/proc") / str(pid))
+    except FileNotFoundError:
+        break
+
+
+def matching_processes():
+    matches = []
+    for path in Path("/proc").iterdir():
+        if not path.name.isdecimal() or int(path.name) in ancestors:
+            continue
+        try:
+            if path.stat().st_uid != uid:
+                continue
+            state, _parent_pid, start_time = process_fields(path)
+            if state == "Z":
+                continue
+            entries = set((path / "environ").read_bytes().split(b"\0"))
+        except FileNotFoundError:
+            continue
+        if scope_entry in entries or secret_entries.intersection(entries):
+            matches.append((int(path.name), start_time))
+    return matches
+
+
+def still_matches(pid, start_time):
+    path = Path("/proc") / str(pid)
+    try:
+        state, _parent_pid, current_start_time = process_fields(path)
+        if state == "Z" or current_start_time != start_time:
+            return False
+        entries = set((path / "environ").read_bytes().split(b"\0"))
+    except FileNotFoundError:
+        return False
+    return scope_entry in entries or bool(secret_entries.intersection(entries))
+
+
+for signum in (signal.SIGTERM, signal.SIGKILL):
+    for _attempt in range(20):
+        matches = matching_processes()
+        if not matches:
+            break
+        for pid, start_time in matches:
+            if not still_matches(pid, start_time):
+                continue
+            try:
+                os.kill(pid, signum)
+            except ProcessLookupError:
+                pass
+        time.sleep(0.05)
+
+if matching_processes():
+    raise RuntimeError("agent credential processes remain")
+"""
+_AGENT_SECRET_CLEANUP_COMMAND = f"python3 -c {shlex.quote(_AGENT_SECRET_CLEANUP_SOURCE)}"
+
+
+class _SecretRedactor:
+    def __init__(self, secrets: Collection[str]) -> None:
+        self._secrets = sorted({secret for secret in secrets if secret}, key=len, reverse=True)
+        self._starts = {secret[0] for secret in self._secrets}
+        self._pending = ""
+
+    def feed(self, chunk: str) -> str:
+        if not self._secrets:
+            return chunk
+
+        self._pending += chunk
+        output: list[str] = []
+
+        while self._pending:
+            candidates = [secret for secret in self._secrets if secret.startswith(self._pending)]
+            if candidates:
+                if self._pending in candidates and not any(len(secret) > len(self._pending) for secret in candidates):
+                    output.append(_REDACTED)
+                    self._pending = ""
+                break
+
+            matches = [secret for secret in self._secrets if self._pending.startswith(secret)]
+            if matches:
+                secret = max(matches, key=len)
+                output.append(_REDACTED)
+                self._pending = self._pending[len(secret) :]
+                continue
+
+            next_start = min(
+                (index for start in self._starts if (index := self._pending.find(start, 1)) >= 0),
+                default=len(self._pending),
+            )
+            output.append(self._pending[:next_start])
+            self._pending = self._pending[next_start:]
+
+        return "".join(output)
+
+    def finish(self) -> str:
+        if not self._pending:
+            return ""
+        self._pending = ""
+        return _REDACTED
+
+    def redact(self, text: str) -> str:
+        for secret in self._secrets:
+            text = text.replace(secret, _REDACTED)
+        return text
+
+
+async def _await_uninterruptibly(operation: Coroutine[Any, Any, None]) -> None:
+    task = asyncio.create_task(operation)
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as error:
+            cancellation = error
+
+    task.result()
+    if cancellation is not None:
+        raise cancellation
 
 
 def get_contract_path(contract_name: str) -> PurePosixPath:
@@ -226,7 +376,7 @@ async def create_sandbox(
         logger.error(f"Error during sandbox execution {sandbox.name}: {e}")
         raise
     finally:
-        await delete_sandbox(sandbox, provider)
+        await _await_uninterruptibly(delete_sandbox(sandbox, provider))
 
 
 @retry(
@@ -314,7 +464,7 @@ async def upload_agent_artifacts(
 
 
 @retry(
-    retry=retry_if_exception_type(SandboxError),
+    retry=retry_if_exception_type(SandboxError) & retry_if_not_exception_type(SandboxSetupError),
     reraise=True,
     stop=stop_after_attempt(3),
     before_sleep=retry_callback("valkyrie.sandbox.deps"),
@@ -323,6 +473,8 @@ async def install_agent_dependencies(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
+    *,
+    agent_env_vars: Mapping[str, str],
 ) -> None:
     """Install agent dependencies in the sandbox."""
     if not contract.install_cmd:
@@ -337,6 +489,7 @@ async def install_agent_dependencies(
         sandbox,
         f"cd {shlex.quote(str(contract_path))} && {install_cmd}",
         log_output,
+        env_vars=agent_env_vars,
     )
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         raise SandboxError(
@@ -372,6 +525,18 @@ async def _exec(sandbox: Sandbox, command: str) -> ExecResult:
         raise SandboxError(str(e)) from e
 
 
+async def _cleanup_agent_secret_processes(sandbox: Sandbox, env_vars: Mapping[str, str]) -> None:
+    cleanup_env = dict(env_vars)
+    cleanup_env[_SECRET_NAMES_ENV] = json.dumps([name for name in env_vars if name != _AGENT_SCOPE_ENV])
+    try:
+        async for _output in sandbox.command(_AGENT_SECRET_CLEANUP_COMMAND, env_vars=cleanup_env):
+            pass
+    except SandboxNotFoundError:
+        return
+    except ProviderSandboxError:
+        raise SandboxSetupError("Failed to clear agent credential processes") from None
+
+
 @_EGRESS_RETRY
 async def _run_egress_operation(operation: Callable[[], Awaitable[None]]) -> None:
     await operation()
@@ -403,27 +568,35 @@ async def _stream_command_output_with_egress_allowlist(
     command: str,
     on_output: Callable[[str], None],
     allowed_addresses: list[str],
+    *,
+    env_vars: Mapping[str, str],
 ) -> tuple[AgentCausedExitReason | None, float]:
     if not allowed_addresses:
-        return await stream_command_output(sandbox, command, on_output)
+        return await stream_command_output(sandbox, command, on_output, env_vars=env_vars)
 
     command_completed = False
     try:
         await _apply_egress_allowlist(sandbox, allowed_addresses)
-        result = await stream_command_output(sandbox, command, on_output)
+        result = await stream_command_output(sandbox, command, on_output, env_vars=env_vars)
         command_completed = True
         return result
     finally:
-        # After a clean agent run, stale egress rules would affect evaluation; otherwise preserve the original error.
-        await _clear_egress_allowlist(sandbox, fail_on_error=command_completed)
+        if command_completed:
+            await _clear_egress_allowlist(sandbox, fail_on_error=True)
 
 
 async def stream_command_output(
     sandbox: Sandbox,
     command: str,
     on_output: Callable[[str], None],
+    *,
+    env_vars: Mapping[str, str],
 ) -> tuple[AgentCausedExitReason | None, float]:
     output: deque[str] = deque(maxlen=50)
+    scoped_env = dict(env_vars)
+    if scoped_env:
+        scoped_env[_AGENT_SCOPE_ENV] = uuid.uuid4().hex
+    redactor = _SecretRedactor(scoped_env.values())
     run_id = uuid.uuid4().hex
     start_ns_path = f"{_STATUS_DIR}/{run_id}.start_ns"
     end_ns_path = f"{_STATUS_DIR}/{run_id}.end_ns"
@@ -439,15 +612,22 @@ async def stream_command_output(
     exit_code = _SUCCESS_EXIT_CODE
     try:
         try:
-            async for data in sandbox.command(timed_command):
-                on_output(data)
-                output.append(data)
+            async for data in sandbox.command(timed_command, env_vars=scoped_env):
+                redacted = redactor.feed(data)
+                if redacted:
+                    on_output(redacted)
+                    output.append(redacted)
         except ProviderSandboxCommandError as e:
             exit_code = e.exit_code
         except SandboxNotFoundError:
             raise
         except ProviderSandboxError as e:
-            raise SandboxError(str(e)) from e
+            raise SandboxError(redactor.redact(str(e))) from None
+
+        final_output = redactor.finish()
+        if final_output:
+            on_output(final_output)
+            output.append(final_output)
 
         start_ns = (await _exec(sandbox, f"cat {shlex.quote(start_ns_path)}")).stdout
         end_ns = (await _exec(sandbox, f"cat {shlex.quote(end_ns_path)}")).stdout
@@ -463,12 +643,16 @@ async def stream_command_output(
         tail = "".join(output).strip().splitlines()
         recent = "\n".join(tail[-10:]) if tail else "(no output)"
         sentry_sdk.set_tag("agent_exit_code", str(exit_code))
-        raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
+        raise AgentRunFailedError(f"Agent command failed with exit code: {exit_code}\nLast output:\n{recent}")
     finally:
         try:
-            await _exec(sandbox, f"rm -f {shlex.quote(start_ns_path)} {shlex.quote(end_ns_path)}")
-        except Exception:
-            pass
+            if scoped_env:
+                await _await_uninterruptibly(_cleanup_agent_secret_processes(sandbox, scoped_env))
+        finally:
+            try:
+                await _exec(sandbox, f"rm -f {shlex.quote(start_ns_path)} {shlex.quote(end_ns_path)}")
+            except Exception:
+                pass
 
 
 @logfire.instrument(
@@ -622,64 +806,54 @@ async def upload_output_artifacts(
         )
 
 
-async def run_agent(
+async def install_agent(
+    sandbox: Sandbox,
+    contract: AgentContractRequest,
+    log_output: Callable[[str], None],
+    agent_env_vars: Mapping[str, str],
+    runtime_source: SandboxSource | None,
+) -> None:
+    if runtime_source is not None:
+        sandbox = runtime_sandbox(sandbox, runtime_source)
+    await install_agent_dependencies(
+        sandbox,
+        contract,
+        log_output,
+        agent_env_vars=agent_env_vars,
+    )
+
+
+async def execute_agent(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     problem_path: str,
     task_id: str,
     log_output: Callable[[str], None],
     cwd: str,
-    aws: AWSCredentials,
-    s3_bucket: str,
-    agent_output_s3_key: str | None = None,
-    agent_timeout: float | None = None,
-    benchmark_id: str | None = None,
-    runtime_source: SandboxSource | None = None,
+    agent_env_vars: Mapping[str, str],
+    agent_timeout: float | None,
+    runtime_source: SandboxSource | None,
 ) -> tuple[AgentCausedExitReason | None, float]:
-    """
-    Run the agent inside the sandbox for a given task.
-
-    Args:
-        sandbox: The sandbox to run the agent in
-        contract: The agent contract configuration
-        problem_path: Path inside the sandbox where the problem statement file was written during setup
-        log_output: Callback to log output
-        cwd: Working directory to run the agent in
-        agent_output_s3_key: S3 key to where we will upload the final output archive to
-        agent_timeout: Optional timeout in seconds to enforce on the agent command
-        runtime_source: Optional source used to adapt agent commands to the task runtime
-
-    Returns:
-        AgentCausedExitReason if the agent was terminated abnormally but recoverably
-        (timeout or OS kill), None on clean exit.
-
-    Raises:
-        SandboxError: If the agent fails to run or times out
-    """
+    """Run an installed agent without uploading its outputs."""
     log_output(f"Running agent {contract.name}")
     if runtime_source is not None:
         sandbox = runtime_sandbox(sandbox, runtime_source)
-
-    await install_agent_dependencies(sandbox, contract, log_output)
 
     run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_path).replace("{task_id}", task_id)
 
     for kwarg_key, kwarg_value in contract.kwargs.items():
         run_cmd = run_cmd.replace(f"{{{kwarg_key}}}", kwarg_value)
 
-    # Apply timeout if specified
     if agent_timeout is not None:
         run_cmd = f"timeout {agent_timeout:g} sh -c {shlex.quote(run_cmd)}"
 
-    # Create cwd if it does not already exist
     await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
-
-    # Run the agent without including task directory dependencies
     exit_reason, agent_run_time = await _stream_command_output_with_egress_allowlist(
         sandbox,
         f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}",
         log_output,
         contract.egress_allowlist,
+        env_vars=agent_env_vars,
     )
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:
@@ -691,7 +865,23 @@ async def run_agent(
             f"[WARNING]:`{contract.name}` was killed by the OS (exit code {_OS_KILL_EXIT_CODE}, likely out-of-memory). The process has been terminated and evaluation will proceed."
         )
 
-    # Upload any output from the agent to S3
+    return exit_reason, agent_run_time
+
+
+async def upload_agent_outputs(
+    sandbox: Sandbox,
+    contract: AgentContractRequest,
+    task_id: str,
+    aws: AWSCredentials,
+    s3_bucket: str,
+    agent_output_s3_key: str | None,
+    benchmark_id: str | None,
+    runtime_source: SandboxSource | None,
+) -> None:
+    """Upload agent outputs after execution-side credentials have been closed."""
+    if runtime_source is not None:
+        sandbox = runtime_sandbox(sandbox, runtime_source)
+
     if contract.final_output:
         result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
         if result.exit_code == _SUCCESS_EXIT_CODE and agent_output_s3_key:
@@ -717,5 +907,69 @@ async def run_agent(
             s3_bucket,
         )
 
-    # Return why the agent terminated abnormally, or None on clean exit
+
+async def run_agent(
+    sandbox: Sandbox,
+    contract: AgentContractRequest,
+    problem_path: str,
+    task_id: str,
+    log_output: Callable[[str], None],
+    cwd: str,
+    aws: AWSCredentials,
+    s3_bucket: str,
+    agent_env_vars: Mapping[str, str],
+    agent_output_s3_key: str | None = None,
+    agent_timeout: float | None = None,
+    benchmark_id: str | None = None,
+    runtime_source: SandboxSource | None = None,
+) -> tuple[AgentCausedExitReason | None, float]:
+    """
+    Run the agent inside the sandbox for a given task.
+
+    Args:
+        sandbox: The sandbox to run the agent in
+        contract: The agent contract configuration
+        problem_path: Path inside the sandbox where the problem statement file was written during setup
+        log_output: Callback to log output
+        cwd: Working directory to run the agent in
+        agent_env_vars: Agent contract secrets scoped to install and run command processes
+        agent_output_s3_key: S3 key to where we will upload the final output archive to
+        agent_timeout: Optional timeout in seconds to enforce on the agent command
+        runtime_source: Optional source used to adapt agent commands to the task runtime
+
+    Returns:
+        AgentCausedExitReason if the agent was terminated abnormally but recoverably
+        (timeout or OS kill), None on clean exit.
+
+    Raises:
+        SandboxError: If the agent fails to run or times out
+    """
+    await install_agent(
+        sandbox,
+        contract,
+        log_output,
+        agent_env_vars,
+        runtime_source,
+    )
+    exit_reason, agent_run_time = await execute_agent(
+        sandbox,
+        contract,
+        problem_path,
+        task_id,
+        log_output,
+        cwd,
+        agent_env_vars,
+        agent_timeout,
+        runtime_source,
+    )
+    await upload_agent_outputs(
+        sandbox,
+        contract,
+        task_id,
+        aws,
+        s3_bucket,
+        agent_output_s3_key,
+        benchmark_id,
+        runtime_source,
+    )
     return exit_reason, agent_run_time

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,7 +1,6 @@
 """Sandbox management utilities for the tracker service."""
 
 import asyncio
-import json
 import shlex
 import time
 import uuid
@@ -79,15 +78,14 @@ CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS = 24 * 60 * 60
 _REDACTED = "[REDACTED]"
 _AGENT_SCOPE_ENV = "VALKYRIE_AGENT_SECRET_SCOPE"
 _SECRET_NAMES_ENV = "VALKYRIE_AGENT_SECRET_NAMES"
-_AGENT_SECRET_CLEANUP_SOURCE = r"""
-import json
+_AGENT_SECRET_CLEANUP_PYTHON_SOURCE = r"""
 import os
 import signal
 import time
 from pathlib import Path
 
 scope_name = "VALKYRIE_AGENT_SECRET_SCOPE"
-names = json.loads(os.environ["VALKYRIE_AGENT_SECRET_NAMES"])
+names = os.environ["VALKYRIE_AGENT_SECRET_NAMES"].splitlines()
 scope_entry = f"{scope_name}={os.environ[scope_name]}".encode()
 secret_entries = {
     f"{name}={os.environ[name]}".encode()
@@ -160,7 +158,150 @@ for signum in (signal.SIGTERM, signal.SIGKILL):
 if matching_processes():
     raise RuntimeError("agent credential processes remain")
 """
-_AGENT_SECRET_CLEANUP_COMMAND = f"python3 -c {shlex.quote(_AGENT_SECRET_CLEANUP_SOURCE)}"
+_AGENT_SECRET_CLEANUP_SHELL_SOURCE = r"""
+set -u
+command -v sleep >/dev/null 2>&1 || exit 1
+IFS= read -r -d '' cleanup_read </dev/null 2>/dev/null
+[ "$?" -eq 1 ] || exit 1
+
+process_fields() {
+    path=$1
+    IFS= read -r stat_line < "$path/stat" || return 1
+    fields=${stat_line##*) }
+    old_ifs=$IFS
+    IFS=' '
+    set -- $fields
+    IFS=$old_ifs
+    [ "$#" -ge 20 ] || return 1
+    PROCESS_STATE=$1
+    PROCESS_PARENT_PID=$2
+    shift 19
+    PROCESS_START_TIME=$1
+}
+
+process_uid() {
+    path=$1
+    while read -r field real_uid _; do
+        if [ "$field" = "Uid:" ]; then
+            PROCESS_UID=$real_uid
+            return 0
+        fi
+    done < "$path/status"
+    return 1
+}
+
+matches_environment() {
+    path=$1
+    if [ ! -r "$path/environ" ]; then
+        [ ! -d "$path" ] && return 1
+        return 2
+    fi
+
+    while IFS= read -r -d '' entry; do
+        [ "$entry" = "VALKYRIE_AGENT_SECRET_SCOPE=$VALKYRIE_AGENT_SECRET_SCOPE" ] && return 0
+
+        entry_name=${entry%%=*}
+        is_secret=0
+        old_ifs=$IFS
+        IFS='
+'
+        for name in $VALKYRIE_AGENT_SECRET_NAMES; do
+            [ "$entry_name" = "$name" ] && is_secret=1
+        done
+        IFS=$old_ifs
+        [ "$is_secret" -eq 0 ] && continue
+
+        while IFS= read -r -d '' cleanup_entry; do
+            [ "$cleanup_entry" = "$entry_name=" ] && continue
+            [ "$entry" = "$cleanup_entry" ] && return 0
+        done < "/proc/$$/environ"
+    done < "$path/environ"
+    return 1
+}
+
+ancestors=" "
+ancestor=$$
+while [ "$ancestor" -gt 1 ]; do
+    ancestors="$ancestors$ancestor "
+    path="/proc/$ancestor"
+    process_fields "$path" || {
+        [ ! -d "$path" ] && break
+        exit 1
+    }
+    ancestor=$PROCESS_PARENT_PID
+done
+
+process_uid "/proc/$$" || exit 1
+uid=$PROCESS_UID
+
+still_matches() {
+    pid=$1
+    expected_start_time=$2
+    path="/proc/$pid"
+    process_fields "$path" || {
+        [ ! -d "$path" ] && return 1
+        return 2
+    }
+    [ "$PROCESS_STATE" = "Z" ] && return 1
+    [ "$PROCESS_START_TIME" = "$expected_start_time" ] || return 1
+    matches_environment "$path"
+}
+
+cleanup_pass() {
+    signal=$1
+    CLEANUP_MATCH_FOUND=0
+    for path in /proc/[0-9]*; do
+        pid=${path##*/}
+        case "$ancestors" in
+            *" $pid "*) continue ;;
+        esac
+
+        process_uid "$path" || {
+            [ ! -d "$path" ] && continue
+            return 2
+        }
+        [ "$PROCESS_UID" = "$uid" ] || continue
+
+        process_fields "$path" || {
+            [ ! -d "$path" ] && continue
+            return 2
+        }
+        [ "$PROCESS_STATE" = "Z" ] && continue
+
+        if matches_environment "$path"; then
+            expected_start_time=$PROCESS_START_TIME
+            if still_matches "$pid" "$expected_start_time"; then
+                CLEANUP_MATCH_FOUND=1
+                [ -z "$signal" ] || kill "-$signal" "$pid" 2>/dev/null || true
+            else
+                result=$?
+                [ "$result" -eq 1 ] || return "$result"
+            fi
+        else
+            result=$?
+            [ "$result" -eq 1 ] || return "$result"
+        fi
+    done
+}
+
+for signal in TERM KILL; do
+    attempt=0
+    while [ "$attempt" -lt 20 ]; do
+        cleanup_pass "$signal" || exit 1
+        [ "$CLEANUP_MATCH_FOUND" -eq 0 ] && break
+        sleep 0.05
+        attempt=$((attempt + 1))
+    done
+done
+
+cleanup_pass "" || exit 1
+[ "$CLEANUP_MATCH_FOUND" -eq 0 ] || exit 1
+"""
+_AGENT_SECRET_CLEANUP_COMMAND = (
+    "if command -v python3 >/dev/null 2>&1; then "
+    f"python3 -c {shlex.quote(_AGENT_SECRET_CLEANUP_PYTHON_SOURCE)}; "
+    f"else sh -c {shlex.quote(_AGENT_SECRET_CLEANUP_SHELL_SOURCE)}; fi"
+)
 
 
 class _SecretRedactor:
@@ -527,7 +668,7 @@ async def _exec(sandbox: Sandbox, command: str) -> ExecResult:
 
 async def _cleanup_agent_secret_processes(sandbox: Sandbox, env_vars: Mapping[str, str]) -> None:
     cleanup_env = dict(env_vars)
-    cleanup_env[_SECRET_NAMES_ENV] = json.dumps([name for name in env_vars if name != _AGENT_SCOPE_ENV])
+    cleanup_env[_SECRET_NAMES_ENV] = "\n".join(name for name in env_vars if name != _AGENT_SCOPE_ENV)
     try:
         async for _output in sandbox.command(_AGENT_SECRET_CLEANUP_COMMAND, env_vars=cleanup_env):
             pass

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import re
 import time
 import traceback
 from asyncio import Semaphore
@@ -28,7 +29,9 @@ from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
 from tracker.aws.cloudwatch_logs import write_benchmark_log_event
 from tracker.aws.s3 import (
+    download_from_s3,
     get_agent_result_s3_key,
+    upload_to_s3,
 )
 from tracker.aws.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
@@ -44,9 +47,25 @@ from tracker.database.models import (
 from tracker.database.session import engine
 from tracker.exceptions import OutputArtifactError, SandboxSetupError, TrackerServiceError
 from tracker.logging import get_logger, task_id_var
+from tracker.model_gateway import (
+    CapabilityEvalResumeState,
+    CapabilityMintRequest,
+    CapabilityUsageSummary,
+    ModelGatewayAdminClient,
+    capability_expires_at,
+    finalize_capability_uninterruptibly,
+    mint_capability_uninterruptibly,
+)
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, retry_callback
-from tracker.sandbox import create_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import (
+    create_sandbox,
+    execute_agent,
+    install_agent,
+    run_agent,
+    upload_agent_artifacts,
+    upload_agent_outputs,
+)
 from tracker.types import (
     AWSCredentials,
     HarnessConfig,
@@ -58,6 +77,31 @@ from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
 logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
+_MODEL_GATEWAY_USAGE_DIRECTORY = "model_gateway_usage"
+_MODEL_GATEWAY_USAGE_RESULT_KEY = "_valkyrie_model_gateway_usage"
+_AGENT_ENV_VAR_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_RESERVED_AGENT_ENV_VAR_NAMES = frozenset(
+    {
+        "LANG",
+        "RUN_ID",
+        "TASK_ID",
+        "TERM",
+        "IDENTITY",
+        "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS",
+        "VALKYRIE_AGENT_SECRET_NAMES",
+        "VALKYRIE_AGENT_SECRET_SCOPE",
+    }
+)
+
+
+def _validate_agent_env_vars(env_vars: dict[str, str]) -> None:
+    invalid_names = sorted(name for name in env_vars if _AGENT_ENV_VAR_NAME.fullmatch(name) is None)
+    if invalid_names:
+        raise SandboxSetupError(f"Invalid agent secret environment variable names: {', '.join(invalid_names)}")
+
+    reserved_names = sorted(env_vars.keys() & _RESERVED_AGENT_ENV_VAR_NAMES)
+    if reserved_names:
+        raise SandboxSetupError(f"Agent secret environment variables use reserved names: {', '.join(reserved_names)}")
 
 
 def _normalized_attempt_time(value: datetime) -> datetime:
@@ -396,9 +440,18 @@ async def process_task(
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
+    capability_usage: CapabilityUsageSummary | None = None
 
     def on_eval_resume_state(state: dict[str, Any]) -> None:
-        save_eval_resume_state(task_row.id, org, state, expected_started_at=attempt_started_at)
+        persisted_state = state
+        if start_benchmark_request.contract.model_gateway_policy is not None:
+            assert capability_usage is not None
+            persisted_state = CapabilityEvalResumeState(
+                kind="model_gateway_eval_resume",
+                capability_id=capability_usage.capability_id,
+                benchmark_state=state,
+            ).model_dump(mode="json")
+        save_eval_resume_state(task_row.id, org, persisted_state, expected_started_at=attempt_started_at)
 
     def task_is_stopped() -> bool:
         with Session(bind=engine) as task_session:
@@ -409,17 +462,48 @@ async def process_task(
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
+                benchmark_eval_resume_state = task_row.eval_resume_state
+                if start_benchmark_request.contract.model_gateway_policy is not None:
+                    try:
+                        resume_state = CapabilityEvalResumeState.model_validate(task_row.eval_resume_state)
+                    except ValidationError:
+                        raise TrackerServiceError("Model gateway evaluation resume state is invalid") from None
+                    usage_artifact = await download_from_s3(
+                        get_agent_result_s3_key(
+                            str(benchmark_id),
+                            task_id,
+                            f"{_MODEL_GATEWAY_USAGE_DIRECTORY}/{resume_state.capability_id}.json",
+                        ),
+                        harness_config.aws,
+                        harness_config.s3_bucket,
+                    )
+                    try:
+                        capability_usage = CapabilityUsageSummary.model_validate_json(usage_artifact)
+                    except ValidationError:
+                        raise TrackerServiceError("Model gateway usage artifact is invalid") from None
+                    if capability_usage.capability_id != resume_state.capability_id:
+                        raise TrackerServiceError("Model gateway usage artifact does not match resume state")
+                    if capability_usage.state != "revoked" or not capability_usage.drained:
+                        raise TrackerServiceError("Model gateway usage artifact is not finalized")
+                    benchmark_eval_resume_state = resume_state.benchmark_state
+
                 resume_eval_start_time = time.perf_counter()
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
                 evaluation_result = await benchmark_service.resume_evaluation(
                     task_row.task_id,
-                    eval_resume_state=task_row.eval_resume_state,
+                    eval_resume_state=benchmark_eval_resume_state,
                     on_message=log_output,
                     on_eval_resume_state=on_eval_resume_state,
                     dataset=start_benchmark_request.dataset,
                     sandbox_provider=sandbox_provider_config,
                 )
+                if capability_usage is not None:
+                    if _MODEL_GATEWAY_USAGE_RESULT_KEY in evaluation_result:
+                        raise TrackerServiceError(
+                            f"Benchmark result uses reserved key {_MODEL_GATEWAY_USAGE_RESULT_KEY!r}"
+                        )
+                    evaluation_result[_MODEL_GATEWAY_USAGE_RESULT_KEY] = capability_usage.model_dump(mode="json")
                 resume_eval_duration = time.perf_counter() - resume_eval_start_time
                 evaluation_result_row = EvaluationResult(
                     org_id=org.id,
@@ -481,8 +565,7 @@ async def process_task(
         if benchmark_started_by_email:
             identity["email"] = benchmark_started_by_email
 
-        env_vars = {
-            **resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws),
+        sandbox_env_vars = {
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
             "IDENTITY": json.dumps(identity),
@@ -493,6 +576,8 @@ async def process_task(
                 f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
             ),
         }
+        _validate_agent_env_vars(start_benchmark_request.contract.secrets)
+        agent_env_vars: dict[str, str] = {}
 
         # We don't want to track the task until the sandbox is actually created.
         task_breakdown = TaskBreakdown()
@@ -503,7 +588,7 @@ async def process_task(
             sandbox_name=task_row.task_id,
             source=task_data.source,
             labels=labels,
-            env_vars=env_vars,
+            env_vars=sandbox_env_vars,
             resources=task_data.resources,
             creation_semaphore=creation_semaphore,
         ) as sandbox:
@@ -548,20 +633,119 @@ async def process_task(
                 if start_benchmark_request.contract.final_output:
                     agent_output_s3_key = get_agent_result_s3_key(str(benchmark_id), task_id, "agent_output.tar.gz")
 
-                exit_reason, agent_run_time = await run_agent(
-                    sandbox,
-                    start_benchmark_request.contract,
-                    task_data.problem_path,
-                    task_id,
-                    log_output,
-                    task_data.cwd,
-                    aws=harness_config.aws,
-                    s3_bucket=harness_config.s3_bucket,
-                    agent_output_s3_key=agent_output_s3_key,
-                    agent_timeout=task_data.agent_timeout,
-                    benchmark_id=str(benchmark_id),
-                    runtime_source=task_data.source,
-                )
+                policy = start_benchmark_request.contract.model_gateway_policy
+                if policy is None:
+                    agent_env_vars = resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws)
+                    try:
+                        exit_reason, agent_run_time = await run_agent(
+                            sandbox,
+                            start_benchmark_request.contract,
+                            task_data.problem_path,
+                            task_id,
+                            log_output,
+                            task_data.cwd,
+                            agent_env_vars=agent_env_vars,
+                            aws=harness_config.aws,
+                            s3_bucket=harness_config.s3_bucket,
+                            agent_output_s3_key=agent_output_s3_key,
+                            agent_timeout=task_data.agent_timeout,
+                            benchmark_id=str(benchmark_id),
+                            runtime_source=task_data.source,
+                        )
+                    finally:
+                        agent_env_vars.clear()
+                else:
+                    if task_data.agent_timeout is None:
+                        raise TrackerServiceError("Task capability requires a finite positive agent_timeout")
+
+                    agent_env_vars = resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws)
+                    try:
+                        await install_agent(
+                            sandbox,
+                            start_benchmark_request.contract,
+                            log_output,
+                            agent_env_vars,
+                            task_data.source,
+                        )
+                    finally:
+                        agent_env_vars.clear()
+
+                    expires_at = capability_expires_at(task_data.agent_timeout, time.time())
+                    async with ModelGatewayAdminClient.from_environment() as gateway:
+
+                        async def write_capability_usage(usage: CapabilityUsageSummary) -> None:
+                            content = (json.dumps(usage.model_dump(mode="json"), sort_keys=True) + "\n").encode()
+                            await upload_to_s3(
+                                content,
+                                get_agent_result_s3_key(
+                                    str(benchmark_id),
+                                    task_id,
+                                    f"{_MODEL_GATEWAY_USAGE_DIRECTORY}/{usage.capability_id}.json",
+                                ),
+                                harness_config.aws,
+                                harness_config.s3_bucket,
+                            )
+                            logger.info(
+                                "model_gateway.capability.finalized",
+                                extra={
+                                    "benchmark_id": str(benchmark_id),
+                                    "task_id": task_id,
+                                    "sandbox_id": sandbox.id,
+                                    **usage.model_dump(mode="json"),
+                                },
+                            )
+
+                        minted = await mint_capability_uninterruptibly(
+                            gateway,
+                            CapabilityMintRequest(
+                                run_id=str(benchmark_id),
+                                task_id=task_id,
+                                model=policy.model,
+                                config=policy.config.model_dump(mode="json"),
+                                sandbox_id=sandbox.id,
+                                identity={"org_id": str(org.id), **identity},
+                                expires_at=expires_at,
+                                max_queries=policy.max_queries,
+                                max_sessions=policy.max_sessions,
+                            ),
+                            write_capability_usage,
+                        )
+                        runtime_env = {
+                            "MODEL_GATEWAY_URL": gateway.gateway_url,
+                            "MODEL_GATEWAY_API_KEY": minted.token,
+                        }
+                        capability_id = minted.capability_id
+                        del minted
+                        try:
+                            exit_reason, agent_run_time = await execute_agent(
+                                sandbox,
+                                start_benchmark_request.contract,
+                                task_data.problem_path,
+                                task_id,
+                                log_output,
+                                task_data.cwd,
+                                runtime_env,
+                                task_data.agent_timeout,
+                                task_data.source,
+                            )
+                        finally:
+                            runtime_env.clear()
+                            capability_usage = await finalize_capability_uninterruptibly(
+                                gateway,
+                                capability_id,
+                                write_capability_usage,
+                            )
+
+                    await upload_agent_outputs(
+                        sandbox,
+                        start_benchmark_request.contract,
+                        task_id,
+                        harness_config.aws,
+                        harness_config.s3_bucket,
+                        agent_output_s3_key,
+                        str(benchmark_id),
+                        task_data.source,
+                    )
                 logger.info(
                     "agent.run.complete",
                     extra={
@@ -610,6 +794,12 @@ async def process_task(
                     dataset=start_benchmark_request.dataset,
                     sandbox_provider=sandbox_provider_config,
                 )
+                if capability_usage is not None:
+                    if _MODEL_GATEWAY_USAGE_RESULT_KEY in evaluation_result:
+                        raise TrackerServiceError(
+                            f"Benchmark result uses reserved key {_MODEL_GATEWAY_USAGE_RESULT_KEY!r}"
+                        )
+                    evaluation_result[_MODEL_GATEWAY_USAGE_RESULT_KEY] = capability_usage.model_dump(mode="json")
                 task_breakdown.evaluation_run_duration = time.perf_counter() - evaluation_start_time
 
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
@@ -652,6 +842,8 @@ async def process_task(
                         return {task_id: None}
 
                 raise
+            finally:
+                agent_env_vars.clear()
 
     except SandboxSetupError as e:
         if task_is_stopped():

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -282,9 +282,11 @@ def _commit_task_status(
         span_attributes["has_error_message"] = True
 
     with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
-        values: dict[str, TaskStatus | datetime] = {"status": to_status}
+        values: dict[str, TaskStatus | datetime | None] = {"status": to_status}
         if to_status in [TaskStatus.FINISHED, TaskStatus.ERROR]:
             values["finished_at"] = datetime.now(ZoneInfo("UTC"))
+        if to_status == TaskStatus.FINISHED:
+            values["eval_resume_state"] = None
 
         task_update = update(Task).where(col(Task.id) == task.id).where(col(Task.org_id) == task.org_id)
         if to_status != TaskStatus.STOPPED:

--- a/services/tracker/tests/integration/test_compose_sandbox.py
+++ b/services/tracker/tests/integration/test_compose_sandbox.py
@@ -99,7 +99,6 @@ async def compose_sandbox(
         "RUN_ID": _COMPOSE_RUN_ID,
         "TASK_ID": _COMPOSE_TASK_ID,
         "IDENTITY": _COMPOSE_IDENTITY,
-        "TRACKER_COMPOSE_SECRET": _COMPOSE_SECRET,
     }
 
     assert isinstance(task_data.source, ComposeSource)
@@ -209,6 +208,7 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
         _COMPOSE_TASK_ID,
         logs.append,
         task_data.cwd,
+        agent_env_vars={"TRACKER_COMPOSE_SECRET": _COMPOSE_SECRET},
         aws=aws,
         s3_bucket="unused",
         runtime_source=task_data.source,
@@ -225,6 +225,7 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
     assert run_proof.stdout == "agent-run"
 
     evaluation = await sandbox.exec(
+        'test -z "${TRACKER_COMPOSE_SECRET+x}" && '
         "test -s /workspace/agent-run.txt && printf '{\"score\":1}' > /workspace/evaluation.json",
         timeout=30,
     )

--- a/services/tracker/tests/integration/test_compose_sandbox.py
+++ b/services/tracker/tests/integration/test_compose_sandbox.py
@@ -188,6 +188,8 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
         install_cmd="sh setup.sh",
         egress_allowlist=["example.com"],
         run_cmd=(
+            "sh -c 'while :; do sleep 3600; done' </dev/null >/dev/null 2>&1 & "
+            "printf '%s' \"$!\" > /workspace/agent-secret-pid && "
             "printf 'agent-run' > /workspace/agent-run.txt && "
             f"test \"$RUN_ID\" = '{_COMPOSE_RUN_ID}' && "
             f"test \"$TASK_ID\" = '{_COMPOSE_TASK_ID}' && "
@@ -226,6 +228,9 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
 
     evaluation = await sandbox.exec(
         'test -z "${TRACKER_COMPOSE_SECRET+x}" && '
+        "pid=$(cat /workspace/agent-secret-pid) && "
+        'if [ -r "/proc/$pid/stat" ]; then '
+        'IFS= read -r stat < "/proc/$pid/stat"; fields=${stat##*) }; set -- $fields; [ "$1" = "Z" ]; fi && '
         "test -s /workspace/agent-run.txt && printf '{\"score\":1}' > /workspace/evaluation.json",
         timeout=30,
     )

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -219,7 +219,7 @@ class TestSandboxOperations:
         await test_sandbox.exec(f"mkdir -p /bundle/{contract_name}")
         await test_sandbox.exec(f"echo '#!/bin/bash\necho hello world' > /bundle/{contract_name}/setup.sh")
 
-        await install_agent_dependencies(test_sandbox, contract, log_callback)
+        await install_agent_dependencies(test_sandbox, contract, log_callback, agent_env_vars={})
 
         # Verify messages were logged
         output = "\n".join(logged_messages)
@@ -262,6 +262,7 @@ class TestSandboxOperations:
             task_id=random_task_id(),
             log_output=log_callback,
             cwd="/",
+            agent_env_vars={},
             aws=aws_credentials,
             s3_bucket=harness_config.s3_bucket,
         )
@@ -306,6 +307,7 @@ class TestSandboxOperations:
             task_id=random_task_id(),
             log_output=log_callback,
             cwd="/",
+            agent_env_vars={},
             aws=aws_credentials,
             s3_bucket=harness_config.s3_bucket,
         )
@@ -341,7 +343,7 @@ class TestSandboxOperations:
         ) as sandbox:
             command = "timeout 15 sleep 70"
 
-            command_timeout, _ = await stream_command_output(sandbox, command, on_output=print)
+            command_timeout, _ = await stream_command_output(sandbox, command, on_output=print, env_vars={})
 
             assert command_timeout
 
@@ -354,7 +356,7 @@ class TestSandboxOperations:
         ) as sandbox:
             command = "timeout 15 sleep 10"
 
-            command_timeout, _ = await stream_command_output(sandbox, command, on_output=print)
+            command_timeout, _ = await stream_command_output(sandbox, command, on_output=print, env_vars={})
 
             assert not command_timeout
 
@@ -386,7 +388,7 @@ class TestSandboxOperations:
         ) as sandbox:
             command = "echo 'STAGE_1' && sleep 1 && echo 'STAGE_2' && sleep 1 && echo 'STAGE_3'"
 
-            timed_out, _ = await stream_command_output(sandbox, command, on_output=log_callback)
+            timed_out, _ = await stream_command_output(sandbox, command, on_output=log_callback, env_vars={})
 
             assert not timed_out
             output = "\n".join(logged_messages)
@@ -423,7 +425,7 @@ class TestSandboxOperations:
                     ready.set()
 
             stream_task = asyncio.create_task(
-                stream_command_output(sandbox, "echo stream-ready && sleep 30", on_output=mark_ready)
+                stream_command_output(sandbox, "echo stream-ready && sleep 30", on_output=mark_ready, env_vars={})
             )
 
             async def destroy_sandbox_after_stream_starts() -> None:
@@ -460,4 +462,4 @@ class TestSandboxOperations:
             # Use `false` (returns 1) instead of `exit 1` — exit kills the writer
             # shell itself, preventing the status file from being written.
             with pytest.raises(SandboxError, match="exit code: 1"):
-                await stream_command_output(sandbox, "false", on_output=lambda _: None)
+                await stream_command_output(sandbox, "false", on_output=lambda _: None, env_vars={})

--- a/services/tracker/tests/unit/test_model_gateway.py
+++ b/services/tracker/tests/unit/test_model_gateway.py
@@ -1,0 +1,337 @@
+import asyncio
+import json
+import math
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from tracker.model_gateway import (
+    CAPABILITY_FINALIZATION_GRACE_SECONDS,
+    MAX_CAPABILITY_LIFETIME_SECONDS,
+    CapabilityMintRequest,
+    CapabilityUsageSummary,
+    ModelGatewayAdminClient,
+    ModelGatewayError,
+    capability_expires_at,
+    finalize_capability_uninterruptibly,
+    mint_capability_uninterruptibly,
+)
+
+
+def _mint_request() -> CapabilityMintRequest:
+    return CapabilityMintRequest(
+        run_id="run-1",
+        task_id="task-1",
+        model="openai/gpt-5.5",
+        config={"client_scope": "shared", "max_tokens": 8192},
+        sandbox_id="sandbox-1",
+        identity={"org_id": "org-1", "agent_name": "osworld_agent"},
+        expires_at=10_000,
+        max_queries=800,
+        max_sessions=4,
+    )
+
+
+def _summary(capability_id: str, state: str, *, drained: bool = True) -> dict[str, object]:
+    return {
+        "capability_id": capability_id,
+        "state": state,
+        "drained": drained,
+        "session_count": 2,
+        "query_count": 3,
+        "completed_queries": 3,
+        "total_input_tokens": 100,
+        "total_output_tokens": 40,
+        "cost_usd": "1.25",
+    }
+
+
+async def test_admin_client_mints_exact_claims_without_exposing_admin_key() -> None:
+    requests: list[dict[str, object]] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"] == "Bearer admin-secret-sentinel"
+        requests.append(json.loads(request.content))
+        return httpx.Response(
+            200,
+            json={
+                "capability_id": "cap_123",
+                "token": "mgc_task-token",
+                "state": "active",
+                "expires_at": 10_000,
+            },
+        )
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+        headers={"Authorization": "Bearer admin-secret-sentinel"},
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        minted = await client.mint(_mint_request())
+
+    assert minted.capability_id == "cap_123"
+    assert minted.token == "mgc_task-token"
+    assert requests == [_mint_request().model_dump(mode="json")]
+    assert "admin-secret-sentinel" not in repr(minted)
+
+
+async def test_finalize_seals_then_revokes_and_returns_usage() -> None:
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        actions.append(action)
+        state = "sealed" if action == "seal" else "revoked"
+        return httpx.Response(200, json=_summary("cap_123", state))
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        summary = await client.finalize("cap_123")
+
+    assert actions == ["seal", "revoke"]
+    assert summary.state == "revoked"
+    assert summary.drained is True
+    assert summary.cost_usd == Decimal("1.25")
+
+
+async def test_finalize_accepts_drained_revoke_after_seal_outage() -> None:
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        actions.append(action)
+        if action == "seal":
+            return httpx.Response(503, json={"code": "admin-secret-sentinel"})
+        return httpx.Response(200, json=_summary("cap_123", "revoked"))
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        summary = await client.finalize("cap_123")
+
+    assert actions == ["seal", "seal", "revoke"]
+    assert summary.state == "revoked"
+    assert summary.drained is True
+
+
+async def test_finalize_accepts_drained_revoke_after_undrained_seal() -> None:
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        actions.append(action)
+        state = "sealed" if action == "seal" else "revoked"
+        return httpx.Response(200, json=_summary("cap_123", state, drained=action != "seal"))
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        summary = await client.finalize("cap_123")
+
+    assert actions == ["seal", "revoke"]
+    assert summary.state == "revoked"
+    assert summary.drained is True
+
+
+async def test_finalize_rejects_undrained_revoke() -> None:
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        actions.append(action)
+        state = "sealed" if action == "seal" else "revoked"
+        return httpx.Response(200, json=_summary("cap_123", state, drained=action == "seal"))
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        with pytest.raises(ModelGatewayError, match="did not drain"):
+            await client.finalize("cap_123")
+
+    assert actions == ["seal", "revoke"]
+
+
+async def test_finalize_retries_transient_transport_and_503_failures() -> None:
+    attempts = {"seal": 0, "revoke": 0}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        attempts[action] += 1
+        if action == "seal" and attempts[action] == 1:
+            raise httpx.ConnectError("transient", request=request)
+        if action == "revoke" and attempts[action] == 1:
+            return httpx.Response(503)
+        state = "sealed" if action == "seal" else "revoked"
+        return httpx.Response(200, json=_summary("cap_123", state))
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        summary = await client.finalize("cap_123")
+
+    assert attempts == {"seal": 2, "revoke": 2}
+    assert summary.state == "revoked"
+
+
+async def test_finalize_fails_after_bounded_persistent_outage() -> None:
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        actions.append(request.url.path.rsplit("/", 1)[-1])
+        return httpx.Response(503)
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        with pytest.raises(ModelGatewayError, match="HTTP 503"):
+            await client.finalize("cap_123")
+
+    assert actions == ["seal", "seal", "revoke", "revoke"]
+
+
+async def test_mint_does_not_retry_503() -> None:
+    requests = 0
+
+    async def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(503)
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        with pytest.raises(ModelGatewayError, match="HTTP 503"):
+            await client.mint(_mint_request())
+
+    assert requests == 1
+
+
+async def test_finalization_finishes_before_delivering_cancellation() -> None:
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        actions.append(action)
+        state = "sealed" if action == "seal" else "revoked"
+        return httpx.Response(200, json=_summary("cap_123", state))
+
+    async def write_usage(summary: CapabilityUsageSummary) -> None:
+        assert summary.state == "revoked"
+        actions.append("write")
+        write_started.set()
+        await release_write.wait()
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+    async with ModelGatewayAdminClient(http_client) as client:
+        finalization = asyncio.create_task(finalize_capability_uninterruptibly(client, "cap_123", write_usage))
+        await write_started.wait()
+        finalization.cancel()
+        release_write.set()
+        with pytest.raises(asyncio.CancelledError):
+            await finalization
+
+    assert actions == ["seal", "revoke", "write"]
+
+
+async def test_stop_during_mint_finalizes_before_delivering_cancellation() -> None:
+    mint_started = asyncio.Event()
+    release_mint = asyncio.Event()
+    actions: list[str] = []
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        action = request.url.path.rsplit("/", 1)[-1]
+        actions.append(action)
+        if action == "mint":
+            mint_started.set()
+            await release_mint.wait()
+            return httpx.Response(
+                200,
+                json={
+                    "capability_id": "cap_123",
+                    "token": "mgc_task-token",
+                    "state": "active",
+                    "expires_at": 10_000,
+                },
+            )
+        state = "sealed" if action == "seal" else "revoked"
+        return httpx.Response(200, json=_summary("cap_123", state))
+
+    http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url="https://gateway.example.test",
+    )
+
+    async def write_usage(summary: CapabilityUsageSummary) -> None:
+        assert summary.state == "revoked"
+        actions.append("write")
+
+    async with ModelGatewayAdminClient(http_client) as client:
+        mint = asyncio.create_task(mint_capability_uninterruptibly(client, _mint_request(), write_usage))
+        await mint_started.wait()
+        mint.cancel()
+        release_mint.set()
+        with pytest.raises(asyncio.CancelledError):
+            await mint
+
+    assert actions == ["mint", "seal", "revoke", "write"]
+
+
+@pytest.mark.parametrize("agent_timeout", [0.0, -1.0, math.inf, -math.inf, math.nan])
+def test_capability_expiry_requires_finite_positive_timeout(agent_timeout: float) -> None:
+    with pytest.raises(ModelGatewayError, match="finite positive"):
+        capability_expires_at(agent_timeout, 1_000.5)
+
+
+def test_capability_expiry_includes_finalization_grace() -> None:
+    assert capability_expires_at(120.1, 1_000.9) == 1_000 + 121 + CAPABILITY_FINALIZATION_GRACE_SECONDS
+
+
+def test_capability_expiry_rejects_more_than_twenty_four_hours() -> None:
+    timeout = MAX_CAPABILITY_LIFETIME_SECONDS - CAPABILITY_FINALIZATION_GRACE_SECONDS + 0.1
+    with pytest.raises(ModelGatewayError, match="24-hour"):
+        capability_expires_at(timeout, 1_000)
+
+
+def test_environment_requires_https_gateway_and_admin_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODEL_GATEWAY_URL", "http://gateway.example.test")
+    monkeypatch.setenv("MODEL_GATEWAY_ADMIN_API_KEY", "admin-key")
+    with pytest.raises(ModelGatewayError, match="absolute HTTPS"):
+        ModelGatewayAdminClient.from_environment()
+
+    monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test")
+    monkeypatch.delenv("MODEL_GATEWAY_ADMIN_API_KEY")
+    with pytest.raises(ModelGatewayError, match="is required"):
+        ModelGatewayAdminClient.from_environment()
+
+
+async def test_environment_builds_authenticated_admin_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test/")
+    monkeypatch.setenv("MODEL_GATEWAY_ADMIN_API_KEY", "admin-secret-sentinel")
+
+    async with ModelGatewayAdminClient.from_environment() as client:
+        http_client = getattr(client, "_client")
+        assert isinstance(http_client, httpx.AsyncClient)
+        assert client.gateway_url == "https://gateway.example.test"
+        assert http_client.headers["Authorization"] == "Bearer admin-secret-sentinel"

--- a/services/tracker/tests/unit/test_process_task_env.py
+++ b/services/tracker/tests/unit/test_process_task_env.py
@@ -1,17 +1,42 @@
+import asyncio
 import json
+import math
+import time
 from asyncio import Semaphore
 from contextlib import asynccontextmanager
+from datetime import timedelta
+from decimal import Decimal
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 import pytest
-from sqlmodel import Session
+from benchmark_service import ImageSource, Resources
+from benchmark_service.client import BenchmarkServiceClient
+from benchmark_service.schemas import RetrieveTaskResponse
+from sqlmodel import Session, select
 
 import tracker.utils.task_execution as utils_module
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
-from tracker.database.models import AgentContractRequest, BenchmarkStatus, Org, Task
+from tracker.database.models import (
+    AgentContractRequest,
+    BenchmarkStatus,
+    EvaluationResult,
+    ModelGatewayPolicyConfig,
+    ModelGatewayTaskCapabilityPolicy,
+    Org,
+    Task,
+    TaskStatus,
+)
+from tracker.exceptions import SandboxSetupError
+from tracker.model_gateway import (
+    CapabilityEvalResumeState,
+    CapabilityMintRequest,
+    CapabilityMintResponse,
+    CapabilityUsageSummary,
+    ModelGatewayError,
+)
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import fetch_sandbox_provider_config, process_task, start_benchmark_request_to_benchmark
 
@@ -22,6 +47,23 @@ _TEST_STARTER = RequestIdentity(
     email=None,
     name=None,
 )
+
+
+def _task_capability_contract(contract: AgentContractRequest) -> AgentContractRequest:
+    model = "openai/gpt-5.5"
+    return contract.model_copy(
+        update={
+            "model": model,
+            "secrets": {"INSTALL_SECRET": "install-secret-name"},
+            "model_gateway_policy": ModelGatewayTaskCapabilityPolicy(
+                kind="task_capability",
+                model=model,
+                config=ModelGatewayPolicyConfig(client_scope="shared", max_tokens=8192),
+                max_queries=800,
+                max_sessions=4,
+            ),
+        }
+    )
 
 
 def _create_task_env(
@@ -100,31 +142,42 @@ async def test_process_task_injects_tracker_owned_attribution_env(
             "contract": contract.model_copy(update={"name": "transient-agent-name"}),
         }
     )
-    captured_env_vars: list[dict[str, str]] = []
+    captured_sandbox_env_vars: list[dict[str, str]] = []
+    captured_agent_env_vars: list[dict[str, str]] = []
+
+    resolved_env_vars = {
+        "UNRELATED_SECRET": "secret-value",
+        "MODEL_GATEWAY_URL": "https://gateway.example.test",
+        "MODEL_GATEWAY_API_KEY": "gateway-key",
+    }
 
     def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
-        return {
-            "RUN_ID": "secret-run-id",
-            "TASK_ID": "secret-task-id",
-            "IDENTITY": '{"source":"secret"}',
-            "UNRELATED_SECRET": "secret-value",
-            "MODEL_GATEWAY_URL": "https://gateway.example.test",
-            "MODEL_GATEWAY_API_KEY": "gateway-key",
-        }
+        return resolved_env_vars
 
     @asynccontextmanager
     async def _capture_create_sandbox(*_args: Any, env_vars: dict[str, str], **_kwargs: Any):
-        captured_env_vars.append(env_vars)
+        captured_sandbox_env_vars.append(env_vars)
         yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
+
+    async def _capture_run_agent(*_args: Any, agent_env_vars: dict[str, str], **_kwargs: Any) -> tuple[None, float]:
+        captured_agent_env_vars.append(dict(agent_env_vars))
+        return None, 0.0
 
     monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_secrets)
     monkeypatch.setattr(utils_module, "create_sandbox", _capture_create_sandbox)
+    monkeypatch.setattr(utils_module, "run_agent", _capture_run_agent)
 
     result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
     assert result == {"task_0": {"status": "success", "score": 1.0}}
-    assert len(captured_env_vars) == 1
-    env_vars = captured_env_vars[0]
+    assert len(captured_sandbox_env_vars) == 1
+    env_vars = captured_sandbox_env_vars[0]
+    assert set(env_vars) == {
+        "RUN_ID",
+        "TASK_ID",
+        "IDENTITY",
+        "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS",
+    }
     assert env_vars["RUN_ID"] == str(benchmark_id)
     assert "QUESTION_ID" not in env_vars
     assert env_vars["TASK_ID"] == "task_0"
@@ -133,9 +186,17 @@ async def test_process_task_injects_tracker_owned_attribution_env(
         "agent_name": contract.name,
         "email": "starter@example.com",
     }
-    assert env_vars["UNRELATED_SECRET"] == "secret-value"
-    assert env_vars["MODEL_GATEWAY_URL"] == "https://gateway.example.test"
-    assert env_vars["MODEL_GATEWAY_API_KEY"] == "gateway-key"
+    assert env_vars["DAYTONA_SANDBOX_OTEL_EXTRA_LABELS"] == (
+        f"benchmark_id={benchmark_id},task_id=task_0,environment={utils_module.ENVIRONMENT}"
+    )
+    assert captured_agent_env_vars == [
+        {
+            "UNRELATED_SECRET": "secret-value",
+            "MODEL_GATEWAY_URL": "https://gateway.example.test",
+            "MODEL_GATEWAY_API_KEY": "gateway-key",
+        }
+    ]
+    assert resolved_env_vars == {}
 
 
 async def test_process_task_omits_identity_email_when_unavailable(
@@ -150,27 +211,826 @@ async def test_process_task_omits_identity_email_when_unavailable(
         database_session,
         harness_config,
     )
-    captured_env_vars: list[dict[str, str]] = []
+    captured_sandbox_env_vars: list[dict[str, str]] = []
+    captured_agent_env_vars: list[dict[str, str]] = []
 
     @asynccontextmanager
     async def _capture_create_sandbox(*_args: Any, env_vars: dict[str, str], **_kwargs: Any):
-        captured_env_vars.append(env_vars)
+        captured_sandbox_env_vars.append(env_vars)
         yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
 
     def _mock_resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
         return {}
 
+    async def _capture_run_agent(*_args: Any, agent_env_vars: dict[str, str], **_kwargs: Any) -> tuple[None, float]:
+        captured_agent_env_vars.append(agent_env_vars)
+        return None, 0.0
+
     monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_no_secrets)
     monkeypatch.setattr(utils_module, "create_sandbox", _capture_create_sandbox)
+    monkeypatch.setattr(utils_module, "run_agent", _capture_run_agent)
 
     result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
     assert result == {"task_0": {"status": "success", "score": 1.0}}
-    assert len(captured_env_vars) == 1
-    env_vars = captured_env_vars[0]
+    assert len(captured_sandbox_env_vars) == 1
+    env_vars = captured_sandbox_env_vars[0]
     assert json.loads(env_vars["IDENTITY"]) == {
         "benchmark_name": "swebench",
         "agent_name": contract.name,
     }
     assert "MODEL_GATEWAY_URL" not in env_vars
     assert "MODEL_GATEWAY_API_KEY" not in env_vars
+    assert captured_agent_env_vars == [{}]
+
+
+async def test_process_task_clears_agent_secrets_before_error_capture(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = contract.model_copy(update={"secrets": {"AGENT_SECRET": "secret-name"}})
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    resolved_env_vars = {"AGENT_SECRET": "sentry-secret-sentinel"}
+    captured_states: list[dict[str, str]] = []
+
+    @asynccontextmanager
+    async def _capture_create_sandbox(*_args: Any, **_kwargs: Any):
+        yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
+
+    async def _fail_run_agent(*_args: Any, agent_env_vars: dict[str, str], **_kwargs: Any) -> tuple[None, float]:
+        assert agent_env_vars == resolved_env_vars
+        raise RuntimeError("agent failed")
+
+    def _capture_exception(exc: BaseException) -> None:
+        captured_states.append(dict(resolved_env_vars))
+        assert "sentry-secret-sentinel" not in str(exc)
+
+    def _resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return resolved_env_vars
+
+    monkeypatch.setattr(utils_module, "resolve_secrets", _resolve_secrets)
+    monkeypatch.setattr(utils_module, "create_sandbox", _capture_create_sandbox)
+    monkeypatch.setattr(utils_module, "run_agent", _fail_run_agent)
+    monkeypatch.setattr(utils_module.sentry_sdk, "capture_exception", _capture_exception)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert result == {"task_0": None}
+    assert captured_states == [{}]
+    assert resolved_env_vars == {}
+
+
+async def test_process_task_does_not_resolve_agent_secrets_before_sandbox_exists(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = contract.model_copy(update={"secrets": {"AGENT_SECRET": "secret-name"}})
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    resolved = False
+
+    def _unexpected_resolve(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        nonlocal resolved
+        resolved = True
+        return {"AGENT_SECRET": "secret-value"}
+
+    @asynccontextmanager
+    async def _fail_create_sandbox(*_args: Any, **_kwargs: Any):
+        raise SandboxSetupError("sandbox creation failed")
+        yield SimpleNamespace(id="unreachable", name="unreachable")
+
+    monkeypatch.setattr(utils_module, "resolve_secrets", _unexpected_resolve)
+    monkeypatch.setattr(utils_module, "create_sandbox", _fail_create_sandbox)
+
+    with pytest.raises(SandboxSetupError, match="sandbox creation failed"):
+        await _run_process_task(
+            start_benchmark_request,
+            task_row,
+            benchmark_id,
+            harness_config,
+        )
+
+    assert not resolved
+
+
+async def test_process_task_runs_task_capability_lifecycle_before_upload_and_evaluation(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    events: list[str] = []
+    mint_requests: list[CapabilityMintRequest] = []
+    install_env_copies: list[dict[str, str]] = []
+    install_env_refs: list[dict[str, str]] = []
+    runtime_env_copies: list[dict[str, str]] = []
+    runtime_env_refs: list[dict[str, str]] = []
+    usage_uploads: list[tuple[bytes, str]] = []
+    persisted_resume_states: list[dict[str, Any] | None] = []
+    resolved_install_env = {"INSTALL_SECRET": "install-secret-value"}
+    usage = CapabilityUsageSummary(
+        capability_id="cap_task",
+        state="revoked",
+        drained=True,
+        session_count=4,
+        query_count=12,
+        completed_queries=12,
+        total_input_tokens=1_000,
+        total_output_tokens=500,
+        cost_usd=Decimal("0.42"),
+    )
+
+    async def retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            source=ImageSource(image="test-image:latest"),
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            agent_timeout=120.0,
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    def resolve_install_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        events.append("resolve")
+        return resolved_install_env
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        agent_env_vars = cast(dict[str, str], _args[3])
+        events.append("install")
+        install_env_copies.append(dict(agent_env_vars))
+        install_env_refs.append(agent_env_vars)
+
+    async def execute_agent(
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> tuple[None, float]:
+        runtime_env = cast(dict[str, str], _args[6])
+        events.append("execute")
+        runtime_env_copies.append(dict(runtime_env))
+        runtime_env_refs.append(runtime_env)
+        return None, 1.5
+
+    async def upload_outputs(*_args: Any, **_kwargs: Any) -> None:
+        events.append("upload")
+
+    async def upload_usage(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+        events.append("usage upload")
+        usage_uploads.append((content, key))
+
+    async def evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        events.append("evaluate")
+        _kwargs["on_eval_resume_state"]({"job_id": "eval-job"})
+        database_session.refresh(task_row)
+        persisted_resume_states.append(task_row.eval_resume_state)
+        return {"status": "success", "score": 1.0}
+
+    class FakeGateway:
+        gateway_url = "https://gateway.example.test"
+
+        async def __aenter__(self) -> "FakeGateway":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("close")
+
+        async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+            events.append("mint")
+            mint_requests.append(request)
+            return CapabilityMintResponse(
+                capability_id="cap_task",
+                token="mgc_task-token",
+                state="active",
+                expires_at=request.expires_at,
+            )
+
+        async def finalize(self, capability_id: str) -> CapabilityUsageSummary:
+            assert capability_id == "cap_task"
+            events.append("finalize")
+            return usage
+
+    gateway = FakeGateway()
+
+    class FakeGatewayFactory:
+        @classmethod
+        def from_environment(cls) -> FakeGateway:
+            return gateway
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", evaluate)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_install_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "upload_to_s3", upload_usage)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", upload_outputs)
+    monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+
+    before = time.time()
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+    after = time.time()
+
+    assert events == [
+        "resolve",
+        "install",
+        "mint",
+        "execute",
+        "finalize",
+        "usage upload",
+        "close",
+        "upload",
+        "evaluate",
+    ]
+    assert install_env_copies == [{"INSTALL_SECRET": "install-secret-value"}]
+    assert install_env_refs == [{}]
+    assert resolved_install_env == {}
+    assert runtime_env_copies == [
+        {
+            "MODEL_GATEWAY_URL": "https://gateway.example.test",
+            "MODEL_GATEWAY_API_KEY": "mgc_task-token",
+        }
+    ]
+    assert runtime_env_refs == [{}]
+    usage_content = (json.dumps(usage.model_dump(mode="json"), sort_keys=True) + "\n").encode()
+    assert usage_uploads == [
+        (
+            usage_content,
+            f"benchmarks/{benchmark_id}/task_0/model_gateway_usage/cap_task.json",
+        ),
+    ]
+    assert persisted_resume_states == [
+        CapabilityEvalResumeState(
+            kind="model_gateway_eval_resume",
+            capability_id="cap_task",
+            benchmark_state={"job_id": "eval-job"},
+        ).model_dump(mode="json")
+    ]
+
+    assert len(mint_requests) == 1
+    mint_request = mint_requests[0]
+    assert mint_request.run_id == str(benchmark_id)
+    assert mint_request.task_id == "task_0"
+    assert mint_request.model == "openai/gpt-5.5"
+    assert mint_request.config == {"client_scope": "shared", "max_tokens": 8192}
+    assert mint_request.sandbox_id == "mock-sandbox-id"
+    assert mint_request.identity == {
+        "org_id": str(TEST_ORG_ID),
+        "benchmark_name": "swebench",
+        "agent_name": contract.name,
+    }
+    assert math.floor(before) + 420 <= mint_request.expires_at <= math.floor(after) + 420
+    assert mint_request.max_queries == 800
+    assert mint_request.max_sessions == 4
+
+    assert result == {
+        "task_0": {
+            "status": "success",
+            "score": 1.0,
+            "_valkyrie_model_gateway_usage": usage.model_dump(mode="json"),
+        }
+    }
+
+
+async def test_process_task_resume_restores_task_capability_usage(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    task_row.status = TaskStatus.EVALUATING
+    task_row.eval_resume_state = CapabilityEvalResumeState(
+        kind="model_gateway_eval_resume",
+        capability_id="cap_task",
+        benchmark_state={"job_id": "eval-job"},
+    ).model_dump(mode="json")
+    database_session.add(task_row)
+    database_session.commit()
+    task_row.started_at += timedelta(seconds=1)
+    database_session.add(task_row)
+    database_session.commit()
+
+    usage = CapabilityUsageSummary(
+        capability_id="cap_task",
+        state="revoked",
+        drained=True,
+        session_count=4,
+        query_count=12,
+        completed_queries=12,
+        total_input_tokens=1_000,
+        total_output_tokens=500,
+        cost_usd=Decimal("0.42"),
+    )
+    artifacts = {
+        f"benchmarks/{benchmark_id}/task_0/model_gateway_usage/cap_task.json": (
+            json.dumps(usage.model_dump(mode="json"), sort_keys=True) + "\n"
+        ).encode(),
+    }
+    downloaded: list[str] = []
+
+    async def download_usage(key: str, *_args: Any, **_kwargs: Any) -> bytes:
+        downloaded.append(key)
+        return artifacts[key]
+
+    async def resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        assert _kwargs["eval_resume_state"] == {"job_id": "eval-job"}
+        return {"status": "success", "score": 1.0}
+
+    @asynccontextmanager
+    async def unexpected_sandbox(*_args: Any, **_kwargs: Any):
+        raise AssertionError("eval resume should not create a sandbox")
+        yield
+
+    monkeypatch.setattr(utils_module, "download_from_s3", download_usage)
+    monkeypatch.setattr(utils_module, "create_sandbox", unexpected_sandbox)
+    monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", resume_evaluation)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    expected = {
+        "status": "success",
+        "score": 1.0,
+        "_valkyrie_model_gateway_usage": usage.model_dump(mode="json"),
+    }
+    evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+    assert result == {"task_0": expected}
+    assert evaluation.result == expected
+    assert downloaded == list(artifacts)
+
+
+async def test_process_task_preserves_out_of_order_usage_from_two_attempts(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    capability_ids = iter(["cap_attempt_1", "cap_attempt_2"])
+    sandbox_ids = iter(["sandbox-attempt-1", "sandbox-attempt-2"])
+    uploads: list[tuple[bytes, str]] = []
+    first_attempt_upload_started = asyncio.Event()
+    release_first_attempt_upload = asyncio.Event()
+
+    async def retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            source=ImageSource(image="test-image:latest"),
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            agent_timeout=120.0,
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    async def no_op(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        return None, 1.0
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    async def capture_upload(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+        if json.loads(content)["capability_id"] == "cap_attempt_1":
+            first_attempt_upload_started.set()
+            await release_first_attempt_upload.wait()
+        uploads.append((content, key))
+
+    @asynccontextmanager
+    async def create_sandbox(*_args: Any, **_kwargs: Any):
+        sandbox_id = next(sandbox_ids)
+        yield SimpleNamespace(id=sandbox_id, name=sandbox_id)
+
+    class FakeGateway:
+        gateway_url = "https://gateway.example.test"
+
+        async def __aenter__(self) -> "FakeGateway":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+            return CapabilityMintResponse(
+                capability_id=next(capability_ids),
+                token="mgc_task-token",
+                state="active",
+                expires_at=request.expires_at,
+            )
+
+        async def finalize(self, capability_id: str) -> CapabilityUsageSummary:
+            return CapabilityUsageSummary(
+                capability_id=capability_id,
+                state="revoked",
+                drained=True,
+                session_count=1,
+                query_count=1,
+                completed_queries=1,
+                total_input_tokens=100,
+                total_output_tokens=50,
+                cost_usd=Decimal("0.10"),
+            )
+
+    gateway = FakeGateway()
+
+    class FakeGatewayFactory:
+        @classmethod
+        def from_environment(cls) -> FakeGateway:
+            return gateway
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "create_sandbox", create_sandbox)
+    monkeypatch.setattr(utils_module, "install_agent", no_op)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "upload_to_s3", capture_upload)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", no_op)
+    monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+
+    first_task = asyncio.create_task(_run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config))
+    await first_attempt_upload_started.wait()
+
+    database_session.refresh(task_row)
+    task_row.status = TaskStatus.PENDING
+    task_row.started_at += timedelta(seconds=1)
+    task_row.finished_at = None
+    task_row.eval_resume_state = None
+    database_session.add(task_row)
+    database_session.commit()
+
+    second_result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+    release_first_attempt_upload.set()
+    first_result = await first_task
+
+    prefix = f"benchmarks/{benchmark_id}/task_0/model_gateway_usage"
+    assert [key for _, key in uploads] == [
+        f"{prefix}/cap_attempt_2.json",
+        f"{prefix}/cap_attempt_1.json",
+    ]
+    assert [json.loads(content)["capability_id"] for content, _ in uploads] == [
+        "cap_attempt_2",
+        "cap_attempt_1",
+    ]
+    assert first_result == {"task_0": None}
+    assert second_result["task_0"] is not None
+
+
+async def test_process_task_cancellation_during_finalization_persists_usage_before_exit(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    finalization_started = asyncio.Event()
+    release_finalization = asyncio.Event()
+    events: list[str] = []
+    upload_keys: list[str] = []
+
+    async def retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            source=ImageSource(image="test-image:latest"),
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            agent_timeout=120.0,
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        events.append("install")
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        events.append("execute")
+        return None, 1.0
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    async def upload_usage(_content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+        events.append("usage upload")
+        upload_keys.append(key)
+
+    async def unexpected(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("cancelled task must not upload outputs or evaluate")
+
+    class FakeGateway:
+        gateway_url = "https://gateway.example.test"
+
+        async def __aenter__(self) -> "FakeGateway":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("close")
+
+        async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+            events.append("mint")
+            return CapabilityMintResponse(
+                capability_id="cap_cancelled",
+                token="mgc_task-token",
+                state="active",
+                expires_at=request.expires_at,
+            )
+
+        async def finalize(self, capability_id: str) -> CapabilityUsageSummary:
+            assert capability_id == "cap_cancelled"
+            events.append("finalize")
+            finalization_started.set()
+            await release_finalization.wait()
+            return CapabilityUsageSummary(
+                capability_id=capability_id,
+                state="revoked",
+                drained=True,
+                session_count=1,
+                query_count=1,
+                completed_queries=1,
+                total_input_tokens=100,
+                total_output_tokens=50,
+                cost_usd=Decimal("0.10"),
+            )
+
+    gateway = FakeGateway()
+
+    class FakeGatewayFactory:
+        @classmethod
+        def from_environment(cls) -> FakeGateway:
+            return gateway
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", unexpected)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "upload_to_s3", upload_usage)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", unexpected)
+    monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+
+    task = asyncio.create_task(_run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config))
+    await finalization_started.wait()
+    task.cancel()
+    release_finalization.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    prefix = f"benchmarks/{benchmark_id}/task_0/model_gateway_usage"
+    assert upload_keys == [f"{prefix}/cap_cancelled.json"]
+    assert events == ["install", "mint", "execute", "finalize", "usage upload", "close"]
+
+
+async def test_process_task_finalizes_capability_after_agent_error_and_blocks_outputs(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    events: list[str] = []
+
+    async def retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            source=ImageSource(image="test-image:latest"),
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            agent_timeout=120.0,
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        events.append("install")
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        events.append("execute")
+        raise RuntimeError("agent failed")
+
+    async def unexpected_upload(*_args: Any, **_kwargs: Any) -> None:
+        events.append("unexpected upload")
+
+    async def upload_usage(*_args: Any, **_kwargs: Any) -> None:
+        events.append("usage upload")
+
+    async def unexpected_evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        events.append("unexpected evaluate")
+        return {}
+
+    class FakeGateway:
+        gateway_url = "https://gateway.example.test"
+
+        async def __aenter__(self) -> "FakeGateway":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("close")
+
+        async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+            events.append("mint")
+            return CapabilityMintResponse(
+                capability_id="cap_task",
+                token="mgc_task-token",
+                state="active",
+                expires_at=request.expires_at,
+            )
+
+        async def finalize(self, capability_id: str) -> CapabilityUsageSummary:
+            assert capability_id == "cap_task"
+            events.append("finalize")
+            return CapabilityUsageSummary(
+                capability_id="cap_task",
+                state="revoked",
+                drained=True,
+                session_count=0,
+                query_count=0,
+                completed_queries=0,
+                total_input_tokens=0,
+                total_output_tokens=0,
+                cost_usd=Decimal("0"),
+            )
+
+    gateway = FakeGateway()
+
+    class FakeGatewayFactory:
+        @classmethod
+        def from_environment(cls) -> FakeGateway:
+            return gateway
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", unexpected_evaluate)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "upload_to_s3", upload_usage)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", unexpected_upload)
+    monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert result == {"task_0": None}
+    assert events == ["install", "mint", "execute", "finalize", "usage upload", "close"]
+
+
+async def test_process_task_blocks_outputs_when_capability_does_not_drain(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    events: list[str] = []
+
+    async def retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            source=ImageSource(image="test-image:latest"),
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            agent_timeout=120.0,
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        events.append("install")
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        events.append("execute")
+        return None, 1.0
+
+    async def unexpected(*_args: Any, **_kwargs: Any) -> None:
+        events.append("unexpected")
+
+    class FakeGateway:
+        gateway_url = "https://gateway.example.test"
+
+        async def __aenter__(self) -> "FakeGateway":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            events.append("close")
+
+        async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+            events.append("mint")
+            return CapabilityMintResponse(
+                capability_id="cap_task",
+                token="mgc_task-token",
+                state="active",
+                expires_at=request.expires_at,
+            )
+
+        async def finalize(self, capability_id: str) -> CapabilityUsageSummary:
+            assert capability_id == "cap_task"
+            events.append("finalize")
+            raise ModelGatewayError("Task capability did not drain before revocation")
+
+    gateway = FakeGateway()
+
+    class FakeGatewayFactory:
+        @classmethod
+        def from_environment(cls) -> FakeGateway:
+            return gateway
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", unexpected)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", unexpected)
+    monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert result == {"task_0": None}
+    assert events == ["install", "mint", "execute", "finalize", "close"]
+
+
+async def test_process_task_rejects_capability_without_agent_timeout_before_install(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    installed = False
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        nonlocal installed
+        installed = True
+
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert result == {"task_0": None}
+    assert not installed
+
+
+@pytest.mark.parametrize(
+    ("name", "message"),
+    [
+        ("BAD-NAME", "Invalid agent secret environment variable names: BAD-NAME"),
+        ("RUN_ID", "Agent secret environment variables use reserved names: RUN_ID"),
+        ("TERM", "Agent secret environment variables use reserved names: TERM"),
+        (
+            "VALKYRIE_AGENT_SECRET_SCOPE",
+            "Agent secret environment variables use reserved names: VALKYRIE_AGENT_SECRET_SCOPE",
+        ),
+    ],
+)
+def test_agent_secret_environment_names_fail_closed(name: str, message: str) -> None:
+    validate_agent_env_vars = getattr(utils_module, "_validate_agent_env_vars")
+
+    with pytest.raises(SandboxSetupError, match=message):
+        validate_agent_env_vars({name: "secret-value"})

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -44,6 +44,15 @@ _apply_egress_allowlist = getattr(sandbox_module, "_apply_egress_allowlist")
 _install_agent_dependencies = getattr(sandbox_module, "install_agent_dependencies")
 _stream_command_output_with_egress_allowlist = getattr(sandbox_module, "_stream_command_output_with_egress_allowlist")
 _upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
+_AGENT_SCOPE_ENV = getattr(sandbox_module, "_AGENT_SCOPE_ENV")
+_SECRET_NAMES_ENV = getattr(sandbox_module, "_SECRET_NAMES_ENV")
+_AGENT_SECRET_CLEANUP_COMMAND = getattr(sandbox_module, "_AGENT_SECRET_CLEANUP_COMMAND")
+_cleanup_agent_secret_processes = getattr(sandbox_module, "_cleanup_agent_secret_processes")
+
+
+def _assert_scoped_env(actual: dict[str, str], expected: dict[str, str]) -> None:
+    assert {name: value for name, value in actual.items() if name != _AGENT_SCOPE_ENV} == expected
+    assert len(actual[_AGENT_SCOPE_ENV]) == 32
 
 
 class TestOutputArtifacts:
@@ -262,6 +271,7 @@ class TestAgentOutputTelemetry:
             "task_0",
             lambda _msg: None,
             "/testbed",
+            agent_env_vars={},
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
             benchmark_id="benchmark-123",
@@ -317,6 +327,7 @@ class TestAgentOutputTelemetry:
             "task_0",
             lambda _msg: None,
             "/testbed",
+            agent_env_vars={},
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
             agent_output_s3_key="benchmarks/run/task/agent_output.tar.gz",
@@ -347,9 +358,16 @@ class TestAgentOutputTelemetry:
             assert command == "mkdir -p /workspace"
             return ExecResult(exit_code=0)
 
-        async def fake_stream_command_output(sandbox: Any, command: str, _log_output: Any) -> tuple[None, float]:
+        async def fake_stream_command_output(
+            sandbox: Any,
+            command: str,
+            _log_output: Any,
+            *,
+            env_vars: dict[str, str],
+        ) -> tuple[None, float]:
             observed_sandboxes.append(sandbox)
             assert command == "cd /workspace && PYTHONSAFEPATH=1 echo done"
+            assert env_vars == {}
             return None, 0.0
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
@@ -367,6 +385,7 @@ class TestAgentOutputTelemetry:
             "task_0",
             lambda _msg: None,
             "/workspace",
+            agent_env_vars={},
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
             runtime_source=ComposeSource(
@@ -400,8 +419,15 @@ class TestAgentOutputTelemetry:
             assert command == "mkdir -p /workspace"
             return ExecResult(exit_code=0)
 
-        async def fake_stream_command_output(_sandbox: Any, command: str, _log_output: Any) -> tuple[None, float]:
+        async def fake_stream_command_output(
+            _sandbox: Any,
+            command: str,
+            _log_output: Any,
+            *,
+            env_vars: dict[str, str],
+        ) -> tuple[None, float]:
             observed_commands.append(command)
+            assert env_vars == {}
             return None, 0.0
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
@@ -418,12 +444,66 @@ class TestAgentOutputTelemetry:
             "task_0",
             lambda _msg: None,
             "/workspace",
+            agent_env_vars={},
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
             agent_timeout=2.5,
         )
 
         assert observed_commands == [f"cd /workspace && PYTHONSAFEPATH=1 timeout 2.5 sh -c {shlex.quote(run_cmd)}"]
+
+    async def test_run_agent_scopes_native_secrets_to_install_and_run(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        secret = "value with spaces; $(touch /tmp/leaked) and 'quotes'"
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="echo install",
+            run_cmd="echo run && echo done",
+            final_output="/tmp/result",
+        )
+        exec_commands: list[str] = []
+        streamed_commands: list[tuple[str, dict[str, str]]] = []
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
+            exec_commands.append(command)
+            return ExecResult(exit_code=1)
+
+        async def fake_stream_command_output(
+            _sandbox: Any,
+            command: str,
+            _log_output: Any,
+            *,
+            env_vars: dict[str, str],
+        ) -> tuple[None, float]:
+            streamed_commands.append((command, env_vars))
+            return None, 0.0
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
+
+        mock_sandbox = Mock(id="sandbox-123", name="task-alias")
+        await run_agent(
+            mock_sandbox,
+            contract,
+            "/tmp/problem.txt",
+            "task_0",
+            lambda _msg: None,
+            "/workspace",
+            agent_env_vars={"AGENT_SECRET": secret},
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+        )
+
+        assert streamed_commands == [
+            ("cd /bundle/test-agent && timeout 600 sh -c 'echo install'", {"AGENT_SECRET": secret}),
+            ("cd /workspace && PYTHONSAFEPATH=1 echo run && echo done", {"AGENT_SECRET": secret}),
+        ]
+        assert exec_commands == ["mkdir -p /workspace", "test -e /tmp/result"]
+        assert all(secret not in command for command, _env_vars in streamed_commands)
+        assert all(secret not in command for command in exec_commands)
 
     def test_sandbox_retry_decorators_use_observability_retry_callbacks(self) -> None:
         upload_before_sleep = _upload_agent_artifacts.retry.before_sleep
@@ -458,8 +538,11 @@ class TestAgentOutputTelemetry:
             _sandbox: Any,
             command: str,
             _log_output: Any,
+            *,
+            env_vars: dict[str, str],
         ) -> tuple[AgentCausedExitReason | None, float]:
             observed_commands.append(command)
+            assert env_vars == {}
 
             return setup_results.popleft()
 
@@ -468,7 +551,7 @@ class TestAgentOutputTelemetry:
 
         monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
 
-        await _install_agent_dependencies(Mock(), contract, log_output)
+        await _install_agent_dependencies(Mock(), contract, log_output, agent_env_vars={})
 
         expected_command = "cd /bundle/test-agent && timeout 600 sh -c 'apt-get update -qq && echo done'"
         assert observed_commands == [expected_command, expected_command]
@@ -701,6 +784,45 @@ class TestAgentOutputTelemetry:
 
         assert increments == [("valkyrie.sandbox.create.errors", {"error_class": "RuntimeError"})]
 
+    async def test_create_sandbox_cancellation_waits_for_deletion(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sandbox = Mock(id="sandbox-123", name="task-alias", state="started")
+        entered = asyncio.Event()
+        delete_started = asyncio.Event()
+        allow_delete = asyncio.Event()
+
+        async def fake_create(*_args: Any, **_kwargs: Any) -> Any:
+            return sandbox
+
+        async def fake_delete(actual_sandbox: Any, _provider: Any) -> None:
+            assert actual_sandbox is sandbox
+            delete_started.set()
+            await allow_delete.wait()
+
+        async def use_sandbox() -> None:
+            async with create_sandbox(
+                provider=AsyncMock(),
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                entered.set()
+                await asyncio.Event().wait()
+
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", fake_create)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", fake_delete)
+        task = asyncio.create_task(use_sandbox())
+        await entered.wait()
+        task.cancel()
+        await delete_started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        allow_delete.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
 
 class TestUploadAgentArtifacts:
     @pytest.mark.parametrize(
@@ -794,6 +916,7 @@ class TestEgressAllowlist:
             "run-agent.sh",
             on_output=ignore_output,
             allowed_addresses=["https://api.openai.com"],
+            env_vars={},
         )
 
         assert result == (None, 2.5)
@@ -827,10 +950,31 @@ class TestEgressAllowlist:
             "run-agent.sh",
             on_output=ignore_output,
             allowed_addresses=[],
+            env_vars={},
         )
 
         assert result == (None, 1.0)
         mock_sandbox.modify_egress_rules.assert_not_awaited()
+        mock_sandbox.clear_egress_rules.assert_not_awaited()
+
+    async def test_failed_agent_command_keeps_egress_restricted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fail_stream(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            raise SandboxSetupError("credential cleanup failed")
+
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fail_stream)
+        mock_sandbox = Mock(id="sandbox-123")
+        mock_sandbox.modify_egress_rules = AsyncMock()
+        mock_sandbox.clear_egress_rules = AsyncMock()
+
+        with pytest.raises(SandboxSetupError, match="credential cleanup failed"):
+            await _stream_command_output_with_egress_allowlist(
+                mock_sandbox,
+                "run-agent.sh",
+                on_output=lambda _message: None,
+                allowed_addresses=["https://api.openai.com"],
+                env_vars={"AGENT_SECRET": "secret"},
+            )
+
         mock_sandbox.clear_egress_rules.assert_not_awaited()
 
     @pytest.mark.parametrize(
@@ -860,8 +1004,16 @@ class TestEgressAllowlist:
 
 
 class TestStreamCommandOutputAgentFailure:
+    @pytest.fixture(autouse=True)
+    def stub_secret_cleanup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def cleanup(_sandbox: Any, _env_vars: Mapping[str, str]) -> None:
+            return
+
+        monkeypatch.setattr(sandbox_module, "_cleanup_agent_secret_processes", cleanup)
+
     async def test_stream_command_output_removes_timing_files(self) -> None:
-        async def stream_command(_command: str) -> Any:
+        async def stream_command(_command: str, *, env_vars: dict[str, str]) -> Any:
+            assert env_vars == {}
             yield "done\n"
 
         exec_commands: list[str] = []
@@ -882,7 +1034,10 @@ class TestStreamCommandOutputAgentFailure:
         mock_sandbox.exec = exec_command
 
         exit_reason, duration = await sandbox_module.stream_command_output(
-            mock_sandbox, "run-agent.sh", on_output=lambda _: None
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=lambda _: None,
+            env_vars={},
         )
 
         assert exit_reason is None
@@ -895,7 +1050,12 @@ class TestStreamCommandOutputAgentFailure:
     async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(
         self, monkeypatch: pytest.MonkeyPatch, exit_code: int
     ) -> None:
-        async def stream_command(_command: str) -> Any:
+        secret = "value with spaces; $(touch /tmp/leaked) and 'quotes'"
+        streamed_commands: list[str] = []
+
+        async def stream_command(command: str, *, env_vars: dict[str, str]) -> Any:
+            streamed_commands.append(command)
+            _assert_scoped_env(env_vars, {"AGENT_SECRET": secret})
             yield "last line\n"
             raise ProviderSandboxCommandError(exit_code)
 
@@ -917,10 +1077,241 @@ class TestStreamCommandOutputAgentFailure:
         monkeypatch.setattr("tracker.sandbox.sentry_sdk.set_tag", fake_set_tag)
 
         with pytest.raises(AgentRunFailedError) as exc_info:
-            await sandbox_module.stream_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)
+            await sandbox_module.stream_command_output(
+                mock_sandbox,
+                "run-agent.sh",
+                on_output=lambda _: None,
+                env_vars={"AGENT_SECRET": secret},
+            )
 
         assert isinstance(exc_info.value, SandboxError)
         assert not isinstance(exc_info.value, SandboxSetupError)
         assert f"exit code: {exit_code}" in str(exc_info.value)
         assert "last line" in str(exc_info.value)
+        assert "AGENT_SECRET" not in str(exc_info.value)
+        assert secret not in str(exc_info.value)
+        assert len(streamed_commands) == 1
+        assert "; run-agent.sh;" in streamed_commands[0]
+        assert secret not in streamed_commands[0]
         assert tagged == {"agent_exit_code": str(exit_code)}
+
+    @pytest.mark.parametrize("split", range(1, len("cross-chunk-secret")))
+    async def test_stream_command_output_redacts_secrets_across_chunk_boundaries(self, split: int) -> None:
+        secret = "cross-chunk-secret"
+        logs: list[str] = []
+
+        async def stream_command(command: str, *, env_vars: dict[str, str]) -> Any:
+            assert secret not in command
+            _assert_scoped_env(env_vars, {"AGENT_SECRET": secret})
+            yield f"before:{secret[:split]}"
+            yield f"{secret[split:]}:after"
+
+        async def exec_command(command: str) -> ExecResult:
+            if command.startswith("cat ") and command.endswith(".start_ns"):
+                return ExecResult(exit_code=0, output="1000000000")
+            if command.startswith("cat ") and command.endswith(".end_ns"):
+                return ExecResult(exit_code=0, output="3000000000")
+            return ExecResult(exit_code=0)
+
+        mock_sandbox = Mock(id="sandbox-123", name="test-sandbox", state="started")
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = exec_command
+
+        await sandbox_module.stream_command_output(
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=logs.append,
+            env_vars={"AGENT_SECRET": secret},
+        )
+
+        assert "".join(logs) == "before:[REDACTED]:after"
+
+    async def test_stream_command_output_redacts_prefix_overlapping_secrets(self) -> None:
+        logs: list[str] = []
+
+        async def stream_command(command: str, *, env_vars: dict[str, str]) -> Any:
+            assert "abcdef" not in command
+            _assert_scoped_env(env_vars, {"SHORT": "abc", "LONG": "abcdef"})
+            yield "0abc"
+            yield "def1abc2"
+
+        async def exec_command(command: str) -> ExecResult:
+            if command.startswith("cat ") and command.endswith(".start_ns"):
+                return ExecResult(exit_code=0, output="1000000000")
+            if command.startswith("cat ") and command.endswith(".end_ns"):
+                return ExecResult(exit_code=0, output="3000000000")
+            return ExecResult(exit_code=0)
+
+        mock_sandbox = Mock(id="sandbox-123", name="test-sandbox", state="started")
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = exec_command
+
+        await sandbox_module.stream_command_output(
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=logs.append,
+            env_vars={"SHORT": "abc", "LONG": "abcdef"},
+        )
+
+        assert "".join(logs) == "0[REDACTED]1[REDACTED]2"
+
+    @pytest.mark.parametrize("secret", ["aaaa", "abab", "abcab"])
+    async def test_stream_command_output_redacts_self_overlapping_secrets(self, secret: str) -> None:
+        logs: list[str] = []
+
+        async def stream_command(_command: str, *, env_vars: dict[str, str]) -> Any:
+            _assert_scoped_env(env_vars, {"AGENT_SECRET": secret})
+            yield secret
+
+        async def exec_command(command: str) -> ExecResult:
+            if command.startswith("cat ") and command.endswith(".start_ns"):
+                return ExecResult(exit_code=0, output="1000000000")
+            if command.startswith("cat ") and command.endswith(".end_ns"):
+                return ExecResult(exit_code=0, output="3000000000")
+            return ExecResult(exit_code=0)
+
+        mock_sandbox = Mock(id="sandbox-123", name="test-sandbox", state="started")
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = exec_command
+
+        await sandbox_module.stream_command_output(
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=logs.append,
+            env_vars={"AGENT_SECRET": secret},
+        )
+
+        assert "".join(logs) == "[REDACTED]"
+
+    async def test_stream_command_output_redacts_dangling_secret_prefix(self) -> None:
+        logs: list[str] = []
+
+        async def stream_command(_command: str, *, env_vars: dict[str, str]) -> Any:
+            _assert_scoped_env(env_vars, {"AGENT_SECRET": "abcdef"})
+            yield "before:abc"
+
+        async def exec_command(command: str) -> ExecResult:
+            if command.startswith("cat ") and command.endswith(".start_ns"):
+                return ExecResult(exit_code=0, output="1000000000")
+            if command.startswith("cat ") and command.endswith(".end_ns"):
+                return ExecResult(exit_code=0, output="3000000000")
+            return ExecResult(exit_code=0)
+
+        mock_sandbox = Mock(id="sandbox-123", name="test-sandbox", state="started")
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = exec_command
+
+        await sandbox_module.stream_command_output(
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=logs.append,
+            env_vars={"AGENT_SECRET": "abcdef"},
+        )
+
+        assert "".join(logs) == "before:[REDACTED]"
+
+    async def test_stream_command_output_redacts_provider_errors(self) -> None:
+        secret = "provider-secret"
+
+        async def stream_command(_command: str, *, env_vars: dict[str, str]) -> Any:
+            _assert_scoped_env(env_vars, {"AGENT_SECRET": secret})
+            raise ProviderSandboxError(f"provider failed: {secret}")
+            yield
+
+        mock_sandbox = Mock(id="sandbox-123", name="test-sandbox", state="started")
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = AsyncMock(return_value=ExecResult(exit_code=0))
+
+        with pytest.raises(SandboxError, match=r"provider failed: \[REDACTED\]") as exc_info:
+            await sandbox_module.stream_command_output(
+                mock_sandbox,
+                "run-agent.sh",
+                on_output=lambda _: None,
+                env_vars={"AGENT_SECRET": secret},
+            )
+
+        assert secret not in str(exc_info.value)
+        assert exc_info.value.__cause__ is None
+
+
+class TestAgentSecretProcessCleanup:
+    async def test_cleanup_uses_native_env_without_putting_secrets_in_command(self) -> None:
+        calls: list[tuple[str, dict[str, str]]] = []
+
+        async def command(command: str, *, env_vars: dict[str, str]) -> Any:
+            calls.append((command, env_vars))
+            yield ""
+
+        sandbox = Mock(command=command)
+        env_vars = {
+            "API_KEY": "secret with spaces; $(touch /tmp/leak)",
+            _AGENT_SCOPE_ENV: "scope-123",
+        }
+
+        await _cleanup_agent_secret_processes(sandbox, env_vars)
+
+        assert len(calls) == 1
+        command_text, cleanup_env = calls[0]
+        assert command_text == _AGENT_SECRET_CLEANUP_COMMAND
+        assert env_vars["API_KEY"] not in command_text
+        assert cleanup_env[_SECRET_NAMES_ENV] == '["API_KEY"]'
+        assert cleanup_env["API_KEY"] == env_vars["API_KEY"]
+        assert cleanup_env[_AGENT_SCOPE_ENV] == "scope-123"
+
+    async def test_cleanup_failure_is_fail_closed_and_redacted(self) -> None:
+        secret = "provider-secret"
+
+        async def command(_command: str, *, env_vars: dict[str, str]) -> Any:
+            assert env_vars["API_KEY"] == secret
+            raise ProviderSandboxError(f"failed with {secret}")
+            yield
+
+        sandbox = Mock(command=command)
+        with pytest.raises(SandboxSetupError, match="Failed to clear agent credential processes") as exc_info:
+            await _cleanup_agent_secret_processes(
+                sandbox,
+                {"API_KEY": secret, _AGENT_SCOPE_ENV: "scope-123"},
+            )
+
+        assert secret not in str(exc_info.value)
+        assert exc_info.value.__cause__ is None
+
+    async def test_cancellation_waits_for_secret_cleanup(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        command_started = asyncio.Event()
+        cleanup_started = asyncio.Event()
+        allow_cleanup = asyncio.Event()
+
+        async def command(_command: str, *, env_vars: dict[str, str]) -> Any:
+            _assert_scoped_env(env_vars, {"API_KEY": "secret"})
+            command_started.set()
+            await asyncio.Event().wait()
+            yield
+
+        async def cleanup(_sandbox: Any, env_vars: Mapping[str, str]) -> None:
+            assert env_vars["API_KEY"] == "secret"
+            cleanup_started.set()
+            await allow_cleanup.wait()
+
+        sandbox = Mock(id="sandbox-123", name="test-sandbox", state="started")
+        sandbox.command = command
+        sandbox.exec = AsyncMock(return_value=ExecResult(exit_code=0))
+        monkeypatch.setattr(sandbox_module, "_cleanup_agent_secret_processes", cleanup)
+
+        task = asyncio.create_task(
+            sandbox_module.stream_command_output(
+                sandbox,
+                "run-agent.sh",
+                on_output=lambda _message: None,
+                env_vars={"API_KEY": "secret"},
+            )
+        )
+        await command_started.wait()
+        task.cancel()
+        await cleanup_started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        allow_cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1254,7 +1254,7 @@ class TestAgentSecretProcessCleanup:
         command_text, cleanup_env = calls[0]
         assert command_text == _AGENT_SECRET_CLEANUP_COMMAND
         assert env_vars["API_KEY"] not in command_text
-        assert cleanup_env[_SECRET_NAMES_ENV] == '["API_KEY"]'
+        assert cleanup_env[_SECRET_NAMES_ENV] == "API_KEY"
         assert cleanup_env["API_KEY"] == env_vars["API_KEY"]
         assert cleanup_env[_AGENT_SCOPE_ENV] == "scope-123"
 

--- a/services/tracker/tests/unit/test_sentry.py
+++ b/services/tracker/tests/unit/test_sentry.py
@@ -73,6 +73,7 @@ def test_init_sentry_registers_otlp_integration_without_exporter_or_propagator(
 
     sentry_module.init_sentry("valkyrie-worker", environment="test")
 
+    assert init_mock.call_args.kwargs["include_local_variables"] is False
     integrations = init_mock.call_args.kwargs["integrations"]
     otlp_integrations = [i for i in integrations if isinstance(i, OTLPIntegration)]
     assert len(otlp_integrations) == 1, "expected exactly one OTLPIntegration in integrations="

--- a/services/tracker/tests/unit/test_stop_and_resume.py
+++ b/services/tracker/tests/unit/test_stop_and_resume.py
@@ -871,7 +871,7 @@ class TestStopAndResume:
         evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
         assert result == {"task_0": {"score": 1.0}}
         assert task_row.status == TaskStatus.FINISHED
-        assert task_row.eval_resume_state == {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        assert task_row.eval_resume_state is None
         assert evaluation.instance_id is None
 
     async def test_process_task_keeps_stopped_eval_resume_task_stopped(

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -264,6 +264,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/6f/07b4af8da8bd27f640362b1ac8271d80895407f2ede0c2bcc9433c06e1ca/cbor2-6.1.3.tar.gz", hash = "sha256:8d70680acb55c04ea5b5ad86da094f9612b53d5a8a65d0f5b3aafc3ce917ecbb", size = 89503, upload-time = "2026-07-04T10:36:48.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/16/cff14259c3d19a7f0ae88b6996fe4c85f6ff1764dad889ac8a39e843e39c/cbor2-6.1.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3d939f55097c21e032f5a2d67592fcc57298986281f219356e2f519e4466f4ea", size = 412779, upload-time = "2026-07-04T10:36:04.975Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6c/f3641d19b7b85a63cb2756c10164131489c2cb46b379ec51ae22283fefb9/cbor2-6.1.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b025009478d644dab407164fd60e3ef4381af284f5af6966df94c663756d949e", size = 457781, upload-time = "2026-07-04T10:36:06.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/85/0c55a66f3037056bfb8e1c7184168085fdea67ae5830404498bcf466233b/cbor2-6.1.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2226d32e102e375737656ad5d141ad8c6ae3e705e04e263f24756f0eb379c6c1", size = 468373, upload-time = "2026-07-04T10:36:07.769Z" },
+    { url = "https://files.pythonhosted.org/packages/46/74/40f7db3e0d880560193916a5c9b744fcf299558bed7113f77c28237c7c29/cbor2-6.1.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e61d465244d66ffed36492eef3b44d43795d76a2bba0663a2f15c186af7f7513", size = 523844, upload-time = "2026-07-04T10:36:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a1/b5e07d6a08441c3a552fe2ae48ccb7e9dfc5065b9f6a3bae9879b4f0fbc0/cbor2-6.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87fe7be8fab6ec4796aa127c1a52e09e79dbafd2aa31caf809cf04b8080a5975", size = 536238, upload-time = "2026-07-04T10:36:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/99/e166be0fd74bf3a91f5a0d103e34883efbc438d970f72cc8200e274787e5/cbor2-6.1.3-cp312-cp312-win32.whl", hash = "sha256:da25d345f01e6a40b2e5c57ef96b4dcff7be69394fb62f0f70e07f437f2376a9", size = 279858, upload-time = "2026-07-04T10:36:12.247Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1b/90b4a121e40aba189c55a5822dd3c698eaf487e1d4a780ab18c804a5ef1c/cbor2-6.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:d5514f693db6fa6f433b4096e9b604e6a7bf151c9ef1d2db86d0858e4c5e768f", size = 300929, upload-time = "2026-07-04T10:36:13.564Z" },
+    { url = "https://files.pythonhosted.org/packages/19/db/52c58a8d33464927389dde8103997b3fa51b081ce29b347ac2cc4fd0dfbf/cbor2-6.1.3-cp312-cp312-win_arm64.whl", hash = "sha256:3d43183d7beb3d3cd198d69b31bd2ee487ed704a1150c75cb0a66d6ad63d8c1a", size = 290908, upload-time = "2026-07-04T10:36:14.857Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -367,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.13.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1#673dde74470594e3aa3f6931358e30ad60af06d5" }
+version = "0.15.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0#3e517a46c7807b6c8c74bbb9f0ca537d34852f1d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -378,6 +394,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "modal" },
     { name = "pyyaml" },
     { name = "starlette" },
     { name = "tenacity" },
@@ -743,12 +760,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -807,6 +859,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -958,6 +1019,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.5.3.dev2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/2fe173141c843455f99b3ff07ddc60958db102e6e0b37cdbbb8d80330ccb/modal-1.5.3.dev2.tar.gz", hash = "sha256:e3f8fb566257a477250254ccc684254401cb00c197f34d9a4cae68aab82aadb9", size = 820241, upload-time = "2026-07-13T00:55:42.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/99/b131dec1c535d646fb2e8b56c4b6cbc9cf5688e6c94bc4822007291fa236/modal-1.5.3.dev2-py3-none-any.whl", hash = "sha256:d8a4361f8f1ac3512fab6a3f5ffd14d6a41132528c5add9135b35790c44d94fe", size = 934363, upload-time = "2026-07-13T00:55:40.007Z" },
 ]
 
 [[package]]
@@ -1803,6 +1888,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
+]
+
+[[package]]
 name = "taskiq"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1922,7 +2019,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -1978,12 +2075,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
 ]
 
 [[package]]

--- a/tests/contract/test_sdk_tracker_contract.py
+++ b/tests/contract/test_sdk_tracker_contract.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from services.tracker.main import app
 from tracker.database.models import (
     AgentContractRequest,
@@ -132,6 +132,52 @@ def test_sdk_and_tracker_wire_models_have_the_same_fields(
     tracker_model: type[BaseModel], sdk_model: type[BaseModel]
 ) -> None:
     assert tracker_model.model_fields.keys() == sdk_model.model_fields.keys()
+
+
+def test_selected_model_gateway_policy_matches_tracker_and_sdk() -> None:
+    payload = {
+        "name": "osworld_agent",
+        "model": "openai/gpt-5.5",
+        "model_gateway_policy": {
+            "kind": "task_capability",
+            "model": "openai/gpt-5.5",
+            "config": {"client_scope": "shared", "max_tokens": 8192},
+            "max_queries": 800,
+            "max_sessions": 4,
+        },
+    }
+
+    tracker = AgentContractRequest.model_validate(payload)
+    sdk = SDKAgentContractRequest.model_validate(payload)
+
+    assert tracker.model_dump(mode="json") == sdk.model_dump(mode="json")
+    assert tracker.model_dump(mode="json")["model_gateway_policy"] == payload["model_gateway_policy"]
+
+
+@pytest.mark.parametrize(
+    "policy_update",
+    [
+        {"model": "openai/other"},
+        {"max_queries": 2001},
+        {"max_sessions": 17},
+        {"routing": "other"},
+        {"config": {"client_scope": "shared", "custom_endpoint": "https://attacker.invalid"}},
+    ],
+)
+def test_selected_model_gateway_policy_rejects_invalid_wire_values(policy_update: dict[str, Any]) -> None:
+    policy = {
+        "kind": "task_capability",
+        "model": "openai/gpt-5.5",
+        "config": {"client_scope": "shared"},
+        "max_queries": 800,
+        "max_sessions": 4,
+        **policy_update,
+    }
+    payload = {"name": "osworld_agent", "model": "openai/gpt-5.5", "model_gateway_policy": policy}
+
+    for request_model in (AgentContractRequest, SDKAgentContractRequest):
+        with pytest.raises(ValidationError):
+            request_model.model_validate(payload)
 
 
 def test_fetch_stream_fixture_matches_tracker_and_sdk_response_models() -> None:

--- a/tests/fixtures/sdk_api/results.json
+++ b/tests/fixtures/sdk_api/results.json
@@ -21,7 +21,8 @@
         ],
         "egress_allowlist": [],
         "secrets": {},
-        "kwargs": {}
+        "kwargs": {},
+        "model_gateway_policy": null
       },
       "concurrency": 2,
       "task_ids": [

--- a/tests/fixtures/sdk_api/start.json
+++ b/tests/fixtures/sdk_api/start.json
@@ -18,7 +18,8 @@
       },
       "kwargs": {
         "temperature": "0"
-      }
+      },
+      "model_gateway_policy": null
     },
     "benchmark_name": "swebench",
     "concurrency": 2,

--- a/tests/unit/sdk/test_artifact_validation.py
+++ b/tests/unit/sdk/test_artifact_validation.py
@@ -15,9 +15,11 @@ from scripts.sdk.validate_sdk_artifacts import ArtifactError, validate_sdist, va
 
 ROOT = Path(__file__).parents[3]
 PACKAGE_ROOT = ROOT / "packages" / "valkyrie-sdk"
-METADATA = """Metadata-Version: 2.4
+PACKAGE_VERSION = tomllib.loads((PACKAGE_ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+SDIST_ROOT = f"valkyrie_sdk-{PACKAGE_VERSION}"
+METADATA = f"""Metadata-Version: 2.4
 Name: valkyrie-sdk
-Version: 0.1.0
+Version: {PACKAGE_VERSION}
 License-Expression: AGPL-3.0-only
 License-File: LICENSE
 Requires-Python: >=3.12
@@ -32,7 +34,7 @@ def write_wheel(
     *,
     extra_members: dict[str, str] | None = None,
     metadata: str = METADATA,
-    dist_info_version: str = "0.1.0",
+    dist_info_version: str = PACKAGE_VERSION,
 ) -> None:
     dist_info = f"valkyrie_sdk-{dist_info_version}.dist-info"
     members = {
@@ -52,13 +54,13 @@ def write_wheel(
 
 def write_sdist(path: Path, *, extra_members: dict[str, str] | None = None) -> None:
     members = {
-        "valkyrie_sdk-0.1.0/.gitignore": ".ruff_cache/\n__pycache__/\ndist/\n",
-        "valkyrie_sdk-0.1.0/LICENSE": "AGPL",
-        "valkyrie_sdk-0.1.0/README.md": "# Valkyrie SDK",
-        "valkyrie_sdk-0.1.0/pyproject.toml": "[project]\nname='valkyrie-sdk'\n",
-        "valkyrie_sdk-0.1.0/PKG-INFO": METADATA,
-        "valkyrie_sdk-0.1.0/src/valkyrie/sdk/__init__.py": "",
-        "valkyrie_sdk-0.1.0/src/valkyrie/sdk/py.typed": "",
+        f"{SDIST_ROOT}/.gitignore": ".ruff_cache/\n__pycache__/\ndist/\n",
+        f"{SDIST_ROOT}/LICENSE": "AGPL",
+        f"{SDIST_ROOT}/README.md": "# Valkyrie SDK",
+        f"{SDIST_ROOT}/pyproject.toml": "[project]\nname='valkyrie-sdk'\n",
+        f"{SDIST_ROOT}/PKG-INFO": METADATA,
+        f"{SDIST_ROOT}/src/valkyrie/sdk/__init__.py": "",
+        f"{SDIST_ROOT}/src/valkyrie/sdk/py.typed": "",
     }
     members.update(extra_members or {})
     with tarfile.open(path, "w:gz") as archive:
@@ -84,8 +86,8 @@ def test_sdk_package_configuration_matches_release_boundaries() -> None:
 
 
 def test_valid_artifacts_are_accepted(tmp_path: Path) -> None:
-    wheel = tmp_path / "valkyrie_sdk-0.1.0-py3-none-any.whl"
-    sdist = tmp_path / "valkyrie_sdk-0.1.0.tar.gz"
+    wheel = tmp_path / f"valkyrie_sdk-{PACKAGE_VERSION}-py3-none-any.whl"
+    sdist = tmp_path / f"valkyrie_sdk-{PACKAGE_VERSION}.tar.gz"
     write_wheel(wheel)
     write_sdist(sdist)
 
@@ -148,7 +150,7 @@ def test_wheel_rejects_forbidden_dependency_declared_by_pyproject(
 ) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        '[project]\nversion = "0.1.0"\nrequires-python = ">=3.12"\ndependencies = ["tracker"]\n',
+        f'[project]\nversion = "{PACKAGE_VERSION}"\nrequires-python = ">=3.12"\ndependencies = ["tracker"]\n',
         encoding="utf-8",
     )
     monkeypatch.setattr(validate_sdk_artifacts, "PACKAGE_PYPROJECT", pyproject)
@@ -163,7 +165,7 @@ def test_wheel_rejects_forbidden_dependency_declared_by_pyproject(
 def test_wheel_rejects_unsupported_optional_dependencies(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text(
-        '[project]\nversion = "0.1.0"\nrequires-python = ">=3.12"\ndependencies = []\n'
+        f'[project]\nversion = "{PACKAGE_VERSION}"\nrequires-python = ">=3.12"\ndependencies = []\n'
         '[project.optional-dependencies]\ncli = ["click>=8"]\n',
         encoding="utf-8",
     )
@@ -177,7 +179,7 @@ def test_wheel_rejects_unsupported_optional_dependencies(tmp_path: Path, monkeyp
 
 def test_wheel_rejects_mismatched_dist_info_version(tmp_path: Path) -> None:
     wheel = tmp_path / "bad.whl"
-    write_wheel(wheel, dist_info_version="0.1.1")
+    write_wheel(wheel, dist_info_version="99.0.0")
 
     with pytest.raises(ArtifactError, match="unexpected wheel metadata directory"):
         validate_wheel(wheel)
@@ -185,7 +187,7 @@ def test_wheel_rejects_mismatched_dist_info_version(tmp_path: Path) -> None:
 
 def test_sdist_rejects_unrelated_repository_files(tmp_path: Path) -> None:
     sdist = tmp_path / "bad.tar.gz"
-    write_sdist(sdist, extra_members={"valkyrie_sdk-0.1.0/services/tracker/app.py": ""})
+    write_sdist(sdist, extra_members={f"{SDIST_ROOT}/services/tracker/app.py": ""})
 
     with pytest.raises(ArtifactError, match="forbidden sdist member"):
         validate_sdist(sdist)

--- a/tests/unit/test_agent_contract.py
+++ b/tests/unit/test_agent_contract.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 from typing import Any, cast
 
 import pytest
+import yaml
 from click.testing import CliRunner
 from pydantic import ValidationError
 from tracker.agent.schemas import AgentConfig, AgentContract, Parameter
@@ -456,6 +457,146 @@ class TestParseYamlContract:
         result = _parse_yaml_contract(path, AgentConfig(model="gpt-4o"))
 
         assert result.model == "gpt-4o"
+        assert result.model_gateway_policy is None
+
+    def test_selects_only_the_exact_model_gateway_policy(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """\
+            name: my_agent
+            install_cmd: bash setup.sh
+            run_cmd: "agent --task {problem_statement_path}"
+            model_gateway_policies:
+              openai/gpt-5.5:
+                config:
+                  client_scope: shared
+                  max_tokens: 8192
+                max_queries: 800
+                max_sessions: 4
+              anthropic/claude-sonnet-5:
+                config:
+                  client_scope: shared
+                  max_tokens: 16000
+                max_queries: 2000
+                max_sessions: 4
+        """,
+        )
+
+        result = _parse_yaml_contract(path, AgentConfig(model="openai/gpt-5.5"))
+
+        assert result.model_gateway_policy is not None
+        assert result.model_gateway_policy.model_dump(mode="json") == {
+            "kind": "task_capability",
+            "model": "openai/gpt-5.5",
+            "config": {"client_scope": "shared", "max_tokens": 8192},
+            "max_queries": 800,
+            "max_sessions": 4,
+        }
+
+    def test_model_gateway_policies_require_an_exact_model(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """\
+            name: my_agent
+            install_cmd: bash setup.sh
+            run_cmd: "agent --task {problem_statement_path}"
+            model_gateway_policies:
+              openai/gpt-5.5:
+                config:
+                  client_scope: shared
+                max_queries: 800
+                max_sessions: 4
+        """,
+        )
+
+        with pytest.raises(ValueError, match="agent_config.model is required"):
+            _parse_yaml_contract(path, AgentConfig())
+        with pytest.raises(ValueError, match="no policy for exact model"):
+            _parse_yaml_contract(path, AgentConfig(model="openai/gpt-5.5-preview"))
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("max_queries", 2001), ("max_queries", 0), ("max_sessions", 17), ("max_sessions", 0)],
+    )
+    def test_model_gateway_policy_limits_are_bounded(self, tmp_path: Path, field: str, value: int) -> None:
+        limits = {"max_queries": 800, "max_sessions": 4, field: value}
+        path = self._write_yaml(
+            tmp_path,
+            f"""\
+            name: my_agent
+            install_cmd: bash setup.sh
+            run_cmd: "agent --task {{problem_statement_path}}"
+            model_gateway_policies:
+              openai/gpt-5.5:
+                config:
+                  client_scope: shared
+                max_queries: {limits["max_queries"]}
+                max_sessions: {limits["max_sessions"]}
+        """,
+        )
+
+        with pytest.raises(ValueError, match=field):
+            _parse_yaml_contract(path, AgentConfig(model="openai/gpt-5.5"))
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("custom_api_key", "secret"),
+            ("custom_endpoint", "https://attacker.invalid"),
+            ("registry_key", "other/model"),
+            ("provider_config", {}),
+            ("native", False),
+            ("unknown_option", True),
+            ("client_scope", "instance"),
+        ],
+    )
+    def test_model_gateway_policy_rejects_routing_and_unknown_config(
+        self,
+        tmp_path: Path,
+        field: str,
+        value: object,
+    ) -> None:
+        config: dict[str, object] = {"client_scope": "shared", field: value}
+        path = tmp_path / "contract.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "my_agent",
+                    "install_cmd": "bash setup.sh",
+                    "run_cmd": "agent --task {problem_statement_path}",
+                    "model_gateway_policies": {
+                        "openai/gpt-5.5": {
+                            "config": config,
+                            "max_queries": 800,
+                            "max_sessions": 4,
+                        }
+                    },
+                }
+            )
+        )
+
+        with pytest.raises(ValueError, match=field):
+            _parse_yaml_contract(path, AgentConfig(model="openai/gpt-5.5"))
+
+    def test_model_gateway_policy_rejects_extra_row_fields(self, tmp_path: Path) -> None:
+        path = self._write_yaml(
+            tmp_path,
+            """\
+            name: my_agent
+            install_cmd: bash setup.sh
+            run_cmd: "agent --task {problem_statement_path}"
+            model_gateway_policies:
+              openai/gpt-5.5:
+                config:
+                  client_scope: shared
+                max_queries: 800
+                max_sessions: 4
+                endpoint: https://attacker.invalid
+        """,
+        )
+
+        with pytest.raises(ValueError, match="endpoint"):
+            _parse_yaml_contract(path, AgentConfig(model="openai/gpt-5.5"))
 
     def test_no_kwargs_in_schema(self, tmp_path: Path) -> None:
         """

--- a/uv.lock
+++ b/uv.lock
@@ -2440,7 +2440,7 @@ dev = [
 
 [[package]]
 name = "valkyrie-sdk"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/valkyrie-sdk" }
 dependencies = [
     { name = "httpx" },

--- a/uv.lock
+++ b/uv.lock
@@ -279,6 +279,22 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/6f/07b4af8da8bd27f640362b1ac8271d80895407f2ede0c2bcc9433c06e1ca/cbor2-6.1.3.tar.gz", hash = "sha256:8d70680acb55c04ea5b5ad86da094f9612b53d5a8a65d0f5b3aafc3ce917ecbb", size = 89503, upload-time = "2026-07-04T10:36:48.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/16/cff14259c3d19a7f0ae88b6996fe4c85f6ff1764dad889ac8a39e843e39c/cbor2-6.1.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3d939f55097c21e032f5a2d67592fcc57298986281f219356e2f519e4466f4ea", size = 412779, upload-time = "2026-07-04T10:36:04.975Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6c/f3641d19b7b85a63cb2756c10164131489c2cb46b379ec51ae22283fefb9/cbor2-6.1.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b025009478d644dab407164fd60e3ef4381af284f5af6966df94c663756d949e", size = 457781, upload-time = "2026-07-04T10:36:06.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/85/0c55a66f3037056bfb8e1c7184168085fdea67ae5830404498bcf466233b/cbor2-6.1.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2226d32e102e375737656ad5d141ad8c6ae3e705e04e263f24756f0eb379c6c1", size = 468373, upload-time = "2026-07-04T10:36:07.769Z" },
+    { url = "https://files.pythonhosted.org/packages/46/74/40f7db3e0d880560193916a5c9b744fcf299558bed7113f77c28237c7c29/cbor2-6.1.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e61d465244d66ffed36492eef3b44d43795d76a2bba0663a2f15c186af7f7513", size = 523844, upload-time = "2026-07-04T10:36:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a1/b5e07d6a08441c3a552fe2ae48ccb7e9dfc5065b9f6a3bae9879b4f0fbc0/cbor2-6.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87fe7be8fab6ec4796aa127c1a52e09e79dbafd2aa31caf809cf04b8080a5975", size = 536238, upload-time = "2026-07-04T10:36:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/99/e166be0fd74bf3a91f5a0d103e34883efbc438d970f72cc8200e274787e5/cbor2-6.1.3-cp312-cp312-win32.whl", hash = "sha256:da25d345f01e6a40b2e5c57ef96b4dcff7be69394fb62f0f70e07f437f2376a9", size = 279858, upload-time = "2026-07-04T10:36:12.247Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1b/90b4a121e40aba189c55a5822dd3c698eaf487e1d4a780ab18c804a5ef1c/cbor2-6.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:d5514f693db6fa6f433b4096e9b604e6a7bf151c9ef1d2db86d0858e4c5e768f", size = 300929, upload-time = "2026-07-04T10:36:13.564Z" },
+    { url = "https://files.pythonhosted.org/packages/19/db/52c58a8d33464927389dde8103997b3fa51b081ce29b347ac2cc4fd0dfbf/cbor2-6.1.3-cp312-cp312-win_arm64.whl", hash = "sha256:3d43183d7beb3d3cd198d69b31bd2ee487ed704a1150c75cb0a66d6ad63d8c1a", size = 290908, upload-time = "2026-07-04T10:36:14.857Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -398,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.13.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1#673dde74470594e3aa3f6931358e30ad60af06d5" }
+version = "0.15.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0#3e517a46c7807b6c8c74bbb9f0ca537d34852f1d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -409,6 +425,7 @@ dependencies = [
     { name = "fastapi", extra = ["standard"] },
     { name = "httpx" },
     { name = "jinja2" },
+    { name = "modal" },
     { name = "pyyaml" },
     { name = "starlette" },
     { name = "tenacity" },
@@ -774,12 +791,47 @@ wheels = [
 ]
 
 [[package]]
+name = "grpclib"
+version = "0.4.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h2" },
+    { name = "multidict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/28/5a2c299ec82a876a252c5919aa895a6f1d1d35c96417c5ce4a4660dc3a80/grpclib-0.4.9.tar.gz", hash = "sha256:cc589c330fa81004c6400a52a566407574498cb5b055fa927013361e21466c46", size = 84798, upload-time = "2025-12-14T22:23:14.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl", hash = "sha256:7762ec1c8ed94dfad597475152dd35cbd11aecaaca2f243e29702435ca24cf0e", size = 77063, upload-time = "2025-12-14T22:23:13.224Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -838,6 +890,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cd/cd/ca91a07ae446451f7476bf3fcc909e98cb942ff032ebfda0e3fe449aca7b/httpx_ws-0.9.0.tar.gz", hash = "sha256:797373326f70eec1ae96f6e43ae9f12002fd7d73aee139a4985eaab964338a08", size = 107105, upload-time = "2026-03-28T14:11:10.781Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/f8/a6bc80313a9e93c888fa10534dfce2ad76ff86911b6f485777ce6de6a073/httpx_ws-0.9.0-py3-none-any.whl", hash = "sha256:71640d2fb1bf9a225775015b33cd755cfd4c5f7e21c885192fe3adc4c387b248", size = 15759, upload-time = "2026-03-28T14:11:11.887Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -1072,6 +1133,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "modal"
+version = "1.5.3.dev2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "cbor2" },
+    { name = "certifi" },
+    { name = "click" },
+    { name = "grpclib" },
+    { name = "protobuf" },
+    { name = "rich" },
+    { name = "synchronicity" },
+    { name = "toml" },
+    { name = "types-certifi" },
+    { name = "types-toml" },
+    { name = "typing-extensions" },
+    { name = "watchfiles" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/91/50/2fe173141c843455f99b3ff07ddc60958db102e6e0b37cdbbb8d80330ccb/modal-1.5.3.dev2.tar.gz", hash = "sha256:e3f8fb566257a477250254ccc684254401cb00c197f34d9a4cae68aab82aadb9", size = 820241, upload-time = "2026-07-13T00:55:42.616Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/99/b131dec1c535d646fb2e8b56c4b6cbc9cf5688e6c94bc4822007291fa236/modal-1.5.3.dev2-py3-none-any.whl", hash = "sha256:d8a4361f8f1ac3512fab6a3f5ffd14d6a41132528c5add9135b35790c44d94fe", size = 934363, upload-time = "2026-07-13T00:55:40.007Z" },
 ]
 
 [[package]]
@@ -2016,6 +2101,18 @@ wheels = [
 ]
 
 [[package]]
+name = "synchronicity"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1c/f51dc54bbd302991026a53f9790735540e0e9e1184e9d5939f02446aa5bc/synchronicity-0.12.5.tar.gz", hash = "sha256:94d96b1d85698e3056b96a793b8c0949af6584e4a7d877fabdeb5385efe230aa", size = 60745, upload-time = "2026-06-18T21:06:23.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/74/ad9b99520f70c0bc3318e582e359d360cfc0f7afd7bf368a7f24013cece7/synchronicity-0.12.5-py3-none-any.whl", hash = "sha256:fdbbb10d437bc08a6b0f814fc66fddd1b58ffed314533d42f1ab555801e781af", size = 41107, upload-time = "2026-06-18T21:06:22.505Z" },
+]
+
+[[package]]
 name = "taskiq"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2118,7 +2215,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.13.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -2194,12 +2291,30 @@ wheels = [
 ]
 
 [[package]]
+name = "types-certifi"
+version = "2021.10.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/68/943c3aeaf14624712a0357c4a67814dba5cea36d194f5c764dad7959a00c/types-certifi-2021.10.8.3.tar.gz", hash = "sha256:72cf7798d165bc0b76e1c10dd1ea3097c7063c42c21d664523b928e88b554a4f", size = 2095, upload-time = "2022-06-09T15:19:05.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/63/2463d89481e811f007b0e1cd0a91e52e141b47f9de724d20db7b861dcfec/types_certifi-2021.10.8.3-py3-none-any.whl", hash = "sha256:b2d1e325e69f71f7c78e5943d410e650b4707bb0ef32e4ddf3da37f54176e88a", size = 2136, upload-time = "2022-06-09T15:19:03.127Z" },
+]
+
+[[package]]
 name = "types-s3transfer"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/64/42689150509eb3e6e82b33ee3d89045de1592488842ddf23c56957786d05/types_s3transfer-0.16.0.tar.gz", hash = "sha256:b4636472024c5e2b62278c5b759661efeb52a81851cde5f092f24100b1ecb443", size = 13557, upload-time = "2025-12-08T08:13:09.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/27/e88220fe6274eccd3bdf95d9382918716d312f6f6cef6a46332d1ee2feff/types_s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:1c0cd111ecf6e21437cb410f5cddb631bfb2263b77ad973e79b9c6d0cb24e0ef", size = 19247, upload-time = "2025-12-08T08:13:08.426Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Make OSWorld-style agent execution safe to resume and bill through the Model Gateway without placing provider or gateway-admin credentials in the agent sandbox.

## Changes

- clear `eval_resume_state` atomically on every terminal `FINISHED` transition
- mint one task/model/run/sandbox-scoped Model Gateway capability after setup and seal, reconcile, and revoke it on every terminal path
- persist immutable capability usage evidence and retry/finalization state
- pass the ephemeral bearer only to the agent process through CBS v0.15.0 process-scoped environments
- remove leaked credential-bearing descendant processes before restoring evaluation egress; use Python when present and an exact BusyBox/Alpine-compatible `/proc` fallback otherwise
- keep the Model Gateway admin key Worker-only and import its exact stage-specific secret ARN from the model-proxy stack
- bump the Valkyrie SDK capability contract to v0.1.1 and update SDK/tracker contract fixtures

## Security invariants

- agent sandbox A receives neither a provider key nor the Model Gateway admin key
- capability identity is bound to the Valkyrie run, task, exact model, sandbox, expiry, and quota
- evaluation starts only after the capability is sealed and credential-bearing processes are gone
- cleanup, cancellation, and provider errors fail closed and preserve monotonic evidence
- hard Worker death leaves the capability bounded by expiry and quota; the next mint atomically revokes any prior active capability for the same run/task
- tracker containers do not receive either Model Gateway environment variable

## Deployment dependency

The matching model-proxy stage from https://github.com/vals-ai/model-proxy/pull/915 (stacked after #921) must be deployed first. It must export:

- `DevGateway-DevGatewayService:CapabilityAdminKeySecretArn`
- `ProdGateway-ProdGatewayService:CapabilityAdminKeySecretArn`

The Valkyrie Worker deployment intentionally fails closed if the stage export is absent.

## Testing

- `uv run pytest tests/unit -q` in `services/tracker`: 284 passed
- `uv run pytest tests/unit/sdk tests/contract -q`: 98 passed
- `PYTHONPATH=. uv run python -m unittest tests.test_monitoring_stack` in `infra`: 9 passed
- Ruff and formatting checks: passed
- targeted strict BasedPyright for the cleanup path: passed
- exact `alpine:3.20` (digest `sha256:d9e853e8...`) controls with Python absent:
  - leaked secret-bearing `sh` plus descendant `sleep` removed
  - no-child cleanup succeeds
  - unrelated process carrying only an empty secret value is preserved

The tracker integration workflow's required manual rerun passed on exact head
`81bb55550637b614299c8a147b896862399ef831` (run `29312337824`, attempt 2).

## Type of change

- [x] Security and lifecycle fix
- [x] Feature
- [x] Infrastructure configuration
- [x] Contract update

## Checklist

- [x] Exact head self-reviewed
- [x] No raw provider/admin credential enters agent runtime
- [x] Error and cancellation paths covered
- [x] Docs and deployment prerequisite updated

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
