### PR TITLE
feat(tracker): expose task outcome history

### DIFF
--- a/services/tracker/openapi.json
+++ b/services/tracker/openapi.json
@@ -69,6 +69,15 @@
         "title": "AWSCredentials",
         "type": "object"
       },
+      "AgentCausedExitReason": {
+        "description": "Exit reasons caused by the agent that continue to evaluation",
+        "enum": [
+          "TIMEOUT",
+          "OS_KILLED"
+        ],
+        "title": "AgentCausedExitReason",
+        "type": "string"
+      },
       "AgentContractRequest": {
         "properties": {
           "egress_allowlist": {
@@ -754,6 +763,96 @@
           }
         },
         "title": "Body_stop_benchmark",
+        "type": "object"
+      },
+      "ErrorTaskAttempt": {
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "error_fingerprint": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Error Fingerprint",
+            "type": "string"
+          },
+          "error_message": {
+            "maxLength": 4000,
+            "title": "Error Message",
+            "type": "string"
+          },
+          "error_message_truncated": {
+            "title": "Error Message Truncated",
+            "type": "boolean"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "const": "error",
+            "default": "error",
+            "title": "Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "error_message",
+          "error_message_truncated",
+          "error_fingerprint"
+        ],
+        "title": "ErrorTaskAttempt",
+        "type": "object"
+      },
+      "EvaluationTaskAttempt": {
+        "properties": {
+          "agent_caused_exit_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentCausedExitReason"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "instance_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Id"
+          },
+          "kind": {
+            "const": "evaluation",
+            "default": "evaluation",
+            "title": "Kind",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "instance_id",
+          "agent_caused_exit_reason"
+        ],
+        "title": "EvaluationTaskAttempt",
         "type": "object"
       },
       "FetchBenchmarkMetadataResponse": {
@@ -1651,6 +1750,41 @@
         "title": "TaskArtifactsResponse",
         "type": "object"
       },
+      "TaskAttemptsResponse": {
+        "properties": {
+          "attempts": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "error": "#/components/schemas/ErrorTaskAttempt",
+                  "evaluation": "#/components/schemas/EvaluationTaskAttempt"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ErrorTaskAttempt"
+                },
+                {
+                  "$ref": "#/components/schemas/EvaluationTaskAttempt"
+                }
+              ]
+            },
+            "title": "Attempts",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "attempts",
+          "total_count"
+        ],
+        "title": "TaskAttemptsResponse",
+        "type": "object"
+      },
       "TaskStatus": {
         "enum": [
           "PENDING",
@@ -2484,6 +2618,79 @@
           }
         },
         "summary": "Get Task Artifacts"
+      }
+    },
+    "/benchmarks/{benchmark_id}/tasks/{task_id}/attempts": {
+      "get": {
+        "description": "Return persisted task outcomes, newest first.",
+        "operationId": "get_task_attempts",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskAttemptsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Task Attempts"
       }
     },
     "/check-results-exist": {

--- a/services/tracker/openapi.json
+++ b/services/tracker/openapi.json
@@ -2662,6 +2662,7 @@
             "required": false,
             "schema": {
               "default": 0,
+              "maximum": 10000,
               "minimum": 0,
               "title": "Offset",
               "type": "integer"

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -102,7 +102,7 @@ def get_task_attempts(
     benchmark_id: UUID,
     task_id: str,
     limit: int = Query(default=50, ge=1, le=100),
-    offset: int = Query(default=0, ge=0),
+    offset: int = Query(default=0, ge=0, le=10_000),
     org: Org = Depends(get_current_org),
     session: Session = Depends(get_session),
 ) -> TaskAttemptsResponse:

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -150,7 +150,7 @@ def get_task_attempts(
                 error_fingerprint=fingerprint,
             )
         )
-    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int, attempt.kind), reverse=True)
+    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int), reverse=True)
 
     evaluation_count = session.exec(select(func.count(col(EvaluationResult.id))).where(*evaluation_filters)).one()
     error_count = session.exec(select(func.count(col(ErrorResult.id))).where(*error_filters)).one()

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import Session, desc, select
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.orm import defer
+from sqlmodel import Session, col, desc, func, select
 
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
@@ -20,10 +22,27 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.database.session import get_session
-from tracker.types import HarnessConfig, SingleTaskResponse, TaskArtifactsResponse
+from tracker.types import (
+    ErrorTaskAttempt,
+    EvaluationTaskAttempt,
+    HarnessConfig,
+    SingleTaskResponse,
+    TaskArtifactsResponse,
+    TaskAttempt,
+    TaskAttemptsResponse,
+    TASK_ATTEMPT_ERROR_MAX_LENGTH,
+)
 from tracker.utils import fetch_harness_config
 
 router = APIRouter(prefix="/benchmarks")
