### PR TITLE
Fix connected runs during task discovery

### DIFF
--- a/services/tracker/src/tracker/utils/reporting.py
+++ b/services/tracker/src/tracker/utils/reporting.py
@@ -30,7 +30,6 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.database.scoping import scoped_select
-from tracker.exceptions import TrackerServiceError
 from tracker.logging import get_logger
 from tracker.types import (
     AverageTaskBreakdown,
@@ -112,11 +111,6 @@ class BenchmarkContext:
         )
 
         result = self._session.exec(statement).all()
-
-        if not result:
-            raise TrackerServiceError(
-                f"No tasks have been discovered for run {self._benchmark_row.id}, cannot provide task breakdown"
-            )
 
         return {TaskStatus(status): count for status, count in result}
 

--- a/services/tracker/tests/integration/local/api/test_single_benchmark.py
+++ b/services/tracker/tests/integration/local/api/test_single_benchmark.py
@@ -6,11 +6,13 @@ Exercise single-benchmark routes through the real app and local database.
 import json
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from tests.factories import make_benchmark, make_task
 from tracker.database.models import (
+    Benchmark,
     BenchmarkStatus,
     ErrorResult,
     FinalEvaluation,
@@ -68,6 +70,52 @@ class TestSingleBenchmark:
 
 class TestBenchmarkStatusStream:
     """Single-benchmark status streaming."""
+
+    def test_stream_survives_task_discovery_transition(
+        self,
+        client: TestClient,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An active run must remain streamable while its task rows are being discovered.
+
+        Test cases:
+        - The first status event reports a valid empty task breakdown.
+        - A later poll reports the discovered task and completes normally.
+        """
+        benchmark = make_benchmark(name="discovering-benchmark", session=database_session)
+
+        async def finish_task_discovery(_seconds: float) -> None:
+            with Session(bind=database_session.bind) as poll_session:
+                persisted_benchmark = poll_session.get(Benchmark, benchmark.id)
+                assert persisted_benchmark is not None
+
+                persisted_benchmark.status = BenchmarkStatus.FINISHED
+                persisted_benchmark.finished_at = persisted_benchmark.started_at
+                poll_session.add(make_task(persisted_benchmark, "discovered-task", status=TaskStatus.FINISHED))
+                poll_session.add(persisted_benchmark)
+                poll_session.commit()
+
+        monkeypatch.setattr("tracker.utils.reporting.asyncio.sleep", finish_task_discovery)
+
+        with client.stream(
+            "GET",
+            "/fetch-benchmark",
+            params={"benchmark_id": str(benchmark.id), "connect": "true"},
+            headers={"Authorization": "Bearer fake"},
+        ) as response:
+            event_lines = [line for line in response.iter_lines() if line]
+
+        assert response.status_code == 200
+        assert event_lines[-1] == "event: complete"
+
+        streamed_statuses = [
+            json.loads(line.removeprefix("data: ")) for line in event_lines if line.startswith("data:")
+        ]
+        assert streamed_statuses[0]["details"]["total_tasks"] == 0
+        assert streamed_statuses[0]["details"]["finished_tasks"] == 0
+        assert streamed_statuses[0]["details"]["task_breakdown"] == {}
+        assert streamed_statuses[1]["details"]["task_breakdown"] == {"FINISHED": 1}
 
     def test_terminal_benchmark_streams_status_and_completes(
         self,

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -568,6 +568,7 @@ class TestTrackerAPI:
         Test Cases:
             - Returns 200 OK
             - Raising exception if benchmark row is not found
+            - Existing benchmark without discovered tasks returns empty progress
             - Benchmark details are returned in the response
             - Benchmark details are updated as benchmark progresses
         """
@@ -582,6 +583,17 @@ class TestTrackerAPI:
 
         database_session.add(benchmark_row)
         database_session.commit()
+
+        # Fetch during the interval between benchmark creation and task discovery.
+        query_params = {"benchmark_id": str(benchmark_row.id)}
+        response = client.get("/fetch-benchmark", params=query_params)
+
+        assert response.status_code == 200
+
+        details = response.json()["details"]
+        assert details["total_tasks"] == 0
+        assert details["finished_tasks"] == 0
+        assert details["task_breakdown"] == {}
 
         # Push some task rows that we can use to check the progress of the benchmark
         task_rows = [Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id) for i in range(10)]

--- a/src/valkyrie/cli/run/progress.py
+++ b/src/valkyrie/cli/run/progress.py
@@ -189,7 +189,6 @@ def stream_benchmark_status(
                     continue
 
                 details = response.details
-
                 bar, progress_pct = BenchmarkFormatter.create_progress_bar(details.finished_tasks, details.total_tasks)
                 status_color = BenchmarkFormatter.STATUS_COLORS[details.status.value]
                 status_text = click.style(details.status.value.replace("_", " ").title(), fg=status_color, bold=True)
@@ -202,11 +201,15 @@ def stream_benchmark_status(
                 click.echo(f"\033[F\033[K{progress_line}\n\033[K{breakdown_text}", nl=False)
 
             elif event.startswith("event: complete"):
+                completion_event = _completion_event(latest)
                 if output_format == "jsonl":
-                    click.echo(format_run_snapshot_json(latest, metadata, event=_completion_event(latest)))
+                    click.echo(format_run_snapshot_json(latest, metadata, event=completion_event))
                 else:
                     click.echo("\n")
-                    click.echo(click.style("✓ Run completed!", fg="green", bold=True))
+                    if completion_event == "error":
+                        click.echo(click.style("✗ Run errored.", fg="red", bold=True))
+                    else:
+                        click.echo(click.style("✓ Run completed!", fg="green", bold=True))
                     click.echo("┌─ Next Steps " + "─" * 66)
                     _stream_next_steps(benchmark_id, s3_url)
                 break

--- a/tests/unit/cli/run/test_output_helpers.py
+++ b/tests/unit/cli/run/test_output_helpers.py
@@ -6,6 +6,7 @@ Run: uv run pytest tests/unit/cli/run/test_output_helpers.py
 import io
 import tarfile
 import tempfile
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from importlib import import_module
 from pathlib import Path
@@ -41,9 +42,11 @@ class StubProgressTracker:
         self,
         response: FetchBenchmarkResponse,
         metadata: FetchBenchmarkMetadataResponse | TrackerServiceError,
+        stream_events: tuple[str, ...] = ("event: disconnect",),
     ) -> None:
         self.response = response
         self.metadata = metadata
+        self.stream_events = stream_events
         self.metadata_calls = 0
 
     def fetch_benchmark(self, _run_id: UUID) -> FetchBenchmarkResponse:
@@ -55,8 +58,8 @@ class StubProgressTracker:
             raise self.metadata
         return self.metadata
 
-    def stream_benchmark(self, _run_id: UUID):
-        yield "event: disconnect"
+    def stream_benchmark(self, _run_id: UUID) -> Iterator[str]:
+        yield from self.stream_events
 
 
 def test_format_benchmark_status_prints_final_score(capsys: pytest.CaptureFixture[str]) -> None:
@@ -133,6 +136,54 @@ def test_shared_connected_stream_omits_identity_by_default(capsys: pytest.Captur
     output = capsys.readouterr().out
     assert "Run Details" not in output
     assert tracker.metadata_calls == 0
+
+
+def test_connected_stream_surfaces_zero_task_terminal_error(capsys: pytest.CaptureFixture[str]) -> None:
+    """A persistent discovery interval must still expose the run's terminal error state.
+
+    Test cases:
+    - Repeated zero-task snapshots remain valid progress data.
+    - The terminal event is rendered as an errored run rather than successful completion.
+    """
+    run_id = uuid4()
+    initial_response = FetchBenchmarkResponse(
+        benchmark_name="swebench",
+        benchmark_id=run_id,
+        details=BenchmarkDetails(
+            status=BenchmarkStatus.IN_PROGRESS,
+            started_at=datetime(2026, 6, 24, tzinfo=timezone.utc),
+            total_tasks=0,
+            finished_tasks=0,
+            task_breakdown={},
+            docent_reading_status=DocentReadingStatus.IDLE,
+        ),
+        s3_bucket_url="https://example.com/run",
+    )
+    error_response = FetchBenchmarkResponse(
+        benchmark_name="swebench",
+        benchmark_id=run_id,
+        details=BenchmarkDetails(
+            status=BenchmarkStatus.ERROR,
+            started_at=datetime(2026, 6, 24, tzinfo=timezone.utc),
+            total_tasks=0,
+            finished_tasks=0,
+            task_breakdown={},
+            docent_reading_status=DocentReadingStatus.IDLE,
+        ),
+        s3_bucket_url="https://example.com/run",
+    )
+    tracker = StubProgressTracker(
+        initial_response,
+        make_fetch_metadata(run_id),
+        (f"data: {error_response.model_dump_json()}", "event: complete"),
+    )
+
+    stream_benchmark_status(cast(TrackerService, tracker), run_id)
+
+    output = capsys.readouterr().out
+    assert "0/0 (0.0%)" in output
+    assert "Run errored" in output
+    assert "Run completed" not in output
 
 
 def test_fetch_connect_enables_identity_header(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -15,9 +15,11 @@ import httpx
 import pytest
 from click.testing import CliRunner, Result
 from tracker.agent.schemas import AgentConfig
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, BenchmarkStatus, DocentReadingStatus, TaskStatus
+from tracker.types import BenchmarkDetails, FetchBenchmarkResponse
 
 from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run.progress import stream_benchmark_status
 
 start_module = import_module("valkyrie.cli.run.start")
 start_command = start_module.start
@@ -42,6 +44,29 @@ def _start_response(run_id: UUID) -> httpx.Response:
             "cloudwatch_url": f"https://cloudwatch.example/{run_id}",
             "s3_bucket_url": f"s3://runs/{run_id}",
         },
+    )
+
+
+def _benchmark_response(
+    run_id: UUID,
+    *,
+    status: BenchmarkStatus,
+    total_tasks: int,
+    finished_tasks: int,
+    task_breakdown: dict[TaskStatus, int],
+) -> FetchBenchmarkResponse:
+    return FetchBenchmarkResponse(
+        benchmark_name="swebench",
+        benchmark_id=run_id,
+        details=BenchmarkDetails(
+            status=status,
+            started_at=_STARTED_AT,
+            total_tasks=total_tasks,
+            finished_tasks=finished_tasks,
+            task_breakdown=task_breakdown,
+            docent_reading_status=DocentReadingStatus.IDLE,
+        ),
+        s3_bucket_url=f"s3://runs/{run_id}",
     )
 
 
@@ -132,6 +157,57 @@ class TestCountedStarts:
 
         assert connected_result.exit_code == 0, connected_result.output
         start_testbed.stream_status.assert_called_once_with(start_testbed.tracker, _FIRST_RUN_ID)
+
+    def test_connected_start_survives_task_discovery(
+        self,
+        start_testbed: StartTestbed,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A confirmed start must stay connected while task rows are being discovered.
+
+        Test cases:
+        - The initial empty status is rendered as task discovery without losing the run ID.
+        - Later task progress and terminal completion are consumed from the same stream.
+        """
+        initial_response = _benchmark_response(
+            _FIRST_RUN_ID,
+            status=BenchmarkStatus.IN_PROGRESS,
+            total_tasks=0,
+            finished_tasks=0,
+            task_breakdown={},
+        )
+        discovered_response = _benchmark_response(
+            _FIRST_RUN_ID,
+            status=BenchmarkStatus.IN_PROGRESS,
+            total_tasks=2,
+            finished_tasks=0,
+            task_breakdown={TaskStatus.PENDING: 1, TaskStatus.BUILDING: 1},
+        )
+        completed_response = _benchmark_response(
+            _FIRST_RUN_ID,
+            status=BenchmarkStatus.FINISHED,
+            total_tasks=2,
+            finished_tasks=2,
+            task_breakdown={TaskStatus.FINISHED: 2},
+        )
+        start_testbed.tracker.fetch_benchmark.return_value = initial_response
+        start_testbed.tracker.stream_benchmark.return_value = iter(
+            [
+                f"data: {discovered_response.model_dump_json()}",
+                f"data: {completed_response.model_dump_json()}",
+                "event: complete",
+            ]
+        )
+        monkeypatch.setattr(start_module, "stream_benchmark_status", stream_benchmark_status)
+
+        result = start_testbed.invoke(["--connect"])
+
+        assert result.exit_code == 0, result.output
+        assert str(_FIRST_RUN_ID) in result.output
+        assert "0/0 (0.0%)" in result.output
+        assert "Pending: 1" in result.output
+        assert "Building: 1" in result.output
+        assert "2/2 (100.0%)" in result.output
 
     def test_counted_start_reuses_contract_and_reports_ids(
         self,

--- a/tests/unit/cli/test_tracker_http.py
+++ b/tests/unit/cli/test_tracker_http.py
@@ -97,6 +97,34 @@ class TestTrackerJsonEndpoints:
             ):
                 tracker.fetch_benchmark(_RUN_ID)
 
+    @pytest.mark.parametrize(
+        ("status_code", "detail"),
+        [(401, "invalid token"), (503, "tracker unavailable")],
+        ids=["authentication", "service"],
+    )
+    def test_status_requests_surface_non_ok_responses(
+        self,
+        status_code: int,
+        detail: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Connected status handling must not retry or hide non-transient tracker responses.
+
+        Test cases:
+        - Authentication failures surface from both fetch and stream requests.
+        - Service failures surface from both fetch and stream requests.
+        """
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code, json={"detail": detail}, request=request)
+
+        with _tracker_with_handler(monkeypatch, handle_request) as tracker:
+            with pytest.raises(TrackerServiceError, match=detail):
+                tracker.fetch_benchmark(_RUN_ID)
+
+            with pytest.raises(TrackerServiceError, match=detail):
+                list(tracker.stream_benchmark(_RUN_ID))
+
     def test_run_read_endpoints_parse_real_http_responses(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Run reads must preserve typed payloads, filters, and task selections over HTTP.
 


### PR DESCRIPTION
## Summary

- treat an existing run with no task rows as a valid zero-count, empty-breakdown tracker response
- keep `valk run start --connect` attached and display a task-discovery state until rows appear
- preserve terminal orchestration errors and non-transient tracker/auth failures
- add regression coverage for one-shot fetches, SSE polling, connected starts, persistent discovery, and HTTP errors

## Root cause

The start endpoint persisted and returned the benchmark before the background worker populated task rows. `BenchmarkContext._task_breakdown` raised `TrackerServiceError` when its grouped task query returned no rows, so both the immediate fetch and every SSE poll failed even though the run existed.

## Validation

- `uv run pytest tests/unit/cli/run/test_start.py tests/unit/cli/run/test_output_helpers.py tests/unit/cli/test_tracker_http.py -q` — 29 passed
- focused tracker fetch/SSE regressions — 10 passed
- Ruff format and lint checks passed
- root and targeted tracker basedpyright checks passed
- `git diff --check` passed

Closes #560