### PR TITLE
Preserve completed evaluations across cleanup failures

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -241,7 +241,12 @@ async def create_sandbox(
         logger.error(f"Error during sandbox execution {sandbox.name}: {e}")
         raise
     finally:
-        await delete_sandbox(sandbox, provider)
+        try:
+            await delete_sandbox(sandbox, provider)
+        except ProviderSandboxError as e:
+            incr("valkyrie.sandbox.delete.errors", tags={"error_class": type(e).__name__})
+            logger.error(f"Failed to delete sandbox {sandbox.name}: {e}", exc_info=True)
+            sentry_sdk.capture_exception(e)
 
 
 @retry(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -347,9 +347,12 @@ def _commit_task_status(
         if to_status in [TaskStatus.FINISHED, TaskStatus.ERROR]:
             values["finished_at"] = datetime.now(ZoneInfo("UTC"))
 
-        task_update = update(Task).where(col(Task.id) == task.id).where(col(Task.org_id) == task.org_id)
-        if to_status != TaskStatus.STOPPED:
-            task_update = task_update.where(col(Task.status) != TaskStatus.STOPPED)
+        task_update = (
+            update(Task)
+            .where(col(Task.id) == task.id)
+            .where(col(Task.org_id) == task.org_id)
+            .where(col(Task.status).notin_([TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]))
+        )
         if expected_started_at is not None:
             task_update = task_update.where(col(Task.started_at) == expected_started_at)
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -813,6 +813,38 @@ class TestSandboxLifecycle:
         ]
         assert context_calls == [("sandbox-123", "ghcr.io/vals/swebench:latest")]
 
+    async def test_create_sandbox_preserves_body_error_when_delete_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        provider = AsyncMock()
+        cleanup_error = ProviderSandboxError("cleanup failed")
+        delete_sandbox = AsyncMock(side_effect=cleanup_error)
+        capture_exception = Mock()
+        increment = Mock()
+
+        async def fake_create_sandbox(*_args: Any, **_kwargs: Any) -> Any:
+            return mock_sandbox
+
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", fake_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", delete_sandbox)
+        monkeypatch.setattr(sandbox_module, "incr", increment)
+        monkeypatch.setattr(sandbox_module.sentry_sdk, "capture_exception", capture_exception)
+
+        with pytest.raises(RuntimeError, match="task failed"):
+            async with create_sandbox(
+                provider=provider,
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                raise RuntimeError("task failed")
+
+        delete_sandbox.assert_awaited_once_with(mock_sandbox, provider)
+        increment.assert_called_once_with("valkyrie.sandbox.delete.errors", tags={"error_class": "SandboxError"})
+        capture_exception.assert_called_once_with(cleanup_error)
+
     async def test_create_sandbox_emits_error_metric(self, monkeypatch: pytest.MonkeyPatch) -> None:
         create_error = RuntimeError("create failed")
         increments: list[tuple[str, dict[str, str]]] = []

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -5,10 +5,12 @@ Run: uv run pytest tests/unit/utils/test_benchmark_service_failures.py
 
 import time
 from typing import Any, Never
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 from benchmark_service.schemas import RetrieveTaskResponse
 from sqlmodel import Session, desc, select
 from websockets.datastructures import Headers
@@ -18,7 +20,15 @@ from websockets.http11 import Response
 
 import tracker.utils.task_execution as utils_module
 from tests.unit.utils.task_execution_support import TEST_ORG, create_task_environment, run_process_task
-from tracker.database.models import AgentContractRequest, BenchmarkStatus, ErrorResult, Task, TaskStatus
+from tracker import sandbox as sandbox_module
+from tracker.database.models import (
+    AgentContractRequest,
+    BenchmarkStatus,
+    ErrorResult,
+    EvaluationResult,
+    Task,
+    TaskStatus,
+)
 from tracker.exceptions import OutputArtifactError
 from tracker.types import HarnessConfig
 from tracker.utils import (
@@ -191,6 +201,42 @@ class TestBenchmarkServiceFailures:
         error_message = self._latest_task_error(database_session, task_row)
         assert "Output artifact error" in error_message
         assert "Required output artifact missing" in error_message
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_completed_evaluation_survives_sandbox_cleanup_error(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id = create_task_environment(
+            contract, database_session, harness_config
+        )
+        sandbox = AsyncMock()
+        sandbox.id = "sandbox-123"
+        sandbox.name = "task_0"
+        provider = AsyncMock()
+        provider.create_sandbox.return_value = sandbox
+        provider.delete_sandbox.side_effect = ProviderSandboxError("File descriptor 49 is used by transport")
+
+        def _mock_get_sandbox_provider(*_args: Any, **_kwargs: Any) -> AsyncMock:
+            return provider
+
+        monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", _mock_get_sandbox_provider)
+        monkeypatch.setattr(utils_module, "create_sandbox", sandbox_module.create_sandbox)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        provider.delete_sandbox.assert_awaited_once_with("sandbox-123")
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+        evaluation_result = database_session.exec(
+            select(EvaluationResult).where(EvaluationResult.task == task_row.id)
+        ).one()
+        assert evaluation_result.result == {"status": "success", "score": 1.0}
+        assert database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).all() == []
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_benchmark_service_error_produces_human_readable_message(

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -518,6 +518,27 @@ class TestRunState:
         assert transition_record["has_error_message"] is True
         assert not any(record["message"].startswith("task.status_transition") for record in log_records)
 
+    @pytest.mark.parametrize("terminal_status", [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED])
+    def test_commit_task_error_does_not_overwrite_terminal_task(
+        self,
+        terminal_status: TaskStatus,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+    ) -> None:
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_0",
+            benchmark=example_benchmark_object.id,
+            status=terminal_status,
+        )
+        database_session.add(task_row)
+        database_session.commit()
+
+        assert not commit_task_error(task_row, database_session, "late cleanup failure")
+        database_session.refresh(task_row)
+        assert task_row.status == terminal_status
+        assert database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).all() == []
+
     async def test_set_benchmark_final_status(
         self, example_benchmark_object: Benchmark, database_session: Session
     ) -> None:


### PR DESCRIPTION
## Summary

Preserve a completed evaluation when sandbox deletion fails after the evaluation body has already succeeded. Cleanup failures remain observable through logs, metrics, and Sentry without replacing the completed result or rewriting a terminal task.

## Changes

- Record provider sandbox deletion failures without masking the body result.
- Refuse late status/error writes once a task is `FINISHED`, `ERROR`, or `STOPPED`.
- Add regressions for cleanup failure precedence and terminal-state immutability.

## Related Issues

Closes vals-ai/valkyrie-ticket-library#148

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [ ] Manually tested
- `uv run pytest tests/unit/test_sandbox.py tests/unit/utils/test_benchmark_service_failures.py tests/unit/utils/test_run_state.py` — 67 passed
- Ruff check and format check — passed

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
