### PR TITLE
Verify tracker coverage across test layers

### DIFF
--- a/.github/workflows/tracker-integration-tests.yaml
+++ b/.github/workflows/tracker-integration-tests.yaml
@@ -34,7 +34,14 @@ jobs:
       - name: Run local integration tests
         run: |
           cd services/tracker
-          make test-integration-local
+          make test-integration-local-coverage
+
+      - name: Upload local integration coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: services/tracker/coverage.xml
+          flags: tracker-integration
 
   tracker-live-integration-tests:
     runs-on: ubuntu-latest
@@ -76,7 +83,7 @@ jobs:
       - name: Run live integration tests
         run: |
           cd services/tracker
-          uv run pytest tests/integration/live -n auto
+          make test-integration-live-coverage
         env:
           TEST_AWS_S3_BUCKET: ${{ secrets.TEST_AWS_S3_BUCKET }}
           TEST_LOG_GROUP: ${{ secrets.TEST_LOG_GROUP }}
@@ -84,3 +91,10 @@ jobs:
           BENCHMARK_SERVICE_BASE_URL: ${{ secrets.BENCHMARK_SERVICE_BASE_URL }}
           BENCHMARK_SERVICE_AUTH_KEY: ${{ secrets.BENCHMARK_SERVICE_AUTH_KEY }}
           AWS_DEFAULT_REGION: us-east-1
+
+      - name: Upload live integration coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: services/tracker/coverage.xml
+          flags: tracker-live-integration

--- a/.github/workflows/tracker-unit-tests.yaml
+++ b/.github/workflows/tracker-unit-tests.yaml
@@ -5,7 +5,6 @@ on:
     paths:
       - "services/tracker/**"
   pull_request:
-    branches: [dev]
     paths:
       - "services/tracker/**"
 

--- a/services/tracker/Makefile
+++ b/services/tracker/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help setup build run stop clean logs tracker-service \
-        test test-integration test-integration-local test-integration-live test-unit test-alembic \
+        test test-integration test-integration-local test-integration-local-coverage test-integration-live \
+        test-integration-live-coverage test-unit test-coverage test-alembic \
         migrate-gen venv-check env-check
 
 PYTHON_VERSION := 3.12
@@ -56,6 +57,11 @@ tracker-service: build run logs
 # --- Tests ---
 test-unit: venv-check
 	$(PYTEST) tests/unit --test-alembic --cov=src/tracker --cov=main --cov-report=term-missing --cov-report=xml
+test-coverage: venv-check
+	uv run coverage erase
+	$(PYTEST) tests/unit --test-alembic --cov=src/tracker --cov=main --cov-report= --cov-fail-under=0
+	$(PYTEST) tests/integration/local/api -n auto --cov=src/tracker --cov=main --cov-append --cov-report= --cov-fail-under=0
+	$(PYTEST) tests/integration/local/database --cov=src/tracker --cov=main --cov-append --cov-report=term-missing --cov-report=xml --cov-fail-under=85
 test-alembic: venv-check
 	$(PYTEST) --test-alembic -m alembic
 test-integration: venv-check env-check
@@ -65,8 +71,15 @@ test-integration: venv-check env-check
 test-integration-local: venv-check
 	$(PYTEST) tests/integration/local/api -n auto
 	$(PYTEST) tests/integration/local/database
+test-integration-local-coverage: venv-check
+	uv run coverage erase
+	$(PYTEST) tests/integration/local/api -n auto --cov=src/tracker --cov=main --cov-report= --cov-fail-under=0
+	$(PYTEST) tests/integration/local/database --cov=src/tracker --cov=main --cov-append --cov-report=term-missing --cov-report=xml --cov-fail-under=0
 test-integration-live: venv-check env-check
 	$(PYTEST) tests/integration/live -n auto
+test-integration-live-coverage: venv-check env-check
+	uv run coverage erase
+	$(PYTEST) tests/integration/live -n auto --cov=src/tracker --cov=main --cov-report=term-missing --cov-report=xml --cov-fail-under=0
 
 # --- Migrations ---
 migrate-gen: venv-check

