### PR TITLE
Use standard S3 retries

### DIFF
--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -9,11 +9,9 @@ import aioboto3
 import logfire
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
-from tenacity import retry, retry_if_exception, stop_after_attempt
 
 from tracker.exceptions import S3Error
 from tracker.logging import get_logger
-from tracker.observability import retry_callback
 
 logger = get_logger(__name__)
 
@@ -26,14 +24,7 @@ _R = TypeVar("_R")
 S3_AGENTS_PREFIX = "agents"
 S3_BENCHMARKS_PREFIX = "benchmarks"
 
-_CLIENT_CONFIG = Config(max_pool_connections=200)
-_FD_TRANSPORT_ERROR_MARKERS = ("file descriptor", "is used by transport", "tcptransport")
-
-
-def _is_fd_transport_error(exc: BaseException) -> bool:
-    """Return whether an AWS request hit the known uvloop fd transport race."""
-    error = str(exc).lower()
-    return isinstance(exc, BotoCoreError) and all(marker in error for marker in _FD_TRANSPORT_ERROR_MARKERS)
+_CLIENT_CONFIG = Config(max_pool_connections=200, retries={"mode": "standard"})
 
 
 @lru_cache(maxsize=32)
@@ -85,12 +76,6 @@ def handle_s3_error(message: str) -> Callable[[Callable[_P, Awaitable[_R]]], Cal
 
 @logfire.instrument("upload_to_s3", extract_args=("s3_key", "s3_bucket"))
 @handle_s3_error(message="Failed to upload to S3")
-@retry(
-    retry=retry_if_exception(_is_fd_transport_error),
-    reraise=True,
-    stop=stop_after_attempt(3),
-    before_sleep=retry_callback("valkyrie.s3.upload"),
-)
 async def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> None:
     """
     Upload file content to S3.

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -9,9 +9,11 @@ import aioboto3
 import logfire
 from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
+from tenacity import retry, retry_if_exception, stop_after_attempt
 
 from tracker.exceptions import S3Error
 from tracker.logging import get_logger
+from tracker.observability import retry_callback
 
 logger = get_logger(__name__)
 
@@ -25,6 +27,13 @@ S3_AGENTS_PREFIX = "agents"
 S3_BENCHMARKS_PREFIX = "benchmarks"
 
 _CLIENT_CONFIG = Config(max_pool_connections=200)
+_FD_TRANSPORT_ERROR_MARKERS = ("file descriptor", "is used by transport", "tcptransport")
+
+
+def _is_fd_transport_error(exc: BaseException) -> bool:
+    """Return whether an AWS request hit the known uvloop fd transport race."""
+    error = str(exc).lower()
+    return isinstance(exc, BotoCoreError) and all(marker in error for marker in _FD_TRANSPORT_ERROR_MARKERS)
 
 
 @lru_cache(maxsize=32)
@@ -76,6 +85,12 @@ def handle_s3_error(message: str) -> Callable[[Callable[_P, Awaitable[_R]]], Cal
 
 @logfire.instrument("upload_to_s3", extract_args=("s3_key", "s3_bucket"))
 @handle_s3_error(message="Failed to upload to S3")
+@retry(
+    retry=retry_if_exception(_is_fd_transport_error),
+    reraise=True,
+    stop=stop_after_attempt(3),
+    before_sleep=retry_callback("valkyrie.s3.upload"),
+)
 async def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> None:
     """
     Upload file content to S3.

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -1,7 +1,7 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
-from botocore.exceptions import BotoCoreError, ClientError, HTTPClientError
+from botocore.exceptions import BotoCoreError, ClientError
 
 from tracker.aws import cloudwatch_logs
 from tracker.aws.cloudwatch_logs import (
@@ -10,7 +10,7 @@ from tracker.aws.cloudwatch_logs import (
     handle_cloudwatch_error,
     write_benchmark_log_event,
 )
-from tracker.aws.s3 import handle_s3_error, upload_to_s3
+from tracker.aws.s3 import handle_s3_error, s3_client
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.types import AWSCredentials
 
@@ -52,60 +52,10 @@ class TestS3DecoratorClient:
         assert exc_info.value.__cause__ == botocore_error
 
 
-class TestS3UploadRetry:
-    @staticmethod
-    def _client_context(client: MagicMock) -> MagicMock:
-        context = MagicMock()
-        context.__aenter__ = AsyncMock(return_value=client)
-        context.__aexit__ = AsyncMock(return_value=False)
-        return context
-
-    async def test_retries_fd_transport_error(self, monkeypatch: pytest.MonkeyPatch):
-        fd_error = HTTPClientError(
-            error=RuntimeError(
-                "File descriptor 423 is used by transport <TCPTransport closed=False reading=True 0xabc>"
-            )
-        )
-        client = MagicMock()
-        client.put_object = AsyncMock(side_effect=[fd_error, None])
-        context = self._client_context(client)
-        s3_client_mock = MagicMock(return_value=context)
-        monkeypatch.setattr("tracker.aws.s3.s3_client", s3_client_mock)
-
-        await upload_to_s3(b"content", "key", _AWS, "bucket")
-
-        assert client.put_object.await_count == 2
-        assert s3_client_mock.call_count == 2
-
-    async def test_does_not_retry_other_botocore_errors(self, monkeypatch: pytest.MonkeyPatch):
-        other_error = HTTPClientError(error=RuntimeError("connection reset"))
-        client = MagicMock()
-        client.put_object = AsyncMock(side_effect=other_error)
-        context = self._client_context(client)
-        monkeypatch.setattr("tracker.aws.s3.s3_client", MagicMock(return_value=context))
-
-        with pytest.raises(S3Error) as exc_info:
-            await upload_to_s3(b"content", "key", _AWS, "bucket")
-
-        assert exc_info.value.__cause__ == other_error
-        assert client.put_object.await_count == 1
-
-    async def test_stops_after_three_fd_transport_errors(self, monkeypatch: pytest.MonkeyPatch):
-        fd_error = HTTPClientError(
-            error=RuntimeError(
-                "File descriptor 423 is used by transport <TCPTransport closed=False reading=True 0xabc>"
-            )
-        )
-        client = MagicMock()
-        client.put_object = AsyncMock(side_effect=fd_error)
-        context = self._client_context(client)
-        monkeypatch.setattr("tracker.aws.s3.s3_client", MagicMock(return_value=context))
-
-        with pytest.raises(S3Error) as exc_info:
-            await upload_to_s3(b"content", "key", _AWS, "bucket")
-
-        assert exc_info.value.__cause__ == fd_error
-        assert client.put_object.await_count == 3
+class TestS3ClientRetry:
+    async def test_uses_standard_retry_mode(self):
+        async with s3_client(_AWS) as client:
+            assert client.meta.config.retries == {"mode": "standard"}
 
 
 class TestCloudWatchClient:

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -1,7 +1,7 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from botocore.exceptions import BotoCoreError, ClientError
+from botocore.exceptions import BotoCoreError, ClientError, HTTPClientError
 
 from tracker.aws import cloudwatch_logs
 from tracker.aws.cloudwatch_logs import (
@@ -10,8 +10,8 @@ from tracker.aws.cloudwatch_logs import (
     handle_cloudwatch_error,
     write_benchmark_log_event,
 )
+from tracker.aws.s3 import handle_s3_error, upload_to_s3
 from tracker.exceptions import CloudWatchError, S3Error
-from tracker.aws.s3 import handle_s3_error
 from tracker.types import AWSCredentials
 
 _AWS = AWSCredentials(
@@ -50,6 +50,62 @@ class TestS3DecoratorClient:
 
         assert "Failed to connect to S3" in str(exc_info.value)
         assert exc_info.value.__cause__ == botocore_error
+
+
+class TestS3UploadRetry:
+    @staticmethod
+    def _client_context(client: MagicMock) -> MagicMock:
+        context = MagicMock()
+        context.__aenter__ = AsyncMock(return_value=client)
+        context.__aexit__ = AsyncMock(return_value=False)
+        return context
+
+    async def test_retries_fd_transport_error(self, monkeypatch: pytest.MonkeyPatch):
+        fd_error = HTTPClientError(
+            error=RuntimeError(
+                "File descriptor 423 is used by transport <TCPTransport closed=False reading=True 0xabc>"
+            )
+        )
+        client = MagicMock()
+        client.put_object = AsyncMock(side_effect=[fd_error, None])
+        context = self._client_context(client)
+        s3_client_mock = MagicMock(return_value=context)
+        monkeypatch.setattr("tracker.aws.s3.s3_client", s3_client_mock)
+
+        await upload_to_s3(b"content", "key", _AWS, "bucket")
+
+        assert client.put_object.await_count == 2
+        assert s3_client_mock.call_count == 2
+
+    async def test_does_not_retry_other_botocore_errors(self, monkeypatch: pytest.MonkeyPatch):
+        other_error = HTTPClientError(error=RuntimeError("connection reset"))
+        client = MagicMock()
+        client.put_object = AsyncMock(side_effect=other_error)
+        context = self._client_context(client)
+        monkeypatch.setattr("tracker.aws.s3.s3_client", MagicMock(return_value=context))
+
+        with pytest.raises(S3Error) as exc_info:
+            await upload_to_s3(b"content", "key", _AWS, "bucket")
+
+        assert exc_info.value.__cause__ == other_error
+        assert client.put_object.await_count == 1
+
+    async def test_stops_after_three_fd_transport_errors(self, monkeypatch: pytest.MonkeyPatch):
+        fd_error = HTTPClientError(
+            error=RuntimeError(
+                "File descriptor 423 is used by transport <TCPTransport closed=False reading=True 0xabc>"
+            )
+        )
+        client = MagicMock()
+        client.put_object = AsyncMock(side_effect=fd_error)
+        context = self._client_context(client)
+        monkeypatch.setattr("tracker.aws.s3.s3_client", MagicMock(return_value=context))
+
+        with pytest.raises(S3Error) as exc_info:
+            await upload_to_s3(b"content", "key", _AWS, "bucket")
+
+        assert exc_info.value.__cause__ == fd_error
+        assert client.put_object.await_count == 3
 
 
 class TestCloudWatchClient:

--- a/services/tracker/tests/unit/test_aws_clients.py
+++ b/services/tracker/tests/unit/test_aws_clients.py
@@ -55,7 +55,7 @@ class TestS3DecoratorClient:
 class TestS3ClientRetry:
     async def test_uses_standard_retry_mode(self):
         async with s3_client(_AWS) as client:
-            assert client.meta.config.retries == {"mode": "standard"}
+            assert client.meta.config.retries["mode"] == "standard"
 
 
 class TestCloudWatchClient:


### PR DESCRIPTION
## Why

Tracker S3 clients inherit botocore's legacy retry mode, which does not retry `HTTPClientError`. The production uvloop fd/transport failure surfaces as that error type.

## Change

Use botocore's standard S3 retry mode.

## Verification

- AWS client tests: 14 passed
- tracker unit suite: 337 passed
- Ruff and format checks: passed
- changed-source BasedPyright: 0 errors
- exact `HTTPClientError` probe through aiobotocore: 3 attempts

Tracks https://github.com/vals-ai/benchmarks/issues/2072.
