### PR TITLE
tracker: retain egress through abortable task cleanup

### DIFF
--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import unittest
 from unittest import mock
@@ -406,12 +407,21 @@ class MonitoringStackTest(unittest.TestCase):
                 )
 
                 tracker_task = next(iter(tracker_template.find_resources("AWS::ECS::TaskDefinition").values()))
+                tracker_environment = {
+                    item["Name"]: item["Value"]
+                    for container in tracker_task["Properties"]["ContainerDefinitions"]
+                    for item in container.get("Environment", [])
+                }
                 tracker_names = {
                     item["Name"]
                     for container in tracker_task["Properties"]["ContainerDefinitions"]
                     for field in ("Environment", "Secrets")
                     for item in container.get(field, [])
                 }
+                self.assertEqual(
+                    tracker_environment["MODEL_GATEWAY_ORIGIN_SHA256"],
+                    hashlib.sha256(gateway_url.encode()).hexdigest(),
+                )
                 self.assertNotIn("MODEL_GATEWAY_URL", tracker_names)
                 self.assertNotIn("MODEL_GATEWAY_ADMIN_API_KEY", tracker_names)
 

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -1,5 +1,6 @@
 """Tracker service stack - public-facing API with ALB and shared RDS database."""
 
+import hashlib
 import os
 from typing import Any
 
@@ -181,6 +182,7 @@ class TrackerStack(Stack):
                 "AUTH_REQUIRED": os.environ.get("AUTH_REQUIRED", "false"),
                 "BENCHMARK_CATALOG_URL": os.environ.get("BENCHMARK_CATALOG_URL", ""),
                 "DESCOPE_PROJECT_ID": os.environ.get("DESCOPE_PROJECT_ID", ""),
