### PR TITLE
fix(tracker): support slashes in task IDs

### DIFF
--- a/services/tracker/openapi.json
+++ b/services/tracker/openapi.json
@@ -2204,6 +2204,56 @@
         "summary": "Patch Benchmark Concurrency"
       }
     },
+    "/benchmarks/{benchmark_id}/task": {
+      "get": {
+        "description": "Fetch a single task's status + evaluation result for the SingleTask page.",
+        "operationId": "get_single_task_by_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleTaskResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Single Task"
+      }
+    },
     "/benchmarks/{benchmark_id}/tasks": {
       "get": {
         "description": "Paginated tasks for a benchmark, with optional status filter + task-id search.\n\nsort=status desc surfaces errors first (attention priority). Default: started_at desc.",

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -119,6 +119,11 @@ async def get_task_artifacts(
 
 
 @router.get(
+    "/{benchmark_id}/task",
+    operation_id="get_single_task_by_query",
+    response_model=SingleTaskResponse,
+)
+@router.get(
     "/{benchmark_id}/tasks/{task_id:path}",
     response_model=SingleTaskResponse,
 )

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -76,36 +76,7 @@ def _fetch_result_objects(session: Session, task: Task, org: Org) -> tuple[Evalu
 
 
 @router.get(
-    "/{benchmark_id}/tasks/{task_id}",
-    response_model=SingleTaskResponse,
-)
-def get_single_task(
-    benchmark_id: UUID,
-    task_id: str,
-    org: Org = Depends(get_current_org),
-    session: Session = Depends(get_session),
-) -> SingleTaskResponse:
-    """Fetch a single task's status + evaluation result for the SingleTask page."""
-    _, task = _load_task_or_404(benchmark_id, task_id, org, session)
-
-    eval_row, error_message = _fetch_result_objects(session, task, org)
-
-    return SingleTaskResponse(
-        id=task.id,
-        task_id=task.task_id,
-        status=task.status,
-        started_at=task.started_at,
-        finished_at=task.finished_at,
-        error_message=error_message,
-        evaluation_result=eval_row.result if eval_row else None,
-        agent_caused_exit_reason=(
-            eval_row.agent_caused_exit_reason.value if eval_row and eval_row.agent_caused_exit_reason else None
-        ),
-    )
-
-
-@router.get(
-    "/{benchmark_id}/tasks/{task_id}/artifacts",
+    "/{benchmark_id}/tasks/{task_id:path}/artifacts",
     response_model=TaskArtifactsResponse,
 )
 async def get_task_artifacts(
@@ -144,4 +115,33 @@ async def get_task_artifacts(
         cloudwatch_url=cloudwatch_url,
         agent_output_url=agent_output_url,
         agent_output_expires_in=ttl_seconds,
+    )
+
+
+@router.get(
+    "/{benchmark_id}/tasks/{task_id:path}",
+    response_model=SingleTaskResponse,
+)
+def get_single_task(
+    benchmark_id: UUID,
+    task_id: str,
+    org: Org = Depends(get_current_org),
+    session: Session = Depends(get_session),
+) -> SingleTaskResponse:
+    """Fetch a single task's status + evaluation result for the SingleTask page."""
+    _, task = _load_task_or_404(benchmark_id, task_id, org, session)
+
+    eval_row, error_message = _fetch_result_objects(session, task, org)
+
+    return SingleTaskResponse(
+        id=task.id,
+        task_id=task.task_id,
+        status=task.status,
+        started_at=task.started_at,
+        finished_at=task.finished_at,
+        error_message=error_message,
+        evaluation_result=eval_row.result if eval_row else None,
+        agent_caused_exit_reason=(
+            eval_row.agent_caused_exit_reason.value if eval_row and eval_row.agent_caused_exit_reason else None
+        ),
     )

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -45,7 +45,7 @@ def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(
 
     finished_task = make_task(
         benchmark,
-        "finished-task",
+        "owner/repo/finished-task",
         status=TaskStatus.FINISHED,
         finished_at=now,
     )
@@ -93,6 +93,7 @@ def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(
     other_org_response = _client.get(f"/benchmarks/{other_benchmark.id}/tasks/unknown")
 
     assert finished_response.status_code == 200
+    assert finished_response.json()["task_id"] == "owner/repo/finished-task"
     assert finished_response.json()["evaluation_result"] == {"score": 1.0}
     assert finished_response.json()["agent_caused_exit_reason"] == "TIMEOUT"
     assert finished_response.json()["error_message"] is None
@@ -117,7 +118,7 @@ def test_task_artifacts_only_presign_existing_output(
     - Missing output returns no S3 URL and does not call the signer again.
     """
     benchmark = example_benchmark_object
-    task = make_task(benchmark, "task-with-output")
+    task = make_task(benchmark, "owner/repo/task-with-output")
     database_session.add_all([benchmark, task])
     database_session.commit()
 

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -56,7 +56,8 @@ def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(
         finished_at=now,
     )
     pending_task = make_task(benchmark, "pending-task")
-    database_session.add_all([finished_task, error_task, pending_task])
+    ambiguous_task = make_task(benchmark, "owner/artifacts")
+    database_session.add_all([finished_task, error_task, pending_task, ambiguous_task])
     database_session.flush()
     database_session.add_all(
         [
@@ -90,6 +91,10 @@ def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(
     finished_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{finished_task.task_id}")
     error_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{error_task.task_id}")
     pending_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{pending_task.task_id}")
+    ambiguous_response = _client.get(
+        f"/benchmarks/{benchmark.id}/task",
+        params={"task_id": ambiguous_task.task_id},
+    )
     other_org_response = _client.get(f"/benchmarks/{other_benchmark.id}/tasks/unknown")
 
     assert finished_response.status_code == 200
@@ -103,6 +108,8 @@ def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(
     assert pending_response.status_code == 200
     assert pending_response.json()["error_message"] is None
     assert pending_response.json()["evaluation_result"] is None
+    assert ambiguous_response.status_code == 200
+    assert ambiguous_response.json()["task_id"] == "owner/artifacts"
     assert other_org_response.status_code == 404
 
 


### PR DESCRIPTION
## Summary

- accept slash-containing task IDs on the current task detail and artifact routes
- register the artifact route before the catch-all task route
- add `GET /benchmarks/{benchmark_id}/task?task_id=...` as an unambiguous lookup for every opaque task ID, including IDs ending in `/artifacts`
- publish and test both path and query forms in the OpenAPI contract

## Stack

- depends on #618

## Verification

- Tracker unit CI
- live Tracker integration CI
- focused task API tests
- canonical OpenAPI check
- Ruff format/check
- basedpyright
- `git diff --check`
