### PR TITLE
Added Dynamic Concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,9 @@ valkyrie run update <id> --concurrency 20
 This updates the persisted concurrency limit for an active run without restarting it. Increases allow more tasks after
 the tracker next refreshes the run; decreases do not cancel in-flight work and pause new admissions until usage falls
 below the new limit. The value must be a positive integer, and completed, stopped, or failed runs cannot be updated.
+The limit is enforced independently by each `process_benchmark` executor. If an active retry creates overlapping
+executors, aggregate admissions may temporarily exceed the persisted value; a strict cross-executor or distributed cap
+is not provided.
 
 ### Monitor a run
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ Starts are fail-fast: if a request fails, no later requests are attempted. The c
 | `--ignore-custom-services` / `--ics` | Ignore custom benchmark services that have been configured. Provides opt-out for custom services. |
 | `--connect` | Stream run updates after the run starts |
 
+### Update a running run's concurrency
+
+```bash
+valkyrie run update <id> --concurrency 20
+```
+
+This updates the persisted concurrency limit for an active run without restarting it. Increases allow more tasks after
+the tracker next refreshes the run; decreases do not cancel in-flight work and pause new admissions until usage falls
+below the new limit. The value must be a positive integer, and completed, stopped, or failed runs cannot be updated.
+
 ### Monitor a run
 
 After starting, use the following commands to check the status of a run: 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -91,6 +91,8 @@ from tracker.types import (
     StartBenchmarkRequest,
     StartBenchmarkResponse,
     StopBenchmarkResponse,
+    UpdateBenchmarkConcurrencyRequest,
+    UpdateBenchmarkConcurrencyResponse,
 )
 from tracker.utils import (
     BenchmarkContext,
@@ -110,6 +112,7 @@ from tracker.utils import (
     start_benchmark_request_to_benchmark,
     stream_benchmark_results,
     upload_final_view,
+    update_benchmark_concurrency,
 )
 
 configure_logging()
@@ -711,6 +714,40 @@ def _apply_resume_secrets(benchmark_row: Benchmark, secrets: dict[str, str]) -> 
     benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": updated_contract})
 
 
+def _update_benchmark_concurrency(
+    benchmark_id: UUID,
+    concurrency: int,
+    session: Session,
+    org: Org,
+) -> Benchmark:
+    try:
+        benchmark_row = update_benchmark_concurrency(benchmark_id, concurrency, session, org)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Not found") from exc
+
+    if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Run {benchmark_id} is currently in the {benchmark_row.status} state.",
+        )
+    return benchmark_row
+
+
+@app.patch("/benchmarks/{benchmark_id}/concurrency")
+def patch_benchmark_concurrency(
+    benchmark_id: TrackedBenchmarkId,
+    request: UpdateBenchmarkConcurrencyRequest,
+    session: Session = Depends(get_session),
+    org: Org = Depends(get_current_org),
+) -> UpdateBenchmarkConcurrencyResponse:
+    benchmark_row = _update_benchmark_concurrency(benchmark_id, request.concurrency, session, org)
+    return UpdateBenchmarkConcurrencyResponse(
+        benchmark_id=benchmark_row.id,
+        status=benchmark_row.status,
+        concurrency=benchmark_row.arguments.concurrency,
+    )
+
+
 @app.post("/retry-or-resume-benchmark/{benchmark_id}")
 async def retry_or_resume_benchmark(
     benchmark_id: TrackedBenchmarkId,
@@ -750,13 +787,18 @@ async def retry_or_resume_benchmark(
             detail=f"Run {benchmark_id} is in the {benchmark_row.status} state. Cannot continue a run that is stopping.",
         )
 
-    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not retry:
+    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not retry and concurrency is None:
         return RetryOrResumeBenchmarkResponse(
             status="success",
         )
 
     if concurrency is not None and concurrency < 1:
         raise HTTPException(status_code=400, detail="Concurrency must be greater than 0.")
+
+    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not retry:
+        assert concurrency is not None
+        _update_benchmark_concurrency(benchmark_id, concurrency, session, org)
+        return RetryOrResumeBenchmarkResponse(status="success")
 
     effective_service_headers = forward_tracker_api_key(
         service_headers,

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -95,6 +95,7 @@ from tracker.types import (
     UpdateBenchmarkConcurrencyResponse,
 )
 from tracker.utils import (
+    BenchmarkConcurrencyUpdate,
     BenchmarkContext,
     YieldingWriter,
     build_benchmark_table_rows,
@@ -113,6 +114,7 @@ from tracker.utils import (
     stream_benchmark_results,
     upload_final_view,
     update_benchmark_concurrency,
+    update_benchmark_resume_arguments,
 )
 
 configure_logging()
@@ -707,19 +709,12 @@ async def stop_benchmark(
     )
 
 
-def _apply_resume_secrets(benchmark_row: Benchmark, secrets: dict[str, str]) -> None:
-    """Merge resume secrets into the stored agent contract."""
-    contract = benchmark_row.arguments.contract
-    updated_contract = contract.model_copy(update={"secrets": {**contract.secrets, **secrets}})
-    benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": updated_contract})
-
-
 def _update_benchmark_concurrency(
     benchmark_id: UUID,
     concurrency: int,
     session: Session,
     org: Org,
-) -> Benchmark:
+) -> BenchmarkConcurrencyUpdate:
     try:
         benchmark_row = update_benchmark_concurrency(benchmark_id, concurrency, session, org)
     except ValueError as exc:
@@ -742,9 +737,9 @@ def patch_benchmark_concurrency(
 ) -> UpdateBenchmarkConcurrencyResponse:
     benchmark_row = _update_benchmark_concurrency(benchmark_id, request.concurrency, session, org)
     return UpdateBenchmarkConcurrencyResponse(
-        benchmark_id=benchmark_row.id,
+        benchmark_id=benchmark_row.benchmark_id,
         status=benchmark_row.status,
-        concurrency=benchmark_row.arguments.concurrency,
+        concurrency=benchmark_row.concurrency,
     )
 
 
@@ -820,17 +815,14 @@ async def retry_or_resume_benchmark(
             status="success",
         )
 
-    if secrets:
-        _apply_resume_secrets(benchmark_row, secrets)
-        session.add(benchmark_row)
-        session.commit()
-
-    if concurrency is not None:
-        # Reassign (not in-place mutate): arguments is a JSON-backed TypeDecorator,
-        # so SQLAlchemy only detects the change when the attribute itself is replaced.
-        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": concurrency})
-        session.add(benchmark_row)
-        session.commit()
+    if secrets or concurrency is not None:
+        benchmark_row = update_benchmark_resume_arguments(
+            benchmark_id,
+            session,
+            org,
+            secrets=secrets,
+            concurrency=concurrency,
+        )
 
     # Ensure that credentials are included with the model dump
     resume_request_json = benchmark_row.start_benchmark_request(

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -182,6 +182,16 @@ class RetryOrResumeBenchmarkResponse(StatusResponse):
     pass
 
 
+class UpdateBenchmarkConcurrencyRequest(BaseModel):
+    concurrency: int = Field(ge=1, strict=True)
+
+
+class UpdateBenchmarkConcurrencyResponse(BaseModel):
+    benchmark_id: UUID
+    status: BenchmarkStatus
+    concurrency: int
+
+
 class Order(str, Enum):
     ASC = "asc"
     DESC = "desc"

--- a/services/tracker/src/tracker/utils/__init__.py
+++ b/services/tracker/src/tracker/utils/__init__.py
@@ -29,6 +29,7 @@ from tracker.utils.reporting import (
     upload_final_view,
 )
 from tracker.utils.resources import (
+    BenchmarkConcurrencyUpdate,
     create_benchmark_service_client,
     create_benchmark_service_client_from_request,
     fetch_benchmark_row,
@@ -36,6 +37,7 @@ from tracker.utils.resources import (
     fetch_task_row,
     start_benchmark_request_to_benchmark,
     update_benchmark_concurrency,
+    update_benchmark_resume_arguments,
 )
 from tracker.utils.run_control import (
     force_stop_sandboxes,
@@ -59,6 +61,7 @@ from tracker.utils.task_execution import (
 
 __all__ = [
     "BenchmarkContext",
+    "BenchmarkConcurrencyUpdate",
     "ResizableLimiter",
     "TaskCounts",
     "TaskMonitor",
@@ -102,4 +105,5 @@ __all__ = [
     "try_fetch_harness_config",
     "upload_final_view",
     "update_benchmark_concurrency",
+    "update_benchmark_resume_arguments",
 ]

--- a/services/tracker/src/tracker/utils/__init__.py
+++ b/services/tracker/src/tracker/utils/__init__.py
@@ -35,6 +35,7 @@ from tracker.utils.resources import (
     fetch_sandbox_provider_config,
     fetch_task_row,
     start_benchmark_request_to_benchmark,
+    update_benchmark_concurrency,
 )
 from tracker.utils.run_control import (
     force_stop_sandboxes,
@@ -44,6 +45,7 @@ from tracker.utils.run_control import (
     stop_sandbox,
 )
 from tracker.utils.task_execution import (
+    ResizableLimiter,
     TaskMonitor,
     TrackedTask,
     TrackedTaskStatus,
@@ -57,6 +59,7 @@ from tracker.utils.task_execution import (
 
 __all__ = [
     "BenchmarkContext",
+    "ResizableLimiter",
     "TaskCounts",
     "TaskMonitor",
     "TrackedTask",
@@ -98,4 +101,5 @@ __all__ = [
     "stream_benchmark_results",
     "try_fetch_harness_config",
     "upload_final_view",
+    "update_benchmark_concurrency",
 ]

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -1,5 +1,6 @@
 """Factory helpers that construct clients, provider configs, and validated DB rows."""
 
+from dataclasses import dataclass
 from uuid import UUID
 
 from benchmark_service import (
@@ -25,6 +26,13 @@ from tracker.types import (
     AWSCredentials,
     StartBenchmarkRequest,
 )
+
+
+@dataclass(frozen=True)
+class BenchmarkConcurrencyUpdate:
+    benchmark_id: UUID
+    status: BenchmarkStatus
+    concurrency: int
 
 
 def fetch_sandbox_provider_config(secret_name: str, aws: AWSCredentials, provider_type: str) -> SandboxProviderConfig:
@@ -112,25 +120,67 @@ def fetch_benchmark_row(
     return benchmark_row
 
 
+def _fetch_locked_benchmark(benchmark_id: UUID, session: Session, org: Org) -> Benchmark:
+    benchmark_row = session.exec(
+        select(Benchmark)
+        .where(Benchmark.id == benchmark_id)
+        .where(Benchmark.org_id == org.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).one_or_none()
+    if benchmark_row is None:
+        raise ValueError(f"Run with id {benchmark_id} not found")
+    return benchmark_row
+
+
 def update_benchmark_concurrency(
     benchmark_id: UUID,
     concurrency: int,
     session: Session,
     org: Org,
-) -> Benchmark:
+) -> BenchmarkConcurrencyUpdate:
     """Lock an org-scoped run and persist a new active-run concurrency limit."""
-    benchmark_row = session.exec(
-        select(Benchmark).where(Benchmark.id == benchmark_id).where(Benchmark.org_id == org.id).with_for_update()
-    ).one_or_none()
-    if benchmark_row is None:
-        raise ValueError(f"Run with id {benchmark_id} not found")
+    benchmark_row = _fetch_locked_benchmark(benchmark_id, session, org)
     if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
-        return benchmark_row
+        return BenchmarkConcurrencyUpdate(
+            benchmark_id=benchmark_row.id,
+            status=benchmark_row.status,
+            concurrency=benchmark_row.arguments.concurrency,
+        )
 
     benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": concurrency})
+    result = BenchmarkConcurrencyUpdate(
+        benchmark_id=benchmark_row.id,
+        status=benchmark_row.status,
+        concurrency=benchmark_row.arguments.concurrency,
+    )
     session.add(benchmark_row)
     session.commit()
-    session.refresh(benchmark_row)
+    return result
+
+
+def update_benchmark_resume_arguments(
+    benchmark_id: UUID,
+    session: Session,
+    org: Org,
+    *,
+    secrets: dict[str, str],
+    concurrency: int | None,
+) -> Benchmark:
+    """Lock and freshly merge JSON-backed arguments used by resume and retry."""
+    benchmark_row = _fetch_locked_benchmark(benchmark_id, session, org)
+    arguments = benchmark_row.arguments
+
+    if secrets:
+        contract = arguments.contract
+        updated_contract = contract.model_copy(update={"secrets": {**contract.secrets, **secrets}})
+        arguments = arguments.model_copy(update={"contract": updated_contract})
+    if concurrency is not None:
+        arguments = arguments.model_copy(update={"concurrency": concurrency})
+
+    benchmark_row.arguments = arguments
+    session.add(benchmark_row)
+    session.commit()
     return benchmark_row
 
 

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -7,7 +7,7 @@ from benchmark_service import (
     sandbox_provider_config_from_mapping,
 )
 from benchmark_service.client import BenchmarkServiceClient
-from sqlmodel import Session
+from sqlmodel import Session, select
 
 from tracker.auth import RequestIdentity
 from tracker.aws.secrets import fetch_aws_secret
@@ -15,6 +15,7 @@ from tracker.config import create_benchmark_service_url
 from tracker.database.models import (
     Benchmark,
     BenchmarkArguments,
+    BenchmarkStatus,
     Org,
     Task,
 )
@@ -108,6 +109,28 @@ def fetch_benchmark_row(
         raise ValueError(f"Run with id {benchmark_id} not found")
     if benchmark_row.org_id != org.id:
         raise ValueError(f"Run {benchmark_id} does not belong to org {org.id}")
+    return benchmark_row
+
+
+def update_benchmark_concurrency(
+    benchmark_id: UUID,
+    concurrency: int,
+    session: Session,
+    org: Org,
+) -> Benchmark:
+    """Lock an org-scoped run and persist a new active-run concurrency limit."""
+    benchmark_row = session.exec(
+        select(Benchmark).where(Benchmark.id == benchmark_id).where(Benchmark.org_id == org.id).with_for_update()
+    ).one_or_none()
+    if benchmark_row is None:
+        raise ValueError(f"Run with id {benchmark_id} not found")
+    if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+        return benchmark_row
+
+    benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": concurrency})
+    session.add(benchmark_row)
+    session.commit()
+    session.refresh(benchmark_row)
     return benchmark_row
 
 

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -154,7 +154,6 @@ def update_benchmark_concurrency(
         status=benchmark_row.status,
         concurrency=benchmark_row.arguments.concurrency,
     )
-    session.add(benchmark_row)
     session.commit()
     return result
 
@@ -179,7 +178,6 @@ def update_benchmark_resume_arguments(
         arguments = arguments.model_copy(update={"concurrency": concurrency})
 
     benchmark_row.arguments = arguments
-    session.add(benchmark_row)
     session.commit()
     return benchmark_row
 

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -257,7 +257,7 @@ async def process_benchmark(
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session, org)
-            persisted_concurrency = benchmark_row.arguments.concurrency
+            limiter = ResizableLimiter(benchmark_row.arguments.concurrency)
 
         task_row_ids: set[str] = {task_id for task_id, _ in task_rows}
         missing_task_ids: list[str] = [task_id for task_id in verified_task_ids if task_id not in task_row_ids]
@@ -289,7 +289,6 @@ async def process_benchmark(
         }
 
         # Start the monitor to track the state the tasks are in and cancel them when no longer valid
-        limiter = ResizableLimiter(persisted_concurrency)
         monitor = TaskMonitor(benchmark_id, tracked_tasks, org, limiter=limiter, notifier=notifier)
         monitor_task = asyncio.create_task(monitor.track_tasks())
 

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -290,7 +290,7 @@ async def process_benchmark(
 
         # Start the monitor to track the state the tasks are in and cancel them when no longer valid
         limiter = ResizableLimiter(persisted_concurrency)
-        monitor = TaskMonitor(benchmark_id, tracked_tasks, org, notifier=notifier, limiter=limiter)
+        monitor = TaskMonitor(benchmark_id, tracked_tasks, org, limiter=limiter, notifier=notifier)
         monitor_task = asyncio.create_task(monitor.track_tasks())
 
         await gather(*[tracked_tasks[task_id].run(limiter, task_row) for task_id, task_row in task_rows])

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -45,7 +45,7 @@ from tracker.utils.resources import (
     fetch_sandbox_provider_config,
 )
 from tracker.utils.reporting import create_final_view, upload_final_view
-from tracker.utils.task_execution import TaskMonitor, TrackedTask, process_task
+from tracker.utils.task_execution import ResizableLimiter, TaskMonitor, TrackedTask, process_task
 
 logger = get_logger(__name__)
 
@@ -257,6 +257,7 @@ async def process_benchmark(
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             task_rows: Sequence[tuple[str, Task]] = create_task_rows(verified_task_ids, benchmark_row, session, org)
+            persisted_concurrency = benchmark_row.arguments.concurrency
 
         task_row_ids: set[str] = {task_id for task_id, _ in task_rows}
         missing_task_ids: list[str] = [task_id for task_id in verified_task_ids if task_id not in task_row_ids]
@@ -288,12 +289,11 @@ async def process_benchmark(
         }
 
         # Start the monitor to track the state the tasks are in and cancel them when no longer valid
-        monitor = TaskMonitor(benchmark_id, tracked_tasks, org, notifier=notifier)
+        limiter = ResizableLimiter(persisted_concurrency)
+        monitor = TaskMonitor(benchmark_id, tracked_tasks, org, notifier=notifier, limiter=limiter)
         monitor_task = asyncio.create_task(monitor.track_tasks())
 
-        semaphore = Semaphore(start_benchmark_request.concurrency)
-
-        await gather(*[tracked_tasks[task_id].run(semaphore, task_row) for task_id, task_row in task_rows])
+        await gather(*[tracked_tasks[task_id].run(limiter, task_row) for task_id, task_row in task_rows])
 
         await monitor_task
 

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -87,14 +87,6 @@ class ResizableLimiter:
         self._in_flight = 0
         self._condition = asyncio.Condition()
 
-    @property
-    def limit(self) -> int:
-        return self._limit
-
-    @property
-    def in_flight(self) -> int:
-        return self._in_flight
-
     async def resize(self, limit: int) -> None:
         if limit < 1:
             raise ValueError("Limit must be greater than 0")
@@ -176,7 +168,7 @@ class TaskMonitor:
     _task_tracking: dict[str, TrackedTask]
     _notifier: SlackNotifier | None
     _org: Org
-    _limiter: ResizableLimiter | None
+    _limiter: ResizableLimiter
     _TRACK_INTERVAL: int = 2
 
     def __init__(
@@ -184,8 +176,8 @@ class TaskMonitor:
         benchmark_id: UUID,
         task_tracking: dict[str, TrackedTask],
         org: Org,
+        limiter: ResizableLimiter,
         notifier: SlackNotifier | None = None,
-        limiter: ResizableLimiter | None = None,
     ):
         self._benchmark_id = benchmark_id
         self._task_tracking = task_tracking
@@ -194,8 +186,6 @@ class TaskMonitor:
         self._limiter = limiter
 
     async def _refresh_concurrency(self) -> None:
-        if self._limiter is None:
-            return
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(self._benchmark_id, session, self._org)
             concurrency = benchmark_row.arguments.concurrency

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -9,6 +9,7 @@ from collections.abc import Coroutine
 from contextlib import suppress
 from datetime import datetime
 from enum import Enum
+from types import TracebackType
 from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
@@ -76,6 +77,49 @@ class TrackedTaskStatus(str, Enum):
     DONE = "done"
 
 
+class ResizableLimiter:
+    """A per-executor admission limit that can change without preempting admitted work."""
+
+    def __init__(self, limit: int):
+        if limit < 1:
+            raise ValueError("Limit must be greater than 0")
+        self._limit = limit
+        self._in_flight = 0
+        self._condition = asyncio.Condition()
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @property
+    def in_flight(self) -> int:
+        return self._in_flight
+
+    async def resize(self, limit: int) -> None:
+        if limit < 1:
+            raise ValueError("Limit must be greater than 0")
+        async with self._condition:
+            previous_limit = self._limit
+            self._limit = limit
+            if limit > previous_limit:
+                self._condition.notify_all()
+
+    async def __aenter__(self) -> None:
+        async with self._condition:
+            await self._condition.wait_for(lambda: self._in_flight < self._limit)
+            self._in_flight += 1
+
+    async def __aexit__(
+        self,
+        _exc_type: type[BaseException] | None,
+        _exc_value: BaseException | None,
+        _traceback: TracebackType | None,
+    ) -> None:
+        async with self._condition:
+            self._in_flight -= 1
+            self._condition.notify_all()
+
+
 class TrackedTask:
     _coro: Coroutine[Any, Any, Any]
     _status: str
@@ -96,10 +140,10 @@ class TrackedTask:
     def task(self) -> asyncio.Task[Any] | None:
         return self._task
 
-    async def run(self, semaphore: asyncio.Semaphore, task_row: Task) -> dict[str, dict[str, Any] | None]:
+    async def run(self, limiter: ResizableLimiter, task_row: Task) -> dict[str, dict[str, Any] | None]:
         async def _wrap_coro():
             """Need to have a task created even if we are not running the coroutine so that we can cancel it before its running"""
-            async with semaphore:
+            async with limiter:
                 self._status = TrackedTaskStatus.RUNNING
                 return await self._coro
 
@@ -132,15 +176,30 @@ class TaskMonitor:
     _task_tracking: dict[str, TrackedTask]
     _notifier: SlackNotifier | None
     _org: Org
+    _limiter: ResizableLimiter | None
     _TRACK_INTERVAL: int = 2
 
     def __init__(
-        self, benchmark_id: UUID, task_tracking: dict[str, TrackedTask], org: Org, notifier: SlackNotifier | None = None
+        self,
+        benchmark_id: UUID,
+        task_tracking: dict[str, TrackedTask],
+        org: Org,
+        notifier: SlackNotifier | None = None,
+        limiter: ResizableLimiter | None = None,
     ):
         self._benchmark_id = benchmark_id
         self._task_tracking = task_tracking
         self._org = org
         self._notifier = notifier
+        self._limiter = limiter
+
+    async def _refresh_concurrency(self) -> None:
+        if self._limiter is None:
+            return
+        with Session(bind=engine) as session:
+            benchmark_row = fetch_benchmark_row(self._benchmark_id, session, self._org)
+            concurrency = benchmark_row.arguments.concurrency
+        await self._limiter.resize(concurrency)
 
     def _fetch_task_row(self, task_id: str) -> Task:
         with Session(bind=engine) as session:
@@ -193,6 +252,7 @@ class TaskMonitor:
         exit_condition_met: bool = False
 
         while not exit_condition_met and self._task_tracking:
+            await self._refresh_concurrency()
             tasks_to_check: list[str] = list(self._task_tracking.keys())
             for task_id in tasks_to_check:
                 task = self._task_tracking[task_id]

--- a/services/tracker/tests/integration/local/api/test_benchmark_concurrency.py
+++ b/services/tracker/tests/integration/local/api/test_benchmark_concurrency.py
@@ -1,0 +1,37 @@
+"""Exercise live concurrency updates through the authenticated tracker app.
+
+Run: uv run pytest tests/integration/local/api/test_benchmark_concurrency.py
+"""
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from tests.factories import make_benchmark
+from tracker.database.models import Benchmark, BenchmarkStatus
+
+
+def test_authenticated_concurrency_update_persists_full_arguments(
+    client: TestClient,
+    database_session: Session,
+) -> None:
+    """An authenticated update must return and persist the requested active-run limit."""
+    benchmark = make_benchmark(concurrency=2, session=database_session)
+    original_arguments = benchmark.arguments
+
+    response = client.patch(
+        f"/benchmarks/{benchmark.id}/concurrency",
+        headers={"Authorization": "Bearer fake"},
+        json={"concurrency": 4},
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json() == {
+        "benchmark_id": str(benchmark.id),
+        "status": BenchmarkStatus.IN_PROGRESS,
+        "concurrency": 4,
+    }
+
+    database_session.expire_all()
+    stored_run = database_session.get(Benchmark, benchmark.id)
+    assert stored_run is not None
+    assert stored_run.arguments == original_arguments.model_copy(update={"concurrency": 4})

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -52,7 +52,7 @@ from tracker.types import (
     HarnessConfig,
     StartBenchmarkRequest,
 )
-from tracker.utils import fetch_harness_config
+from tracker.utils import fetch_harness_config, update_benchmark_concurrency
 
 client = TestClient(app)
 
@@ -180,6 +180,70 @@ class TestTrackerAPI:
         assert response.status_code == 409
         database_session.refresh(example_benchmark_object)
         assert example_benchmark_object.arguments.concurrency == 5
+
+    def test_update_benchmark_concurrency_refreshes_preloaded_state_before_mutating(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        with Session(bind=database_session.get_bind()) as concurrent_session:
+            concurrent_benchmark = concurrent_session.get(Benchmark, example_benchmark_object.id)
+            assert concurrent_benchmark is not None
+            concurrent_benchmark.status = BenchmarkStatus.STOPPED
+            concurrent_session.add(concurrent_benchmark)
+            concurrent_session.commit()
+
+        result = update_benchmark_concurrency(
+            example_benchmark_object.id,
+            9,
+            database_session,
+            Org(id=TEST_ORG_ID, name="default"),
+        )
+
+        assert result.status == BenchmarkStatus.STOPPED
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, example_benchmark_object.id)
+        assert persisted is not None
+        assert persisted.status == BenchmarkStatus.STOPPED
+        assert persisted.arguments.concurrency == 5
+
+    def test_update_benchmark_concurrency_returns_snapshot_from_locked_transaction(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+        commit_update = database_session.commit
+
+        def commit_then_stop() -> None:
+            commit_update()
+            with Session(bind=database_session.get_bind()) as concurrent_session:
+                concurrent_benchmark = concurrent_session.get(Benchmark, example_benchmark_object.id)
+                assert concurrent_benchmark is not None
+                concurrent_benchmark.status = BenchmarkStatus.STOPPED
+                concurrent_session.add(concurrent_benchmark)
+                concurrent_session.commit()
+
+        monkeypatch.setattr(database_session, "commit", commit_then_stop)
+
+        result = update_benchmark_concurrency(
+            example_benchmark_object.id,
+            9,
+            database_session,
+            Org(id=TEST_ORG_ID, name="default"),
+        )
+
+        assert result.status == BenchmarkStatus.IN_PROGRESS
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, example_benchmark_object.id)
+        assert persisted is not None
+        assert persisted.status == BenchmarkStatus.STOPPED
+        assert persisted.arguments.concurrency == 9
 
     def test_trailing_slash_does_not_redirect(self, monkeypatch: MonkeyPatch) -> None:
         """

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -30,7 +30,7 @@ from sqlmodel import Session, select
 from main import app, tracker_service_error_handler
 from tests.unit.utils.task_execution_support import MockKicker
 from tests.utils import TEST_ORG_ID, async_iterator
-from tracker.auth import RequestIdentity, get_current_starter
+from tracker.auth import RequestIdentity, get_current_org, get_current_starter
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -83,6 +83,103 @@ class TestTrackerAPI:
         assert response.status_code == 200
 
         assert response.json() == {"status": "ok"}
+
+    @pytest.mark.parametrize("concurrency", [0, -1, 1.5, "2", True])
+    def test_update_benchmark_concurrency_rejects_non_positive_or_non_integer_values(
+        self,
+        concurrency: object,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        response = client.patch(
+            f"/benchmarks/{example_benchmark_object.id}/concurrency",
+            json={"concurrency": concurrency},
+        )
+
+        assert response.status_code == 422
+        database_session.refresh(example_benchmark_object)
+        assert example_benchmark_object.arguments.concurrency == 5
+
+    def test_update_benchmark_concurrency_persists_full_arguments_and_is_idempotent(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        original_arguments = example_benchmark_object.arguments
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        first_response = client.patch(
+            f"/benchmarks/{example_benchmark_object.id}/concurrency",
+            json={"concurrency": 9},
+        )
+        retry_response = client.patch(
+            f"/benchmarks/{example_benchmark_object.id}/concurrency",
+            json={"concurrency": 9},
+        )
+
+        expected_response = {
+            "benchmark_id": str(example_benchmark_object.id),
+            "status": BenchmarkStatus.IN_PROGRESS.value,
+            "concurrency": 9,
+        }
+        assert first_response.status_code == 200
+        assert first_response.json() == expected_response
+        assert retry_response.status_code == 200
+        assert retry_response.json() == expected_response
+
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, example_benchmark_object.id)
+        assert persisted is not None
+        assert persisted.arguments == original_arguments.model_copy(update={"concurrency": 9})
+
+    def test_update_benchmark_concurrency_hides_missing_and_other_org_runs(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+        missing_response = client.patch(
+            f"/benchmarks/{uuid4()}/concurrency",
+            json={"concurrency": 9},
+        )
+        other_org = Org(id=uuid4(), name="other")
+        monkeypatch.setitem(app.dependency_overrides, get_current_org, lambda: other_org)
+
+        response = client.patch(
+            f"/benchmarks/{example_benchmark_object.id}/concurrency",
+            json={"concurrency": 9},
+        )
+
+        assert missing_response.status_code == 404
+        assert missing_response.json() == {"detail": "Not found"}
+        assert response.status_code == 404
+        assert response.json() == {"detail": "Not found"}
+        database_session.refresh(example_benchmark_object)
+        assert example_benchmark_object.arguments.concurrency == 5
+
+    def test_update_benchmark_concurrency_rejects_non_active_run(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        example_benchmark_object.status = BenchmarkStatus.STOPPED
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        response = client.patch(
+            f"/benchmarks/{example_benchmark_object.id}/concurrency",
+            json={"concurrency": 9},
+        )
+
+        assert response.status_code == 409
+        database_session.refresh(example_benchmark_object)
+        assert example_benchmark_object.arguments.concurrency == 5
 
     def test_trailing_slash_does_not_redirect(self, monkeypatch: MonkeyPatch) -> None:
         """

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -128,6 +128,70 @@ class TestRunRecovery:
 
         assert observed_limits == [2]
 
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_process_benchmark_refreshes_shared_limiter_to_admit_waiting_task(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        task_ids = ["task_0", "task_1"]
+        request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=1,
+            task_ids=task_ids,
+            harness_config=harness_config,
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(request, self._test_starter)
+        database_session.add(benchmark_row)
+        database_session.commit()
+        admitted_task_ids: list[str] = []
+        first_admitted = asyncio.Event()
+        release_first = asyncio.Event()
+        second_admitted = asyncio.Event()
+        sandbox_count = 0
+
+        @asynccontextmanager
+        async def unique_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            nonlocal sandbox_count
+            sandbox_count += 1
+            sandbox = AsyncMock()
+            sandbox.id = f"mock-sandbox-id-{sandbox_count}"
+            yield sandbox
+
+        async def controlled_retrieve_task(*_args: Any, task_id: str, **_kwargs: Any) -> RetrieveTaskResponse:
+            admitted_task_ids.append(task_id)
+            if len(admitted_task_ids) == 1:
+                first_admitted.set()
+                await release_first.wait()
+            else:
+                second_admitted.set()
+            return make_retrieve_task_response()
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", controlled_retrieve_task)
+        monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", unique_sandbox)
+
+        process_future = asyncio.create_task(
+            process_benchmark(
+                start_benchmark_request_json=request.model_dump(),
+                benchmark_id_str=str(benchmark_row.id),
+                verified_task_ids=task_ids,
+            )
+        )
+        try:
+            await asyncio.wait_for(first_admitted.wait(), timeout=2)
+            benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": 2})
+            database_session.add(benchmark_row)
+            database_session.commit()
+            await asyncio.wait_for(second_admitted.wait(), timeout=2)
+        finally:
+            release_first.set()
+            await asyncio.wait_for(process_future, timeout=5)
+
+        assert admitted_task_ids == task_ids
+
     async def test_stop_selected_tasks_scopes_graceful_and_force(
         self,
         example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -42,6 +42,7 @@ from tracker.database.models import (
 )
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import (
+    ResizableLimiter,
     TaskMonitor,
     TrackedTask,
     TrackedTaskStatus,
@@ -90,6 +91,41 @@ class TestRunRecovery:
 
     _test_org = Org(id=TEST_ORG_ID, name="default")
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_process_benchmark_initializes_limiter_from_persisted_concurrency(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        request = StartBenchmarkRequest(
+            benchmark_name="swebench",
+            contract=contract,
+            concurrency=7,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(request, self._test_starter)
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": 2})
+        database_session.add(benchmark_row)
+        database_session.commit()
+        observed_limits: list[int] = []
+
+        def recording_limiter(limit: int) -> ResizableLimiter:
+            observed_limits.append(limit)
+            return ResizableLimiter(limit)
+
+        monkeypatch.setattr("tracker.utils.run_orchestration.ResizableLimiter", recording_limiter)
+
+        await process_benchmark(
+            start_benchmark_request_json=request.model_dump(),
+            benchmark_id_str=str(benchmark_row.id),
+            verified_task_ids=["task_0"],
+        )
+
+        assert observed_limits == [2]
 
     async def test_stop_selected_tasks_scopes_graceful_and_force(
         self,
@@ -1121,6 +1157,31 @@ class TestRunRecovery:
 
         task_row = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).one()
         assert task_row.status == TaskStatus.ERROR
+
+    async def test_running_resume_updates_concurrency_without_enqueuing_work(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        def _unexpected_kicker() -> None:
+            raise AssertionError("updating active-run concurrency should not enqueue duplicate work")
+
+        monkeypatch.setattr("main.process_benchmark.kicker", _unexpected_kicker)
+
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?concurrency=8")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "success"}
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted is not None
+        assert persisted.arguments.concurrency == 8
 
     async def test_running_retry_only_resets_error_tasks(
         self,

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -94,42 +94,7 @@ class TestRunRecovery:
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
 
     @pytest.mark.usefixtures("process_benchmark_env")
-    async def test_process_benchmark_initializes_limiter_from_persisted_concurrency(
-        self,
-        contract: AgentContractRequest,
-        database_session: Session,
-        harness_config: HarnessConfig,
-        monkeypatch: MonkeyPatch,
-    ) -> None:
-        request = StartBenchmarkRequest(
-            benchmark_name="swebench",
-            contract=contract,
-            concurrency=7,
-            task_ids=["task_0"],
-            harness_config=harness_config,
-        )
-        benchmark_row = start_benchmark_request_to_benchmark(request, self._test_starter)
-        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": 2})
-        database_session.add(benchmark_row)
-        database_session.commit()
-        observed_limits: list[int] = []
-
-        def recording_limiter(limit: int) -> ResizableLimiter:
-            observed_limits.append(limit)
-            return ResizableLimiter(limit)
-
-        monkeypatch.setattr("tracker.utils.run_orchestration.ResizableLimiter", recording_limiter)
-
-        await process_benchmark(
-            start_benchmark_request_json=request.model_dump(),
-            benchmark_id_str=str(benchmark_row.id),
-            verified_task_ids=["task_0"],
-        )
-
-        assert observed_limits == [2]
-
-    @pytest.mark.usefixtures("process_benchmark_env")
-    async def test_process_benchmark_refreshes_shared_limiter_to_admit_waiting_task(
+    async def test_process_benchmark_uses_persisted_and_refreshed_concurrency(
         self,
         contract: AgentContractRequest,
         database_session: Session,
@@ -140,11 +105,12 @@ class TestRunRecovery:
         request = StartBenchmarkRequest(
             benchmark_name="swebench",
             contract=contract,
-            concurrency=1,
+            concurrency=7,
             task_ids=task_ids,
             harness_config=harness_config,
         )
         benchmark_row = start_benchmark_request_to_benchmark(request, self._test_starter)
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": 1})
         database_session.add(benchmark_row)
         database_session.commit()
         admitted_task_ids: list[str] = []
@@ -1454,7 +1420,12 @@ class TestRunRecovery:
         cancel_mock.side_effect = _cancel
         setattr(tracked_task, "_task", Mock(cancel=cancel_mock, done=lambda: False))
 
-        monitor = TaskMonitor(benchmark_row.id, {task_row.task_id: tracked_task}, org=self._test_org)
+        monitor = TaskMonitor(
+            benchmark_row.id,
+            {task_row.task_id: tracked_task},
+            org=self._test_org,
+            limiter=ResizableLimiter(limit=1),
+        )
         setattr(monitor, "_TRACK_INTERVAL", 0)
 
         await monitor.track_tasks()

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -53,6 +53,7 @@ from tracker.utils import (
     process_task,
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
+    update_benchmark_concurrency,
 )
 
 UTC = ZoneInfo("UTC")
@@ -1102,6 +1103,51 @@ class TestRunRecovery:
         }
         database_session.refresh(benchmark_row)
         assert benchmark_row.arguments.contract.secrets == queued_request["contract"]["secrets"]
+
+    async def test_retry_or_resume_secret_merge_preserves_concurrent_concurrency_update(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        benchmark_row.arguments.contract.secrets = {"ANTHROPIC_API_KEY": "old-secret"}
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        async def _concurrent_reset(*_args: Any, **_kwargs: Any) -> list[str]:
+            with Session(bind=database_session.get_bind()) as control_session:
+                persisted = control_session.get(Benchmark, benchmark_row.id)
+                assert persisted is not None
+                persisted.status = BenchmarkStatus.IN_PROGRESS
+                control_session.add(persisted)
+                control_session.commit()
+                update_benchmark_concurrency(benchmark_row.id, 9, control_session, self._test_org)
+            return ["task_0"]
+
+        monkeypatch.setattr("main.reset_to_in_progress_status", _concurrent_reset)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            json={
+                "task_ids": [],
+                "service_headers": {},
+                "secrets": {"ANTHROPIC_API_KEY": "new-secret"},
+            },
+        )
+
+        assert response.status_code == 200
+        queued_request = mock_kicker.queued_calls[0]["start_benchmark_request_json"]
+        assert queued_request["concurrency"] == 9
+        assert queued_request["contract"]["secrets"] == {"ANTHROPIC_API_KEY": "new-secret"}
+
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted is not None
+        assert persisted.arguments.concurrency == 9
+        assert persisted.arguments.contract.secrets == {"ANTHROPIC_API_KEY": "new-secret"}
 
     async def test_running_retry_noops_without_error_tasks(
         self,

--- a/services/tracker/tests/unit/utils/test_task_execution.py
+++ b/services/tracker/tests/unit/utils/test_task_execution.py
@@ -4,7 +4,6 @@ Run: uv run pytest tests/unit/utils/test_task_execution.py
 """
 
 import asyncio
-from asyncio import Semaphore
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
@@ -13,13 +12,104 @@ from sqlmodel import Session
 
 from tests.utils import TEST_ORG_ID
 from tracker.database.models import Benchmark, Org, Task, TaskStatus
-from tracker.utils import TaskMonitor, TrackedTask, TrackedTaskStatus
+from tracker.utils import ResizableLimiter, TaskMonitor, TrackedTask, TrackedTaskStatus
 
 
 class TestTaskExecution:
     """Task monitoring and tracked task state transitions."""
 
     _test_org = Org(id=TEST_ORG_ID, name="default")
+
+    async def test_resizable_limiter_increase_wakes_waiting_admission(self) -> None:
+        limiter = ResizableLimiter(limit=1)
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        second_started = asyncio.Event()
+
+        async def worker(started: asyncio.Event, release: asyncio.Event | None = None) -> None:
+            async with limiter:
+                started.set()
+                if release is not None:
+                    await release.wait()
+
+        first = asyncio.create_task(worker(first_started, release_first))
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        second = asyncio.create_task(worker(second_started))
+        await asyncio.sleep(0)
+        assert not second_started.is_set()
+
+        await limiter.resize(2)
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+
+        release_first.set()
+        await asyncio.gather(first, second)
+        assert limiter.in_flight == 0
+
+    async def test_resizable_limiter_decrease_is_non_preemptive(self) -> None:
+        limiter = ResizableLimiter(limit=2)
+        first_started = asyncio.Event()
+        second_started = asyncio.Event()
+        third_started = asyncio.Event()
+        release_first = asyncio.Event()
+        release_second = asyncio.Event()
+
+        async def worker(started: asyncio.Event, release: asyncio.Event | None = None) -> None:
+            async with limiter:
+                started.set()
+                if release is not None:
+                    await release.wait()
+
+        first = asyncio.create_task(worker(first_started, release_first))
+        second = asyncio.create_task(worker(second_started, release_second))
+        await asyncio.wait_for(first_started.wait(), timeout=1)
+        await asyncio.wait_for(second_started.wait(), timeout=1)
+
+        await limiter.resize(1)
+        third = asyncio.create_task(worker(third_started))
+        await asyncio.sleep(0)
+        assert limiter.in_flight == 2
+        assert not first.done()
+        assert not second.done()
+        assert not third_started.is_set()
+
+        release_first.set()
+        await first
+        await asyncio.sleep(0)
+        assert limiter.in_flight == 1
+        assert not third_started.is_set()
+
+        release_second.set()
+        await second
+        await asyncio.wait_for(third_started.wait(), timeout=1)
+        await third
+        assert limiter.in_flight == 0
+
+    async def test_task_monitor_refreshes_limiter_from_persisted_concurrency(
+        self,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        example_benchmark_object.arguments = example_benchmark_object.arguments.model_copy(update={"concurrency": 2})
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        tracked_task = TrackedTask(coro=asyncio.sleep(0), org=self._test_org)
+        setattr(tracked_task, "_status", TrackedTaskStatus.DONE)
+        limiter = ResizableLimiter(limit=5)
+        monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
+        monitor = TaskMonitor(
+            example_benchmark_object.id,
+            {"task_id_1": tracked_task},
+            org=self._test_org,
+            limiter=limiter,
+        )
+        monkeypatch.setattr(monitor, "_TRACK_INTERVAL", 0)
+
+        await monitor.track_tasks()
+
+        assert limiter.limit == 2
+        getattr(tracked_task, "_coro").close()
 
     async def test_task_monitor(
         self, database_session: Session, example_benchmark_object: Benchmark, monkeypatch: pytest.MonkeyPatch
@@ -104,7 +194,7 @@ class TestTaskExecution:
             await release.wait()
             return {task_id: {"result": task_id}}
 
-        semaphore = Semaphore(value=1)
+        limiter = ResizableLimiter(limit=1)
         running_started = asyncio.Event()
         release_running = asyncio.Event()
         waiting_started = asyncio.Event()
@@ -117,9 +207,9 @@ class TestTaskExecution:
         assert running.status == TrackedTaskStatus.WAITING
         assert running.task is None
 
-        running_call = asyncio.create_task(running.run(semaphore, running_row))
+        running_call = asyncio.create_task(running.run(limiter, running_row))
         await running_started.wait()
-        waiting_call = asyncio.create_task(waiting.run(semaphore, waiting_row))
+        waiting_call = asyncio.create_task(waiting.run(limiter, waiting_row))
         await asyncio.sleep(0)
 
         assert running.status == TrackedTaskStatus.RUNNING

--- a/services/tracker/tests/unit/utils/test_task_execution.py
+++ b/services/tracker/tests/unit/utils/test_task_execution.py
@@ -24,9 +24,16 @@ class TestTaskExecution:
         limiter = ResizableLimiter(limit=1)
         first_started = asyncio.Event()
         release_first = asyncio.Event()
+        second_attempted = asyncio.Event()
         second_started = asyncio.Event()
 
-        async def worker(started: asyncio.Event, release: asyncio.Event | None = None) -> None:
+        async def worker(
+            started: asyncio.Event,
+            release: asyncio.Event | None = None,
+            attempting: asyncio.Event | None = None,
+        ) -> None:
+            if attempting is not None:
+                attempting.set()
             async with limiter:
                 started.set()
                 if release is not None:
@@ -34,8 +41,8 @@ class TestTaskExecution:
 
         first = asyncio.create_task(worker(first_started, release_first))
         await asyncio.wait_for(first_started.wait(), timeout=1)
-        second = asyncio.create_task(worker(second_started))
-        await asyncio.sleep(0)
+        second = asyncio.create_task(worker(second_started, attempting=second_attempted))
+        await asyncio.wait_for(second_attempted.wait(), timeout=1)
         assert not second_started.is_set()
 
         await limiter.resize(2)
@@ -45,13 +52,29 @@ class TestTaskExecution:
         await asyncio.gather(first, second)
         assert limiter.in_flight == 0
 
-    async def test_resizable_limiter_decrease_is_non_preemptive(self) -> None:
+    async def test_resizable_limiter_decrease_is_non_preemptive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         limiter = ResizableLimiter(limit=2)
         first_started = asyncio.Event()
         second_started = asyncio.Event()
         third_started = asyncio.Event()
         release_first = asyncio.Event()
         release_second = asyncio.Event()
+        third_wait_attempted = asyncio.Event()
+        third_rewait_attempted = asyncio.Event()
+        condition = getattr(limiter, "_condition")
+        condition_wait = getattr(condition, "wait")
+        wait_attempts = 0
+
+        async def observed_condition_wait() -> bool:
+            nonlocal wait_attempts
+            wait_attempts += 1
+            if wait_attempts == 1:
+                third_wait_attempted.set()
+            elif wait_attempts == 2:
+                third_rewait_attempted.set()
+            return await condition_wait()
+
+        monkeypatch.setattr(condition, "wait", observed_condition_wait)
 
         async def worker(started: asyncio.Event, release: asyncio.Event | None = None) -> None:
             async with limiter:
@@ -66,7 +89,7 @@ class TestTaskExecution:
 
         await limiter.resize(1)
         third = asyncio.create_task(worker(third_started))
-        await asyncio.sleep(0)
+        await asyncio.wait_for(third_wait_attempted.wait(), timeout=1)
         assert limiter.in_flight == 2
         assert not first.done()
         assert not second.done()
@@ -74,7 +97,7 @@ class TestTaskExecution:
 
         release_first.set()
         await first
-        await asyncio.sleep(0)
+        await asyncio.wait_for(third_rewait_attempted.wait(), timeout=1)
         assert limiter.in_flight == 1
         assert not third_started.is_set()
 
@@ -197,6 +220,7 @@ class TestTaskExecution:
         limiter = ResizableLimiter(limit=1)
         running_started = asyncio.Event()
         release_running = asyncio.Event()
+        waiting_attempted = asyncio.Event()
         waiting_started = asyncio.Event()
         release_waiting = asyncio.Event()
         running_row = MagicMock(spec=Task, task_id="task_id_1")
@@ -209,8 +233,13 @@ class TestTaskExecution:
 
         running_call = asyncio.create_task(running.run(limiter, running_row))
         await running_started.wait()
-        waiting_call = asyncio.create_task(waiting.run(limiter, waiting_row))
-        await asyncio.sleep(0)
+
+        async def run_waiting() -> dict[str, dict[str, Any] | None]:
+            waiting_attempted.set()
+            return await waiting.run(limiter, waiting_row)
+
+        waiting_call = asyncio.create_task(run_waiting())
+        await waiting_attempted.wait()
 
         assert running.status == TrackedTaskStatus.RUNNING
         assert waiting.status == TrackedTaskStatus.WAITING

--- a/services/tracker/tests/unit/utils/test_task_execution.py
+++ b/services/tracker/tests/unit/utils/test_task_execution.py
@@ -50,7 +50,6 @@ class TestTaskExecution:
 
         release_first.set()
         await asyncio.gather(first, second)
-        assert limiter.in_flight == 0
 
     async def test_resizable_limiter_decrease_is_non_preemptive(self, monkeypatch: pytest.MonkeyPatch) -> None:
         limiter = ResizableLimiter(limit=2)
@@ -90,7 +89,6 @@ class TestTaskExecution:
         await limiter.resize(1)
         third = asyncio.create_task(worker(third_started))
         await asyncio.wait_for(third_wait_attempted.wait(), timeout=1)
-        assert limiter.in_flight == 2
         assert not first.done()
         assert not second.done()
         assert not third_started.is_set()
@@ -98,41 +96,12 @@ class TestTaskExecution:
         release_first.set()
         await first
         await asyncio.wait_for(third_rewait_attempted.wait(), timeout=1)
-        assert limiter.in_flight == 1
         assert not third_started.is_set()
 
         release_second.set()
         await second
         await asyncio.wait_for(third_started.wait(), timeout=1)
         await third
-        assert limiter.in_flight == 0
-
-    async def test_task_monitor_refreshes_limiter_from_persisted_concurrency(
-        self,
-        database_session: Session,
-        example_benchmark_object: Benchmark,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        example_benchmark_object.arguments = example_benchmark_object.arguments.model_copy(update={"concurrency": 2})
-        database_session.add(example_benchmark_object)
-        database_session.commit()
-
-        tracked_task = TrackedTask(coro=asyncio.sleep(0), org=self._test_org)
-        setattr(tracked_task, "_status", TrackedTaskStatus.DONE)
-        limiter = ResizableLimiter(limit=5)
-        monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
-        monitor = TaskMonitor(
-            example_benchmark_object.id,
-            {"task_id_1": tracked_task},
-            org=self._test_org,
-            limiter=limiter,
-        )
-        monkeypatch.setattr(monitor, "_TRACK_INTERVAL", 0)
-
-        await monitor.track_tasks()
-
-        assert limiter.limit == 2
-        getattr(tracked_task, "_coro").close()
 
     async def test_task_monitor(
         self, database_session: Session, example_benchmark_object: Benchmark, monkeypatch: pytest.MonkeyPatch
@@ -160,7 +129,12 @@ class TestTaskExecution:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monitor = TaskMonitor(benchmark_row.id, task_tracking.copy(), org=self._test_org)
+        monitor = TaskMonitor(
+            benchmark_row.id,
+            task_tracking.copy(),
+            org=self._test_org,
+            limiter=ResizableLimiter(limit=1),
+        )
         monkeypatch.setattr(monitor, "_TRACK_INTERVAL", 0)
 
         # Change task status to running and add a task to the object

--- a/src/valkyrie/cli/run/__init__.py
+++ b/src/valkyrie/cli/run/__init__.py
@@ -10,6 +10,7 @@ from valkyrie.cli.run.resume import resume, retry_command
 from valkyrie.cli.run.start import start
 from valkyrie.cli.run.status import status_runs
 from valkyrie.cli.run.stop import stop
+from valkyrie.cli.run.update import update
 
 
 @click.group()
@@ -30,6 +31,7 @@ run.add_command(retry_command)
 run.add_command(start)
 run.add_command(status_runs)
 run.add_command(stop)
+run.add_command(update)
 
 __all__ = [
     "list_runs",

--- a/src/valkyrie/cli/run/update.py
+++ b/src/valkyrie/cli/run/update.py
@@ -1,0 +1,31 @@
+"""Update live concurrency for an active benchmark run."""
+
+from uuid import UUID
+
+import click
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.tracker_client import TrackerService
+
+
+@click.command(
+    help=(
+        "Update concurrency for an active run. \n\n"
+        "Example:\nvalkyrie run update 123e4567-e89b-12d3-a456-426614174000 --concurrency 10"
+    )
+)
+@click.argument("run_id", type=UUID)
+@click.option(
+    "--concurrency",
+    type=click.IntRange(min=1),
+    required=True,
+    help="New maximum number of concurrent tasks",
+)
+def update(run_id: UUID, concurrency: int) -> None:
+    """Update the concurrency limit for an active run."""
+    try:
+        with TrackerService() as tracker:
+            response = tracker.update_benchmark_concurrency(run_id, concurrency)
+        click.echo(click.style(f"✓ Run concurrency updated to {response.concurrency}.", fg="green", bold=True))
+    except TrackerServiceError as e:
+        raise click.ClickException(str(e)) from e

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -31,6 +31,8 @@ from tracker.types import (
     S3UploadResultsResponse,
     StartBenchmarkRequest,
     StopBenchmarkResponse,
+    UpdateBenchmarkConcurrencyRequest,
+    UpdateBenchmarkConcurrencyResponse,
 )
 
 from valkyrie.cli.exceptions import TrackerNotFoundError, TrackerServiceError
@@ -645,6 +647,26 @@ class TrackerService:
             return _parse_model_response(response, "Failed to stop run", StopBenchmarkResponse)
         except httpx.HTTPError as e:
             raise TrackerServiceError(f"Failed to stop run: {e}") from e
+
+    def update_benchmark_concurrency(
+        self,
+        benchmark_id: UUID,
+        concurrency: int,
+    ) -> UpdateBenchmarkConcurrencyResponse:
+        """Update the concurrency limit for an active benchmark run."""
+        payload = UpdateBenchmarkConcurrencyRequest(concurrency=concurrency)
+        try:
+            response = self._client.patch(
+                f"{self._base_url}/benchmarks/{benchmark_id}/concurrency",
+                json=payload.model_dump(),
+            )
+            return _parse_model_response(
+                response,
+                "Failed to update run concurrency",
+                UpdateBenchmarkConcurrencyResponse,
+            )
+        except httpx.HTTPError as e:
+            raise TrackerServiceError(f"Failed to update run concurrency: {e}") from e
 
     def retry_or_resume_benchmark(
         self,

--- a/tests/contract/test_sdk_tracker_contract.py
+++ b/tests/contract/test_sdk_tracker_contract.py
@@ -179,6 +179,7 @@ MODEL_PAIRS = (
     (FetchBenchmarkMetadataResponse, SDKFetchBenchmarkMetadataResponse),
 )
 INTERNAL_ROUTES = {
+    ("/benchmarks/{benchmark_id}/concurrency", "patch"),
     ("/benchmarks/filter-options", "get"),
     ("/health", "get"),
     ("/init", "post"),

--- a/tests/integration/local/cli/test_write_commands.py
+++ b/tests/integration/local/cli/test_write_commands.py
@@ -47,6 +47,60 @@ def test_cli_stops_only_selected_pending_tasks(
     assert stored_run.status == BenchmarkStatus.IN_PROGRESS
 
 
+def test_cli_updates_active_run_concurrency_through_tracker(
+    cli_runner: CliRunner,
+    seeded_runs: tuple[Benchmark, Benchmark],
+    database_session: Session,
+) -> None:
+    """The public CLI must persist live concurrency through the production HTTP path.
+
+    Test cases:
+    - A live update travels through Click, the tracker client, and the FastAPI route.
+    - Repeating the same update is idempotent.
+    - A subsequent CLI read and direct database read return the new limit.
+    - Updating concurrency preserves the rest of the stored benchmark arguments.
+    """
+    running, _finished = seeded_runs
+    original_arguments = running.arguments
+
+    for _ in range(2):
+        result = cli_runner.invoke(cli, ["run", "update", str(running.id), "--concurrency", "4"])
+
+        assert result.exit_code == 0, result.output
+        assert result.output == "✓ Run concurrency updated to 4.\n"
+
+    fetch_result = cli_runner.invoke(cli, ["run", "fetch", str(running.id), "--format", "json"])
+
+    assert fetch_result.exit_code == 0, fetch_result.output
+    assert json.loads(fetch_result.output)["max_concurrency"] == 4
+
+    database_session.expire_all()
+    stored_run = database_session.get(Benchmark, running.id)
+    assert stored_run is not None
+    assert stored_run.arguments == original_arguments.model_copy(update={"concurrency": 4})
+
+
+def test_cli_rejects_concurrency_update_for_finished_run(
+    cli_runner: CliRunner,
+    seeded_runs: tuple[Benchmark, Benchmark],
+    database_session: Session,
+) -> None:
+    """A terminal run must reject updates without changing its stored arguments."""
+    _running, finished = seeded_runs
+    original_arguments = finished.arguments
+
+    result = cli_runner.invoke(cli, ["run", "update", str(finished.id), "--concurrency", "4"])
+
+    assert result.exit_code == 1
+    assert "Failed to update run concurrency" in result.output
+    assert "BenchmarkStatus.FINISHED" in result.output
+
+    database_session.expire_all()
+    stored_run = database_session.get(Benchmark, finished.id)
+    assert stored_run is not None
+    assert stored_run.arguments == original_arguments
+
+
 def test_cli_exports_tracker_results_without_private_contract_values(
     cli_runner: CliRunner,
     seeded_runs: tuple[Benchmark, Benchmark],

--- a/tests/unit/cli/run/test_update.py
+++ b/tests/unit/cli/run/test_update.py
@@ -1,12 +1,13 @@
 """Tests for updating live run concurrency.
 
 Run: uv run pytest tests/unit/cli/run/test_update.py
+
+Covers successful updates, CLI validation, and tracker errors.
 """
 
 from importlib import import_module
 from uuid import UUID
 
-import click
 import pytest
 from click.testing import CliRunner
 from tracker.database.models import BenchmarkStatus
@@ -18,7 +19,7 @@ from valkyrie.cli.run import run
 update_module = import_module("valkyrie.cli.run.update")
 
 
-class StubUpdateTracker:
+class MockUpdateTracker:
     """Record concurrency updates and return deterministic tracker results."""
 
     def __init__(
@@ -28,7 +29,7 @@ class StubUpdateTracker:
         self.response = response
         self.calls: list[tuple[UUID, int]] = []
 
-    def __enter__(self) -> "StubUpdateTracker":
+    def __enter__(self) -> "MockUpdateTracker":
         return self
 
     def __exit__(self, *_exc_info: object) -> None:
@@ -45,17 +46,13 @@ class StubUpdateTracker:
         return self.response
 
 
-def _require_update_command() -> click.Command:
-    command = run.commands.get("update")
-    assert command is not None, "run update command is not registered"
-    return command
-
-
-def test_update_uses_effective_tracker_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_update_uses_effective_tracker_concurrency(
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Print the effective concurrency returned by the tracker."""
-    _require_update_command()
     run_id = UUID("123e4567-e89b-12d3-a456-426614174000")
-    tracker = StubUpdateTracker(
+    tracker = MockUpdateTracker(
         UpdateBenchmarkConcurrencyResponse(
             benchmark_id=run_id,
             status=BenchmarkStatus.IN_PROGRESS,
@@ -64,7 +61,7 @@ def test_update_uses_effective_tracker_concurrency(monkeypatch: pytest.MonkeyPat
     )
     monkeypatch.setattr(update_module, "TrackerService", lambda: tracker)
 
-    result = CliRunner().invoke(run, ["update", str(run_id), "--concurrency", "9"])
+    result = cli_runner.invoke(run, ["update", str(run_id), "--concurrency", "9"])
 
     assert result.exit_code == 0, result.output
     assert tracker.calls == [(run_id, 9)]
@@ -72,19 +69,12 @@ def test_update_uses_effective_tracker_concurrency(monkeypatch: pytest.MonkeyPat
 
 
 @pytest.mark.parametrize("value", ["0", "-1", "1.5", "not-an-integer"])
-def test_update_rejects_non_positive_integer_before_tracker_construction(
-    monkeypatch: pytest.MonkeyPatch,
+def test_update_rejects_non_positive_integer(
+    cli_runner: CliRunner,
     value: str,
 ) -> None:
     """Reject invalid concurrency values before contacting the tracker."""
-    _require_update_command()
-
-    def unexpected_tracker() -> StubUpdateTracker:
-        raise AssertionError("invalid concurrency should not construct a tracker client")
-
-    monkeypatch.setattr(update_module, "TrackerService", unexpected_tracker)
-
-    result = CliRunner().invoke(
+    result = cli_runner.invoke(
         run,
         ["update", "123e4567-e89b-12d3-a456-426614174000", "--concurrency", value],
     )
@@ -93,13 +83,15 @@ def test_update_rejects_non_positive_integer_before_tracker_construction(
     assert "--concurrency" in result.output
 
 
-def test_update_surfaces_tracker_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_update_surfaces_tracker_error(
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Render tracker rejections as concise Click errors."""
-    _require_update_command()
-    tracker = StubUpdateTracker(TrackerServiceError("Run is not in progress."))
+    tracker = MockUpdateTracker(TrackerServiceError("Run is not in progress."))
     monkeypatch.setattr(update_module, "TrackerService", lambda: tracker)
 
-    result = CliRunner().invoke(
+    result = cli_runner.invoke(
         run,
         ["update", "123e4567-e89b-12d3-a456-426614174000", "--concurrency", "4"],
     )

--- a/tests/unit/cli/run/test_update.py
+++ b/tests/unit/cli/run/test_update.py
@@ -1,0 +1,108 @@
+"""Tests for updating live run concurrency.
+
+Run: uv run pytest tests/unit/cli/run/test_update.py
+"""
+
+from importlib import import_module
+from uuid import UUID
+
+import click
+import pytest
+from click.testing import CliRunner
+from tracker.database.models import BenchmarkStatus
+from tracker.types import UpdateBenchmarkConcurrencyResponse
+
+from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run import run
+
+update_module = import_module("valkyrie.cli.run.update")
+
+
+class StubUpdateTracker:
+    """Record concurrency updates and return deterministic tracker results."""
+
+    def __init__(
+        self,
+        response: UpdateBenchmarkConcurrencyResponse | TrackerServiceError,
+    ) -> None:
+        self.response = response
+        self.calls: list[tuple[UUID, int]] = []
+
+    def __enter__(self) -> "StubUpdateTracker":
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def update_benchmark_concurrency(
+        self,
+        run_id: UUID,
+        concurrency: int,
+    ) -> UpdateBenchmarkConcurrencyResponse:
+        self.calls.append((run_id, concurrency))
+        if isinstance(self.response, TrackerServiceError):
+            raise self.response
+        return self.response
+
+
+def _require_update_command() -> click.Command:
+    command = run.commands.get("update")
+    assert command is not None, "run update command is not registered"
+    return command
+
+
+def test_update_uses_effective_tracker_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Print the effective concurrency returned by the tracker."""
+    _require_update_command()
+    run_id = UUID("123e4567-e89b-12d3-a456-426614174000")
+    tracker = StubUpdateTracker(
+        UpdateBenchmarkConcurrencyResponse(
+            benchmark_id=run_id,
+            status=BenchmarkStatus.IN_PROGRESS,
+            concurrency=6,
+        )
+    )
+    monkeypatch.setattr(update_module, "TrackerService", lambda: tracker)
+
+    result = CliRunner().invoke(run, ["update", str(run_id), "--concurrency", "9"])
+
+    assert result.exit_code == 0, result.output
+    assert tracker.calls == [(run_id, 9)]
+    assert result.output == "✓ Run concurrency updated to 6.\n"
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "1.5", "not-an-integer"])
+def test_update_rejects_non_positive_integer_before_tracker_construction(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    """Reject invalid concurrency values before contacting the tracker."""
+    _require_update_command()
+
+    def unexpected_tracker() -> StubUpdateTracker:
+        raise AssertionError("invalid concurrency should not construct a tracker client")
+
+    monkeypatch.setattr(update_module, "TrackerService", unexpected_tracker)
+
+    result = CliRunner().invoke(
+        run,
+        ["update", "123e4567-e89b-12d3-a456-426614174000", "--concurrency", value],
+    )
+
+    assert result.exit_code == 2
+    assert "--concurrency" in result.output
+
+
+def test_update_surfaces_tracker_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Render tracker rejections as concise Click errors."""
+    _require_update_command()
+    tracker = StubUpdateTracker(TrackerServiceError("Run is not in progress."))
+    monkeypatch.setattr(update_module, "TrackerService", lambda: tracker)
+
+    result = CliRunner().invoke(
+        run,
+        ["update", "123e4567-e89b-12d3-a456-426614174000", "--concurrency", "4"],
+    )
+
+    assert result.exit_code == 1
+    assert result.output == "Error: Run is not in progress.\n"

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -407,6 +407,72 @@ def test_stop_benchmark_sends_task_selection(
     assert mock_client.json == {"task_ids": None}
 
 
+def test_update_benchmark_concurrency_uses_patch_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Send concurrency updates to the dedicated tracker endpoint."""
+    requests: list[httpx.Request] = []
+    run_id = UUID("123e4567-e89b-12d3-a456-426614174000")
+
+    def handle_request(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "benchmark_id": str(run_id),
+                "status": "IN_PROGRESS",
+                "concurrency": 9,
+            },
+        )
+
+    transport = httpx.MockTransport(handle_request)
+    original_client = httpx.Client
+
+    def build_client(
+        *,
+        timeout: float | httpx.Timeout | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Client:
+        return original_client(transport=transport, timeout=timeout, headers=headers)
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(_empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", _empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_client.httpx.Client", build_client)
+
+    response = TrackerService(base_url="http://tracker").update_benchmark_concurrency(run_id, 9)
+
+    assert len(requests) == 1
+    assert requests[0].method == "PATCH"
+    assert str(requests[0].url) == f"http://tracker/benchmarks/{run_id}/concurrency"
+    assert json.loads(requests[0].content) == {"concurrency": 9}
+    assert response.benchmark_id == run_id
+    assert response.concurrency == 9
+
+
+def test_update_benchmark_concurrency_surfaces_tracker_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Preserve the tracker's useful rejection detail for CLI callers."""
+    original_client = httpx.Client
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(409, json={"detail": "Run is currently in the FINISHED state."})
+    )
+
+    def build_client(
+        *,
+        timeout: float | httpx.Timeout | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Client:
+        return original_client(transport=transport, timeout=timeout, headers=headers)
+
+    monkeypatch.setattr(TrackerService, "_load_config", staticmethod(_empty_config))
+    monkeypatch.setattr(TrackerService, "parse_config_keys", _empty_config_keys)
+    monkeypatch.setattr("valkyrie.cli.tracker_client.httpx.Client", build_client)
+
+    tracker = TrackerService(base_url="http://tracker")
+    with pytest.raises(
+        TrackerServiceError,
+        match="Failed to update run concurrency: Run is currently in the FINISHED state",
+    ):
+        tracker.update_benchmark_concurrency(uuid4(), 9)
+
+
 def test_tracker_client_checks_health_on_context_entry(monkeypatch: pytest.MonkeyPatch) -> None:
     """Commands should fail before making tracker requests when the tracker is unhealthy.
 


### PR DESCRIPTION
## Summary

Adds live concurrency updates for in-progress Valkyrie runs without stopping or restarting them.

Operators can now run:

```bash
valkyrie run update <run-id> --concurrency <N>
```

Increases admit additional waiting tasks after the worker's next monitor refresh. Decreases preserve in-flight work and pause new admissions until usage falls below the new limit.

## Changes

- Added `PATCH /benchmarks/{benchmark_id}/concurrency` with:
  - strict positive-integer validation;
  - organization-scoped authorization;
  - row-locked, idempotent persistence;
  - `IN_PROGRESS`-only updates and deterministic `404`/`409` responses.
- Added a condition-based `ResizableLimiter` shared by task admission and the existing run monitor.
- Initialize concurrency from persisted benchmark arguments, so queued requests and worker restarts cannot restore stale values.
- Refresh persisted concurrency on the existing monitor interval without interrupting admitted tasks.
- Preserve concurrent concurrency updates when resume/retry secrets are merged into JSON-backed arguments.
- Apply `resume --concurrency N` to active runs without enqueuing duplicate work.
- Added the tracker client method and `valkyrie run update` CLI command.
- Added README usage and runtime-semantics documentation.
- Removed test-only limiter inspection hooks and duplicate TDD scaffolding after behavioral coverage was established.

## Runtime Notes

- No database migration or deployment configuration change is required.
- Tracker and worker should be deployed from the same revision.
- Enforcement is per `process_benchmark` executor. Overlapping active-retry executors may temporarily exceed the persisted aggregate value; strict distributed enforcement is outside this PR.

## Related Issues

- Related to [vals-ai/valkyrie-ticket-library#136](https://github.com/vals-ai/valkyrie-ticket-library/issues/136)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [x] Docs / config

## Testing

- [x] Added/updated unit tests
- [ ] Manually tested — Devin smoke test requested; results pending

Automated verification:

- Root CLI/local integration suite: `195 passed`
- Tracker unit/local integration suite: `391 passed`
- Root and tracker Ruff format/lint checks: passed
- Root and changed-tracker basedpyright checks: `0 errors, 0 warnings`

Coverage includes strict API validation, organization isolation, idempotency, terminal-state rejection, simultaneous update races, resume-secret merge preservation, persisted initialization, live increases, non-preemptive decreases, CLI validation, and error propagation.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->