### PR TITLE
Finalize benchmark runs atomically

### DIFF
--- a/services/tracker/src/tracker/database/migrations/versions/2d7a4c9e1b30_unique_final_evaluation.py
+++ b/services/tracker/src/tracker/database/migrations/versions/2d7a4c9e1b30_unique_final_evaluation.py
@@ -1,0 +1,52 @@
+"""Enforce one final evaluation per benchmark.
+
+Revision ID: 2d7a4c9e1b30
+Revises: 6f3c2d9a8b10
+Create Date: 2026-07-17 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "2d7a4c9e1b30"
+down_revision: Union[str, Sequence[str], None] = "6f3c2d9a8b10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    duplicates = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                """
+            SELECT benchmark, COUNT(*) AS row_count
+            FROM finalevaluation
+            GROUP BY benchmark
+            HAVING COUNT(*) > 1
+            ORDER BY benchmark
+            """
+            )
+        )
+        .all()
+    )
+    if duplicates:
+        audit = ", ".join(f"{benchmark} ({row_count} rows)" for benchmark, row_count in duplicates)
+        raise RuntimeError(f"Resolve duplicate final evaluations before migrating: {audit}")
+
+    op.create_unique_constraint(
+        "unique_final_evaluation_per_benchmark",
+        "finalevaluation",
+        ["benchmark"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "unique_final_evaluation_per_benchmark",
+        "finalevaluation",
+        type_="unique",
+    )

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -167,6 +167,10 @@ class BenchmarkArguments(BaseModel):
 
 
 class FinalEvaluation(SQLModel, table=True):
+    __table_args__: tuple[UniqueConstraint] = (
+        UniqueConstraint("benchmark", name="unique_final_evaluation_per_benchmark"),
+    )
+
     id: UUID = Field(default_factory=uuid4, primary_key=True)
     org_id: UUID = Field(foreign_key="org.id")
     benchmark: UUID = Field(foreign_key="benchmark.id")

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -231,6 +231,8 @@ async def reset_to_in_progress_status(
         # Can already be in progress when retrying errored tasks while the run is ongoing.
         if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
             benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+            benchmark_row.finished_at = None
+            benchmark_row.error_message = None
             session.add(benchmark_row)
 
         for task in existing_rows:

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -55,7 +55,7 @@ _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.I
 
 def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: Org) -> None:
     """
