### PR TITLE
Raise tracker benchmark-service frame limit

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.16.2" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "f9bb1980ff85b18e16112c403b6fa3b745d54079" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -27,6 +27,8 @@ from tracker.types import (
     StartBenchmarkRequest,
 )
 
+_MAX_BENCHMARK_SERVICE_WEBSOCKET_MESSAGE_SIZE = 16 * 1024 * 1024
+
 
 @dataclass(frozen=True)
 class BenchmarkConcurrencyUpdate:
@@ -53,7 +55,11 @@ def create_benchmark_service_client(
     headers = dict(service_headers or {})
     validate_service_headers(headers)
 
-    return BenchmarkServiceClient(url=url, headers=headers)
+    return BenchmarkServiceClient(
+        url=url,
+        headers=headers,
+        max_websocket_message_size=_MAX_BENCHMARK_SERVICE_WEBSOCKET_MESSAGE_SIZE,
+    )
 
 
 def create_benchmark_service_client_from_request(request: StartBenchmarkRequest) -> BenchmarkServiceClient:

--- a/services/tracker/tests/unit/utils/test_resources.py
+++ b/services/tracker/tests/unit/utils/test_resources.py
@@ -1,0 +1,16 @@
+"""Tests for benchmark-service client construction."""
+
+from unittest.mock import patch
+
+from tracker.utils.resources import create_benchmark_service_client
+
+
+def test_benchmark_service_client_uses_bounded_larger_websocket_limit() -> None:
+    with patch("tracker.utils.resources.BenchmarkServiceClient") as client_cls:
+        create_benchmark_service_client("https://benchmark-service.example.com")
+
+    client_cls.assert_called_once_with(
+        url="https://benchmark-service.example.com",
+        headers={},
+        max_websocket_message_size=16 * 1024 * 1024,
+    )

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.16.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2#ae42d388ff633a0be595169f8899de044e594faa" }
+version = "0.16.3.dev1+gf9bb1980f"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=f9bb1980ff85b18e16112c403b6fa3b745d54079#f9bb1980ff85b18e16112c403b6fa3b745d54079" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2021,7 +2021,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=f9bb1980ff85b18e16112c403b6fa3b745d54079" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.16.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2#ae42d388ff633a0be595169f8899de044e594faa" }
+version = "0.16.3.dev1+gf9bb1980f"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=f9bb1980ff85b18e16112c403b6fa3b745d54079#f9bb1980ff85b18e16112c403b6fa3b745d54079" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -783,9 +783,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -2217,7 +2215,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=f9bb1980ff85b18e16112c403b6fa3b745d54079" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
Raises the tracker benchmark-service inbound WebSocket bound from 10 MiB to 16 MiB via a new per-client framework override. The framework default remains 10 MiB.

This unblocks a valid 11,047,264-byte SWE-bench prediction payload while retaining a bounded limit. The framework dependency is pinned to an immutable v0.16.2-based backport containing only this API addition.

Checks: tracker unit suite 366/366, focused wiring/security 85/85, Ruff, BasedPyright; framework backport unit suite 312/312 plus focused boundary tests.