+                "MODEL_GATEWAY_ORIGIN_SHA256": hashlib.sha256(stage_config.model_gateway_url.encode()).hexdigest(),
                 "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
             },
             secrets={

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -75,6 +75,7 @@ from tracker.docent_analysis import (
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
 from tracker.middleware import RequestContextMiddleware
+from tracker.model_gateway import model_gateway_origin_sha256
 from tracker.observability import configure_observability
 from tracker.types import (
     AnalyzeBenchmarkRequest,
@@ -186,23 +187,27 @@ async def benchmark_service_error_handler(_request: Request, exc: BenchmarkServi
 @app.get("/health")
 def health_check() -> dict[str, str]:
     """
-    Health check to ensure that the tracker service is running correctly.
+    Health check for the tracker database and configured model gateway origin.
 
     Usage:
     curl -X GET http://<endpoint>/health
 
     Returns:
     {
-        "status": "ok"
+        "status": "ok",
+        "model_gateway_origin_sha256": "..."
     }
 
     Returns:
-    - 200 OK if the server is running and database is accessible
+    - 200 OK if the database and model gateway origin are valid
     - 503 Service Unavailable if the database is not accessible
     """
     if not check_database_connection():
         raise HTTPException(status_code=503, detail="Database is not accessible")
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+        "model_gateway_origin_sha256": model_gateway_origin_sha256(),
+    }
 
 
 @app.post("/init")

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -75,7 +75,7 @@ from tracker.docent_analysis import (
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
 from tracker.middleware import RequestContextMiddleware
-from tracker.model_gateway import model_gateway_origin_sha256
+from tracker.model_gateway import configured_model_gateway_origin_sha256
 from tracker.observability import configure_observability
 from tracker.types import (
     AnalyzeBenchmarkRequest,
@@ -206,7 +206,7 @@ def health_check() -> dict[str, str]:
         raise HTTPException(status_code=503, detail="Database is not accessible")
     return {
         "status": "ok",
-        "model_gateway_origin_sha256": model_gateway_origin_sha256(),
+        "model_gateway_origin_sha256": configured_model_gateway_origin_sha256(),
     }
 
 

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", tag = "v0.15.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "204afe519a6d0cd0fba3cc35cb915e55b4e60438" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/model_gateway.py
+++ b/services/tracker/src/tracker/model_gateway.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import math
 import os
+import re
 from collections.abc import Awaitable, Callable
 from decimal import Decimal
 from typing import Any, Literal
@@ -97,8 +98,7 @@ def capability_expires_at(agent_timeout: float, now: float) -> int:
     return math.floor(now) + lifetime
 
 
-def _model_gateway_origin() -> str:
-    gateway_url = os.environ.get("MODEL_GATEWAY_URL", "")
+def _canonical_model_gateway_origin(gateway_url: str) -> str:
     parsed_url = httpx.URL(gateway_url)
     if (
         parsed_url.scheme != "https"
@@ -114,8 +114,16 @@ def _model_gateway_origin() -> str:
     return str(parsed_url).rstrip("/")
 
 
-def model_gateway_origin_sha256() -> str:
-    return hashlib.sha256(_model_gateway_origin().encode("utf-8")).hexdigest()
+def model_gateway_origin_sha256(gateway_url: str) -> str:
+    origin = _canonical_model_gateway_origin(gateway_url)
+    return hashlib.sha256(origin.encode("utf-8")).hexdigest()
+
+
+def configured_model_gateway_origin_sha256() -> str:
+    digest = os.environ.get("MODEL_GATEWAY_ORIGIN_SHA256", "")
+    if re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+        raise ModelGatewayError("MODEL_GATEWAY_ORIGIN_SHA256 must be a SHA-256 digest")
+    return digest
 
 
 class ModelGatewayAdminClient:
@@ -124,7 +132,7 @@ class ModelGatewayAdminClient:
 
     @classmethod
     def from_environment(cls) -> "ModelGatewayAdminClient":
-        gateway_url = _model_gateway_origin()
+        gateway_url = _canonical_model_gateway_origin(os.environ.get("MODEL_GATEWAY_URL", ""))
         admin_key = os.environ.get("MODEL_GATEWAY_ADMIN_API_KEY", "")
         if not admin_key or admin_key != admin_key.strip():
             raise ModelGatewayError("MODEL_GATEWAY_ADMIN_API_KEY is required for task capabilities")

--- a/services/tracker/src/tracker/model_gateway.py
+++ b/services/tracker/src/tracker/model_gateway.py
@@ -1,6 +1,7 @@
 """Administrative client for task-scoped model gateway capabilities."""
 
 import asyncio
+import hashlib
 import math
 import os
 from collections.abc import Awaitable, Callable
@@ -96,24 +97,35 @@ def capability_expires_at(agent_timeout: float, now: float) -> int:
     return math.floor(now) + lifetime
 
 
+def _model_gateway_origin() -> str:
+    gateway_url = os.environ.get("MODEL_GATEWAY_URL", "")
+    parsed_url = httpx.URL(gateway_url)
+    if (
+        parsed_url.scheme != "https"
+        or not parsed_url.host
+        or parsed_url.userinfo
+        or parsed_url.path != "/"
+        or parsed_url.query
+        or parsed_url.fragment
+    ):
+        raise ModelGatewayError("MODEL_GATEWAY_URL must be an absolute HTTPS URL")
+    if parsed_url.port == 443:
+        parsed_url = parsed_url.copy_with(port=None)
+    return str(parsed_url).rstrip("/")
+
+
+def model_gateway_origin_sha256() -> str:
+    return hashlib.sha256(_model_gateway_origin().encode("utf-8")).hexdigest()
+
+
 class ModelGatewayAdminClient:
     def __init__(self, client: httpx.AsyncClient) -> None:
         self._client = client
 
     @classmethod
     def from_environment(cls) -> "ModelGatewayAdminClient":
-        gateway_url = os.environ.get("MODEL_GATEWAY_URL", "").rstrip("/")
+        gateway_url = _model_gateway_origin()
         admin_key = os.environ.get("MODEL_GATEWAY_ADMIN_API_KEY", "")
-        parsed_url = httpx.URL(gateway_url)
-        if (
-            parsed_url.scheme != "https"
-            or not parsed_url.host
-            or parsed_url.userinfo
-            or parsed_url.path != "/"
-            or parsed_url.query
-            or parsed_url.fragment
-        ):
-            raise ModelGatewayError("MODEL_GATEWAY_URL must be an absolute HTTPS URL")
         if not admin_key or admin_key != admin_key.strip():
             raise ModelGatewayError("MODEL_GATEWAY_ADMIN_API_KEY is required for task capabilities")
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -885,11 +885,10 @@ async def _wait_for_egress(
         ) from None
 
 
-@asynccontextmanager
-async def restricted_agent_egress(
+async def restrict_agent_egress(
     sandbox: Sandbox,
     allowed_addresses: list[str],
-) -> AsyncGenerator[EgressReadiness, None]:
+) -> EgressReadiness:
     if not allowed_addresses:
         raise ValueError("restricted_agent_egress requires at least one allowed address")
 
@@ -903,19 +902,41 @@ async def restricted_agent_egress(
     await _apply_egress_allowlist(sandbox, allowed_addresses)
     update_returned_at = time.time()
     ready_at, attempts = await _wait_for_egress(sandbox, "restricted", allowed_addresses, sentinels)
+    return EgressReadiness(
+        sentinel_addresses=sentinels,
+        update_returned_at=update_returned_at,
+        ready_at=ready_at,
+        attempts=attempts,
+    )
+
+
+@asynccontextmanager
+async def sandbox_lifetime_restricted_agent_egress(
+    sandbox: Sandbox,
+    allowed_addresses: list[str],
+) -> AsyncGenerator[EgressReadiness, None]:
+    yield await restrict_agent_egress(sandbox, allowed_addresses)
+
+
+@asynccontextmanager
+async def restricted_agent_egress(
+    sandbox: Sandbox,
+    allowed_addresses: list[str],
+) -> AsyncGenerator[EgressReadiness, None]:
+    readiness = await restrict_agent_egress(sandbox, allowed_addresses)
     completed = False
     try:
-        yield EgressReadiness(
-            sentinel_addresses=sentinels,
-            update_returned_at=update_returned_at,
-            ready_at=ready_at,
-            attempts=attempts,
-        )
+        yield readiness
         completed = True
     finally:
         if completed:
             await _clear_egress_allowlist(sandbox, fail_on_error=True)
-            _ = await _wait_for_egress(sandbox, "unrestricted", allowed_addresses, sentinels)
+            _ = await _wait_for_egress(
+                sandbox,
+                "unrestricted",
+                allowed_addresses,
+                readiness.sentinel_addresses,
+            )
 
 
 async def _stream_command_output_with_egress_allowlist(

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,8 @@
 """Sandbox management utilities for the tracker service."""
 
 import asyncio
+import ipaddress
+import json
 import shlex
 import time
 import uuid
@@ -8,8 +10,10 @@ from asyncio import Semaphore
 from collections import deque
 from collections.abc import Awaitable, Callable, Collection, Coroutine, Mapping
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import PurePosixPath
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Literal, cast
+from urllib.parse import urlsplit
 
 import logfire
 import sentry_sdk
@@ -654,6 +658,63 @@ _EGRESS_RETRY = retry(
     stop=stop_after_attempt(3),
     before_sleep=retry_callback("valkyrie.sandbox.egress"),
 )
+_EGRESS_SENTINEL_HOSTS = ("www.iana.org", "www.python.org")
+_EGRESS_READY_TIMEOUT_SECONDS = 30
+_EGRESS_READY_CONSECUTIVE_OBSERVATIONS = 2
+_EGRESS_PROBE_SOURCE = r"""
+import json
+import socket
+import ssl
+import sys
+
+payload = json.loads(sys.argv[1])
+
+
+def connect(host, port, use_tls):
+    try:
+        with socket.create_connection((host, port), timeout=2) as connection:
+            if use_tls:
+                with ssl.create_default_context().wrap_socket(connection, server_hostname=host):
+                    pass
+        return True
+    except OSError:
+        return False
+
+
+if payload["state"] == "baseline":
+    addresses = []
+    for host in payload["sentinel_hosts"]:
+        try:
+            items = socket.getaddrinfo(host, 443, family=socket.AF_INET, type=socket.SOCK_STREAM)
+        except OSError:
+            continue
+        for item in items:
+            address = item[4][0]
+            if connect(address, 443, False):
+                addresses.append(address)
+                break
+    runtime_ready = all(connect(host, 443, True) for host in payload["sentinel_hosts"])
+    print(json.dumps({"runtime_ready": runtime_ready, "sentinels": addresses}))
+elif payload["state"] == "restricted":
+    allowed = all(connect(item["host"], item["port"], item["tls"]) for item in payload["allowed"])
+    blocked = all(not connect(address, 443, False) for address in payload["sentinels"])
+    print(json.dumps({"ready": allowed and blocked}))
+elif payload["state"] == "unrestricted":
+    restored = all(connect(address, 443, False) for address in payload["sentinels"])
+    resolved = all(connect(host, 443, True) for host in payload["sentinel_hosts"])
+    ready = restored and resolved
+    print(json.dumps({"ready": ready}))
+else:
+    raise AssertionError("unknown egress probe state")
+"""
+
+
+@dataclass(frozen=True)
+class EgressReadiness:
+    sentinel_addresses: tuple[str, ...]
+    update_returned_at: float
+    ready_at: float
+    attempts: int
 
 
 @logfire.instrument("sandbox.exec", extract_args=False)
@@ -703,6 +764,158 @@ async def _clear_egress_allowlist(sandbox: Sandbox, fail_on_error: bool) -> None
         logger.warning("failed to clear egress rules for sandbox %s", sandbox.id, exc_info=True)
         if fail_on_error:
             raise SandboxSetupError("Failed to clear egress rules") from e
+
+
+def _egress_probe_command(payload: dict[str, object]) -> str:
+    return f"python3 -c {shlex.quote(_EGRESS_PROBE_SOURCE)} {shlex.quote(json.dumps(payload))}"
+
+
+async def _egress_probe(sandbox: Sandbox, payload: dict[str, object]) -> dict[str, object]:
+    result = await _exec(sandbox, _egress_probe_command(payload))
+    if result.exit_code != 0:
+        raise SandboxSetupError("Egress readiness probe requires python3 and trusted CA certificates")
+    try:
+        value = cast(object, json.loads(result.stdout))
+    except json.JSONDecodeError:
+        raise SandboxSetupError("Egress readiness probe returned invalid output") from None
+    if not isinstance(value, dict):
+        raise SandboxSetupError("Egress readiness probe returned invalid output")
+    return cast(dict[str, object], value)
+
+
+async def _prevalidate_egress_sentinels(sandbox: Sandbox, allowed_addresses: list[str]) -> tuple[str, ...]:
+    networks: list[ipaddress.IPv4Network] = []
+    for address in allowed_addresses:
+        try:
+            network = ipaddress.ip_network(address, strict=False)
+        except ValueError:
+            continue
+        if not isinstance(network, ipaddress.IPv4Network):
+            raise SandboxSetupError("IPv6 egress readiness is not supported")
+        networks.append(network)
+
+    previous: tuple[str, ...] | None = None
+    matches = 0
+    while True:
+        result = await _egress_probe(
+            sandbox,
+            {"state": "baseline", "sentinel_hosts": _EGRESS_SENTINEL_HOSTS},
+        )
+        values = result.get("sentinels")
+        if not isinstance(values, list):
+            raise SandboxSetupError("Egress readiness probe returned invalid sentinels")
+        sentinel_values = cast(list[object], values)
+        if any(not isinstance(value, str) for value in sentinel_values):
+            raise SandboxSetupError("Egress readiness probe returned invalid sentinels")
+        sentinels = tuple(
+            value
+            for value in dict.fromkeys(cast(list[str], sentinel_values))
+            if not any(ipaddress.ip_address(value) in network for network in networks)
+        )
+        ready = result.get("runtime_ready") is True and len(sentinels) == len(_EGRESS_SENTINEL_HOSTS)
+        if not ready:
+            matches = 0
+        elif sentinels == previous:
+            matches += 1
+        else:
+            matches = 1
+        if matches == _EGRESS_READY_CONSECUTIVE_OBSERVATIONS:
+            return sentinels
+        previous = sentinels if ready else None
+        await asyncio.sleep(0.25)
+
+
+def _allowed_egress_probes(allowed_addresses: list[str]) -> list[dict[str, object]]:
+    probes: list[dict[str, object]] = []
+    for address in allowed_addresses:
+        try:
+            _ = ipaddress.ip_network(address, strict=False)
+            continue
+        except ValueError:
+            pass
+
+        parsed = urlsplit(address if "://" in address else f"https://{address}")
+        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+            raise SandboxSetupError(f"Unsupported egress probe address: {address}")
+        probes.append(
+            {
+                "host": parsed.hostname,
+                "port": parsed.port or (443 if parsed.scheme == "https" else 80),
+                "tls": parsed.scheme == "https",
+            }
+        )
+    return probes
+
+
+async def _wait_for_egress(
+    sandbox: Sandbox,
+    state: Literal["restricted", "unrestricted"],
+    allowed_addresses: list[str],
+    sentinels: tuple[str, ...],
+) -> tuple[float, int]:
+    matches = 0
+    attempts = 0
+    try:
+        async with asyncio.timeout(_EGRESS_READY_TIMEOUT_SECONDS):
+            while True:
+                attempts += 1
+                if state == "restricted":
+                    payload: dict[str, object] = {
+                        "state": state,
+                        "allowed": _allowed_egress_probes(allowed_addresses),
+                        "sentinels": sentinels,
+                    }
+                elif state == "unrestricted":
+                    payload = {
+                        "state": state,
+                        "sentinel_hosts": _EGRESS_SENTINEL_HOSTS,
+                        "sentinels": sentinels,
+                    }
+                else:
+                    raise AssertionError(f"Unknown egress state: {state}")
+
+                result = await _egress_probe(sandbox, payload)
+                matches = matches + 1 if result.get("ready") is True else 0
+                if matches == _EGRESS_READY_CONSECUTIVE_OBSERVATIONS:
+                    return time.time(), attempts
+                await asyncio.sleep(0.25)
+    except TimeoutError:
+        raise SandboxSetupError(
+            f"Egress did not become {state} within {_EGRESS_READY_TIMEOUT_SECONDS} seconds"
+        ) from None
+
+
+@asynccontextmanager
+async def restricted_agent_egress(
+    sandbox: Sandbox,
+    allowed_addresses: list[str],
+) -> AsyncGenerator[EgressReadiness, None]:
+    if not allowed_addresses:
+        raise ValueError("restricted_agent_egress requires at least one allowed address")
+
+    try:
+        async with asyncio.timeout(_EGRESS_READY_TIMEOUT_SECONDS):
+            sentinels = await _prevalidate_egress_sentinels(sandbox, allowed_addresses)
+    except TimeoutError:
+        raise SandboxSetupError(
+            f"Egress prevalidation did not complete within {_EGRESS_READY_TIMEOUT_SECONDS} seconds"
+        ) from None
+    await _apply_egress_allowlist(sandbox, allowed_addresses)
+    update_returned_at = time.time()
+    ready_at, attempts = await _wait_for_egress(sandbox, "restricted", allowed_addresses, sentinels)
+    completed = False
+    try:
+        yield EgressReadiness(
+            sentinel_addresses=sentinels,
+            update_returned_at=update_returned_at,
+            ready_at=ready_at,
+            attempts=attempts,
+        )
+        completed = True
+    finally:
+        if completed:
+            await _clear_egress_allowlist(sandbox, fail_on_error=True)
+            _ = await _wait_for_egress(sandbox, "unrestricted", allowed_addresses, sentinels)
 
 
 async def _stream_command_output_with_egress_allowlist(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -24,6 +24,7 @@ from benchmark_service import (
     SandboxProviderConfig,
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+from benchmark_service.schemas import AbortableSetupLifecycle, StandardSetupLifecycle
 from opentelemetry import trace
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlmodel import Session, col, select, update
@@ -71,6 +72,7 @@ from tracker.sandbox import (
     restricted_agent_egress,
     run_agent,
     runtime_sandbox,
+    sandbox_lifetime_restricted_agent_egress,
     upload_agent_artifacts,
     upload_agent_outputs,
 )
@@ -89,6 +91,8 @@ _MODEL_GATEWAY_USAGE_DIRECTORY = "model_gateway_usage"
 _MODEL_GATEWAY_USAGE_RESULT_KEY = "_valkyrie_model_gateway_usage"
 _AGENT_EGRESS_DIRECTORY = "agent_egress"
 _AGENT_EGRESS_RESULT_KEY = "_valkyrie_agent_egress"
+# The CBS client owns the three-hour retry budget; Tracker only bounds a stuck client.
+_ABORT_TASK_DEADLINE_SECONDS = 3 * 60 * 60 + 60
 _AGENT_ENV_VAR_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _RESERVED_AGENT_ENV_VAR_NAMES = frozenset(
     {
@@ -202,6 +206,35 @@ async def _upload_egress_readiness_receipt(
         harness_config.s3_bucket,
     )
     return hashlib.sha256(content).hexdigest()
+
+
+async def _abort_task_uninterruptibly(
+    benchmark_service: BenchmarkServiceClient,
+    task_id: str,
+    run_id: str,
+    instance_id: str,
+    dataset: str | None,
+) -> None:
+    async def abort_before_deadline() -> None:
+        try:
+            async with asyncio.timeout(_ABORT_TASK_DEADLINE_SECONDS):
+                await benchmark_service.abort_task(task_id, run_id, instance_id, dataset)
+        except TimeoutError:
+            raise TrackerServiceError(
+                f"Benchmark abort did not complete within {_ABORT_TASK_DEADLINE_SECONDS} seconds"
+            ) from None
+
+    abort = asyncio.create_task(abort_before_deadline())
+    cancellation: asyncio.CancelledError | None = None
+    while not abort.done():
+        try:
+            await asyncio.shield(abort)
+        except asyncio.CancelledError as error:
+            cancellation = error
+
+    abort.result()
+    if cancellation is not None:
+        raise cancellation
 
 
 def _parse_egress_readiness_receipt(content: bytes, benchmark_id: UUID, task_id: str) -> dict[str, Any]:
@@ -799,6 +832,13 @@ async def process_task(
 
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
+        match task_data.setup_lifecycle:
+            case StandardSetupLifecycle():
+                abortable_setup = False
+                egress_scope = restricted_agent_egress
+            case AbortableSetupLifecycle():
+                abortable_setup = True
+                egress_scope = sandbox_lifetime_restricted_agent_egress
 
         # Labels that show up in the UI we can use to filter sandboxes
         labels = {
@@ -854,6 +894,7 @@ async def process_task(
         ) as sandbox:
             task_breakdown.sandbox_build_duration = time.perf_counter() - start_sandbox_build_time
             start_sandbox_run_time = time.perf_counter()
+            abortable_setup_owned = False
 
             try:
                 with Session(bind=engine) as task_session:
@@ -878,6 +919,7 @@ async def process_task(
 
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
+                abortable_setup_owned = abortable_setup
                 setup_response = await benchmark_service.setup_task(
                     task_row.task_id,
                     sandbox.id,
@@ -890,6 +932,8 @@ async def process_task(
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
                 setup_addresses = setup_response.egress_allowlist
+                if abortable_setup and not setup_addresses:
+                    raise SandboxSetupError("Abortable setup requires a dynamic egress allowlist")
                 contract_with_setup_egress = start_benchmark_request.contract.model_copy(
                     update={
                         "egress_allowlist": _merge_egress_addresses(
@@ -936,7 +980,7 @@ async def process_task(
                             )
                             command_contract = contract_with_setup_egress.model_copy(update={"egress_allowlist": []})
                             agent_sandbox = runtime_sandbox(sandbox, task_data.source)
-                            async with restricted_agent_egress(
+                            async with egress_scope(
                                 agent_sandbox, contract_with_setup_egress.egress_allowlist
                             ) as readiness:
                                 egress_readiness_receipt = _egress_readiness_receipt(
@@ -1024,7 +1068,7 @@ async def process_task(
                         )
                         command_contract = contract_with_setup_egress.model_copy(update={"egress_allowlist": []})
                         agent_sandbox = runtime_sandbox(sandbox, task_data.source)
-                        async with restricted_agent_egress(agent_sandbox, effective_addresses) as readiness:
+                        async with egress_scope(agent_sandbox, effective_addresses) as readiness:
                             egress_readiness_receipt = _egress_readiness_receipt(
                                 benchmark_id,
                                 task_id,
@@ -1141,6 +1185,7 @@ async def process_task(
                     dataset=start_benchmark_request.dataset,
                     sandbox_provider=sandbox_provider_config,
                 )
+                abortable_setup_owned = False
                 if capability_usage is not None:
                     if _MODEL_GATEWAY_USAGE_RESULT_KEY in evaluation_result:
                         raise TrackerServiceError(
@@ -1195,6 +1240,14 @@ async def process_task(
                 raise
             finally:
                 agent_env_vars.clear()
+                if abortable_setup_owned:
+                    await _abort_task_uninterruptibly(
+                        benchmark_service,
+                        task_row.task_id,
+                        str(benchmark_id),
+                        sandbox.id,
+                        start_benchmark_request.dataset,
+                    )
 
     except SandboxSetupError as e:
         if task_is_stopped():

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -1,7 +1,10 @@
 """Logic for executing, tracking, and transitioning the status of a single task."""
 
 import asyncio
+import hashlib
+import ipaddress
 import json
+import math
 import re
 import time
 import traceback
@@ -10,7 +13,8 @@ from collections.abc import Coroutine
 from contextlib import suppress
 from datetime import datetime
 from enum import Enum
-from typing import Any
+from typing import Any, Literal, cast
+from urllib.parse import urlsplit
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
@@ -21,7 +25,7 @@ from benchmark_service import (
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from opentelemetry import trace
-from pydantic import ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlmodel import Session, col, select, update
 from tenacity import retry as tenacity_retry
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
@@ -60,10 +64,13 @@ from tracker.model_gateway import (
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, retry_callback
 from tracker.sandbox import (
+    EgressReadiness,
     create_sandbox,
     execute_agent,
     install_agent,
+    restricted_agent_egress,
     run_agent,
+    runtime_sandbox,
     upload_agent_artifacts,
     upload_agent_outputs,
 )
@@ -80,6 +87,8 @@ logger = get_logger(__name__)
 _PTY_TASK_RETRY_LIMIT: int = 1
 _MODEL_GATEWAY_USAGE_DIRECTORY = "model_gateway_usage"
 _MODEL_GATEWAY_USAGE_RESULT_KEY = "_valkyrie_model_gateway_usage"
+_AGENT_EGRESS_DIRECTORY = "agent_egress"
+_AGENT_EGRESS_RESULT_KEY = "_valkyrie_agent_egress"
 _AGENT_ENV_VAR_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _RESERVED_AGENT_ENV_VAR_NAMES = frozenset(
     {
@@ -93,6 +102,168 @@ _RESERVED_AGENT_ENV_VAR_NAMES = frozenset(
         "VALKYRIE_AGENT_SECRET_SCOPE",
     }
 )
+
+
+class EgressEvalResumeState(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    kind: Literal["agent_egress_eval_resume"]
+    egress_receipt_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    benchmark_state: dict[str, Any]
+
+
+class CapabilityEgressEvalResumeState(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    kind: Literal["model_gateway_egress_eval_resume"]
+    capability_id: str = Field(pattern=r"^cap_[A-Za-z0-9_-]+$")
+    egress_receipt_sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    benchmark_state: dict[str, Any]
+
+
+def _canonical_egress_origin(address: str) -> str:
+    value = address.strip()
+    if not value:
+        raise SandboxSetupError("Egress addresses cannot be empty")
+    try:
+        return str(ipaddress.ip_network(value, strict=False))
+    except ValueError:
+        pass
+
+    parsed = urlsplit(value if "://" in value else f"https://{value}")
+    if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+        raise SandboxSetupError(f"Unsupported egress address: {address}")
+    port = parsed.port
+    default_port = 443 if parsed.scheme == "https" else 80
+    suffix = f":{port}" if port is not None and port != default_port else ""
+    return f"{parsed.scheme}://{parsed.hostname.lower()}{suffix}"
+
+
+def _merge_egress_addresses(*sources: list[str]) -> list[str]:
+    merged: dict[str, str] = {}
+    for source in sources:
+        for address in source:
+            merged.setdefault(_canonical_egress_origin(address), address)
+    return list(merged.values())
+
+
+def _egress_origin_set_sha256(addresses: list[str]) -> str:
+    origins = sorted({_canonical_egress_origin(address) for address in addresses})
+    content = json.dumps(origins, separators=(",", ":")).encode()
+    return hashlib.sha256(content).hexdigest()
+
+
+def _egress_readiness_receipt(
+    benchmark_id: UUID,
+    task_id: str,
+    sandbox_id: str,
+    contract_addresses: list[str],
+    setup_addresses: list[str],
+    gateway_addresses: list[str],
+    readiness: EgressReadiness,
+) -> dict[str, Any]:
+    effective = _merge_egress_addresses(contract_addresses, setup_addresses, gateway_addresses)
+    return {
+        "schema_version": 1,
+        "run_id": str(benchmark_id),
+        "task_id": task_id,
+        "sandbox_id": sandbox_id,
+        "allowed_origin_set_sha256": {
+            "contract": _egress_origin_set_sha256(contract_addresses),
+            "setup": _egress_origin_set_sha256(setup_addresses),
+            "model_gateway": _egress_origin_set_sha256(gateway_addresses),
+            "effective": _egress_origin_set_sha256(effective),
+        },
+        "sentinel_sha256": sorted(
+            hashlib.sha256(f"{address}:443".encode()).hexdigest() for address in readiness.sentinel_addresses
+        ),
+        "update_returned_at": readiness.update_returned_at,
+        "ready_at": readiness.ready_at,
+        "readiness_attempts": readiness.attempts,
+        "required_consecutive_observations": 2,
+    }
+
+
+async def _upload_egress_readiness_receipt(
+    receipt: dict[str, Any],
+    benchmark_id: UUID,
+    task_id: str,
+    harness_config: HarnessConfig,
+) -> str:
+    content = (json.dumps(receipt, sort_keys=True) + "\n").encode()
+    await upload_to_s3(
+        content,
+        get_agent_result_s3_key(
+            str(benchmark_id),
+            task_id,
+            f"{_AGENT_EGRESS_DIRECTORY}/readiness-v1.json",
+        ),
+        harness_config.aws,
+        harness_config.s3_bucket,
+    )
+    return hashlib.sha256(content).hexdigest()
+
+
+def _parse_egress_readiness_receipt(content: bytes, benchmark_id: UUID, task_id: str) -> dict[str, Any]:
+    try:
+        raw: object = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise TrackerServiceError("Agent egress readiness artifact is invalid JSON") from exc
+    if not isinstance(raw, dict):
+        raise TrackerServiceError("Agent egress readiness artifact is invalid")
+    receipt = cast(dict[str, Any], raw)
+    origins = receipt.get("allowed_origin_set_sha256")
+    sentinels = receipt.get("sentinel_sha256")
+    update_returned_at = receipt.get("update_returned_at")
+    ready_at = receipt.get("ready_at")
+    attempts = receipt.get("readiness_attempts")
+    schema_version = receipt.get("schema_version")
+    required_observations = receipt.get("required_consecutive_observations")
+    if not isinstance(origins, dict) or not isinstance(sentinels, list):
+        raise TrackerServiceError("Agent egress readiness artifact is invalid")
+    origin_values = cast(dict[str, object], origins)
+    sentinel_values = cast(list[object], sentinels)
+    expected = {
+        "schema_version",
+        "run_id",
+        "task_id",
+        "sandbox_id",
+        "allowed_origin_set_sha256",
+        "sentinel_sha256",
+        "update_returned_at",
+        "ready_at",
+        "readiness_attempts",
+        "required_consecutive_observations",
+    }
+    if (
+        set(receipt) != expected
+        or type(schema_version) is not int
+        or schema_version != 1
+        or receipt.get("run_id") != str(benchmark_id)
+        or receipt.get("task_id") != task_id
+        or not isinstance(receipt.get("sandbox_id"), str)
+        or set(origin_values) != {"contract", "setup", "model_gateway", "effective"}
+        or any(
+            not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None
+            for value in origin_values.values()
+        )
+        or len(sentinel_values) != 2
+        or any(not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None for value in sentinel_values)
+        or sentinel_values != sorted(set(cast(list[str], sentinel_values)))
+        or isinstance(update_returned_at, bool)
+        or not isinstance(update_returned_at, int | float)
+        or not math.isfinite(update_returned_at)
+        or isinstance(ready_at, bool)
+        or not isinstance(ready_at, int | float)
+        or not math.isfinite(ready_at)
+        or ready_at < update_returned_at
+        or type(attempts) is not int
+        or attempts < 2
+        or type(required_observations) is not int
+        or required_observations != 2
+    ):
+        raise TrackerServiceError("Agent egress readiness artifact is invalid")
+    return receipt
 
 
 def _validate_agent_env_vars(env_vars: dict[str, str]) -> None:
@@ -463,14 +634,30 @@ async def process_task(
 
     flush_task = asyncio.create_task(auto_flush_logs())
     capability_usage: CapabilityUsageSummary | None = None
+    egress_readiness_receipt: dict[str, Any] | None = None
+    egress_receipt_sha256: str | None = None
 
     def on_eval_resume_state(state: dict[str, Any]) -> None:
         persisted_state = state
         if start_benchmark_request.contract.model_gateway_policy is not None:
             assert capability_usage is not None
-            persisted_state = CapabilityEvalResumeState(
-                kind="model_gateway_eval_resume",
-                capability_id=capability_usage.capability_id,
+            if egress_receipt_sha256 is None:
+                persisted_state = CapabilityEvalResumeState(
+                    kind="model_gateway_eval_resume",
+                    capability_id=capability_usage.capability_id,
+                    benchmark_state=state,
+                ).model_dump(mode="json")
+            else:
+                persisted_state = CapabilityEgressEvalResumeState(
+                    kind="model_gateway_egress_eval_resume",
+                    capability_id=capability_usage.capability_id,
+                    egress_receipt_sha256=egress_receipt_sha256,
+                    benchmark_state=state,
+                ).model_dump(mode="json")
+        elif egress_receipt_sha256 is not None:
+            persisted_state = EgressEvalResumeState(
+                kind="agent_egress_eval_resume",
+                egress_receipt_sha256=egress_receipt_sha256,
                 benchmark_state=state,
             ).model_dump(mode="json")
         save_eval_resume_state(task_row.id, org, persisted_state, expected_started_at=attempt_started_at)
@@ -485,16 +672,45 @@ async def process_task(
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
                 benchmark_eval_resume_state = task_row.eval_resume_state
-                if start_benchmark_request.contract.model_gateway_policy is not None:
+                capability_id: str | None = None
+                kind = task_row.eval_resume_state.get("kind")
+                if kind == "model_gateway_egress_eval_resume":
+                    if start_benchmark_request.contract.model_gateway_policy is None:
+                        raise TrackerServiceError("Model gateway evaluation resume state has no model policy")
                     try:
-                        resume_state = CapabilityEvalResumeState.model_validate(task_row.eval_resume_state)
+                        resume_state = CapabilityEgressEvalResumeState.model_validate(task_row.eval_resume_state)
+                    except ValidationError:
+                        raise TrackerServiceError("Model gateway egress evaluation resume state is invalid") from None
+                    capability_id = resume_state.capability_id
+                    egress_receipt_sha256 = resume_state.egress_receipt_sha256
+                    benchmark_eval_resume_state = resume_state.benchmark_state
+                elif kind == "model_gateway_eval_resume":
+                    if start_benchmark_request.contract.model_gateway_policy is None:
+                        raise TrackerServiceError("Model gateway evaluation resume state has no model policy")
+                    try:
+                        legacy_state = CapabilityEvalResumeState.model_validate(task_row.eval_resume_state)
                     except ValidationError:
                         raise TrackerServiceError("Model gateway evaluation resume state is invalid") from None
+                    capability_id = legacy_state.capability_id
+                    benchmark_eval_resume_state = legacy_state.benchmark_state
+                elif kind == "agent_egress_eval_resume":
+                    if start_benchmark_request.contract.model_gateway_policy is not None:
+                        raise TrackerServiceError("Agent egress evaluation resume state is missing model capability")
+                    try:
+                        egress_state = EgressEvalResumeState.model_validate(task_row.eval_resume_state)
+                    except ValidationError:
+                        raise TrackerServiceError("Agent egress evaluation resume state is invalid") from None
+                    egress_receipt_sha256 = egress_state.egress_receipt_sha256
+                    benchmark_eval_resume_state = egress_state.benchmark_state
+                elif start_benchmark_request.contract.model_gateway_policy is not None:
+                    raise TrackerServiceError("Model gateway evaluation resume state is invalid")
+
+                if capability_id is not None:
                     usage_artifact = await download_from_s3(
                         get_agent_result_s3_key(
                             str(benchmark_id),
                             task_id,
-                            f"{_MODEL_GATEWAY_USAGE_DIRECTORY}/{resume_state.capability_id}.json",
+                            f"{_MODEL_GATEWAY_USAGE_DIRECTORY}/{capability_id}.json",
                         ),
                         harness_config.aws,
                         harness_config.s3_bucket,
@@ -503,11 +719,28 @@ async def process_task(
                         capability_usage = CapabilityUsageSummary.model_validate_json(usage_artifact)
                     except ValidationError:
                         raise TrackerServiceError("Model gateway usage artifact is invalid") from None
-                    if capability_usage.capability_id != resume_state.capability_id:
+                    if capability_usage.capability_id != capability_id:
                         raise TrackerServiceError("Model gateway usage artifact does not match resume state")
                     if capability_usage.state != "revoked" or not capability_usage.drained:
                         raise TrackerServiceError("Model gateway usage artifact is not finalized")
-                    benchmark_eval_resume_state = resume_state.benchmark_state
+
+                if egress_receipt_sha256 is not None:
+                    egress_artifact = await download_from_s3(
+                        get_agent_result_s3_key(
+                            str(benchmark_id),
+                            task_id,
+                            f"{_AGENT_EGRESS_DIRECTORY}/readiness-v1.json",
+                        ),
+                        harness_config.aws,
+                        harness_config.s3_bucket,
+                    )
+                    if hashlib.sha256(egress_artifact).hexdigest() != egress_receipt_sha256:
+                        raise TrackerServiceError("Agent egress readiness artifact does not match resume state")
+                    egress_readiness_receipt = _parse_egress_readiness_receipt(
+                        egress_artifact,
+                        benchmark_id,
+                        task_id,
+                    )
 
                 resume_eval_start_time = time.perf_counter()
                 # Reset timer to keep the last received message from the benchmarks service accurate
@@ -526,6 +759,10 @@ async def process_task(
                             f"Benchmark result uses reserved key {_MODEL_GATEWAY_USAGE_RESULT_KEY!r}"
                         )
                     evaluation_result[_MODEL_GATEWAY_USAGE_RESULT_KEY] = capability_usage.model_dump(mode="json")
+                if egress_readiness_receipt is not None:
+                    if _AGENT_EGRESS_RESULT_KEY in evaluation_result:
+                        raise TrackerServiceError(f"Benchmark result uses reserved key {_AGENT_EGRESS_RESULT_KEY!r}")
+                    evaluation_result[_AGENT_EGRESS_RESULT_KEY] = egress_readiness_receipt
                 resume_eval_duration = time.perf_counter() - resume_eval_start_time
                 evaluation_result_row = EvaluationResult(
                     org_id=org.id,
@@ -641,7 +878,7 @@ async def process_task(
 
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
-                _ = await benchmark_service.setup_task(
+                setup_response = await benchmark_service.setup_task(
                     task_row.task_id,
                     sandbox.id,
                     on_message=log_output,
@@ -652,6 +889,16 @@ async def process_task(
                 # Force flush the logs if anything has been buffered
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
 
+                setup_addresses = setup_response.egress_allowlist
+                contract_with_setup_egress = start_benchmark_request.contract.model_copy(
+                    update={
+                        "egress_allowlist": _merge_egress_addresses(
+                            start_benchmark_request.contract.egress_allowlist,
+                            setup_addresses,
+                        )
+                    }
+                )
+
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
                 if start_benchmark_request.contract.final_output:
@@ -661,22 +908,73 @@ async def process_task(
                 if policy is None:
                     agent_env_vars = resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws)
                     try:
-                        exit_reason, agent_run_time = await run_agent(
-                            sandbox,
-                            start_benchmark_request.contract,
-                            task_data.problem_path,
-                            task_id,
-                            log_output,
-                            task_data.cwd,
-                            agent_env_vars=agent_env_vars,
-                            retry_policy=retry_policy,
-                            aws=harness_config.aws,
-                            s3_bucket=harness_config.s3_bucket,
-                            agent_output_s3_key=agent_output_s3_key,
-                            agent_timeout=task_data.agent_timeout,
-                            benchmark_id=str(benchmark_id),
-                            runtime_source=task_data.source,
-                        )
+                        if not setup_addresses:
+                            exit_reason, agent_run_time = await run_agent(
+                                sandbox,
+                                contract_with_setup_egress,
+                                task_data.problem_path,
+                                task_id,
+                                log_output,
+                                task_data.cwd,
+                                agent_env_vars=agent_env_vars,
+                                retry_policy=retry_policy,
+                                aws=harness_config.aws,
+                                s3_bucket=harness_config.s3_bucket,
+                                agent_output_s3_key=agent_output_s3_key,
+                                agent_timeout=task_data.agent_timeout,
+                                benchmark_id=str(benchmark_id),
+                                runtime_source=task_data.source,
+                            )
+                        else:
+                            await install_agent(
+                                sandbox,
+                                contract_with_setup_egress,
+                                log_output,
+                                agent_env_vars,
+                                task_data.source,
+                                retry_policy=retry_policy,
+                            )
+                            command_contract = contract_with_setup_egress.model_copy(update={"egress_allowlist": []})
+                            agent_sandbox = runtime_sandbox(sandbox, task_data.source)
+                            async with restricted_agent_egress(
+                                agent_sandbox, contract_with_setup_egress.egress_allowlist
+                            ) as readiness:
+                                egress_readiness_receipt = _egress_readiness_receipt(
+                                    benchmark_id,
+                                    task_id,
+                                    sandbox.id,
+                                    start_benchmark_request.contract.egress_allowlist,
+                                    setup_addresses,
+                                    [],
+                                    readiness,
+                                )
+                                egress_receipt_sha256 = await _upload_egress_readiness_receipt(
+                                    egress_readiness_receipt,
+                                    benchmark_id,
+                                    task_id,
+                                    harness_config,
+                                )
+                                exit_reason, agent_run_time = await execute_agent(
+                                    sandbox,
+                                    command_contract,
+                                    task_data.problem_path,
+                                    task_id,
+                                    log_output,
+                                    task_data.cwd,
+                                    agent_env_vars,
+                                    task_data.agent_timeout,
+                                    task_data.source,
+                                )
+                            await upload_agent_outputs(
+                                sandbox,
+                                command_contract,
+                                task_id,
+                                harness_config.aws,
+                                harness_config.s3_bucket,
+                                agent_output_s3_key,
+                                str(benchmark_id),
+                                task_data.source,
+                            )
                     finally:
                         agent_env_vars.clear()
                 else:
@@ -687,7 +985,7 @@ async def process_task(
                     try:
                         await install_agent(
                             sandbox,
-                            start_benchmark_request.contract,
+                            contract_with_setup_egress,
                             log_output,
                             agent_env_vars,
                             task_data.source,
@@ -696,7 +994,6 @@ async def process_task(
                     finally:
                         agent_env_vars.clear()
 
-                    expires_at = capability_expires_at(task_data.agent_timeout, time.time())
                     async with ModelGatewayAdminClient.from_environment() as gateway:
 
                         async def write_capability_usage(usage: CapabilityUsageSummary) -> None:
@@ -721,46 +1018,69 @@ async def process_task(
                                 },
                             )
 
-                        minted = await mint_capability_uninterruptibly(
-                            gateway,
-                            CapabilityMintRequest(
-                                run_id=str(benchmark_id),
-                                task_id=task_id,
-                                model=policy.model,
-                                config=policy.config.model_dump(mode="json"),
-                                sandbox_id=sandbox.id,
-                                identity={"org_id": str(org.id), **identity},
-                                expires_at=expires_at,
-                                max_queries=policy.max_queries,
-                                max_sessions=policy.max_sessions,
-                            ),
-                            write_capability_usage,
+                        effective_addresses = _merge_egress_addresses(
+                            contract_with_setup_egress.egress_allowlist,
+                            [gateway.gateway_url],
                         )
-                        runtime_env = {
-                            "MODEL_GATEWAY_URL": gateway.gateway_url,
-                            "MODEL_GATEWAY_API_KEY": minted.token,
-                        }
-                        capability_id = minted.capability_id
-                        del minted
-                        try:
-                            exit_reason, agent_run_time = await execute_agent(
-                                sandbox,
-                                start_benchmark_request.contract,
-                                task_data.problem_path,
+                        command_contract = contract_with_setup_egress.model_copy(update={"egress_allowlist": []})
+                        agent_sandbox = runtime_sandbox(sandbox, task_data.source)
+                        async with restricted_agent_egress(agent_sandbox, effective_addresses) as readiness:
+                            egress_readiness_receipt = _egress_readiness_receipt(
+                                benchmark_id,
                                 task_id,
-                                log_output,
-                                task_data.cwd,
-                                runtime_env,
-                                task_data.agent_timeout,
-                                task_data.source,
+                                sandbox.id,
+                                start_benchmark_request.contract.egress_allowlist,
+                                setup_addresses,
+                                [gateway.gateway_url],
+                                readiness,
                             )
-                        finally:
-                            runtime_env.clear()
-                            capability_usage = await finalize_capability_uninterruptibly(
+                            egress_receipt_sha256 = await _upload_egress_readiness_receipt(
+                                egress_readiness_receipt,
+                                benchmark_id,
+                                task_id,
+                                harness_config,
+                            )
+                            expires_at = capability_expires_at(task_data.agent_timeout, time.time())
+                            minted = await mint_capability_uninterruptibly(
                                 gateway,
-                                capability_id,
+                                CapabilityMintRequest(
+                                    run_id=str(benchmark_id),
+                                    task_id=task_id,
+                                    model=policy.model,
+                                    config=policy.config.model_dump(mode="json"),
+                                    sandbox_id=sandbox.id,
+                                    identity={"org_id": str(org.id), **identity},
+                                    expires_at=expires_at,
+                                    max_queries=policy.max_queries,
+                                    max_sessions=policy.max_sessions,
+                                ),
                                 write_capability_usage,
                             )
+                            runtime_env = {
+                                "MODEL_GATEWAY_URL": gateway.gateway_url,
+                                "MODEL_GATEWAY_API_KEY": minted.token,
+                            }
+                            capability_id = minted.capability_id
+                            del minted
+                            try:
+                                exit_reason, agent_run_time = await execute_agent(
+                                    sandbox,
+                                    command_contract,
+                                    task_data.problem_path,
+                                    task_id,
+                                    log_output,
+                                    task_data.cwd,
+                                    runtime_env,
+                                    task_data.agent_timeout,
+                                    task_data.source,
+                                )
+                            finally:
+                                runtime_env.clear()
+                                capability_usage = await finalize_capability_uninterruptibly(
+                                    gateway,
+                                    capability_id,
+                                    write_capability_usage,
+                                )
 
                     await upload_agent_outputs(
                         sandbox,
@@ -827,6 +1147,10 @@ async def process_task(
                             f"Benchmark result uses reserved key {_MODEL_GATEWAY_USAGE_RESULT_KEY!r}"
                         )
                     evaluation_result[_MODEL_GATEWAY_USAGE_RESULT_KEY] = capability_usage.model_dump(mode="json")
+                if egress_readiness_receipt is not None:
+                    if _AGENT_EGRESS_RESULT_KEY in evaluation_result:
+                        raise TrackerServiceError(f"Benchmark result uses reserved key {_AGENT_EGRESS_RESULT_KEY!r}")
+                    evaluation_result[_AGENT_EGRESS_RESULT_KEY] = egress_readiness_receipt
                 task_breakdown.evaluation_run_duration = time.perf_counter() - evaluation_start_time
 
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time

--- a/services/tracker/tests/integration/test_health_check.py
+++ b/services/tracker/tests/integration/test_health_check.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.engine import Engine
@@ -19,11 +21,15 @@ class TestHealthCheckIntegration:
 
         # Override the engine used by check_database_connection
         monkeypatch.setattr(session_module, "engine", postgres_engine)
+        monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test")
 
         response = client.get("/health")
 
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        assert response.json() == {
+            "status": "ok",
+            "model_gateway_origin_sha256": hashlib.sha256(b"https://gateway.example.test").hexdigest(),
+        }
 
         # Clean up
         app.dependency_overrides.clear()

--- a/services/tracker/tests/integration/test_health_check.py
+++ b/services/tracker/tests/integration/test_health_check.py
@@ -21,14 +21,15 @@ class TestHealthCheckIntegration:
 
         # Override the engine used by check_database_connection
         monkeypatch.setattr(session_module, "engine", postgres_engine)
-        monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test")
+        gateway_sha256 = hashlib.sha256(b"https://gateway.example.test").hexdigest()
+        monkeypatch.setenv("MODEL_GATEWAY_ORIGIN_SHA256", gateway_sha256)
 
         response = client.get("/health")
 
         assert response.status_code == 200
         assert response.json() == {
             "status": "ok",
-            "model_gateway_origin_sha256": hashlib.sha256(b"https://gateway.example.test").hexdigest(),
+            "model_gateway_origin_sha256": gateway_sha256,
         }
 
         # Clean up

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -24,6 +24,7 @@ from tracker.exceptions import SandboxError
 from tracker.sandbox import (
     create_sandbox,
     install_agent_dependencies,
+    restricted_agent_egress,
     run_agent,
     stream_command_output,
     upload_agent_artifacts,
@@ -320,6 +321,45 @@ class TestSandboxOperations:
         restored_result = await test_sandbox.exec(restored_egress_probe_command)
         assert restored_result.exit_code == 0
         assert "restored=True" in restored_result.stdout
+
+    async def test_restricted_agent_egress_preserves_process_state(self, test_sandbox: Sandbox) -> None:
+        """Prove live policy readiness and restoration without restarting the runtime."""
+        start = await test_sandbox.exec(
+            "nohup sh -c 'while :; do date +%s%N >> /tmp/egress-heartbeat; sleep 0.2; done' "
+            ">/tmp/egress-heartbeat.log 2>&1 & echo $! > /tmp/egress-heartbeat.pid"
+        )
+        assert start.exit_code == 0
+        heartbeat_ready = await test_sandbox.exec(
+            "for i in $(seq 1 30); do test -s /tmp/egress-heartbeat && exit 0; sleep 0.1; done; exit 1"
+        )
+        assert heartbeat_ready.exit_code == 0
+        identity_command = (
+            "pid=$(cat /tmp/egress-heartbeat.pid); "
+            "test -d /proc/$pid; "
+            "printf '%s ' \"$pid\"; "
+            "awk '{print $22}' /proc/$pid/stat; "
+            "wc -l < /tmp/egress-heartbeat"
+        )
+
+        async def identity() -> tuple[str, int]:
+            result = await test_sandbox.exec(identity_command)
+            assert result.exit_code == 0
+            lines = result.stdout.splitlines()
+            return lines[0], int(lines[1])
+
+        try:
+            before = await identity()
+            async with restricted_agent_egress(test_sandbox, ["https://example.com"]) as readiness:
+                await asyncio.sleep(1)
+                restricted = await identity()
+                assert len(readiness.sentinel_addresses) == 2
+                assert readiness.attempts >= 2
+            restored = await identity()
+        finally:
+            await test_sandbox.exec("kill $(cat /tmp/egress-heartbeat.pid) 2>/dev/null || true")
+
+        assert before[0] == restricted[0] == restored[0]
+        assert before[1] < restricted[1] <= restored[1]
 
     async def test_deterministic_timeout_behavior(
         self,

--- a/services/tracker/tests/integration/test_sandbox.py
+++ b/services/tracker/tests/integration/test_sandbox.py
@@ -26,6 +26,7 @@ from tracker.sandbox import (
     install_agent_dependencies,
     restricted_agent_egress,
     run_agent,
+    sandbox_lifetime_restricted_agent_egress,
     stream_command_output,
     upload_agent_artifacts,
 )
@@ -360,6 +361,23 @@ class TestSandboxOperations:
 
         assert before[0] == restricted[0] == restored[0]
         assert before[1] < restricted[1] <= restored[1]
+
+    async def test_sandbox_lifetime_egress_remains_restricted_after_context(
+        self,
+        test_sandbox: Sandbox,
+        egress_allowlist_probe_command: str,
+    ) -> None:
+        """Prove abortable-task egress is never restored before fixture deletion."""
+        async with sandbox_lifetime_restricted_agent_egress(
+            test_sandbox,
+            ["http://example.com"],
+        ) as readiness:
+            assert len(readiness.sentinel_addresses) == 2
+            assert readiness.attempts >= 2
+
+        restricted = await test_sandbox.exec(egress_allowlist_probe_command)
+        assert restricted.exit_code == 0
+        assert "allowed=True blocked=False" in restricted.stdout
 
     async def test_deterministic_timeout_behavior(
         self,

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+import hashlib
 import io
 import logging
 import tarfile
@@ -60,12 +61,16 @@ class TestFastapiServer:
         """
         # Mock database connection check for unit tests
         monkeypatch.setattr("main.check_database_connection", lambda: True)
+        monkeypatch.setenv("MODEL_GATEWAY_URL", "HTTPS://Gateway.Example.Test:443/")
 
         response = client.get("/health")
 
         assert response.status_code == 200
 
-        assert response.json() == {"status": "ok"}
+        assert response.json() == {
+            "status": "ok",
+            "model_gateway_origin_sha256": hashlib.sha256(b"https://gateway.example.test").hexdigest(),
+        }
 
     async def test_fetch_benchmark_tasks(
         self,

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -61,7 +61,8 @@ class TestFastapiServer:
         """
         # Mock database connection check for unit tests
         monkeypatch.setattr("main.check_database_connection", lambda: True)
-        monkeypatch.setenv("MODEL_GATEWAY_URL", "HTTPS://Gateway.Example.Test:443/")
+        gateway_sha256 = hashlib.sha256(b"https://gateway.example.test").hexdigest()
+        monkeypatch.setenv("MODEL_GATEWAY_ORIGIN_SHA256", gateway_sha256)
 
         response = client.get("/health")
 
@@ -69,7 +70,7 @@ class TestFastapiServer:
 
         assert response.json() == {
             "status": "ok",
-            "model_gateway_origin_sha256": hashlib.sha256(b"https://gateway.example.test").hexdigest(),
+            "model_gateway_origin_sha256": gateway_sha256,
         }
 
     async def test_fetch_benchmark_tasks(

--- a/services/tracker/tests/unit/test_logging.py
+++ b/services/tracker/tests/unit/test_logging.py
@@ -225,7 +225,7 @@ async def test_request_context_middleware_sets_request_id(monkeypatch: pytest.Mo
     from main import app
 
     monkeypatch.setattr("main.check_database_connection", lambda: True)
-    monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test")
+    monkeypatch.setenv("MODEL_GATEWAY_ORIGIN_SHA256", "0" * 64)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/health")

--- a/services/tracker/tests/unit/test_logging.py
+++ b/services/tracker/tests/unit/test_logging.py
@@ -225,6 +225,7 @@ async def test_request_context_middleware_sets_request_id(monkeypatch: pytest.Mo
     from main import app
 
     monkeypatch.setattr("main.check_database_connection", lambda: True)
+    monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test")
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/health")

--- a/services/tracker/tests/unit/test_model_gateway.py
+++ b/services/tracker/tests/unit/test_model_gateway.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import json
 import math
 from decimal import Decimal
@@ -16,6 +17,7 @@ from tracker.model_gateway import (
     capability_expires_at,
     finalize_capability_uninterruptibly,
     mint_capability_uninterruptibly,
+    model_gateway_origin_sha256,
 )
 
 
@@ -326,8 +328,35 @@ def test_environment_requires_https_gateway_and_admin_key(monkeypatch: pytest.Mo
         ModelGatewayAdminClient.from_environment()
 
 
+def test_model_gateway_origin_sha256_hashes_canonical_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODEL_GATEWAY_URL", "HTTPS://Gateway.Example.Test:443/")
+
+    expected = hashlib.sha256(b"https://gateway.example.test").hexdigest()
+
+    assert model_gateway_origin_sha256() == expected
+
+
+@pytest.mark.parametrize(
+    "gateway_url",
+    [
+        "http://gateway.example.test",
+        "https://gateway.example.test/path",
+        "https://gateway.example.test?query=value",
+        "https://user@gateway.example.test",
+    ],
+)
+def test_model_gateway_origin_sha256_requires_https_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    gateway_url: str,
+) -> None:
+    monkeypatch.setenv("MODEL_GATEWAY_URL", gateway_url)
+
+    with pytest.raises(ModelGatewayError, match="absolute HTTPS"):
+        model_gateway_origin_sha256()
+
+
 async def test_environment_builds_authenticated_admin_client(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MODEL_GATEWAY_URL", "https://gateway.example.test/")
+    monkeypatch.setenv("MODEL_GATEWAY_URL", "HTTPS://Gateway.Example.Test:443/")
     monkeypatch.setenv("MODEL_GATEWAY_ADMIN_API_KEY", "admin-secret-sentinel")
 
     async with ModelGatewayAdminClient.from_environment() as client:

--- a/services/tracker/tests/unit/test_model_gateway.py
+++ b/services/tracker/tests/unit/test_model_gateway.py
@@ -15,6 +15,7 @@ from tracker.model_gateway import (
     ModelGatewayAdminClient,
     ModelGatewayError,
     capability_expires_at,
+    configured_model_gateway_origin_sha256,
     finalize_capability_uninterruptibly,
     mint_capability_uninterruptibly,
     model_gateway_origin_sha256,
@@ -328,12 +329,10 @@ def test_environment_requires_https_gateway_and_admin_key(monkeypatch: pytest.Mo
         ModelGatewayAdminClient.from_environment()
 
 
-def test_model_gateway_origin_sha256_hashes_canonical_origin(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MODEL_GATEWAY_URL", "HTTPS://Gateway.Example.Test:443/")
-
+def test_model_gateway_origin_sha256_hashes_canonical_origin() -> None:
     expected = hashlib.sha256(b"https://gateway.example.test").hexdigest()
 
-    assert model_gateway_origin_sha256() == expected
+    assert model_gateway_origin_sha256("HTTPS://Gateway.Example.Test:443/") == expected
 
 
 @pytest.mark.parametrize(
@@ -346,13 +345,17 @@ def test_model_gateway_origin_sha256_hashes_canonical_origin(monkeypatch: pytest
     ],
 )
 def test_model_gateway_origin_sha256_requires_https_origin(
-    monkeypatch: pytest.MonkeyPatch,
     gateway_url: str,
 ) -> None:
-    monkeypatch.setenv("MODEL_GATEWAY_URL", gateway_url)
-
     with pytest.raises(ModelGatewayError, match="absolute HTTPS"):
-        model_gateway_origin_sha256()
+        model_gateway_origin_sha256(gateway_url)
+
+
+def test_configured_model_gateway_origin_sha256_requires_digest(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODEL_GATEWAY_ORIGIN_SHA256", "not-a-digest")
+
+    with pytest.raises(ModelGatewayError, match="must be a SHA-256 digest"):
+        configured_model_gateway_origin_sha256()
 
 
 async def test_environment_builds_authenticated_admin_client(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/tracker/tests/unit/test_process_task_env.py
+++ b/services/tracker/tests/unit/test_process_task_env.py
@@ -1,19 +1,22 @@
 import asyncio
+import hashlib
 import json
 import math
 import time
 from asyncio import Semaphore
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import AsyncMock
 from uuid import UUID
 
 import pytest
 from benchmark_service import ImageSource, Resources
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import RetrieveTaskResponse
+from benchmark_service.schemas import RetrieveTaskResponse, SetupTaskResponse
 from sqlmodel import Session, select
 
 import tracker.utils.task_execution as utils_module
@@ -31,14 +34,14 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
-from tracker.exceptions import SandboxSetupError
+from tracker.exceptions import SandboxSetupError, TrackerServiceError
 from tracker.model_gateway import (
-    CapabilityEvalResumeState,
     CapabilityMintRequest,
     CapabilityMintResponse,
     CapabilityUsageSummary,
     ModelGatewayError,
 )
+from tracker.sandbox import EgressReadiness
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
     commit_task_status_transition,
@@ -54,6 +57,20 @@ _TEST_STARTER = RequestIdentity(
     email=None,
     name=None,
 )
+
+
+@pytest.fixture(autouse=True)
+def stub_restricted_egress(monkeypatch: pytest.MonkeyPatch) -> None:
+    @asynccontextmanager
+    async def restricted_egress(*_args: Any, **_kwargs: Any) -> AsyncGenerator[EgressReadiness, None]:
+        yield EgressReadiness(
+            sentinel_addresses=("192.0.2.10", "192.0.2.11"),
+            update_returned_at=10.0,
+            ready_at=12.5,
+            attempts=3,
+        )
+
+    monkeypatch.setattr(utils_module, "restricted_agent_egress", restricted_egress)
 
 
 def _task_capability_contract(contract: AgentContractRequest) -> AgentContractRequest:
@@ -536,7 +553,9 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
     monkeypatch: pytest.MonkeyPatch,
     harness_config: HarnessConfig,
 ) -> None:
-    contract = _task_capability_contract(contract)
+    contract = _task_capability_contract(
+        contract.model_copy(update={"egress_allowlist": ["https://static.example.test"]})
+    )
     start_benchmark_request, task_row, benchmark_id = _create_task_env(
         contract,
         database_session,
@@ -549,6 +568,7 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
     runtime_env_copies: list[dict[str, str]] = []
     runtime_env_refs: list[dict[str, str]] = []
     usage_uploads: list[tuple[bytes, str]] = []
+    effective_egress: list[list[str]] = []
     persisted_resume_states: list[dict[str, Any] | None] = []
     resolved_install_env = {"INSTALL_SECRET": "install-secret-value"}
     usage = CapabilityUsageSummary(
@@ -572,6 +592,12 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
             resources=Resources(vcpu=2, memory=4, disk=5),
         )
 
+    async def setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+        return SetupTaskResponse(
+            status="ok",
+            egress_allowlist=["https://controller-token.preview.test"],
+        )
+
     def resolve_install_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
         events.append("resolve")
         return resolved_install_env
@@ -586,8 +612,10 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
         *_args: Any,
         **_kwargs: Any,
     ) -> tuple[None, float]:
+        command_contract = cast(AgentContractRequest, _args[1])
         runtime_env = cast(dict[str, str], _args[6])
         events.append("execute")
+        assert command_contract.egress_allowlist == []
         runtime_env_copies.append(dict(runtime_env))
         runtime_env_refs.append(runtime_env)
         return None, 1.5
@@ -596,8 +624,23 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
         events.append("upload")
 
     async def upload_usage(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
-        events.append("usage upload")
+        events.append("egress upload" if "/agent_egress/" in key else "usage upload")
         usage_uploads.append((content, key))
+
+    @asynccontextmanager
+    async def restricted_egress(
+        _sandbox: Any,
+        allowed_addresses: list[str],
+    ) -> AsyncGenerator[EgressReadiness, None]:
+        events.append("egress ready")
+        effective_egress.append(allowed_addresses)
+        yield EgressReadiness(
+            sentinel_addresses=("192.0.2.10", "192.0.2.11"),
+            update_returned_at=10.0,
+            ready_at=12.5,
+            attempts=3,
+        )
+        events.append("egress clear")
 
     async def evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
         events.append("evaluate")
@@ -638,12 +681,14 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
             return gateway
 
     monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "setup_task", setup_task)
     monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", evaluate)
     monkeypatch.setattr(utils_module, "resolve_secrets", resolve_install_secrets)
     monkeypatch.setattr(utils_module, "install_agent", install_agent)
     monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
     monkeypatch.setattr(utils_module, "upload_to_s3", upload_usage)
     monkeypatch.setattr(utils_module, "upload_agent_outputs", upload_outputs)
+    monkeypatch.setattr(utils_module, "restricted_agent_egress", restricted_egress)
     monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
 
     before = time.time()
@@ -653,10 +698,13 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
     assert events == [
         "resolve",
         "install",
+        "egress ready",
+        "egress upload",
         "mint",
         "execute",
         "finalize",
         "usage upload",
+        "egress clear",
         "close",
         "upload",
         "evaluate",
@@ -671,19 +719,53 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
         }
     ]
     assert runtime_env_refs == [{}]
+    assert effective_egress == [
+        [
+            "https://static.example.test",
+            "https://controller-token.preview.test",
+            "https://gateway.example.test",
+        ]
+    ]
+    egress_receipt = {
+        "schema_version": 1,
+        "run_id": str(benchmark_id),
+        "task_id": "task_0",
+        "sandbox_id": "mock-sandbox-id",
+        "allowed_origin_set_sha256": {
+            "contract": hashlib.sha256(b'["https://static.example.test"]').hexdigest(),
+            "setup": hashlib.sha256(b'["https://controller-token.preview.test"]').hexdigest(),
+            "model_gateway": hashlib.sha256(b'["https://gateway.example.test"]').hexdigest(),
+            "effective": hashlib.sha256(
+                b'["https://controller-token.preview.test","https://gateway.example.test","https://static.example.test"]'
+            ).hexdigest(),
+        },
+        "sentinel_sha256": sorted(
+            hashlib.sha256(f"{address}:443".encode()).hexdigest() for address in ("192.0.2.10", "192.0.2.11")
+        ),
+        "update_returned_at": 10.0,
+        "ready_at": 12.5,
+        "readiness_attempts": 3,
+        "required_consecutive_observations": 2,
+    }
+    egress_content = (json.dumps(egress_receipt, sort_keys=True) + "\n").encode()
     usage_content = (json.dumps(usage.model_dump(mode="json"), sort_keys=True) + "\n").encode()
     assert usage_uploads == [
+        (
+            egress_content,
+            f"benchmarks/{benchmark_id}/task_0/agent_egress/readiness-v1.json",
+        ),
         (
             usage_content,
             f"benchmarks/{benchmark_id}/task_0/model_gateway_usage/cap_task.json",
         ),
     ]
     assert persisted_resume_states == [
-        CapabilityEvalResumeState(
-            kind="model_gateway_eval_resume",
-            capability_id="cap_task",
-            benchmark_state={"job_id": "eval-job"},
-        ).model_dump(mode="json")
+        {
+            "kind": "model_gateway_egress_eval_resume",
+            "capability_id": "cap_task",
+            "egress_receipt_sha256": hashlib.sha256(egress_content).hexdigest(),
+            "benchmark_state": {"job_id": "eval-job"},
+        }
     ]
 
     assert len(mint_requests) == 1
@@ -707,11 +789,47 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
             "status": "success",
             "score": 1.0,
             "_valkyrie_model_gateway_usage": usage.model_dump(mode="json"),
+            "_valkyrie_agent_egress": egress_receipt,
         }
     }
 
 
-async def test_process_task_resume_restores_task_capability_usage(
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("schema_version", True),
+        ("schema_version", 1.0),
+        ("required_consecutive_observations", True),
+        ("required_consecutive_observations", 2.0),
+    ],
+)
+def test_egress_readiness_receipt_requires_exact_integer_fields(field: str, value: bool | float) -> None:
+    benchmark_id = UUID("00000000-0000-0000-0000-000000000123")
+    receipt: dict[str, object] = {
+        "schema_version": 1,
+        "run_id": str(benchmark_id),
+        "task_id": "task_0",
+        "sandbox_id": "sandbox-0",
+        "allowed_origin_set_sha256": {
+            "contract": "1" * 64,
+            "setup": "2" * 64,
+            "model_gateway": "3" * 64,
+            "effective": "4" * 64,
+        },
+        "sentinel_sha256": ["5" * 64, "6" * 64],
+        "update_returned_at": 10.0,
+        "ready_at": 12.5,
+        "readiness_attempts": 3,
+        "required_consecutive_observations": 2,
+    }
+    receipt[field] = value
+    parse_receipt = getattr(utils_module, "_parse_egress_readiness_receipt")
+
+    with pytest.raises(TrackerServiceError, match="artifact is invalid"):
+        parse_receipt(json.dumps(receipt).encode(), benchmark_id, "task_0")
+
+
+async def test_process_task_resume_restores_capability_and_egress_receipts(
     contract: AgentContractRequest,
     database_session: Session,
     process_benchmark_env: None,
@@ -725,17 +843,6 @@ async def test_process_task_resume_restores_task_capability_usage(
         harness_config,
     )
     task_row.status = TaskStatus.EVALUATING
-    task_row.eval_resume_state = CapabilityEvalResumeState(
-        kind="model_gateway_eval_resume",
-        capability_id="cap_task",
-        benchmark_state={"job_id": "eval-job"},
-    ).model_dump(mode="json")
-    database_session.add(task_row)
-    database_session.commit()
-    task_row.started_at += timedelta(seconds=1)
-    database_session.add(task_row)
-    database_session.commit()
-
     usage = CapabilityUsageSummary(
         capability_id="cap_task",
         state="revoked",
@@ -747,10 +854,41 @@ async def test_process_task_resume_restores_task_capability_usage(
         total_output_tokens=500,
         cost_usd=Decimal("0.42"),
     )
+    egress_receipt = {
+        "schema_version": 1,
+        "run_id": str(benchmark_id),
+        "task_id": "task_0",
+        "sandbox_id": "sandbox-0",
+        "allowed_origin_set_sha256": {
+            "contract": "1" * 64,
+            "setup": "2" * 64,
+            "model_gateway": "3" * 64,
+            "effective": "4" * 64,
+        },
+        "sentinel_sha256": ["5" * 64, "6" * 64],
+        "update_returned_at": 10.0,
+        "ready_at": 12.5,
+        "readiness_attempts": 3,
+        "required_consecutive_observations": 2,
+    }
+    egress_content = (json.dumps(egress_receipt, sort_keys=True) + "\n").encode()
+    task_row.eval_resume_state = {
+        "kind": "model_gateway_egress_eval_resume",
+        "capability_id": "cap_task",
+        "egress_receipt_sha256": hashlib.sha256(egress_content).hexdigest(),
+        "benchmark_state": {"job_id": "eval-job"},
+    }
+    database_session.add(task_row)
+    database_session.commit()
+    task_row.started_at += timedelta(seconds=1)
+    database_session.add(task_row)
+    database_session.commit()
+
     artifacts = {
         f"benchmarks/{benchmark_id}/task_0/model_gateway_usage/cap_task.json": (
             json.dumps(usage.model_dump(mode="json"), sort_keys=True) + "\n"
         ).encode(),
+        f"benchmarks/{benchmark_id}/task_0/agent_egress/readiness-v1.json": egress_content,
     }
     downloaded: list[str] = []
 
@@ -777,11 +915,361 @@ async def test_process_task_resume_restores_task_capability_usage(
         "status": "success",
         "score": 1.0,
         "_valkyrie_model_gateway_usage": usage.model_dump(mode="json"),
+        "_valkyrie_agent_egress": egress_receipt,
     }
     evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
     assert result == {"task_0": expected}
     assert evaluation.result == expected
     assert downloaded == list(artifacts)
+
+
+async def test_process_task_resume_accepts_legacy_capability_state(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    task_row.status = TaskStatus.EVALUATING
+    task_row.eval_resume_state = {
+        "kind": "model_gateway_eval_resume",
+        "capability_id": "cap_task",
+        "benchmark_state": {"job_id": "eval-job"},
+    }
+    database_session.add(task_row)
+    database_session.commit()
+    task_row.started_at += timedelta(seconds=1)
+    database_session.add(task_row)
+    database_session.commit()
+    usage = CapabilityUsageSummary(
+        capability_id="cap_task",
+        state="revoked",
+        drained=True,
+        session_count=1,
+        query_count=1,
+        completed_queries=1,
+        total_input_tokens=1,
+        total_output_tokens=1,
+        cost_usd=Decimal("0.01"),
+    )
+    usage_content = (json.dumps(usage.model_dump(mode="json"), sort_keys=True) + "\n").encode()
+
+    async def download_usage(*_args: Any, **_kwargs: Any) -> bytes:
+        return usage_content
+
+    async def resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        assert _kwargs["eval_resume_state"] == {"job_id": "eval-job"}
+        return {"status": "success", "score": 1.0}
+
+    @asynccontextmanager
+    async def unexpected_sandbox(*_args: Any, **_kwargs: Any):
+        raise AssertionError("eval resume should not create a sandbox")
+        yield
+
+    monkeypatch.setattr(utils_module, "download_from_s3", download_usage)
+    monkeypatch.setattr(utils_module, "create_sandbox", unexpected_sandbox)
+    monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", resume_evaluation)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert result == {
+        "task_0": {
+            "status": "success",
+            "score": 1.0,
+            "_valkyrie_model_gateway_usage": usage.model_dump(mode="json"),
+        }
+    }
+
+
+async def test_process_task_scopes_dynamic_setup_egress_without_model_gateway(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    events: list[str] = []
+    uploads: list[tuple[bytes, str]] = []
+    resume_states: list[dict[str, Any] | None] = []
+    agent_runtime = SimpleNamespace(id="agent-runtime")
+
+    async def setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+        return SetupTaskResponse(status="ok", egress_allowlist=["https://controller.preview.test"])
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        events.append("install")
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        command_contract = cast(AgentContractRequest, _args[1])
+        assert command_contract.egress_allowlist == []
+        events.append("execute")
+        return None, 1.0
+
+    @asynccontextmanager
+    async def restricted_egress(
+        sandbox: Any,
+        allowed_addresses: list[str],
+    ) -> AsyncGenerator[EgressReadiness, None]:
+        assert sandbox is agent_runtime
+        assert allowed_addresses == ["https://controller.preview.test"]
+        events.append("egress ready")
+        yield EgressReadiness(
+            sentinel_addresses=("192.0.2.10", "192.0.2.11"),
+            update_returned_at=10.0,
+            ready_at=12.5,
+            attempts=3,
+        )
+        events.append("egress clear")
+
+    async def upload_receipt(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+        events.append("egress upload")
+        uploads.append((content, key))
+
+    async def upload_outputs(*_args: Any, **_kwargs: Any) -> None:
+        events.append("upload")
+
+    async def evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        events.append("evaluate")
+        _kwargs["on_eval_resume_state"]({"job_id": "eval-job"})
+        database_session.refresh(task_row)
+        resume_states.append(task_row.eval_resume_state)
+        return {"status": "success", "score": 1.0}
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    def adapt_runtime(*_args: Any) -> Any:
+        return agent_runtime
+
+    monkeypatch.setattr(BenchmarkServiceClient, "setup_task", setup_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", evaluate)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "restricted_agent_egress", restricted_egress)
+    monkeypatch.setattr(utils_module, "runtime_sandbox", adapt_runtime)
+    monkeypatch.setattr(utils_module, "upload_to_s3", upload_receipt)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", upload_outputs)
+    run_agent = AsyncMock()
+    monkeypatch.setattr(utils_module, "run_agent", run_agent)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert events == ["install", "egress ready", "egress upload", "execute", "egress clear", "upload", "evaluate"]
+    run_agent.assert_not_awaited()
+    evaluation = cast(dict[str, Any], result["task_0"])
+    receipt = cast(dict[str, Any], evaluation["_valkyrie_agent_egress"])
+    content = (json.dumps(receipt, sort_keys=True) + "\n").encode()
+    assert uploads == [
+        (
+            content,
+            f"benchmarks/{benchmark_id}/task_0/agent_egress/readiness-v1.json",
+        )
+    ]
+    assert receipt["allowed_origin_set_sha256"]["model_gateway"] == hashlib.sha256(b"[]").hexdigest()
+    assert resume_states == [
+        {
+            "kind": "agent_egress_eval_resume",
+            "egress_receipt_sha256": hashlib.sha256(content).hexdigest(),
+            "benchmark_state": {"job_id": "eval-job"},
+        }
+    ]
+
+
+async def test_process_task_resume_restores_dynamic_setup_egress_receipt(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    receipt = {
+        "schema_version": 1,
+        "run_id": str(benchmark_id),
+        "task_id": "task_0",
+        "sandbox_id": "sandbox-0",
+        "allowed_origin_set_sha256": {
+            "contract": "1" * 64,
+            "setup": "2" * 64,
+            "model_gateway": "3" * 64,
+            "effective": "4" * 64,
+        },
+        "sentinel_sha256": ["5" * 64, "6" * 64],
+        "update_returned_at": 10.0,
+        "ready_at": 12.5,
+        "readiness_attempts": 3,
+        "required_consecutive_observations": 2,
+    }
+    content = (json.dumps(receipt, sort_keys=True) + "\n").encode()
+    task_row.status = TaskStatus.EVALUATING
+    task_row.eval_resume_state = {
+        "kind": "agent_egress_eval_resume",
+        "egress_receipt_sha256": hashlib.sha256(content).hexdigest(),
+        "benchmark_state": {"job_id": "eval-job"},
+    }
+    database_session.add(task_row)
+    database_session.commit()
+    task_row.started_at += timedelta(seconds=1)
+    database_session.add(task_row)
+    database_session.commit()
+
+    async def download_receipt(*_args: Any, **_kwargs: Any) -> bytes:
+        return content
+
+    async def resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        assert _kwargs["eval_resume_state"] == {"job_id": "eval-job"}
+        return {"status": "success", "score": 1.0}
+
+    @asynccontextmanager
+    async def unexpected_sandbox(*_args: Any, **_kwargs: Any):
+        raise AssertionError("eval resume should not create a sandbox")
+        yield
+
+    monkeypatch.setattr(utils_module, "download_from_s3", download_receipt)
+    monkeypatch.setattr(utils_module, "create_sandbox", unexpected_sandbox)
+    monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", resume_evaluation)
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    expected = {"status": "success", "score": 1.0, "_valkyrie_agent_egress": receipt}
+    evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+    assert result == {"task_0": expected}
+    assert evaluation.result == expected
+
+
+async def test_process_task_dynamic_setup_readiness_failure_executes_no_agent(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+
+    async def setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+        return SetupTaskResponse(status="ok", egress_allowlist=["https://controller.preview.test"])
+
+    @asynccontextmanager
+    async def fail_readiness(*_args: Any, **_kwargs: Any) -> AsyncGenerator[EgressReadiness, None]:
+        raise SandboxSetupError("egress readiness failed")
+        yield
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    execute_agent = AsyncMock()
+    run_agent = AsyncMock()
+    upload_outputs = AsyncMock()
+    monkeypatch.setattr(BenchmarkServiceClient, "setup_task", setup_task)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", AsyncMock())
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "restricted_agent_egress", fail_readiness)
+    monkeypatch.setattr(utils_module, "run_agent", run_agent)
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", upload_outputs)
+
+    with pytest.raises(SandboxSetupError, match="egress readiness failed"):
+        await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    execute_agent.assert_not_awaited()
+    run_agent.assert_not_awaited()
+    upload_outputs.assert_not_awaited()
+
+
+async def test_process_task_readiness_failure_mints_no_capability(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    contract = _task_capability_contract(contract)
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+    )
+    minted = False
+    executed = False
+
+    async def retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+        return RetrieveTaskResponse(
+            source=ImageSource(image="test-image:latest"),
+            problem_path="/tmp/problem_statement.txt",
+            cwd="/testbed",
+            agent_timeout=120.0,
+            resources=Resources(vcpu=2, memory=4, disk=5),
+        )
+
+    @asynccontextmanager
+    async def fail_readiness(*_args: Any, **_kwargs: Any) -> AsyncGenerator[EgressReadiness, None]:
+        raise SandboxSetupError("egress readiness failed")
+        yield
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        nonlocal executed
+        executed = True
+        return None, 1.0
+
+    class FakeGateway:
+        gateway_url = "https://gateway.example.test"
+
+        async def __aenter__(self) -> "FakeGateway":
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            pass
+
+        async def mint(self, request: CapabilityMintRequest) -> CapabilityMintResponse:
+            nonlocal minted
+            minted = True
+            return CapabilityMintResponse(
+                capability_id="unreachable",
+                token="unreachable",
+                state="active",
+                expires_at=request.expires_at,
+            )
+
+    class FakeGatewayFactory:
+        @classmethod
+        def from_environment(cls) -> FakeGateway:
+            return FakeGateway()
+
+    def resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
+    monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
+    monkeypatch.setattr(utils_module, "install_agent", AsyncMock())
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "restricted_agent_egress", fail_readiness)
+    monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+
+    with pytest.raises(SandboxSetupError, match="egress readiness failed"):
+        await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert not minted
+    assert not executed
 
 
 async def test_process_task_preserves_out_of_order_usage_from_two_attempts(
@@ -822,7 +1310,10 @@ async def test_process_task_preserves_out_of_order_usage_from_two_attempts(
         return {}
 
     async def capture_upload(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
-        if json.loads(content)["capability_id"] == "cap_attempt_1":
+        payload = json.loads(content)
+        if "capability_id" not in payload:
+            return
+        if payload["capability_id"] == "cap_attempt_1":
             first_attempt_upload_started.set()
             await release_first_attempt_upload.wait()
         uploads.append((content, key))
@@ -944,6 +1435,8 @@ async def test_process_task_cancellation_during_finalization_persists_usage_befo
         return {}
 
     async def upload_usage(_content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+        if "/agent_egress/" in key:
+            return
         events.append("usage upload")
         upload_keys.append(key)
 
@@ -1047,7 +1540,9 @@ async def test_process_task_finalizes_capability_after_agent_error_and_blocks_ou
     async def unexpected_upload(*_args: Any, **_kwargs: Any) -> None:
         events.append("unexpected upload")
 
-    async def upload_usage(*_args: Any, **_kwargs: Any) -> None:
+    async def upload_usage(_content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+        if "/agent_egress/" in key:
+            return
         events.append("usage upload")
 
     async def unexpected_evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
@@ -1146,6 +1641,9 @@ async def test_process_task_blocks_outputs_when_capability_does_not_drain(
     async def unexpected(*_args: Any, **_kwargs: Any) -> None:
         events.append("unexpected")
 
+    async def upload_receipt(*_args: Any, **_kwargs: Any) -> None:
+        pass
+
     class FakeGateway:
         gateway_url = "https://gateway.example.test"
 
@@ -1184,6 +1682,7 @@ async def test_process_task_blocks_outputs_when_capability_does_not_drain(
     monkeypatch.setattr(utils_module, "resolve_secrets", resolve_no_secrets)
     monkeypatch.setattr(utils_module, "install_agent", install_agent)
     monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "upload_to_s3", upload_receipt)
     monkeypatch.setattr(utils_module, "upload_agent_outputs", unexpected)
     monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
 

--- a/services/tracker/tests/unit/test_process_task_env.py
+++ b/services/tracker/tests/unit/test_process_task_env.py
@@ -10,13 +10,18 @@ from datetime import timedelta
 from decimal import Decimal
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 from uuid import UUID
 
 import pytest
 from benchmark_service import ImageSource, Resources
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import RetrieveTaskResponse, SetupTaskResponse
+from benchmark_service.schemas import (
+    AbortableSetupLifecycle,
+    AbortTaskResponse,
+    RetrieveTaskResponse,
+    SetupTaskResponse,
+)
 from sqlmodel import Session, select
 
 import tracker.utils.task_execution as utils_module
@@ -87,6 +92,16 @@ def _task_capability_contract(contract: AgentContractRequest) -> AgentContractRe
                 max_sessions=4,
             ),
         }
+    )
+
+
+def _abortable_task_response() -> RetrieveTaskResponse:
+    return RetrieveTaskResponse(
+        source=ImageSource(image="test-image:latest"),
+        problem_path="/tmp/problem_statement.txt",
+        cwd="/testbed",
+        resources=Resources(vcpu=2, memory=4, disk=5),
+        setup_lifecycle=AbortableSetupLifecycle(),
     )
 
 
@@ -590,6 +605,7 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
             cwd="/testbed",
             agent_timeout=120.0,
             resources=Resources(vcpu=2, memory=4, disk=5),
+            setup_lifecycle=AbortableSetupLifecycle(),
         )
 
     async def setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
@@ -628,7 +644,7 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
         usage_uploads.append((content, key))
 
     @asynccontextmanager
-    async def restricted_egress(
+    async def persistent_egress(
         _sandbox: Any,
         allowed_addresses: list[str],
     ) -> AsyncGenerator[EgressReadiness, None]:
@@ -640,7 +656,7 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
             ready_at=12.5,
             attempts=3,
         )
-        events.append("egress clear")
+        events.append("egress remains")
 
     async def evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
         events.append("evaluate")
@@ -674,6 +690,7 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
             return usage
 
     gateway = FakeGateway()
+    abort_task = AsyncMock(return_value=AbortTaskResponse())
 
     class FakeGatewayFactory:
         @classmethod
@@ -682,14 +699,16 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
 
     monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", retrieve_task)
     monkeypatch.setattr(BenchmarkServiceClient, "setup_task", setup_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "abort_task", abort_task)
     monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", evaluate)
     monkeypatch.setattr(utils_module, "resolve_secrets", resolve_install_secrets)
     monkeypatch.setattr(utils_module, "install_agent", install_agent)
     monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
     monkeypatch.setattr(utils_module, "upload_to_s3", upload_usage)
     monkeypatch.setattr(utils_module, "upload_agent_outputs", upload_outputs)
-    monkeypatch.setattr(utils_module, "restricted_agent_egress", restricted_egress)
+    monkeypatch.setattr(utils_module, "sandbox_lifetime_restricted_agent_egress", persistent_egress)
     monkeypatch.setattr(utils_module, "ModelGatewayAdminClient", FakeGatewayFactory)
+    monkeypatch.setattr(utils_module, "buffer_logs", Mock())
 
     before = time.time()
     result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
@@ -704,11 +723,12 @@ async def test_process_task_runs_task_capability_lifecycle_before_upload_and_eva
         "execute",
         "finalize",
         "usage upload",
-        "egress clear",
+        "egress remains",
         "close",
         "upload",
         "evaluate",
     ]
+    abort_task.assert_not_awaited()
     assert install_env_copies == [{"INSTALL_SECRET": "install-secret-value"}]
     assert install_env_refs == [{}]
     assert resolved_install_env == {}
@@ -985,6 +1005,227 @@ async def test_process_task_resume_accepts_legacy_capability_state(
             "_valkyrie_model_gateway_usage": usage.model_dump(mode="json"),
         }
     }
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [None, "setup", "empty setup", "install", "readiness", "execute", "upload", "evaluation"],
+)
+async def test_process_task_abortable_setup_ownership(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+    failure: str | None,
+) -> None:
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+        retry_policy=RetryPolicy.FORBID,
+    )
+
+    async def setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+        if failure == "setup":
+            raise RuntimeError("setup failed")
+        addresses = [] if failure == "empty setup" else ["https://controller.preview.test"]
+        return SetupTaskResponse(status="ok", egress_allowlist=addresses)
+
+    async def install_agent(*_args: Any, **_kwargs: Any) -> None:
+        if failure == "install":
+            raise RuntimeError("install failed")
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        if failure == "execute":
+            raise RuntimeError("execute failed")
+        return None, 1.0
+
+    @asynccontextmanager
+    async def persistent_egress(*_args: Any, **_kwargs: Any) -> AsyncGenerator[EgressReadiness, None]:
+        if failure == "readiness":
+            raise RuntimeError("readiness failed")
+        yield EgressReadiness(
+            sentinel_addresses=("192.0.2.10", "192.0.2.11"),
+            update_returned_at=10.0,
+            ready_at=12.5,
+            attempts=3,
+        )
+
+    async def upload_outputs(*_args: Any, **_kwargs: Any) -> None:
+        if failure == "upload":
+            raise RuntimeError("upload failed")
+
+    async def evaluate(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        if failure == "evaluation":
+            raise RuntimeError("evaluation failed")
+        return {"status": "success", "score": 1.0}
+
+    abort_task = AsyncMock(return_value=AbortTaskResponse())
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", AsyncMock(return_value=_abortable_task_response()))
+    monkeypatch.setattr(BenchmarkServiceClient, "setup_task", setup_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "abort_task", abort_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", evaluate)
+    monkeypatch.setattr(utils_module, "resolve_secrets", Mock(return_value={}))
+    monkeypatch.setattr(utils_module, "install_agent", install_agent)
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "sandbox_lifetime_restricted_agent_egress", persistent_egress)
+    monkeypatch.setattr(utils_module, "upload_to_s3", AsyncMock())
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", upload_outputs)
+    monkeypatch.setattr(utils_module, "buffer_logs", Mock())
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    if failure is None:
+        abort_task.assert_not_awaited()
+        evaluation = cast(dict[str, Any], result["task_0"])
+        assert evaluation["status"] == "success"
+        assert evaluation["score"] == 1.0
+        assert "_valkyrie_agent_egress" in evaluation
+        return
+
+    assert result == {"task_0": None}
+    abort_task.assert_awaited_once_with("task_0", str(benchmark_id), "mock-sandbox-id", None)
+
+
+async def test_process_task_cancellation_waits_for_abort_before_sandbox_delete(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+        retry_policy=RetryPolicy.FORBID,
+    )
+    events: list[str] = []
+    execute_started = asyncio.Event()
+    abort_started = asyncio.Event()
+    release_abort = asyncio.Event()
+
+    @asynccontextmanager
+    async def create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Any, None]:
+        try:
+            yield SimpleNamespace(id="sandbox-abortable", name="sandbox-abortable")
+        finally:
+            events.append("sandbox delete")
+
+    async def execute_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+        events.append("execute")
+        execute_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    @asynccontextmanager
+    async def persistent_egress(*_args: Any, **_kwargs: Any) -> AsyncGenerator[EgressReadiness, None]:
+        try:
+            yield EgressReadiness(
+                sentinel_addresses=("192.0.2.10", "192.0.2.11"),
+                update_returned_at=10.0,
+                ready_at=12.5,
+                attempts=3,
+            )
+        finally:
+            events.append("restriction retained")
+
+    async def abort_task(
+        _client: BenchmarkServiceClient,
+        task_id: str,
+        run_id: str,
+        instance_id: str,
+        dataset: str | None = None,
+    ) -> AbortTaskResponse:
+        assert (task_id, run_id, instance_id, dataset) == (
+            "task_0",
+            str(benchmark_id),
+            "sandbox-abortable",
+            None,
+        )
+        events.append("abort start")
+        abort_started.set()
+        await release_abort.wait()
+        events.append("abort done")
+        return AbortTaskResponse()
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", AsyncMock(return_value=_abortable_task_response()))
+    monkeypatch.setattr(
+        BenchmarkServiceClient,
+        "setup_task",
+        AsyncMock(return_value=SetupTaskResponse(status="ok", egress_allowlist=["https://controller.preview.test"])),
+    )
+    monkeypatch.setattr(BenchmarkServiceClient, "abort_task", abort_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", AsyncMock(side_effect=AssertionError("evaluate")))
+    monkeypatch.setattr(utils_module, "create_sandbox", create_sandbox)
+    monkeypatch.setattr(utils_module, "resolve_secrets", Mock(return_value={}))
+    monkeypatch.setattr(utils_module, "install_agent", AsyncMock())
+    monkeypatch.setattr(utils_module, "execute_agent", execute_agent)
+    monkeypatch.setattr(utils_module, "sandbox_lifetime_restricted_agent_egress", persistent_egress)
+    monkeypatch.setattr(utils_module, "upload_to_s3", AsyncMock())
+    monkeypatch.setattr(utils_module, "upload_agent_outputs", AsyncMock(side_effect=AssertionError("upload")))
+    monkeypatch.setattr(utils_module, "buffer_logs", Mock())
+
+    task = asyncio.create_task(_run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config))
+    await asyncio.wait_for(execute_started.wait(), timeout=1)
+    task.cancel()
+    await asyncio.wait_for(abort_started.wait(), timeout=1)
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    release_abort.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert events == ["execute", "restriction retained", "abort start", "abort done", "sandbox delete"]
+
+
+async def test_process_task_abort_deadline_still_deletes_sandbox(
+    contract: AgentContractRequest,
+    database_session: Session,
+    process_benchmark_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_config: HarnessConfig,
+) -> None:
+    start_benchmark_request, task_row, benchmark_id = _create_task_env(
+        contract,
+        database_session,
+        harness_config,
+        retry_policy=RetryPolicy.FORBID,
+    )
+    events: list[str] = []
+
+    @asynccontextmanager
+    async def create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[Any, None]:
+        try:
+            yield SimpleNamespace(id="sandbox-abortable", name="sandbox-abortable")
+        finally:
+            events.append("sandbox delete")
+
+    async def setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+        raise RuntimeError("setup failed after allocating resources")
+
+    async def abort_task(*_args: Any, **_kwargs: Any) -> AbortTaskResponse:
+        events.append("abort start")
+        try:
+            await asyncio.Event().wait()
+        finally:
+            events.append("abort cancelled")
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", AsyncMock(return_value=_abortable_task_response()))
+    monkeypatch.setattr(BenchmarkServiceClient, "setup_task", setup_task)
+    monkeypatch.setattr(BenchmarkServiceClient, "abort_task", abort_task)
+    monkeypatch.setattr(utils_module, "create_sandbox", create_sandbox)
+    monkeypatch.setattr(utils_module, "_ABORT_TASK_DEADLINE_SECONDS", 0.01)
+    monkeypatch.setattr(utils_module, "buffer_logs", Mock())
+
+    result = await _run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+    assert result == {"task_0": None}
+    assert events == ["abort start", "abort cancelled", "sandbox delete"]
 
 
 async def test_process_task_scopes_dynamic_setup_egress_without_model_gateway(

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1047,6 +1047,30 @@ class TestEgressAllowlist:
 
         mock_sandbox.clear_egress_rules.assert_not_awaited()
 
+    async def test_persistent_restriction_is_not_cleared_after_readiness(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def prevalidate(*_args: Any, **_kwargs: Any) -> tuple[str, ...]:
+            return ("192.0.2.10", "192.0.2.11")
+
+        async def ready(*_args: Any, **_kwargs: Any) -> tuple[float, int]:
+            return 12.5, 3
+
+        monkeypatch.setattr(sandbox_module, "_prevalidate_egress_sentinels", prevalidate)
+        monkeypatch.setattr(sandbox_module, "_wait_for_egress", ready)
+        mock_sandbox = Mock(id="sandbox-123")
+        mock_sandbox.modify_egress_rules = AsyncMock()
+        mock_sandbox.clear_egress_rules = AsyncMock()
+
+        readiness = await sandbox_module.restrict_agent_egress(mock_sandbox, ["https://api.openai.com"])
+
+        assert readiness.sentinel_addresses == ("192.0.2.10", "192.0.2.11")
+        assert readiness.ready_at == 12.5
+        assert readiness.attempts == 3
+        mock_sandbox.modify_egress_rules.assert_awaited_once_with(["https://api.openai.com"])
+        mock_sandbox.clear_egress_rules.assert_not_awaited()
+
     async def test_prevalidation_has_a_hard_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
         async def never_returns(*_args: Any, **_kwargs: Any) -> tuple[str, ...]:
             await asyncio.Event().wait()

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -42,8 +42,11 @@ _create_sandbox = getattr(sandbox_module, "_create_sandbox")
 _delete_sandbox = getattr(sandbox_module, "delete_sandbox")
 _exec = getattr(sandbox_module, "_exec")
 _apply_egress_allowlist = getattr(sandbox_module, "_apply_egress_allowlist")
+_egress_probe = getattr(sandbox_module, "_egress_probe")
+_prevalidate_egress_sentinels = getattr(sandbox_module, "_prevalidate_egress_sentinels")
 _install_agent_dependencies = getattr(sandbox_module, "install_agent_dependencies")
 _stream_command_output_with_egress_allowlist = getattr(sandbox_module, "_stream_command_output_with_egress_allowlist")
+_wait_for_egress = getattr(sandbox_module, "_wait_for_egress")
 _upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
 _AGENT_SCOPE_ENV = getattr(sandbox_module, "_AGENT_SCOPE_ENV")
 _SECRET_NAMES_ENV = getattr(sandbox_module, "_SECRET_NAMES_ENV")
@@ -1003,6 +1006,9 @@ class TestEgressAllowlist:
         async def fail_stream(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
             raise SandboxSetupError("credential cleanup failed")
 
+        def ignore_output(_message: str) -> None:
+            pass
+
         monkeypatch.setattr(sandbox_module, "stream_command_output", fail_stream)
         mock_sandbox = Mock(id="sandbox-123")
         mock_sandbox.modify_egress_rules = AsyncMock()
@@ -1012,12 +1018,171 @@ class TestEgressAllowlist:
             await _stream_command_output_with_egress_allowlist(
                 mock_sandbox,
                 "run-agent.sh",
-                on_output=lambda _message: None,
+                on_output=ignore_output,
                 allowed_addresses=["https://api.openai.com"],
                 env_vars={"AGENT_SECRET": "secret"},
             )
 
         mock_sandbox.clear_egress_rules.assert_not_awaited()
+
+    async def test_readiness_timeout_blocks_agent_and_keeps_egress_restricted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def fail_readiness(*_args: Any, **_kwargs: Any) -> tuple[float, int]:
+            raise SandboxSetupError("Egress did not become restricted")
+
+        async def prevalidate(*_args: Any, **_kwargs: Any) -> tuple[str, ...]:
+            return ("192.0.2.10", "192.0.2.11")
+
+        monkeypatch.setattr(sandbox_module, "_prevalidate_egress_sentinels", prevalidate)
+        monkeypatch.setattr(sandbox_module, "_wait_for_egress", fail_readiness)
+        mock_sandbox = Mock(id="sandbox-123")
+        mock_sandbox.modify_egress_rules = AsyncMock()
+        mock_sandbox.clear_egress_rules = AsyncMock()
+
+        with pytest.raises(SandboxSetupError, match="did not become restricted"):
+            async with sandbox_module.restricted_agent_egress(mock_sandbox, ["https://api.openai.com"]):
+                raise AssertionError("unreachable")
+
+        mock_sandbox.clear_egress_rules.assert_not_awaited()
+
+    async def test_prevalidation_has_a_hard_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def never_returns(*_args: Any, **_kwargs: Any) -> tuple[str, ...]:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(sandbox_module, "_EGRESS_READY_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(sandbox_module, "_prevalidate_egress_sentinels", never_returns)
+        mock_sandbox = Mock(id="sandbox-123")
+        mock_sandbox.modify_egress_rules = AsyncMock()
+
+        with pytest.raises(SandboxSetupError, match="prevalidation did not complete within 0.01 seconds"):
+            async with sandbox_module.restricted_agent_egress(mock_sandbox, ["https://api.openai.com"]):
+                raise AssertionError("unreachable")
+
+        mock_sandbox.modify_egress_rules.assert_not_awaited()
+
+    async def test_prevalidation_requires_two_matching_vals_sentinel_observations(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        responses = deque[dict[str, object]](
+            (
+                {"runtime_ready": False, "sentinels": []},
+                {"runtime_ready": True, "sentinels": ["192.0.2.10", "192.0.2.11"]},
+                {"runtime_ready": True, "sentinels": ["192.0.2.10", "192.0.2.11"]},
+            )
+        )
+
+        async def probe(_sandbox: Any, payload: dict[str, object]) -> dict[str, object]:
+            assert payload == {
+                "state": "baseline",
+                "sentinel_hosts": ("www.iana.org", "www.python.org"),
+            }
+            return responses.popleft()
+
+        monkeypatch.setattr(sandbox_module, "_egress_probe", probe)
+        monkeypatch.setattr(sandbox_module.asyncio, "sleep", AsyncMock())
+
+        sentinels = await _prevalidate_egress_sentinels(Mock(), [])
+
+        assert sentinels == ("192.0.2.10", "192.0.2.11")
+
+    async def test_wait_for_restricted_egress_requires_two_consecutive_observations(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        results = iter((True, False, True, True))
+        payloads: list[dict[str, object]] = []
+
+        async def probe(_sandbox: Any, payload: dict[str, object]) -> dict[str, object]:
+            payloads.append(payload)
+            return {"ready": next(results)}
+
+        monkeypatch.setattr(sandbox_module, "_egress_probe", probe)
+        monkeypatch.setattr(sandbox_module.asyncio, "sleep", AsyncMock())
+
+        _, attempts = await _wait_for_egress(
+            Mock(),
+            "restricted",
+            ["https://api.openai.com"],
+            ("192.0.2.10", "192.0.2.11"),
+        )
+
+        assert attempts == 4
+        assert (
+            payloads
+            == [
+                {
+                    "state": "restricted",
+                    "allowed": [{"host": "api.openai.com", "port": 443, "tls": True}],
+                    "sentinels": ("192.0.2.10", "192.0.2.11"),
+                }
+            ]
+            * 4
+        )
+
+    async def test_wait_for_unrestricted_egress_checks_cached_ips_and_fresh_dns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        payloads: list[dict[str, object]] = []
+
+        async def probe(_sandbox: Any, payload: dict[str, object]) -> dict[str, object]:
+            payloads.append(payload)
+            return {"ready": True}
+
+        monkeypatch.setattr(sandbox_module, "_egress_probe", probe)
+        monkeypatch.setattr(sandbox_module.asyncio, "sleep", AsyncMock())
+
+        _, attempts = await _wait_for_egress(
+            Mock(),
+            "unrestricted",
+            ["https://api.openai.com"],
+            ("192.0.2.10", "192.0.2.11"),
+        )
+
+        assert attempts == 2
+        assert (
+            payloads
+            == [
+                {
+                    "state": "unrestricted",
+                    "sentinel_hosts": ("www.iana.org", "www.python.org"),
+                    "sentinels": ("192.0.2.10", "192.0.2.11"),
+                }
+            ]
+            * 2
+        )
+
+    async def test_wait_for_egress_has_a_hard_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def never_returns(*_args: Any, **_kwargs: Any) -> dict[str, object]:
+            await asyncio.Event().wait()
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(sandbox_module, "_EGRESS_READY_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(sandbox_module, "_egress_probe", never_returns)
+
+        with pytest.raises(SandboxSetupError, match="within 0.01 seconds"):
+            await _wait_for_egress(
+                Mock(),
+                "restricted",
+                ["https://api.openai.com"],
+                ("192.0.2.10", "192.0.2.11"),
+            )
+
+    async def test_egress_probe_rejects_invalid_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def invalid_output(*_args: Any, **_kwargs: Any) -> ExecResult:
+            return ExecResult(exit_code=0, output="not-json")
+
+        monkeypatch.setattr(sandbox_module, "_exec", invalid_output)
+
+        with pytest.raises(SandboxSetupError, match="invalid output"):
+            await _egress_probe(Mock(), {"state": "restricted"})
 
     @pytest.mark.parametrize(
         ("provider_error", "expected_error", "message"),

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.15.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0#3e517a46c7807b6c8c74bbb9f0ca537d34852f1d" }
+version = "0.15.1.dev1+g594964e7e"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a#594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2019,7 +2019,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.15.1.dev1+g594964e7e"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a#594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" }
+version = "0.15.1.dev4+g204afe519"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=204afe519a6d0cd0fba3cc35cb915e55b4e60438#204afe519a6d0cd0fba3cc35cb915e55b4e60438" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2019,7 +2019,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=204afe519a6d0cd0fba3cc35cb915e55b4e60438" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.15.1.dev1+g594964e7e"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a#594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" }
+version = "0.15.1.dev4+g204afe519"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=204afe519a6d0cd0fba3cc35cb915e55b4e60438#204afe519a6d0cd0fba3cc35cb915e55b4e60438" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2215,7 +2215,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=204afe519a6d0cd0fba3cc35cb915e55b4e60438" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.15.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0#3e517a46c7807b6c8c74bbb9f0ca537d34852f1d" }
+version = "0.15.1.dev1+g594964e7e"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a#594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2215,7 +2215,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?tag=v0.15.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=594964e7e91a0a27ae3d4e3325f5cb0345e3d07a" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
Stacked on #551.

## Summary

- merge task-specific setup egress with the model-capability gateway origin and prove two consecutive restricted data-plane observations before Agent execution
- keep abortable-task egress restricted through execution, output collection, evaluation, benchmark abort, and outer sandbox deletion; preserve legacy restoration for standard tasks
- acquire abort ownership before setup begins and fail closed if an abortable service returns no dynamic allowlist
- invoke idempotent benchmark cleanup on setup/install/readiness/execute/upload/evaluation failures, early returns, and repeated cancellation
- give the CBS client its three-hour retry budget and retain an independent Tracker hard stop at three hours plus 60 seconds so sandbox deletion always resumes
- persist immutable egress readiness through evaluator resume and expose only the canonical model-gateway-origin SHA-256 from Tracker `/health`

No paid OSWorld task is started by this change.

## Verification

- 333 Tracker unit tests passed
- 12 focused lifecycle/deadline tests passed
- 102 root SDK/contract tests passed
- 9 infrastructure stack tests plus 11 subtests passed
- the hosted persistent-egress integration test collects exactly once
- latest-head hosted integration attempt 2 passed all 65 tests: run `29344815093`, job `87125691083`
- Ruff lint/format, strict changed-file and root Basedpyright, both lock checks, and diff checks passed
- exact temporary CBS source and lock pin: `204afe519a6d0cd0fba3cc35cb915e55b4e60438`
- independent lifecycle/concurrency review found no P0/P1

## Release gate

CBS PR #96 must merge and release first. Replace the temporary commit reference with the released minor-version tag and regenerate both locks before merge. Roll out Tracker and drain old workers before enabling the abortable OSWorld service.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/553" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
