### PR TITLE
Fix connected runs during task discovery

### DIFF
--- a/services/tracker/src/tracker/utils/reporting.py
+++ b/services/tracker/src/tracker/utils/reporting.py
@@ -30,7 +30,6 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.database.scoping import scoped_select
-from tracker.exceptions import TrackerServiceError
 from tracker.logging import get_logger
 from tracker.types import (
     AverageTaskBreakdown,
@@ -112,11 +111,6 @@ class BenchmarkContext:
         )
 
         result = self._session.exec(statement).all()
-
-        if not result:
-            raise TrackerServiceError(
-                f"No tasks have been discovered for run {self._benchmark_row.id}, cannot provide task breakdown"
-            )
 
         return {TaskStatus(status): count for status, count in result}
 

--- a/services/tracker/tests/integration/local/api/test_single_benchmark.py
+++ b/services/tracker/tests/integration/local/api/test_single_benchmark.py
@@ -6,11 +6,13 @@ Exercise single-benchmark routes through the real app and local database.
 import json
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 from tests.factories import make_benchmark, make_task
 from tracker.database.models import (
+    Benchmark,
     BenchmarkStatus,
     ErrorResult,
     FinalEvaluation,
@@ -68,6 +70,50 @@ class TestSingleBenchmark:
 
 class TestBenchmarkStatusStream:
     """Single-benchmark status streaming."""
+
+    def test_stream_survives_task_discovery_transition(
+        self,
+        client: TestClient,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An active run must remain streamable while its task rows are being discovered.
+
+        Test cases:
+        - The first status event reports a valid empty task breakdown.
+        - A later poll reports the discovered task and completes normally.
+        """
+        benchmark = make_benchmark(name="discovering-benchmark", session=database_session)
+
+        async def finish_task_discovery(_seconds: float) -> None:
+            with Session(bind=database_session.bind) as poll_session:
+                persisted_benchmark = poll_session.get(Benchmark, benchmark.id)
+                assert persisted_benchmark is not None
+
+                persisted_benchmark.status = BenchmarkStatus.FINISHED
+                poll_session.add(make_task(persisted_benchmark, "discovered-task", status=TaskStatus.FINISHED))
+                poll_session.commit()
+
+        monkeypatch.setattr("tracker.utils.reporting.asyncio.sleep", finish_task_discovery)
+
+        with client.stream(
+            "GET",
+            "/fetch-benchmark",
+            params={"benchmark_id": str(benchmark.id), "connect": "true"},
+            headers={"Authorization": "Bearer fake"},
+        ) as response:
+            event_lines = [line for line in response.iter_lines() if line]
+
+        assert response.status_code == 200
+        assert event_lines[-1] == "event: complete"
+
+        streamed_statuses = [
+            json.loads(line.removeprefix("data: ")) for line in event_lines if line.startswith("data:")
+        ]
+        assert streamed_statuses[0]["details"]["total_tasks"] == 0
+        assert streamed_statuses[0]["details"]["finished_tasks"] == 0
+        assert streamed_statuses[0]["details"]["task_breakdown"] == {}
+        assert streamed_statuses[1]["details"]["task_breakdown"] == {"FINISHED": 1}
 
     def test_terminal_benchmark_streams_status_and_completes(
         self,

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -568,6 +568,7 @@ class TestTrackerAPI:
         Test Cases:
             - Returns 200 OK
             - Raising exception if benchmark row is not found
+            - Existing benchmark without discovered tasks returns empty progress
             - Benchmark details are returned in the response
             - Benchmark details are updated as benchmark progresses
             - Run-level errors are returned only after the benchmark reaches ERROR
@@ -583,6 +584,17 @@ class TestTrackerAPI:
 
         database_session.add(benchmark_row)
         database_session.commit()
+
+        # Fetch during the interval between benchmark creation and task discovery.
+        query_params = {"benchmark_id": str(benchmark_row.id)}
+        response = client.get("/fetch-benchmark", params=query_params)
+
+        assert response.status_code == 200
+
+        details = response.json()["details"]
+        assert details["total_tasks"] == 0
+        assert details["finished_tasks"] == 0
+        assert details["task_breakdown"] == {}
 
         # Push some task rows that we can use to check the progress of the benchmark
         task_rows = [Task(org_id=TEST_ORG_ID, task_id=f"task_{i}", benchmark=benchmark_row.id) for i in range(10)]

--- a/tests/unit/cli/factories.py
+++ b/tests/unit/cli/factories.py
@@ -17,7 +17,9 @@ def make_fetch_response(
     run_id: UUID,
     *,
     status: BenchmarkStatus = BenchmarkStatus.IN_PROGRESS,
+    total_tasks: int = 4,
     finished_tasks: int = 1,
+    task_breakdown: dict[TaskStatus, int] | None = None,
     final_score: float | None = None,
 ) -> FetchBenchmarkResponse:
     """Build a run response with configurable progress and terminal state."""
@@ -27,11 +29,13 @@ def make_fetch_response(
         details=BenchmarkDetails(
             status=status,
             started_at=datetime(2026, 7, 9, 12, 30, tzinfo=timezone.utc),
-            total_tasks=4,
+            total_tasks=total_tasks,
             finished_tasks=finished_tasks,
-            task_breakdown={
+            task_breakdown=task_breakdown
+            if task_breakdown is not None
+            else {
                 TaskStatus.FINISHED: finished_tasks,
-                TaskStatus.IN_PROGRESS: 4 - finished_tasks,
+                TaskStatus.IN_PROGRESS: total_tasks - finished_tasks,
             },
             docent_reading_status=DocentReadingStatus.IDLE,
         ),

--- a/tests/unit/cli/run/test_output_helpers.py
+++ b/tests/unit/cli/run/test_output_helpers.py
@@ -143,7 +143,7 @@ def test_connected_fetch_uses_terminal_error_status(capsys: pytest.CaptureFixtur
 
     Test cases:
     - A run that is already errored uses the normal fetch output without opening a stream.
-    - A live run whose completion event carries an error response prints the final error status.
+    - A live run remains connected through zero-task progress and prints its final error status.
     """
     run_id = uuid4()
     error_message = "No tasks were completed successfully. 1 distinct error:\n- 4/4 tasks: Secret error"
@@ -162,16 +162,26 @@ def test_connected_fetch_uses_terminal_error_status(capsys: pytest.CaptureFixtur
     assert f"Error: {error_message}" in terminal_output
     assert terminal_tracker.stream_calls == 0
 
+    zero_task_response = make_fetch_response(run_id, total_tasks=0, finished_tasks=0, task_breakdown={})
+    zero_task_error_response = make_fetch_response(
+        run_id,
+        status=BenchmarkStatus.ERROR,
+        total_tasks=0,
+        finished_tasks=0,
+        task_breakdown={},
+    ).model_copy(update={"error_message": error_message})
+
     # Live streams should trust the final payload status over the event name.
     live_tracker = StubProgressTracker(
-        make_fetch_response(run_id),
+        zero_task_response,
         make_fetch_metadata(run_id),
-        events=(f"data: {error_response.model_dump_json()}", "event: complete"),
+        events=(f"data: {zero_task_error_response.model_dump_json()}", "event: complete"),
     )
 
     stream_benchmark_status(cast(TrackerService, live_tracker), run_id, show_identity=True)
 
     live_output = capsys.readouterr().out
+    assert "0/0 (0.0%)" in live_output
     assert "✗ Run errored." in live_output
     assert "✓ Run completed!" not in live_output
     assert f"Error: {error_message}" in live_output

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -15,9 +15,12 @@ import httpx
 import pytest
 from click.testing import CliRunner, Result
 from tracker.agent.schemas import AgentConfig
-from tracker.database.models import AgentContractRequest
+from tracker.database.models import AgentContractRequest, BenchmarkStatus, TaskStatus
 
 from valkyrie.cli.exceptions import TrackerServiceError
+from valkyrie.cli.run.progress import stream_benchmark_status
+
+from tests.unit.cli.factories import make_fetch_response
 
 start_module = import_module("valkyrie.cli.run.start")
 start_command = start_module.start
@@ -132,6 +135,56 @@ class TestCountedStarts:
 
         assert connected_result.exit_code == 0, connected_result.output
         start_testbed.stream_status.assert_called_once_with(start_testbed.tracker, _FIRST_RUN_ID)
+
+    def test_connected_start_survives_task_discovery(
+        self,
+        start_testbed: StartTestbed,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A confirmed start must stay connected while task rows are being discovered.
+
+        Test cases:
+        - The initial empty status is rendered as task discovery without losing the run ID.
+        - Later task progress and terminal completion are consumed from the same stream.
+        """
+        initial_response = make_fetch_response(
+            _FIRST_RUN_ID,
+            status=BenchmarkStatus.IN_PROGRESS,
+            total_tasks=0,
+            finished_tasks=0,
+            task_breakdown={},
+        )
+        discovered_response = make_fetch_response(
+            _FIRST_RUN_ID,
+            status=BenchmarkStatus.IN_PROGRESS,
+            total_tasks=2,
+            finished_tasks=0,
+            task_breakdown={TaskStatus.PENDING: 1, TaskStatus.BUILDING: 1},
+        )
+        completed_response = make_fetch_response(
+            _FIRST_RUN_ID,
+            status=BenchmarkStatus.FINISHED,
+            total_tasks=2,
+            finished_tasks=2,
+            task_breakdown={TaskStatus.FINISHED: 2},
+        )
+        start_testbed.tracker.fetch_benchmark.return_value = initial_response
+        start_testbed.tracker.stream_benchmark.return_value = iter(
+            [
+                f"data: {discovered_response.model_dump_json()}",
+                f"data: {completed_response.model_dump_json()}",
+                "event: complete",
+            ]
+        )
+        monkeypatch.setattr(start_module, "stream_benchmark_status", stream_benchmark_status)
+
+        result = start_testbed.invoke(["--connect"])
+
+        assert result.exit_code == 0, result.output
+        assert str(_FIRST_RUN_ID) in result.output
+        assert "0/0 (0.0%)" in result.output
+        assert "Pending: 1" in result.output
+        assert "2/2 (100.0%)" in result.output
 
     def test_counted_start_reuses_contract_and_reports_ids(
         self,

--- a/tests/unit/cli/test_tracker_http.py
+++ b/tests/unit/cli/test_tracker_http.py
@@ -97,6 +97,34 @@ class TestTrackerJsonEndpoints:
             ):
                 tracker.fetch_benchmark(_RUN_ID)
 
+    @pytest.mark.parametrize(
+        ("status_code", "detail"),
+        [(401, "invalid token"), (400, "invalid status request")],
+        ids=["authentication", "request"],
+    )
+    def test_status_requests_surface_non_ok_responses(
+        self,
+        status_code: int,
+        detail: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Connected status handling must not hide non-retryable tracker responses.
+
+        Test cases:
+        - Authentication failures surface from both fetch and stream requests.
+        - Invalid requests surface from both fetch and stream requests.
+        """
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code, json={"detail": detail}, request=request)
+
+        with _tracker_with_handler(monkeypatch, handle_request) as tracker:
+            with pytest.raises(TrackerServiceError, match=detail):
+                tracker.fetch_benchmark(_RUN_ID)
+
+            with pytest.raises(TrackerServiceError, match=detail):
+                list(tracker.stream_benchmark(_RUN_ID))
+
     def test_run_read_endpoints_parse_real_http_responses(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Run reads must preserve typed payloads, filters, and task selections over HTTP.
 


### PR DESCRIPTION
## Summary

Fixes `valk run start --connect` exiting after a run is successfully created when task discovery has not populated task rows yet. Existing runs now return a valid zero-count status during that interval, allowing the connected CLI and tracker SSE stream to remain active until task discovery progresses or the run reaches a terminal state.

## Changes

- Return an empty task breakdown instead of raising when an existing run has no discovered task rows.
- Reuse the connected CLI's existing zero-count and terminal-error behavior without adding another retry layer.
- Add regression coverage for one-shot fetches, SSE transitions, connected starts, persistent discovery ending in error, and non-retryable HTTP failures.

## Related Issues

Closes #560

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] Manually tested

- Root `make test`: 201 passed
- Tracker `make test`: 407 passed
- Root and tracker Ruff format/lint checks passed
- Root basedpyright and focused changed-file tracker basedpyright checks passed
- `git diff --check` passed

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
