### PR TITLE
Expire eval-resume artifacts after 30 days

### DIFF
--- a/infra/shared.py
+++ b/infra/shared.py
@@ -50,6 +50,14 @@ DEPLOYMENT_FAILURE_STATUSES = (
     "DELETE_FAILED",
 )
 
+EVAL_RESUME_RETENTION_PREFIXES = (
+    "code-migration/benchmarks/",
+    "cyberbench/eval-resume/",
+    "emb/eval-resume/",
+    "programbench/eval-resume/",
+    "swebench/eval-resume/",
+)
+
 
 class SharedStack(Stack):
     """Shared infrastructure for all services."""
@@ -116,6 +124,14 @@ class SharedStack(Stack):
             enforce_ssl=None if self.stage.is_prod else True,
             object_ownership=None if self.stage.is_prod else aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
             versioned=None if self.stage.is_prod else True,
+            lifecycle_rules=[
+                aws_s3.LifecycleRule(
+                    prefix=prefix,
+                    expiration=cdk.Duration.days(30),
+                    noncurrent_version_expiration=cdk.Duration.days(30),
+                )
+                for prefix in EVAL_RESUME_RETENTION_PREFIXES
+            ],
         )
 
         # ── ElastiCache Redis ─────────────────────────────────────────────

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -54,6 +54,7 @@ EVAL_RESUME_RETENTION_PREFIXES = (
     "code-migration/benchmarks/",
     "cyberbench/eval-resume/",
     "emb/eval-resume/",
+    "harvey/eval-resume/",
     "programbench/eval-resume/",
     "swebench/eval-resume/",
 )

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -77,6 +77,13 @@ def dev_shared_stack() -> tuple[cdk.App, SharedStack]:
     return app, shared
 
 
+def prod_shared_stack() -> tuple[cdk.App, SharedStack]:
+    app = cdk.App(context=PROD_CONTEXT)
+    stage = Stage(PROD)
+    shared = SharedStack(app, stage.stack_id("SharedStack"), stage=stage, env=TEST_ENV)
+    return app, shared
+
+
 def dev_tracker_template() -> assertions.Template:
     app, shared = dev_shared_stack()
     stage = Stage(DEV)
@@ -110,6 +117,27 @@ def ssm_parameter_id(template: Mapping[str, object], parameter_name: str) -> str
 
 
 class DevAccountInfrastructureTest(unittest.TestCase):
+    def test_eval_resume_artifacts_expire_after_30_days(self) -> None:
+        for _, shared in (dev_shared_stack(), prod_shared_stack()):
+            with self.subTest(stage=shared.stage.name):
+                shared_template = assertions.Template.from_stack(shared)
+                bucket = next(iter(shared_template.find_resources("AWS::S3::Bucket").values()))
+                rules = bucket["Properties"]["LifecycleConfiguration"]["Rules"]
+
+                for rule in rules:
+                    self.assertEqual(rule["NoncurrentVersionExpiration"], {"NoncurrentDays": 30})
+
+                self.assertEqual(
+                    {rule["Prefix"]: rule["ExpirationInDays"] for rule in rules if rule["Status"] == "Enabled"},
+                    {
+                        "code-migration/benchmarks/": 30,
+                        "cyberbench/eval-resume/": 30,
+                        "emb/eval-resume/": 30,
+                        "programbench/eval-resume/": 30,
+                        "swebench/eval-resume/": 30,
+                    },
+                )
+
     def test_dev_bucket_is_named_and_hardened(self) -> None:
         _, shared = dev_shared_stack()
         shared_template = assertions.Template.from_stack(shared)

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -133,6 +133,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
                         "code-migration/benchmarks/": 30,
                         "cyberbench/eval-resume/": 30,
                         "emb/eval-resume/": 30,
+                        "harvey/eval-resume/": 30,
                         "programbench/eval-resume/": 30,
                         "swebench/eval-resume/": 30,
                     },


### PR DESCRIPTION
## Context

Issue vals-ai/valkyrie-ticket-library#121 adds durable eval-only retry artifacts to several benchmark services. The shared `agentic-harness` bucket had no lifecycle policy, so run-scoped artifacts could be retained indefinitely.

## Changes

- expire current objects after 30 days under the service-owned retry prefixes for SWE-bench, ProgramBench, CyberBench, EMB, and Code Migration
- expire noncurrent versions after 30 days as well, covering both enabled and suspended bucket versioning
- assert the exact DEV and production lifecycle configuration in CDK tests

The services retain read/write access only. They do not receive delete permissions, and failed retry checkpoints remain available throughout the 30-day retry window.

## Verification

- `cd infra && make test` — 19 tests passed
- `cd infra && make lint` — passed
- `cd infra && make typecheck` — 0 errors

No infrastructure was deployed.