### PR TITLE
change: drop account-id suffix from dev harness bucket name

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -32,7 +32,7 @@ tracker = TrackerStack(
     cluster=shared.cluster,
     namespace=shared.namespace,
     hosted_zone=shared.hosted_zone,
-    bucket=shared.bucket,
+    bucket_name=shared.bucket_name,
     redis_url=shared.redis_url,
     env=env,
 )
@@ -46,7 +46,7 @@ worker = WorkerStack(
     cluster=shared.cluster,
     namespace=shared.namespace,
     redis_url=shared.redis_url,
-    bucket=shared.bucket,
+    bucket_name=shared.bucket_name,
     database=tracker.database,
     db_credentials=tracker.db_credentials,
     tracker_service=tracker.tracker_fargate_service,

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -104,6 +104,7 @@ class SharedStack(Stack):
             )
 
         bucket_name = self.stage.phys(S3_BUCKET_NAME)
+        self.bucket_name = bucket_name
 
         self.bucket = aws_s3.Bucket(
             self,

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -104,8 +104,6 @@ class SharedStack(Stack):
             )
 
         bucket_name = self.stage.phys(S3_BUCKET_NAME)
-        if not self.stage.is_prod:
-            bucket_name = f"{bucket_name}-{self.account}"
 
         self.bucket = aws_s3.Bucket(
             self,

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -88,7 +88,7 @@ def dev_tracker_template() -> assertions.Template:
         cluster=shared.cluster,
         namespace=shared.namespace,
         hosted_zone=shared.hosted_zone,
-        bucket=shared.bucket,
+        bucket_name=shared.bucket_name,
         redis_url=shared.redis_url,
         env=TEST_ENV,
     )

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -110,7 +110,7 @@ def ssm_parameter_id(template: Mapping[str, object], parameter_name: str) -> str
 
 
 class DevAccountInfrastructureTest(unittest.TestCase):
-    def test_dev_bucket_is_account_qualified_and_hardened(self) -> None:
+    def test_dev_bucket_is_named_and_hardened(self) -> None:
         _, shared = dev_shared_stack()
         shared_template = assertions.Template.from_stack(shared)
 
@@ -119,7 +119,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         bucket = next(iter(buckets.values()))
         self.assertEqual(bucket["DeletionPolicy"], "Retain")
         self.assertEqual(bucket["UpdateReplacePolicy"], "Retain")
-        self.assertEqual(bucket["Properties"]["BucketName"], f"agentic-harness-dev-{TEST_ACCOUNT}")
+        self.assertEqual(bucket["Properties"]["BucketName"], "agentic-harness-dev")
         self.assertEqual(
             bucket["Properties"]["PublicAccessBlockConfiguration"],
             {

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -159,7 +159,7 @@ def _service_templates(stage_name: str) -> tuple[assertions.Template, assertions
         cluster=shared.cluster,
         namespace=shared.namespace,
         hosted_zone=shared.hosted_zone,
-        bucket=shared.bucket,
+        bucket_name=shared.bucket_name,
         redis_url=shared.redis_url,
         env=env,
     )
@@ -171,7 +171,7 @@ def _service_templates(stage_name: str) -> tuple[assertions.Template, assertions
         cluster=shared.cluster,
         namespace=shared.namespace,
         redis_url=shared.redis_url,
-        bucket=shared.bucket,
+        bucket_name=shared.bucket_name,
         database=tracker.database,
         db_credentials=tracker.db_credentials,
         tracker_service=tracker.tracker_fargate_service,

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -15,7 +15,6 @@ from aws_cdk import (
     aws_logs,
     aws_rds,
     aws_route53,
-    aws_s3,
     aws_secretsmanager,
     aws_servicediscovery,
     aws_ssm,
@@ -70,7 +69,7 @@ class TrackerStack(Stack):
         cluster: aws_ecs.ICluster,
         namespace: aws_servicediscovery.IPrivateDnsNamespace,
         hosted_zone: aws_route53.IHostedZone | None,
-        bucket: aws_s3.IBucket,
+        bucket_name: str,
         redis_url: str,
         **kwargs: Any,
     ):
@@ -87,7 +86,7 @@ class TrackerStack(Stack):
         # Shared environment variables
         shared_env = {
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
-            "AWS_S3_BUCKET": bucket.bucket_name,
+            "AWS_S3_BUCKET": bucket_name,
             "ENVIRONMENT": stage_config.runtime_environment,
             "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",

--- a/infra/worker_stack.py
+++ b/infra/worker_stack.py
@@ -16,7 +16,6 @@ from aws_cdk import (
     aws_iam,
     aws_logs,
     aws_rds,
-    aws_s3,
     aws_secretsmanager,
     aws_servicediscovery,
 )
@@ -59,7 +58,7 @@ class WorkerStack(Stack):
         cluster: aws_ecs.ICluster,
         namespace: aws_servicediscovery.IPrivateDnsNamespace,
         redis_url: str,
-        bucket: aws_s3.IBucket,
+        bucket_name: str,
         database: aws_rds.DatabaseInstance,
         db_credentials: aws_rds.DatabaseSecret,
         tracker_service: aws_ecs.FargateService,
@@ -80,7 +79,7 @@ class WorkerStack(Stack):
 
         shared_env = {
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
-            "AWS_S3_BUCKET": bucket.bucket_name,
+            "AWS_S3_BUCKET": bucket_name,
             "ENVIRONMENT": stage_config.runtime_environment,
             "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",


### PR DESCRIPTION
## Why

The dev agentic-harness S3 bucket was named `agentic-harness-dev-<account-id>` (e.g. `agentic-harness-dev-533328366429`). The account ID was there for global-uniqueness, but the account ID and the `-dev` suffix are redundant for that purpose — a single dev-account name is enough and far easier to reference in config. Prod is unchanged (`agentic-harness`).

## What changed

- `infra/shared.py` — dev bucket name is now `agentic-harness-dev` (dropped the `-<account>` suffix). Prod path untouched.
- `infra/tests/test_dev_account.py` — assertion + test name updated to match.

## How to review

The change only touches the non-prod branch of the name derivation; the prod bucket name (`agentic-harness`) is byte-identical. Note the operational consequence for whoever deploys: a bucket-name change forces replacement, and the bucket is `RemovalPolicy.RETAIN`, so the existing `agentic-harness-dev-<account>` bucket is orphaned (retained, not deleted) and a fresh empty `agentic-harness-dev` is created — the agent upload and any prior run outputs must be re-uploaded/repointed.

## Verification

`uv run ruff check` clean; `python -m unittest tests.test_dev_account` — 5 passed.