### PR TITLE
Preserve benchmark-service WebSocket close details

### DIFF
--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -674,14 +674,8 @@ async def process_task(
         if task_is_stopped():
             return {task_id: None}
         seconds = int(time.monotonic() - last_log_time)
-        close_details = "without a close frame"
-        if e.rcvd is not None:
-            close_details = f"with code {e.rcvd.code}"
-            if e.rcvd.reason:
-                close_details += f" ({e.rcvd.reason})"
         error_message = (
-            f"Benchmark service WebSocket disconnected {close_details}; "
-            f"last application message received {seconds}s ago"
+            f"Benchmark service WebSocket disconnected: {e}; last application message received {seconds}s ago"
         )
         logger.warning(error_message)
         log_output(f"\n[ERROR] {error_message}")

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -670,13 +670,18 @@ async def process_task(
             commit_task_error(task, task_session, error_message, expected_started_at=attempt_started_at)
 
         return {task_id: None}
-    except ConnectionClosedError:
+    except ConnectionClosedError as e:
         if task_is_stopped():
             return {task_id: None}
         seconds = int(time.monotonic() - last_log_time)
+        close_details = "without a close frame"
+        if e.rcvd is not None:
+            close_details = f"with code {e.rcvd.code}"
+            if e.rcvd.reason:
+                close_details += f" ({e.rcvd.reason})"
         error_message = (
-            f"Benchmark service has not sent a message, causing the connection to disconnect: "
-            f"last message received {seconds}s ago"
+            f"Benchmark service WebSocket disconnected {close_details}; "
+            f"last application message received {seconds}s ago"
         )
         logger.warning(error_message)
         log_output(f"\n[ERROR] {error_message}")

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -10,6 +10,7 @@ from benchmark_service.schemas import RetrieveTaskResponse
 from sqlmodel import Session, desc, select
 from websockets.datastructures import Headers
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
+from websockets.frames import Close
 from websockets.http11 import Response
 
 import tracker.utils.task_execution as utils_module
@@ -116,9 +117,45 @@ class TestBenchmarkServiceDisconnect:
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
-        assert "Benchmark service has not sent a message, causing the connection to disconnect" in error_message
-        assert "last message received" in error_message
+        assert "Benchmark service WebSocket disconnected without a close frame" in error_message
+        assert "last application message received" in error_message
         assert "10s ago" in error_message
+
+    @pytest.mark.parametrize(
+        ("code", "reason"),
+        [
+            (1008, "Unauthorized"),
+            (1011, "keepalive ping timeout"),
+        ],
+    )
+    async def test_connection_closed_preserves_remote_close_details(
+        self,
+        code: int,
+        reason: str,
+        contract: AgentContractRequest,
+        database_session: Session,
+        process_benchmark_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id = self._create_task_env(
+            contract, database_session, harness_config
+        )
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise ConnectionClosedError(Close(code, reason), Close(code, reason), True)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await self._run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+        assert result == {"task_0": None}
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        error_message = self._latest_task_error(database_session, task_row)
+        assert f"Benchmark service WebSocket disconnected with code {code} ({reason})" in error_message
+        assert "last application message received" in error_message
 
     async def test_validation_error_produces_human_readable_message(
         self,

--- a/services/tracker/tests/unit/test_benchmark_service_disconnect.py
+++ b/services/tracker/tests/unit/test_benchmark_service_disconnect.py
@@ -117,7 +117,7 @@ class TestBenchmarkServiceDisconnect:
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
-        assert "Benchmark service WebSocket disconnected without a close frame" in error_message
+        assert "Benchmark service WebSocket disconnected: no close frame received or sent" in error_message
         assert "last application message received" in error_message
         assert "10s ago" in error_message
 
@@ -154,7 +154,8 @@ class TestBenchmarkServiceDisconnect:
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
-        assert f"Benchmark service WebSocket disconnected with code {code} ({reason})" in error_message
+        assert f"received {code}" in error_message
+        assert reason in error_message
         assert "last application message received" in error_message
 
     async def test_validation_error_produces_human_readable_message(


### PR DESCRIPTION
## Why

Tracker task errors replaced every `ConnectionClosedError` with a generic inactivity message. During the Kimi readiness run this hid `1008 Unauthorized` and made auth failures look like heartbeat timeouts, leading recovery toward the wrong subsystem.

## Change

Persist the native WebSocket close details, including received and sent direction or a missing close frame, and label the elapsed value accurately as time since the last application message.

## Verification

1. Reproduced generic errors on exact FAB, SWE, Code Migration, and Terminal tasks.
2. Compared current task errors with raw worker exceptions and recovered their close frames.
3. Traced the loss to the tracker catch block discarding the exception object.
4. Distinguished verified controls: `1008 Unauthorized`, `1011 keepalive ping timeout`, and no close frame.
5. Added focused tests for all three shapes.

Checks:

- Focused tracker tests: 9 passed
- Ruff check + format check: passed
- BasedPyright on changed source: passed
- `git diff --check`: passed

Readiness source of truth: https://github.com/vals-ai/benchmarks/issues/2072
