### PR TITLE
fix(cli): pass AWS_SESSION_TOKEN through to S3 credentials

### DIFF
--- a/src/valkyrie/cli/s3_config.py
+++ b/src/valkyrie/cli/s3_config.py
@@ -21,6 +21,7 @@ def aws_credentials() -> AWSCredentials:
         aws_access_key_id=config["AWS_ACCESS_KEY_ID"],
         aws_secret_access_key=config["AWS_SECRET_ACCESS_KEY"],
         aws_default_region=config["AWS_DEFAULT_REGION"],
+        aws_session_token=config.get("AWS_SESSION_TOKEN"),
     )
 
 

--- a/tests/unit/cli/test_s3_config.py
+++ b/tests/unit/cli/test_s3_config.py
@@ -17,9 +17,7 @@ _BASE_CONFIG = {
 
 def test_aws_credentials_passes_session_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """Temporary credentials (SSO / assumed role) must keep their session token."""
-    monkeypatch.setattr(
-        s3_config, "load_config", lambda: {**_BASE_CONFIG, "AWS_SESSION_TOKEN": "token123"}
-    )
+    monkeypatch.setattr(s3_config, "load_config", lambda: {**_BASE_CONFIG, "AWS_SESSION_TOKEN": "token123"})
     creds = s3_config.aws_credentials()
     assert creds.aws_session_token == "token123"
     assert creds.aws_access_key_id == "ASIAEXAMPLE"

--- a/tests/unit/cli/test_s3_config.py
+++ b/tests/unit/cli/test_s3_config.py
@@ -1,0 +1,32 @@
+"""Tests for CLI S3 credential construction.
+
+Run: uv run pytest tests/unit/cli/test_s3_config.py
+"""
+
+import pytest
+
+from valkyrie.cli import s3_config
+
+_BASE_CONFIG = {
+    "AWS_ACCESS_KEY_ID": "ASIAEXAMPLE",
+    "AWS_SECRET_ACCESS_KEY": "secret",
+    "AWS_DEFAULT_REGION": "us-east-1",
+    "S3_BUCKET": "bucket",
+}
+
+
+def test_aws_credentials_passes_session_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Temporary credentials (SSO / assumed role) must keep their session token."""
+    monkeypatch.setattr(
+        s3_config, "load_config", lambda: {**_BASE_CONFIG, "AWS_SESSION_TOKEN": "token123"}
+    )
+    creds = s3_config.aws_credentials()
+    assert creds.aws_session_token == "token123"
+    assert creds.aws_access_key_id == "ASIAEXAMPLE"
+
+
+def test_aws_credentials_without_session_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Static credentials keep working with no token configured."""
+    monkeypatch.setattr(s3_config, "load_config", lambda: dict(_BASE_CONFIG))
+    creds = s3_config.aws_credentials()
+    assert creds.aws_session_token is None


### PR DESCRIPTION
## Problem

`valkyrie.yaml` accepts `AWS_SESSION_TOKEN` (the SDK's `ValkyrieConfig` has the alias, and `tracker/aws/s3.py`'s `_s3_session` passes it to aioboto3), but the CLI's `aws_credentials()` in `src/valkyrie/cli/s3_config.py` built `AWSCredentials` without it.

Anyone on temporary credentials (AWS SSO / assumed roles — ASIA-prefixed keys) gets:

```
S3 error: Failed to push agent to S3: An error occurred (InvalidAccessKeyId) when calling the
CreateMultipartUpload operation: The AWS Access Key Id you provided does not exist in our records.
```

from every CLI S3 operation — `valkyrie agent push`, and the `HeadObject` existence check in `run start` (surfaces as a 403).

## Fix

Pass `aws_session_token=config.get("AWS_SESSION_TOKEN")` in `aws_credentials()`. Audited the other `AWSCredentials` construction sites: the SDK's `harness_config()` already forwards the token, and all CLI S3 call sites (`agent/storage.py` ×4) go through this one function, so this is the only change needed.

## Testing

- New unit tests: token present → forwarded; token absent → `None` (static creds unaffected).
- Verified end-to-end on an EC2 box with SSO (`Baseline`) credentials from `aws configure export-credentials`: `valkyrie agent push` fails with `InvalidAccessKeyId` before, succeeds (reaches S3 authorization) after.

## Repro

1. `aws sso login`, then write `~/.config/valkyrie/valkyrie.yaml` with `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` from `aws configure export-credentials`
2. `valkyrie agent push <dir> --name test` → `InvalidAccessKeyId` before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->