+
+
+def _summarize_attempt_error(message: str) -> tuple[str, bool, str]:
+    return (
+        message[:TASK_ATTEMPT_ERROR_MAX_LENGTH],
+        len(message) > TASK_ATTEMPT_ERROR_MAX_LENGTH,
+        hashlib.sha256(message.encode()).hexdigest(),
+    )
 
 
 def _load_task_or_404(benchmark_id: UUID, task_id: str, org: Org, session: Session) -> tuple[Benchmark, Task]:
@@ -73,6 +92,72 @@ def _fetch_result_objects(session: Session, task: Task, org: Org) -> tuple[Evalu
         return cast(EvaluationResult | None, result), None
 
     return None, cast(str | None, result)
+
+
+@router.get(
+    "/{benchmark_id}/tasks/{task_id:path}/attempts",
+    response_model=TaskAttemptsResponse,
+)
+def get_task_attempts(
+    benchmark_id: UUID,
+    task_id: str,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    org: Org = Depends(get_current_org),
+    session: Session = Depends(get_session),
+) -> TaskAttemptsResponse:
+    """Return persisted task outcomes, newest first."""
+    _, task = _load_task_or_404(benchmark_id, task_id, org, session)
+    page_end = offset + limit
+    evaluation_filters = (
+        col(EvaluationResult.task) == task.id,
+        col(EvaluationResult.org_id) == org.id,
+    )
+    error_filters = (
+        col(ErrorResult.task) == task.id,
+        col(ErrorResult.org_id) == org.id,
+    )
+    evaluation_rows = session.exec(
+        select(EvaluationResult)
+        .where(*evaluation_filters)
+        .order_by(desc(EvaluationResult.created_at), desc(EvaluationResult.id))
+        .options(defer(EvaluationResult.result))  # pyright: ignore[reportArgumentType]
+        .limit(page_end)
+    ).all()
+    error_rows = session.exec(
+        select(ErrorResult)
+        .where(*error_filters)
+        .order_by(desc(ErrorResult.created_at), desc(ErrorResult.id))
+        .limit(page_end)
+    ).all()
+    attempts: list[TaskAttempt] = [
+        EvaluationTaskAttempt(
+            id=row.id,
+            created_at=row.created_at,
+            instance_id=row.instance_id,
+            agent_caused_exit_reason=row.agent_caused_exit_reason,
+        )
+        for row in evaluation_rows
+    ]
+    for row in error_rows:
+        message, truncated, fingerprint = _summarize_attempt_error(row.error_message)
+        attempts.append(
+            ErrorTaskAttempt(
+                id=row.id,
+                created_at=row.created_at,
+                error_message=message,
+                error_message_truncated=truncated,
+                error_fingerprint=fingerprint,
+            )
+        )
+    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int, attempt.kind), reverse=True)
+
+    evaluation_count = session.exec(select(func.count(col(EvaluationResult.id))).where(*evaluation_filters)).one()
+    error_count = session.exec(select(func.count(col(ErrorResult.id))).where(*error_filters)).one()
+    return TaskAttemptsResponse(
+        attempts=attempts[offset:page_end],
+        total_count=evaluation_count + error_count,
+    )
 
 
 @router.get(

--- a/services/tracker/src/tracker/database/migrations/versions/c4e8a1b2d3f5_add_task_outcome_history_indexes.py
+++ b/services/tracker/src/tracker/database/migrations/versions/c4e8a1b2d3f5_add_task_outcome_history_indexes.py
@@ -1,0 +1,31 @@
+"""Add task outcome history indexes
+
+Revision ID: c4e8a1b2d3f5
+Revises: 6f3c2d9a8b10
+Create Date: 2026-07-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4e8a1b2d3f5"
+down_revision: Union[str, Sequence[str], None] = "6f3c2d9a8b10"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    for table in ("evaluationresult", "errorresult"):
+        op.create_index(
+            f"ix_{table}_org_task_created_at_id",
+            table,
+            ["org_id", "task", sa.text("created_at DESC"), sa.text("id DESC")],
+        )
+
+
+def downgrade() -> None:
+    for table in ("errorresult", "evaluationresult"):
+        op.drop_index(f"ix_{table}_org_task_created_at_id", table_name=table)

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -452,10 +452,30 @@ class ResultBase(SQLModel):
 
 
 class EvaluationResult(ResultBase, table=True):
+    __table_args__ = (
+        Index(
+            "ix_evaluationresult_org_task_created_at_id",
+            "org_id",
+            "task",
+            text("created_at DESC"),
+            text("id DESC"),
+        ),
+    )
+
     instance_id: str | None = Field(default=None, unique=True)
     agent_caused_exit_reason: AgentCausedExitReason | None = Field(default=None)
     result: dict[str, Any] = Field(default_factory=dict, sa_column=Column(JSON, nullable=False))
 
 
 class ErrorResult(ResultBase, table=True):
+    __table_args__ = (
+        Index(
+            "ix_errorresult_org_task_created_at_id",
+            "org_id",
+            "task",
+            text("created_at DESC"),
+            text("id DESC"),
+        ),
+    )
+
     error_message: str = Field(nullable=False)

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from benchmark_service.client import BenchmarkServiceClient
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from tracker.config import create_benchmark_service_url
 from tracker.database.models import (
+    AgentCausedExitReason,
     AgentContractRequest,
     BenchmarkArguments,
     BenchmarkStatus,
@@ -20,6 +21,8 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.outbound_security import validate_benchmark_name, validate_service_url_syntax
+
+TASK_ATTEMPT_ERROR_MAX_LENGTH = 4_000
 
 
 def _serialize_utc(value: datetime | None) -> str | None:
@@ -389,6 +392,38 @@ class SingleTaskResponse(BaseModel):
     @field_serializer("finished_at")
     def _serialize_finished_at(self, value: datetime | None) -> str | None:
         return _serialize_utc(value)
+
+
+class TaskAttemptBase(BaseModel):
+    id: UUID
+    created_at: datetime
+
+    @field_serializer("created_at")
+    def _serialize_created_at(self, value: datetime) -> str:
+        result = _serialize_utc(value)
+        assert result is not None
+        return result
+
+
+class ErrorTaskAttempt(TaskAttemptBase):
+    kind: Literal["error"] = "error"
+    error_message: str = Field(max_length=TASK_ATTEMPT_ERROR_MAX_LENGTH)
+    error_message_truncated: bool
+    error_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+
+class EvaluationTaskAttempt(TaskAttemptBase):
+    kind: Literal["evaluation"] = "evaluation"
+    instance_id: str | None
+    agent_caused_exit_reason: AgentCausedExitReason | None
+
+
+TaskAttempt = Annotated[ErrorTaskAttempt | EvaluationTaskAttempt, Field(discriminator="kind")]
+
+
+class TaskAttemptsResponse(BaseModel):
+    attempts: list[TaskAttempt]
+    total_count: int
 
 
 class AgentEntry(BaseModel):

--- a/services/tracker/tests/integration/local/database/test_schema.py
+++ b/services/tracker/tests/integration/local/database/test_schema.py
@@ -32,6 +32,16 @@ class TestTrackerSchema:
 
         assert {"benchmark", "task", "evaluationresult", "finalevaluation"} <= tables
 
+    def test_task_outcome_history_has_query_indexes(self, postgres_engine: Engine) -> None:
+        inspector = inspect(postgres_engine)
+
+        assert "ix_evaluationresult_org_task_created_at_id" in {
+            index["name"] for index in inspector.get_indexes("evaluationresult")
+        }
+        assert "ix_errorresult_org_task_created_at_id" in {
+            index["name"] for index in inspector.get_indexes("errorresult")
+        }
+
     def test_terminal_statuses_set_finished_timestamps_in_postgres(self, postgres_session: Session) -> None:
         """Terminal state transitions must persist completion timestamps in production Postgres.
 

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -154,11 +154,13 @@ def test_task_attempts_enforce_org_scope_and_page_limit(
     response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/attempts")
     foreign_response = _client.get(f"/benchmarks/{other_benchmark.id}/tasks/{other_task.task_id}/attempts")
     oversized_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/attempts?limit=101")
+    distant_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/attempts?offset=10001")
 
     assert response.status_code == 200
     assert [attempt["error_message"] for attempt in response.json()["attempts"]] == ["target failure"]
     assert foreign_response.status_code == 404
     assert oversized_response.status_code == 422
+    assert distant_response.status_code == 422
 
 
 def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -6,8 +6,10 @@ Cover task details and artifact-link behavior.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from hashlib import sha256
+from urllib.parse import quote
 from unittest.mock import ANY, AsyncMock, Mock
-from uuid import uuid4
+from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -25,6 +27,138 @@ from tracker.database.models import (
 )
 
 _client = TestClient(app)
+
+
+def test_task_attempts_page_retry_history_newest_first(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+) -> None:
+    benchmark = example_benchmark_object
+    task = make_task(
+        benchmark,
+        "suite/task",
+        status=TaskStatus.ERROR,
+        finished_at=datetime(2026, 6, 24, 16, tzinfo=ZoneInfo("UTC")),
+    )
+    database_session.add_all([benchmark, task])
+    database_session.flush()
+
+    newest_evaluation = make_evaluation_result(
+        task,
+        "evaluation-new",
+        {"score": 1.0},
+        datetime(2026, 6, 24, 16, tzinfo=ZoneInfo("UTC")),
+    )
+    repeated_error_new = make_error_result(
+        task,
+        "identical failure",
+        datetime(2026, 6, 24, 15, tzinfo=ZoneInfo("UTC")),
+    )
+    repeated_error_old = make_error_result(
+        task,
+        "identical failure",
+        datetime(2026, 6, 24, 15, tzinfo=ZoneInfo("UTC")),
+    )
+    older_evaluation = make_evaluation_result(
+        task,
+        "evaluation-old",
+        {"score": 0.25},
+        datetime(2026, 6, 24, 14, tzinfo=ZoneInfo("UTC")),
+        exit_reason=AgentCausedExitReason.TIMEOUT,
+    )
+    newest_evaluation.id = UUID("00000000-0000-0000-0000-000000000004")
+    repeated_error_new.id = UUID("00000000-0000-0000-0000-000000000003")
+    repeated_error_old.id = UUID("00000000-0000-0000-0000-000000000002")
+    older_evaluation.id = UUID("00000000-0000-0000-0000-000000000001")
+    database_session.add_all(
+        [
+            newest_evaluation,
+            repeated_error_new,
+            repeated_error_old,
+            older_evaluation,
+        ]
+    )
+    database_session.commit()
+
+    task_path = quote(task.task_id, safe="")
+    first_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task_path}/attempts?limit=2")
+    second_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task_path}/attempts?limit=2&offset=2")
+
+    fingerprint = sha256(b"identical failure").hexdigest()
+    assert first_response.status_code == 200, first_response.text
+    assert first_response.json() == {
+        "attempts": [
+            {
+                "kind": "evaluation",
+                "id": str(newest_evaluation.id),
+                "created_at": "2026-06-24T16:00:00+00:00",
+                "instance_id": "evaluation-new",
+                "agent_caused_exit_reason": None,
+            },
+            {
+                "kind": "error",
+                "id": str(repeated_error_new.id),
+                "created_at": "2026-06-24T15:00:00+00:00",
+                "error_message": "identical failure",
+                "error_message_truncated": False,
+                "error_fingerprint": fingerprint,
+            },
+        ],
+        "total_count": 4,
+    }
+    assert second_response.status_code == 200, second_response.text
+    assert second_response.json() == {
+        "attempts": [
+            {
+                "kind": "error",
+                "id": str(repeated_error_old.id),
+                "created_at": "2026-06-24T15:00:00+00:00",
+                "error_message": "identical failure",
+                "error_message_truncated": False,
+                "error_fingerprint": fingerprint,
+            },
+            {
+                "kind": "evaluation",
+                "id": str(older_evaluation.id),
+                "created_at": "2026-06-24T14:00:00+00:00",
+                "instance_id": "evaluation-old",
+                "agent_caused_exit_reason": "TIMEOUT",
+            },
+        ],
+        "total_count": 4,
+    }
+
+
+def test_task_attempts_enforce_org_scope_and_page_limit(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+) -> None:
+    benchmark = example_benchmark_object
+    task = make_task(benchmark, "target", status=TaskStatus.ERROR)
+    other_org = Org(id=uuid4(), name="other-org")
+    other_benchmark = Benchmark(
+        org_id=other_org.id,
+        name=benchmark.name,
+        arguments=benchmark.arguments,
+    )
+    other_task = make_task(other_benchmark, task.task_id, status=TaskStatus.ERROR)
+    database_session.add_all([benchmark, task, other_org, other_benchmark, other_task])
+    database_session.flush()
+
+    target_error = make_error_result(task, "target failure", datetime.now(ZoneInfo("UTC")))
+    foreign_error = make_error_result(task, "foreign failure", datetime.now(ZoneInfo("UTC")))
+    foreign_error.org_id = other_org.id
+    database_session.add_all([target_error, foreign_error])
+    database_session.commit()
+
+    response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/attempts")
+    foreign_response = _client.get(f"/benchmarks/{other_benchmark.id}/tasks/{other_task.task_id}/attempts")
+    oversized_response = _client.get(f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/attempts?limit=101")
+
+    assert response.status_code == 200
+    assert [attempt["error_message"] for attempt in response.json()["attempts"]] == ["target failure"]
+    assert foreign_response.status_code == 404
+    assert oversized_response.status_code == 422
 
 
 def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(


### PR DESCRIPTION
## Summary

- add `GET /benchmarks/{benchmark_id}/tasks/{task_id:path}/attempts`
- return persisted evaluation and error outcomes newest first with bounded offset pagination
- expose a discriminated `evaluation` / `error` response instead of optional mixed fields
- include a full-message SHA-256 fingerprint and a bounded 4,000-character excerpt so repeated failures can be grouped without returning unbounded logs
- enforce organization scope and publish the endpoint in the committed OpenAPI contract
- add production indexes matching the endpoint's `(org_id, task, created_at DESC, id DESC)` scans

## Stack

1. #618 publishes the deterministic Tracker OpenAPI contract.
2. #619 makes task routes slash-safe.
3. This PR adds read-only task outcome history.

This PR adds no runtime orchestration, log streaming, artifact access, sandbox access, or authentication changes.

## Verification

- full Tracker unit CI
- live Tracker integration CI
- disposable-Postgres Alembic/schema tests
- Ruff format/check
- basedpyright
- canonical OpenAPI check
- `git diff --check`