--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -43,13 +43,16 @@ Tracker-service reads this when running `valkyrie config service list` to show t
 
 ```bash
 make test-unit          # Unit tests + Alembic migrations + branch coverage
+make test-coverage      # Unit + local integration coverage; requires Docker
 make test-alembic       # Alembic migration tests only
 make test-integration-local  # API + Postgres tests; no cloud credentials
+make test-integration-local-coverage  # Local integration tests + coverage XML
 make test-integration-live   # AWS + benchmark service + sandbox tests
+make test-integration-live-coverage  # Live tests + coverage XML
 make test-integration   # Full integration suite (requires the variables below)
 ```
 
-Unit coverage includes both the `tracker` package and the FastAPI entrypoint in `main.py`. The configured coverage floor prevents tracker application coverage from dropping below the current baseline.
+Unit and integration coverage include both the `tracker` package and the FastAPI entrypoint in `main.py`. `make test-coverage` combines unit and local layers and enforces 85% coverage. CI uploads unit, local integration, and gated live integration reports separately so each layer contributes to the tracker coverage view without rerunning a suite.
 
 Local integration tests live under `tests/integration/local` and use the FastAPI app, SQLite, and disposable Postgres. They require Docker for the Postgres container but do not need cloud credentials. Live tests are grouped by orchestration, sandbox, and storage under `tests/integration/live`; they require a `.env` file at `services/tracker/.env`:
 

--- a/services/tracker/tests/integration/live/api/test_s3_routes.py
+++ b/services/tracker/tests/integration/live/api/test_s3_routes.py
@@ -17,20 +17,20 @@ from tracker.types import HarnessConfig
 
 async def test_agent_catalog_and_download_url_round_trip_real_s3(
     live_api_client: TestClient,
+    test_agent_name: str,
+    seeded_test_agent_artifact: None,
 ) -> None:
-    """Agent listing and download signing must agree on a deployed S3 object.
+    """Agent listing and download signing must agree on the seeded S3 object.
 
     Test cases:
