### PR TITLE
change: use ValkDev prefix for dev stack names

### DIFF
--- a/infra/Makefile
+++ b/infra/Makefile
@@ -10,7 +10,7 @@ PROFILE ?=
 SCOPE ?= all
 
 EXPECTED_ACCOUNT_ID = $(if $(filter dev,$(STAGE)),$(DEV_ACCOUNT_ID),$(if $(filter prod,$(STAGE)),$(PRODUCTION_ACCOUNT_ID),))
-STACK_PREFIX = $(if $(filter dev,$(STAGE)),Valk-Dev-,)
+STACK_PREFIX = $(if $(filter dev,$(STAGE)),ValkDev,)
 STACKS_shared = $(STACK_PREFIX)SharedStack
 STACKS_tracker = $(STACK_PREFIX)TrackerStack
 STACKS_worker = $(STACK_PREFIX)WorkerStack

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -2,7 +2,7 @@
 
 prod  -> every helper is the identity function, so `cdk synth -c stage=prod` is
         byte-identical to the pre-refactor `cdk synth`.
-dev   -> stacks get a "Valk-Dev-" construct-id prefix; physical names get a "-dev"
+dev   -> stacks get a "ValkDev" construct-id prefix; physical names get a "-dev"
         suffix; FQDNs get "-dev" on their first label.
 
 """
@@ -13,7 +13,7 @@ import aws_cdk as cdk
 
 PROD = "prod"
 DEV = "dev"
-DEV_STACK_PREFIX = "Valk-Dev-"
+DEV_STACK_PREFIX = "ValkDev"
 
 
 class Stage:


### PR DESCRIPTION
## Why

Dev CloudFormation stack names used a hyphenated `Valk-Dev-` prefix (`Valk-Dev-SharedStack`), which is inconsistent with the PascalCase construct-id convention and a naming preference raised by the team. This aligns dev stack names to PascalCase (`ValkDevSharedStack`). Dev-only — production stack names are unchanged.

## What changed

- `DEV_STACK_PREFIX` `"Valk-Dev-"` → `"ValkDev"` (`infra/stage.py`) — the single code source of the dev stack-name prefix.
- Matching `STACK_PREFIX` in `infra/Makefile`, kept in sync so `make deploy scope=<x>` targets the right stack name.
- Comment updated. No physical resource names, DNS, or logical-construct behavior change. The deployment-notification event filter and the prefix unit test both derive the name from the `stage.stack_id()` helper, so they follow automatically.

Dev stacks are now `ValkDevSharedStack` / `ValkDevTrackerStack` / `ValkDevWorkerStack` / `ValkDevMonitoringStack`. Prod remains `SharedStack` / `TrackerStack` / `WorkerStack` / `MonitoringStack`.

## How to review

CloudFormation cannot rename a stack in place: deploying this creates new `ValkDev*` stacks and orphans the existing `Valk-Dev-*` dev stacks (whose RDS instance and artifact bucket are `RETAIN`). Applying it to the live dev environment therefore means destroying the four `Valk-Dev-*` stacks — disabling RDS deletion protection and cleaning up the retained RDS instance + bucket — then redeploying. No effect on production.

## Verification

- `cd infra && make lint` — passed
- `cd infra && make typecheck` — 0 errors, 0 warnings, 0 notes
- `cd infra && make test` — 18 passed
- `cdk list -c stage=dev` → `ValkDev{Shared,Tracker,Worker,Monitoring}Stack`
- `cdk list -c stage=prod` → unchanged (`SharedStack`, `TrackerStack`, `WorkerStack`, `MonitoringStack`)
- Not deployed; this PR changes no live stacks.