### PR TITLE
Cover tracker API routes against live S3

### DIFF
--- a/services/tracker/tests/integration/live/api/conftest.py
+++ b/services/tracker/tests/integration/live/api/conftest.py
@@ -1,0 +1,39 @@
+"""FastAPI fixtures that retain live AWS boundaries."""
+
+from collections.abc import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from main import app
+from tests.conftest import TEST_ORG_ID
+from tracker.auth import get_current_org
+from tracker.database.models import DEFAULT_ORG_NAME, Org
+from tracker.database.session import get_session
+from tracker.types import HarnessConfig
+from tracker.utils import fetch_harness_config
+
+
+@pytest.fixture
+def live_api_client(
+    database_session: Session,
+    tracker_database: None,
+    harness_config: HarnessConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[TestClient, None, None]:
+    """Route the app through local persistence and real harness credentials."""
+
+    def get_test_session() -> Generator[Session, None, None]:
+        yield database_session
+
+    monkeypatch.setitem(app.dependency_overrides, get_session, get_test_session)
+    monkeypatch.setitem(app.dependency_overrides, fetch_harness_config, lambda: harness_config)
+    monkeypatch.setitem(
+        app.dependency_overrides,
+        get_current_org,
+        lambda: Org(id=TEST_ORG_ID, name=DEFAULT_ORG_NAME),
+    )
+
+    with TestClient(app) as client:
+        yield client

--- a/services/tracker/tests/integration/live/api/test_s3_routes.py
+++ b/services/tracker/tests/integration/live/api/test_s3_routes.py
@@ -1,0 +1,105 @@
+"""Live S3 coverage for tracker API routes."""
+
+from io import BytesIO
+from typing import Any, cast
+from uuid import uuid4
+from zipfile import ZipFile
+
+import httpx
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from tests.conftest import TEST_ORG_ID
+from tracker.aws.s3 import delete_from_s3, upload_to_s3
+from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkArguments, Task
+from tracker.types import HarnessConfig
+
+
+async def test_agent_catalog_and_download_url_round_trip_real_s3(
+    live_api_client: TestClient,
+) -> None:
+    """Agent listing and download signing must agree on a deployed S3 object.
+
+    Test cases:
+    - The live catalog contains at least one named agent with its last-modified value.
+    - The route's five-minute presigned URL downloads the original valid agent archive.
+    - A name absent from the real bucket returns 404.
+    """
+    catalog_response = live_api_client.get("/agents")
+
+    assert catalog_response.status_code == 200
+    named_agents = [agent for agent in catalog_response.json()["agents"] if agent["name"]]
+    assert named_agents
+    selected_agent = next((agent for agent in named_agents if agent["name"] == "agent"), named_agents[0])
+    assert selected_agent["last_modified"] is not None
+
+    download_response = live_api_client.get(f"/agents/{selected_agent['name']}/download-url")
+    assert download_response.status_code == 200
+    assert download_response.json()["expires_in"] == 300
+
+    async with httpx.AsyncClient() as http_client:
+        artifact_response = await http_client.get(download_response.json()["download_url"])
+
+    assert artifact_response.status_code == 200
+    with ZipFile(BytesIO(artifact_response.content)) as archive:
+        assert archive.namelist()
+        assert archive.testzip() is None
+
+    missing_response = live_api_client.get(f"/agents/missing-{uuid4()}/download-url")
+    assert missing_response.status_code == 404
+
+
+async def test_task_artifact_route_round_trips_real_s3_and_handles_missing_output(
+    live_api_client: TestClient,
+    database_session: Session,
+    harness_config: HarnessConfig,
+) -> None:
+    """Task artifact signing must expose existing output and suppress missing output.
+
+    Test cases:
+    - A real output object is discovered, signed for five minutes, and downloaded byte-for-byte.
+    - Deleting the object makes the same route return no output URL.
+    """
+    benchmark = Benchmark(
+        org_id=TEST_ORG_ID,
+        name="swebench",
+        arguments=BenchmarkArguments(
+            contract=AgentContractRequest(name="live-s3-agent", install_cmd="true", run_cmd="true"),
+            concurrency=1,
+        ),
+    )
+    task = Task(org_id=TEST_ORG_ID, benchmark=benchmark.id, task_id="live-s3-output")
+    database_session.add_all([benchmark, task])
+    database_session.commit()
+
+    object_key = f"benchmarks/{benchmark.id}/{task.task_id}/agent_output.tar.gz"
+    expected_content = b"live tracker output artifact"
+    await cast(Any, upload_to_s3)(
+        file_content=expected_content,
+        s3_key=object_key,
+        aws=harness_config.aws,
+        s3_bucket=harness_config.s3_bucket,
+    )
+
+    try:
+        artifact_response = live_api_client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/artifacts")
+        assert artifact_response.status_code == 200
+        assert artifact_response.json()["agent_output_expires_in"] == 300
+        assert artifact_response.json()["cloudwatch_url"] is not None
+
+        async with httpx.AsyncClient() as http_client:
+            download_response = await http_client.get(artifact_response.json()["agent_output_url"])
+
+        assert download_response.status_code == 200
+        assert download_response.content == expected_content
+    finally:
+        await cast(Any, delete_from_s3)(
+            s3_key=object_key,
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+        )
+
+    missing_response = live_api_client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/artifacts")
+    assert missing_response.status_code == 200
+    assert missing_response.json()["agent_output_url"] is None
+    assert missing_response.json()["agent_output_expires_in"] is None


### PR DESCRIPTION
## Summary
Add live API coverage that keeps S3 as a real boundary from FastAPI request through presigned download.

Stacked on #566.

## Changes
- exercise the live agent catalog, five-minute download URL, ZIP validity, and missing-agent 404
- upload a benchmark task output to the configured test bucket
- call the task-artifact route, download the presigned object byte-for-byte, and verify the missing-object response after cleanup
- keep only authentication and local database dependencies inside the test fixture; S3 listing, existence checks, signing, upload, download, and delete remain real

## Related Issues
None

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Commands:
- live S3 API tests (2 passed)
- make test-unit (343 passed; 83.39% coverage; 10.46 seconds)
- make test-integration-local (36 passed)
- pytest tests/integration/live --collect-only (27 collected)
- uv run ruff check src main.py tests
- uv run ruff format --check src main.py tests
- basedpyright tests/integration/live/api (0 errors)
- locally built tracker Docker stack and requested GET /health (200 with status ok)

The configured developer AWS identity cannot run existing live tests that seed agents because the bucket policy denies writes to agents/. The new live route tests avoid that local-only limitation, and the full live suite remains assigned to the CI test role.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed