### PR TITLE
Rotate matching benchmark-service auth with hosted API key

### DIFF
--- a/src/valkyrie/cli/config/settings.py
+++ b/src/valkyrie/cli/config/settings.py
@@ -67,6 +67,7 @@ def init() -> None:
 
     if mode == "hosted":
         api_key = (os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key")).strip()
+        _rotate_matching_benchmark_auth(current_config, api_key)
         current_config["api_key"] = api_key
 
         # Validate the key and create/confirm org (uses default tracker URL)

--- a/src/valkyrie/cli/config/settings.py
+++ b/src/valkyrie/cli/config/settings.py
@@ -19,6 +19,31 @@ _REQUIRED_ENVIRONMENT_VARIABLES: dict[str, str | None | int] = {
 }
 
 
+def _rotate_matching_benchmark_auth(config: dict[str, Any], new_api_key: str) -> int:
+    """Rotate benchmark credentials derived from the previous hosted API key."""
+    previous_api_key = config.get("api_key")
+    benchmark_auth = config.get("benchmark_auth")
+    if (
+        not isinstance(previous_api_key, str)
+        or not previous_api_key
+        or previous_api_key == new_api_key
+        or not isinstance(benchmark_auth, dict)
+    ):
+        return 0
+
+    replacements = {
+        previous_api_key: new_api_key,
+        f"Bearer {previous_api_key}": f"Bearer {new_api_key}",
+    }
+    updated = 0
+    for benchmark_name, credential in benchmark_auth.items():
+        if isinstance(credential, str) and credential in replacements:
+            benchmark_auth[benchmark_name] = replacements[credential]
+            updated += 1
+
+    return updated
+
+
 @click.command()
 def init() -> None:
     """
@@ -115,11 +140,18 @@ def set(key: str, value: str) -> None:
             f"Key '{key}' is not a valid config key. Valid keys: {', '.join(m.value for m in ConfigValue)}"
         )
 
+    rotated_benchmark_auth = 0
+    if config_value is ConfigValue.API_KEY:
+        rotated_benchmark_auth = _rotate_matching_benchmark_auth(current, value)
+
     current[config_value.value] = value
 
     write_config(current)
 
     click.echo(click.style(f"  {key} updated.", fg="green"))
+    if rotated_benchmark_auth:
+        label = "benchmark" if rotated_benchmark_auth == 1 else "benchmarks"
+        click.echo(f"  Updated benchmark service auth for {rotated_benchmark_auth} {label}.")
 
 
 @click.command(name="remove")

--- a/tests/unit/test_config_init.py
+++ b/tests/unit/test_config_init.py
@@ -98,3 +98,42 @@ def test_init_whitespace_only_required_value_aborts(config_path: Path, monkeypat
 
     assert result.exit_code != 0
     assert "AWS_ACCESS_KEY_ID is required" in result.output
+
+
+def test_set_api_key_rotates_matching_benchmark_auth(config_path: Path) -> None:
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "api_key": "old-key",
+                "benchmark_auth": {
+                    "raw-key-service": "old-key",
+                    "bearer-service": "Bearer old-key",
+                    "independent-service": "independent-key",
+                },
+            }
+        )
+    )
+
+    result = CliRunner().invoke(settings.set, ["api_key", "new-key"])
+
+    assert result.exit_code == 0, result.output
+    config = yaml.safe_load(config_path.read_text())
+    assert config["api_key"] == "new-key"
+    assert config["benchmark_auth"] == {
+        "raw-key-service": "new-key",
+        "bearer-service": "Bearer new-key",
+        "independent-service": "independent-key",
+    }
+    assert "Updated benchmark service auth for 2 benchmarks." in result.output
+
+
+def test_set_api_key_without_previous_key_preserves_benchmark_auth(config_path: Path) -> None:
+    config_path.write_text(yaml.safe_dump({"benchmark_auth": {"independent-service": "independent-key"}}))
+
+    result = CliRunner().invoke(settings.set, ["api_key", "new-key"])
+
+    assert result.exit_code == 0, result.output
+    config = yaml.safe_load(config_path.read_text())
+    assert config["api_key"] == "new-key"
+    assert config["benchmark_auth"] == {"independent-service": "independent-key"}
+    assert "Updated benchmark service auth" not in result.output

--- a/tests/unit/test_config_init.py
+++ b/tests/unit/test_config_init.py
@@ -54,6 +54,18 @@ def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.Monke
     for key in settings._REQUIRED_ENVIRONMENT_VARIABLES:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("VALKYRIE_API_KEY", raising=False)
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "api_key": "old-key",
+                "benchmark_auth": {
+                    "raw-key-service": "old-key",
+                    "bearer-service": "Bearer old-key",
+                    "independent-service": "independent-key",
+                },
+            }
+        )
+    )
 
     init_org_calls: list[str] = []
 
@@ -87,6 +99,11 @@ def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.Monke
     assert init_org_calls == ["secret-key"]
     config = yaml.safe_load(config_path.read_text())
     assert config["api_key"] == "secret-key"
+    assert config["benchmark_auth"] == {
+        "raw-key-service": "secret-key",
+        "bearer-service": "Bearer secret-key",
+        "independent-service": "independent-key",
+    }
 
 
 def test_init_whitespace_only_required_value_aborts(config_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Why

Hosted tracker auth and benchmark-service auth are stored separately. Updating the hosted API key left per-benchmark credentials derived from the old key stale, so retries kept receiving 401 responses unless every mapping was edited manually.

## Change

Both `valk config set api_key ...` and hosted `valk config init` now rotate only `benchmark_auth` values that exactly match the previous key in raw or `Bearer ...` form. Independent per-service credentials are preserved, and output never displays credentials.

## Verification

1. Reproduced Unauthorized failures on exact Legal, EMB, and Terminal tasks launched before key rotation.
2. Confirmed current error cohorts and separated 401s from service-disconnect errors.
3. Traced both config entry points, `benchmark_service_headers`, and retry/resume header construction.
4. Confirmed exact tasks retried after explicit benchmark auth passed the former 401 point.
5. Added raw, Bearer, and independent-key regression coverage for both `config set` and hosted `config init`.

Checks run on the final diff:

- `uv run pytest tests/unit -q` — 209 passed
- `uv run basedpyright` — 0 errors
- full Ruff check and format check — passed
- `git diff --check` — passed

Current frozen tasks still need targeted retries after the credential is corrected; this change prevents future key rotations from leaving matching mappings stale.
