### PR TITLE
Use CBS v0.17.3 provider-level Daytona retries

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.17.3" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.16.2" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.17.3.dev1+ge6dec5e6e"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907#e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" }
+version = "0.17.3"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3#748a1a808ee1f75a3f361cc9053934d086f143e3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2021,7 +2021,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.16.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2#ae42d388ff633a0be595169f8899de044e594faa" }
+version = "0.17.3.dev1+ge6dec5e6e"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907#e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2021,7 +2021,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.16.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2#ae42d388ff633a0be595169f8899de044e594faa" }
+version = "0.17.3.dev1+ge6dec5e6e"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907#e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2217,7 +2217,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.16.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.17.3.dev1+ge6dec5e6e"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907#e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" }
+version = "0.17.3"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3#748a1a808ee1f75a3f361cc9053934d086f143e3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2217,7 +2217,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=e6dec5e6e580cf68690fc3a30a25dd9fb9f46907" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

Upgrade `create-benchmark-service` to the published `v0.17.3` tag containing vals-ai/create-benchmark-service#108.

CBS now treats Daytona's generic provider failures as transient and retries only the failed API call. It does **not** restart the agent command or retry the whole Valkyrie task.

## Retry policy

Six total attempts with staged waits around 5s, 25s, 90s, 5m, and 7m, with bounded jitter. Total planned wait remains within 14 minutes.

## Validation

- root and tracker lockfiles pass `uv lock --check`
- `uv run pytest services/tracker/tests/unit/test_sandbox.py -q` — 35 passed