-    - The live catalog contains at least one named agent with its last-modified value.
-    - The route's five-minute presigned URL downloads the original valid agent archive.
+    - The live catalog contains the uniquely seeded agent with its last-modified value.
+    - The route's five-minute presigned URL downloads that valid agent archive.
     - A name absent from the real bucket returns 404.
     """
     catalog_response = live_api_client.get("/agents")
 
     assert catalog_response.status_code == 200
-    named_agents = [agent for agent in catalog_response.json()["agents"] if agent["name"]]
-    assert named_agents
-    selected_agent = next((agent for agent in named_agents if agent["name"] == "agent"), named_agents[0])
+    selected_agent = next(agent for agent in catalog_response.json()["agents"] if agent["name"] == test_agent_name)
     assert selected_agent["last_modified"] is not None
 
     download_response = live_api_client.get(f"/agents/{selected_agent['name']}/download-url")

--- a/services/tracker/tests/integration/local/database/test_schema.py
+++ b/services/tracker/tests/integration/local/database/test_schema.py
@@ -1,7 +1,18 @@
 """Local Postgres schema integration tests."""
 
 from sqlalchemy.engine import Engine
-from sqlmodel import inspect
+from sqlmodel import Session, inspect
+
+from tests.conftest import TEST_ORG_ID
+from tracker.database.models import (
+    AgentContractRequest,
+    Benchmark,
+    BenchmarkArguments,
+    BenchmarkStatus,
+    Org,
+    Task,
+    TaskStatus,
+)
 
 
 def test_tracker_schema_contains_core_tables(postgres_engine: Engine) -> None:
@@ -14,3 +25,41 @@ def test_tracker_schema_contains_core_tables(postgres_engine: Engine) -> None:
     tables = set(inspect(postgres_engine).get_table_names())
 
     assert {"benchmark", "task", "evaluationresult", "finalevaluation"} <= tables
+
+
+def test_terminal_statuses_set_finished_timestamps_in_postgres(postgres_session: Session) -> None:
+    """Terminal state transitions must persist completion timestamps in production Postgres.
+
+    Test cases:
+    - Finishing a benchmark sets its completion timestamp.
+    - Marking a task as errored sets its completion timestamp.
+    """
+    postgres_session.add(Org(id=TEST_ORG_ID, name="postgres-status-org"))
+    postgres_session.flush()
+
+    benchmark = Benchmark(
+        org_id=TEST_ORG_ID,
+        name="postgres-status-events",
+        arguments=BenchmarkArguments(
+            contract=AgentContractRequest(name="status-agent", install_cmd="true", run_cmd="true"),
+            concurrency=1,
+        ),
+    )
+    postgres_session.add(benchmark)
+    postgres_session.flush()
+    assert benchmark.finished_at is None
+
+    benchmark.status = BenchmarkStatus.FINISHED
+    postgres_session.add(benchmark)
+    postgres_session.flush()
+    assert benchmark.finished_at is not None
+
+    task = Task(org_id=TEST_ORG_ID, benchmark=benchmark.id, task_id="status-task")
+    postgres_session.add(task)
+    postgres_session.flush()
+    assert task.finished_at is None
+
+    task.status = TaskStatus.ERROR
+    postgres_session.add(task)
+    postgres_session.flush()
+    assert task.finished_at is not None

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -35,6 +35,7 @@ from tracker.database.models import (
     Benchmark,
     BenchmarkArguments,
     BenchmarkStatus,
+    DocentReadingStatus,
     ErrorResult,
     EvaluationResult,
     FinalEvaluation,
@@ -97,6 +98,46 @@ class TestFastapiServer:
         assert canonical_response.status_code == 200
         assert slash_response.status_code == 404
         assert "location" not in slash_response.headers
+
+    def test_analyze_benchmark_enforces_state_and_reuses_cached_result(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        """Docent analysis must reject invalid runs and return a completed cached result.
+
+        Test cases:
+        - An active run cannot be analyzed.
+        - A finished uncached run requires an analyzer Lambda.
+        - A finished cached run returns its stored reading-plan URL without invoking Lambda.
+        """
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        active_response = client.post(
+            f"/analyze-benchmark/{example_benchmark_object.id}",
+            json={"lambda_function": "docent-analyzer"},
+        )
+        assert active_response.status_code == 400
+        assert "must be FINISHED" in active_response.json()["detail"]
+
+        example_benchmark_object.status = BenchmarkStatus.FINISHED
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+        missing_lambda_response = client.post(f"/analyze-benchmark/{example_benchmark_object.id}", json={})
+        assert missing_lambda_response.status_code == 400
+        assert "No ingest_lambda provided" in missing_lambda_response.json()["detail"]
+
+        example_benchmark_object.docent_reading_status = DocentReadingStatus.DONE
+        example_benchmark_object.docent_reading_url = "https://results.example/reading-plan"
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+        cached_response = client.post(f"/analyze-benchmark/{example_benchmark_object.id}", json={})
+        assert cached_response.status_code == 200
+        assert cached_response.json() == {
+            "status": "done",
+            "reading_plan_url": "https://results.example/reading-plan",
+        }
 
     async def test_tracker_service_error_hides_internal_detail(
         self,


### PR DESCRIPTION
## Summary

Adds the final verification layer for the tracker test stack. It makes stacked PRs run unit CI, reports local and live integration coverage separately, and provides a reproducible 85% combined coverage gate.

## Changes

- Run tracker unit CI for PRs targeting stacked branches, not only `dev`.
- Add `make test-coverage`, which combines unit and local integration coverage and enforces an 85% floor.
- Upload local and gated live integration coverage under separate Codecov flags.
- Seed a unique real-S3 agent archive so the live route test does not depend on shared bucket contents.
- Restore a focused Postgres regression for terminal benchmark and task timestamps.
- Cover Docent analysis state guards and cached-result behavior through the FastAPI route.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] Manually tested

Commands and results:

- `make test-coverage`: 344 unit, 33 local API, and 4 disposable-Postgres tests passed; combined branch coverage is 85.03%.
- `make test-integration-local-coverage`: 37 local integration tests passed and generated `coverage.xml`.
- `uv run pytest tests/integration/live --collect-only -q`: 27 live tests collected.
- `uv run basedpyright tests/integration/live/api tests/integration/local/database/test_schema.py`: 0 errors.
- `uv run ruff check src main.py tests` and `uv run ruff format --check src main.py tests`: passed.

The live CI job retains its existing manual AWS-role gate. Before making its agent fixture self-contained, both new route tests passed against real S3; the gated CI rerun is required to exercise the seeded-agent version with write access to the `agents/` prefix.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