-    Delegates status depending on if any tasks have been stopped.
+    Set and flush the terminal status; the caller owns the final commit.
     """
 
     # Check if any tasks are still in the pending or in progress state
@@ -88,7 +88,7 @@ def set_benchmark_final_status(benchmark_row: Benchmark, session: Session, org: 
     benchmark_row.status = benchmark_status
     benchmark_row.error_message = None
     session.add(benchmark_row)
-    session.commit()
+    session.flush()
 
 
 def create_task_rows(
@@ -309,6 +309,7 @@ async def process_benchmark(
                 benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
                 if has_stopped_tasks(session, benchmark_row, org):
                     set_benchmark_final_status(benchmark_row, session, org)
+                    session.commit()
                     return
             raise TrackerServiceError("No tasks were completed successfully")
 
@@ -324,27 +325,22 @@ async def process_benchmark(
                 finalization_deferred = True
                 return
 
-        # Create the final evaluation row and add it to the database
-        final_evaluation_row = FinalEvaluation(
-            org_id=org.id,
-            benchmark=benchmark_id,
-            final_score=final_score_response.final_score,
-            properties=final_score_response.metadata,
-        )
-
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
             if has_runnable_tasks(session, benchmark_row, org):
                 finalization_deferred = True
                 return
 
-            # Delete existing final evaluation if re-running
-            if benchmark_row.final_evaluation:
-                session.delete(benchmark_row.final_evaluation)
-                session.flush()
+            final_evaluation = benchmark_row.final_evaluation or FinalEvaluation(
+                org_id=org.id,
+                benchmark=benchmark_id,
+                final_score=final_score_response.final_score,
+            )
+            final_evaluation.final_score = final_score_response.final_score
+            final_evaluation.properties = final_score_response.metadata
+            benchmark_row.final_evaluation = final_evaluation
+            session.add(final_evaluation)
 
-            session.add(final_evaluation_row)
-            # Commit the final score and terminal status together while retry/resume is blocked.
             set_benchmark_final_status(benchmark_row, session, org)
 
             # Push the final benchmark view to the bucket
@@ -361,6 +357,8 @@ async def process_benchmark(
                 lambda_payload["benchmark_name"] = benchmark_row.name
 
                 invoke_lambda(lambda_client(harness_config.aws), arguments.lambda_function, lambda_payload)
+
+            session.commit()
 
     except BenchmarkServiceUnauthenticatedError as e:
         logfire.warn("process_benchmark failed due to benchmark service auth error")
@@ -406,6 +404,8 @@ async def process_benchmark(
 
 
 def commit_benchmark_error(benchmark_row: Benchmark, session: Session, error_message: str) -> None:
+    if benchmark_row.final_evaluation:
+        session.delete(benchmark_row.final_evaluation)
     benchmark_row.status = BenchmarkStatus.ERROR
     benchmark_row.error_message = error_message
     session.add(benchmark_row)

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -32,6 +32,120 @@ from tracker.utils import process_benchmark
 class TestRunFinalization:
     """Run finalization and concurrent retry behavior."""
 
+    async def test_active_retry_defers_until_original_task_finishes(
+        self,
+        postgres_engine: Engine,
+        postgres_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        org = Org(id=uuid4(), name=f"active-retry-{uuid4()}")
+        contract = AgentContractRequest(name="retry-agent", install_cmd="true", run_cmd="true")
+        benchmark = make_benchmark(
+            name="active-retry",
+            org_id=org.id,
+            contract=contract,
+            status=BenchmarkStatus.IN_PROGRESS,
+        )
+        original_task = make_task(benchmark, "original", status=TaskStatus.PENDING)
+        retry_task = make_task(benchmark, "retry", status=TaskStatus.ERROR)
+        postgres_session.add(org)
+        postgres_session.flush()
+        postgres_session.add(benchmark)
+        postgres_session.flush()
+        postgres_session.add_all([original_task, retry_task])
+        postgres_session.commit()
+
+        retry_task.status = TaskStatus.PENDING
+        retry_task.finished_at = None
+        postgres_session.add(retry_task)
+        postgres_session.commit()
+
+        async def skip_cloud_operation(*_args: Any, **_kwargs: Any) -> None:
+            return None
+
+        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
+            return "test-log-group"
+
+        def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
+            return DaytonaProviderConfig(
+                DAYTONA_API_KEY="test-key",
+                DAYTONA_API_URL="https://example.com",
+                DAYTONA_TARGET="test-target",
+            )
+
+        async def final_score(*_args: Any, **_kwargs: Any) -> FinalScoreResponse:
+            return FinalScoreResponse(
+                tasks_evaluated=[original_task.task_id, retry_task.task_id],
+                final_score=1.0,
+                metadata={},
+            )
+
+        monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
+        monkeypatch.setattr(run_orchestration_module, "copy_agent_to_benchmark", skip_cloud_operation)
+        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
+        monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
+        monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", final_score)
+
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name=benchmark.name,
+            concurrency=2,
+            harness_config=harness_config,
+        )
+
+        retry_task.status = TaskStatus.FINISHED
+        postgres_session.add(retry_task)
+        postgres_session.flush()
+        postgres_session.add(
+            EvaluationResult(
+                org_id=org.id,
+                task=retry_task.id,
+                instance_id=f"retry-{retry_task.id}",
+                result={"score": 1.0},
+            )
+        )
+        postgres_session.commit()
+
+        await process_benchmark(
+            start_benchmark_request_json=request.model_dump(),
+            benchmark_id_str=str(benchmark.id),
+            verified_task_ids=[],
+        )
+
+        with Session(postgres_engine) as assertion_session:
+            persisted_benchmark = assertion_session.get_one(Benchmark, benchmark.id)
+            assert persisted_benchmark.status == BenchmarkStatus.IN_PROGRESS
+            assert persisted_benchmark.final_evaluation is None
+
+        original_task.status = TaskStatus.FINISHED
+        postgres_session.add(original_task)
+        postgres_session.flush()
+        postgres_session.add(
+            EvaluationResult(
+                org_id=org.id,
+                task=original_task.id,
+                instance_id=f"original-{original_task.id}",
+                result={"score": 1.0},
+            )
+        )
+        postgres_session.commit()
+
+        await process_benchmark(
+            start_benchmark_request_json=request.model_dump(),
+            benchmark_id_str=str(benchmark.id),
+            verified_task_ids=[],
+        )
+
+        with Session(postgres_engine) as assertion_session:
+            persisted_benchmark = assertion_session.get_one(Benchmark, benchmark.id)
+            final_evaluations = assertion_session.exec(
+                select(FinalEvaluation).where(FinalEvaluation.benchmark == benchmark.id)
+            ).all()
+            assert persisted_benchmark.status == BenchmarkStatus.FINISHED
+            assert len(final_evaluations) == 1
+
     async def test_concurrent_retry_prevents_stale_final_evaluation(
         self,
         postgres_engine: Engine,

--- a/services/tracker/tests/unit/database/test_final_evaluation_migration.py
+++ b/services/tracker/tests/unit/database/test_final_evaluation_migration.py
@@ -1,0 +1,44 @@
+import runpy
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+
+def _migration() -> dict[str, Any]:
+    path = (
+        Path(__file__).parents[3] / "src/tracker/database/migrations/versions/2d7a4c9e1b30_unique_final_evaluation.py"
+    )
+    return runpy.run_path(str(path))
+
+
+def test_migration_reports_duplicates_before_schema_change(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _migration()
+    connection = Mock()
+    connection.execute.return_value.all.return_value = [("benchmark-a", 2), ("benchmark-b", 3)]
+    create_unique_constraint = Mock()
+    monkeypatch.setattr(migration["op"], "get_bind", lambda: connection)
+    monkeypatch.setattr(migration["op"], "create_unique_constraint", create_unique_constraint)
+
+    with pytest.raises(RuntimeError, match=r"benchmark-a \(2 rows\), benchmark-b \(3 rows\)"):
+        migration["upgrade"]()
+
+    create_unique_constraint.assert_not_called()
+
+
+def test_migration_adds_uniqueness_after_clean_preflight(monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = _migration()
+    connection = Mock()
+    connection.execute.return_value.all.return_value = []
+    create_unique_constraint = Mock()
+    monkeypatch.setattr(migration["op"], "get_bind", lambda: connection)
+    monkeypatch.setattr(migration["op"], "create_unique_constraint", create_unique_constraint)
+
+    migration["upgrade"]()
+
+    create_unique_constraint.assert_called_once_with(
+        "unique_final_evaluation_per_benchmark",
+        "finalevaluation",
+        ["benchmark"],
+    )

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -698,6 +698,7 @@ class TestRunRecovery:
         benchmark_row = start_benchmark_request_to_benchmark(start_benchmark_request, self._test_starter)
         benchmark_row.status = BenchmarkStatus.FINISHED
         benchmark_row.finished_at = datetime.now(ZoneInfo("UTC"))
+        benchmark_row.error_message = "stale finalization error"
         database_session.add(benchmark_row)
         database_session.flush()
         database_session.add(FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark_row.id, final_score=2.0))
@@ -745,6 +746,10 @@ class TestRunRecovery:
             org=self._test_org,
         )
         assert verified_task_ids == [new_task_id]
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+        assert benchmark_row.finished_at is None
+        assert benchmark_row.error_message is None
 
         stale_final_evaluation = database_session.exec(
             select(FinalEvaluation).where(FinalEvaluation.benchmark == benchmark_row.id)
@@ -1257,6 +1262,126 @@ class TestRunRecovery:
         assert final_score_inputs
         assert set(final_score_inputs[-1]) == {"task_retry", "task_original"}
         assert benchmark_row.final_evaluation is not None
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_finalization_failure_does_not_persist_final_evaluation(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"lambda_function": "vals-format-lambda"})
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.FINISHED,
+        )
+        database_session.add_all([benchmark_row, task_row])
+        database_session.flush()
+        database_session.add_all(
+            [
+                EvaluationResult(
+                    org_id=TEST_ORG_ID,
+                    task=task_row.id,
+                    instance_id="task_0",
+                    result={"status": "success", "score": 1.0},
+                ),
+                FinalEvaluation(
+                    org_id=TEST_ORG_ID,
+                    benchmark=benchmark_row.id,
+                    final_score=0.0,
+                ),
+            ]
+        )
+        database_session.commit()
+
+        def fail_finalization(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("lambda failed")
+
+        monkeypatch.setattr("tracker.utils.run_orchestration.lambda_client", Mock(return_value=object()))
+        monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", fail_finalization)
+
+        await process_benchmark(
+            start_benchmark_request_json=benchmark_row.start_benchmark_request(harness_config).model_dump(),
+            benchmark_id_str=str(benchmark_row.id),
+            verified_task_ids=[],
+        )
+
+        database_session.expire_all()
+        benchmark_row = database_session.get_one(Benchmark, benchmark_row.id)
+        final_evaluations = database_session.exec(
+            select(FinalEvaluation).where(FinalEvaluation.benchmark == benchmark_row.id)
+        ).all()
+        assert benchmark_row.status == BenchmarkStatus.ERROR
+        assert final_evaluations == []
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_finalization_only_retry_updates_one_final_evaluation(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.ERROR
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"lambda_function": "vals-format-lambda"})
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.FINISHED,
+        )
+        database_session.add_all([benchmark_row, task_row])
+        database_session.flush()
+        database_session.add_all(
+            [
+                EvaluationResult(
+                    org_id=TEST_ORG_ID,
+                    task=task_row.id,
+                    instance_id="task_0",
+                    result={"status": "success", "score": 1.0},
+                ),
+                FinalEvaluation(
+                    org_id=TEST_ORG_ID,
+                    benchmark=benchmark_row.id,
+                    final_score=0.0,
+                ),
+            ]
+        )
+        database_session.commit()
+        original_final_evaluation = database_session.exec(
+            select(FinalEvaluation).where(FinalEvaluation.benchmark == benchmark_row.id)
+        ).one()
+        lambda_calls = 0
+
+        def count_finalization(*_args: Any, **_kwargs: Any) -> None:
+            nonlocal lambda_calls
+            lambda_calls += 1
+
+        monkeypatch.setattr("tracker.utils.run_orchestration.lambda_client", Mock(return_value=object()))
+        monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", count_finalization)
+
+        for expected_lambda_calls in (1, 2):
+            response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true")
+            assert response.status_code == 200
+            dispatch = mock_kicker.queued_calls[-1]
+            assert dispatch["verified_task_ids"] == []
+
+            await process_benchmark(**dispatch)
+
+            database_session.expire_all()
+            benchmark_row = database_session.get_one(Benchmark, benchmark_row.id)
+            final_evaluations = database_session.exec(
+                select(FinalEvaluation).where(FinalEvaluation.benchmark == benchmark_row.id)
+            ).all()
+            assert benchmark_row.status == BenchmarkStatus.FINISHED
+            assert [row.id for row in final_evaluations] == [original_final_evaluation.id]
+            assert lambda_calls == expected_lambda_calls
 
     async def test_task_monitor_cancels_waiting_stopped_task(
         self, example_benchmark_object: Benchmark, database_session: Session, monkeypatch: MonkeyPatch


### PR DESCRIPTION
## Summary

Make benchmark finalization atomic so a run cannot expose a terminal benchmark without its matching final evaluation, or a final evaluation without its matching terminal status. A database constraint enforces one final evaluation per benchmark and fails closed if historical duplicates exist.

## Changes

- Upsert the final evaluation and terminal benchmark state in one transaction.
- Add a unique database constraint for one final evaluation per benchmark.
- Clear stale terminal fields when a run is reset to `IN_PROGRESS`.
- Add migration, retry/recovery, and concurrent-finalization coverage.

## Related Issues

Related to https://github.com/vals-ai/benchmarks/issues/2116

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] Manually tested
- `uv run --frozen pytest -q tests/unit/database/test_final_evaluation_migration.py tests/unit/utils/test_run_recovery.py` — 25 passed
- PostgreSQL finalization integration coverage — 2 passed
- Ruff check and format check — passed

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

## Rollout

Run the database migration before deploying tracker workers from this branch.

## Paired publication change

https://github.com/vals-ai/benchmarks/pull/2140
