### PR TITLE
change: deploy dev automatically on push

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: Deploy to AWS
 
 on:
   push:
-    branches: [prod]
+    branches: [dev, prod]
 
   workflow_dispatch:
     inputs:
@@ -88,7 +88,7 @@ jobs:
           uv run cdk deploy --all -c stage=prod --require-approval never
 
   run-dev-operation:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev'
+    if: github.ref == 'refs/heads/dev' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-24.04-arm
     environment: dev
     env:
@@ -99,8 +99,9 @@ jobs:
       CDK_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       DESCOPE_PROJECT_ID: ${{ vars.DESCOPE_PROJECT_ID }}
       DEV_ACCOUNT_ID: ${{ vars.DEV_ACCOUNT_ID }}
-      OPERATION: ${{ inputs.operation }}
+      OPERATION: ${{ github.event_name == 'push' && 'deploy' || inputs.operation }}
       PRODUCTION_ACCOUNT_ID: "613431292675"
+      SCOPE: ${{ github.event_name == 'push' && 'all' || inputs.scope }}
       SENTRY_DSN_SECRET_NAME: ${{ vars.SENTRY_DSN_SECRET_NAME }}
 
     steps:
@@ -147,43 +148,43 @@ jobs:
           fi
 
       - name: Checkout code
-        if: inputs.operation != 'credentials-only'
+        if: env.OPERATION != 'credentials-only'
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        if: inputs.operation != 'credentials-only'
+        if: env.OPERATION != 'credentials-only'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
 
       - name: Setup Python
-        if: inputs.operation != 'credentials-only'
+        if: env.OPERATION != 'credentials-only'
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
       - name: Install uv
-        if: inputs.operation != 'credentials-only'
+        if: env.OPERATION != 'credentials-only'
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "infra/uv.lock"
 
       - name: Install CDK
-        if: inputs.operation != 'credentials-only'
+        if: env.OPERATION != 'credentials-only'
         run: npm install -g aws-cdk@2.1132.0
 
       - name: Install infra dependencies
-        if: inputs.operation != 'credentials-only'
+        if: env.OPERATION != 'credentials-only'
         working-directory: infra
         run: make install
 
       - name: Plan dev infrastructure
-        if: inputs.operation == 'plan'
+        if: env.OPERATION == 'plan'
         working-directory: infra
-        run: make plan STAGE=dev SCOPE=${{ inputs.scope }} DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"
+        run: make plan STAGE=dev SCOPE="$SCOPE" DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"
 
       - name: Deploy dev infrastructure
-        if: inputs.operation == 'deploy'
+        if: env.OPERATION == 'deploy'
         working-directory: infra
-        run: make deploy STAGE=dev SCOPE=${{ inputs.scope }} DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"
+        run: make deploy STAGE=dev SCOPE="$SCOPE" DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -7,14 +7,20 @@ WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "deploy.yaml"
 
 
 class DeployWorkflowTest(unittest.TestCase):
-    def test_dev_is_manual_protected_and_validated_before_tooling(self) -> None:
+    def test_dev_push_deploys_all_through_protected_validated_path(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         dev_job = workflow.split("  run-dev-operation:", maxsplit=1)[1]
 
-        self.assertIn("branches: [prod]", workflow)
+        self.assertIn("branches: [dev, prod]", workflow)
         self.assertIn("uv run cdk deploy --all -c stage=prod --require-approval never", workflow)
-        self.assertIn("github.ref == 'refs/heads/dev'", dev_job)
+        self.assertIn(
+            "github.ref == 'refs/heads/dev' && (github.event_name == 'push' || "
+            "github.event_name == 'workflow_dispatch')",
+            dev_job,
+        )
         self.assertIn("environment: dev", dev_job)
+        self.assertIn("OPERATION: ${{ github.event_name == 'push' && 'deploy' || inputs.operation }}", dev_job)
+        self.assertIn("SCOPE: ${{ github.event_name == 'push' && 'all' || inputs.scope }}", dev_job)
         self.assertIn("DESCOPE_PROJECT_ID: ${{ vars.DESCOPE_PROJECT_ID }}", dev_job)
         self.assertIn('PRODUCTION_ACCOUNT_ID: "613431292675"', dev_job)
         self.assertIn("SENTRY_DSN_SECRET_NAME: ${{ vars.SENTRY_DSN_SECRET_NAME }}", dev_job)
@@ -24,15 +30,15 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("allowed-account-ids: ${{ env.DEV_ACCOUNT_ID }}", dev_job)
         self.assertIn("AWS_REGION must be us-east-1", dev_job)
         self.assertLess(dev_job.index("Validate dev AWS identity"), dev_job.index("Checkout code"))
-        self.assertIn("if: inputs.operation != 'credentials-only'", dev_job)
-        self.assertIn("if: inputs.operation == 'plan'", dev_job)
+        self.assertIn("if: env.OPERATION != 'credentials-only'", dev_job)
+        self.assertIn("if: env.OPERATION == 'plan'", dev_job)
         self.assertIn(
-            'run: make plan STAGE=dev SCOPE=${{ inputs.scope }} DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"',
+            'run: make plan STAGE=dev SCOPE="$SCOPE" DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"',
             dev_job,
         )
-        self.assertIn("if: inputs.operation == 'deploy'", dev_job)
+        self.assertIn("if: env.OPERATION == 'deploy'", dev_job)
         self.assertIn(
-            'run: make deploy STAGE=dev SCOPE=${{ inputs.scope }} DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"',
+            'run: make deploy STAGE=dev SCOPE="$SCOPE" DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"',
             dev_job,
         )
         self.assertNotIn("submodules: recursive", workflow)


### PR DESCRIPTION
## Why

Valkyrie dev infrastructure currently updates only when someone manually dispatches the Deploy to AWS workflow. The protected dev environment already restricts deployments to the `dev` branch, and the existing account, region, and STS identity checks have completed successfully in a full dev deployment: https://github.com/vals-ai/Valkyrie/actions/runs/29667101121.

## What changed

- Run the dev deployment job for pushes to `dev` as well as manual dispatches.
- Treat a push as a full deployment while preserving manually selected credentials, plan, deploy, and scope operations.
- Keep both automatic and manual operations behind the protected dev environment and the existing AWS target validation.

## Verification

- `cd infra && make lint` — Ruff formatting and lint checks passed.
- `cd infra && make test` — 18 tests passed, including the automatic-push workflow contract.
- `cd infra && make typecheck` — 0 errors, 0 warnings, 0 notes.
- Live GitHub configuration check — the dev environment accepts deployments only from the `dev` branch.
- Not tested: an automatic push deployment cannot run before this workflow reaches `dev`. Merging this PR will immediately deploy the current `dev` head through the validated full-stack path.