### PR TITLE
fix(tracker): serialize and chunk CloudWatch logs

### DIFF
--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -159,6 +159,7 @@ def write_benchmark_log_event(stream_key: str, message: str, aws: "AWSCredential
             raise CloudWatchError(f"Failed to create log stream '{stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
+    chunks_written = 0
     try:
         for chunk in _log_event_chunks(message):
             client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
@@ -166,5 +167,6 @@ def write_benchmark_log_event(stream_key: str, message: str, aws: "AWSCredential
                 logStreamName=stream_name,
                 logEvents=[{"timestamp": int(time.time() * 1000), "message": chunk}],
             )
+            chunks_written += 1
     except (ClientError, BotoCoreError) as e:
-        raise CloudWatchError(f"Failed to put log event: {e}") from e
+        raise CloudWatchError(f"Failed to put log event after {chunks_written} complete chunks: {e}") from e

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -1,5 +1,6 @@
 import re
 import time
+from collections.abc import Iterator
 from functools import lru_cache, wraps
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
     from tracker.types import AWSCredentials
 
 _created_streams: set[str] = set()
+_MAX_LOG_EVENT_BYTES = 1_048_576 - 26
 
 
 def _sanitize_log_stream_name(task_id: str) -> str:
@@ -27,6 +29,17 @@ def _sanitize_log_stream_name(task_id: str) -> str:
     forbidden characters so logging degrades gracefully instead of failing.
     """
     return re.sub(r"[:*]", "_", task_id)
+
+
+def _log_event_chunks(message: str) -> Iterator[str]:
+    encoded = message.encode()
+    start = 0
+    while start < len(encoded):
+        end = min(start + _MAX_LOG_EVENT_BYTES, len(encoded))
+        while end < len(encoded) and encoded[end] & 0b1100_0000 == 0b1000_0000:
+            end -= 1
+        yield encoded[start:end].decode()
+        start = end
 
 
 @lru_cache(maxsize=32)
@@ -147,10 +160,11 @@ def write_benchmark_log_event(stream_key: str, message: str, aws: "AWSCredential
         _created_streams.add(stream_key)
 
     try:
-        client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group_name,
-            logStreamName=stream_name,
-            logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
-        )
+        for chunk in _log_event_chunks(message):
+            client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
+                logGroupName=log_group_name,
+                logStreamName=stream_name,
+                logEvents=[{"timestamp": int(time.time() * 1000), "message": chunk}],
+            )
     except (ClientError, BotoCoreError) as e:
         raise CloudWatchError(f"Failed to put log event: {e}") from e

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -45,6 +45,7 @@ from tracker.database.models import (
 )
 from tracker.database.session import engine
 from tracker.exceptions import (
+    CloudWatchError,
     DependencySetupExhaustedError,
     OutputArtifactError,
     SandboxSetupError,
@@ -283,7 +284,9 @@ def handle_early_exit(task_row: Task, task_session: Session) -> bool:
 
 
 def buffer_logs(
-    log_queue: asyncio.Queue[str], stream_key: str, aws: AWSCredentials, log_group: str, force_flush: bool = False
+    log_queue: asyncio.Queue[str],
+    write_queue: asyncio.Queue[str | None],
+    force_flush: bool = False,
 ) -> None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
@@ -295,9 +298,20 @@ def buffer_logs(
     while not log_queue.empty():
         messages.append(log_queue.get_nowait())
 
-    message = "".join(messages)
-    loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws, log_group)
+    write_queue.put_nowait("".join(messages))
+
+
+async def write_buffered_logs(
+    write_queue: asyncio.Queue[str | None],
+    stream_key: str,
+    aws: AWSCredentials,
+    log_group: str,
+) -> None:
+    while (message := await write_queue.get()) is not None:
+        try:
+            await asyncio.to_thread(write_benchmark_log_event, stream_key, message, aws, log_group)
+        except CloudWatchError:
+            logger.exception("Failed to write task logs")
 
 
 def save_eval_resume_state(
@@ -465,6 +479,7 @@ async def _process_task_attempt(
     stream_suffix = f"{int(task_row.started_at.timestamp() * 1_000_000):x}"
     stream_key: str = f"{benchmark_id}:{task_id}_{stream_suffix}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
+    write_queue: asyncio.Queue[str | None] = asyncio.Queue()
 
     last_log_time: float = time.monotonic()
 
@@ -473,7 +488,7 @@ async def _process_task_attempt(
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group)
+        buffer_logs(log_queue, write_queue)
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -481,9 +496,17 @@ async def _process_task_attempt(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
+                buffer_logs(log_queue, write_queue, force_flush=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
+    write_task = asyncio.create_task(
+        write_buffered_logs(
+            write_queue,
+            stream_key,
+            harness_config.aws,
+            harness_config.log_group,
+        )
+    )
 
     def on_eval_resume_state(state: dict[str, Any]) -> None:
         save_eval_resume_state(task_row.id, org, state, expected_started_at=attempt_started_at)
@@ -629,7 +652,7 @@ async def _process_task_attempt(
                 )
 
                 # Force flush the logs if anything has been buffered
-                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
+                buffer_logs(log_queue, write_queue, force_flush=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -708,7 +731,7 @@ async def _process_task_attempt(
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
+                buffer_logs(log_queue, write_queue, force_flush=True)
 
                 # Save the evaluation result to the database with the task row
                 # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
@@ -835,7 +858,9 @@ async def _process_task_attempt(
         flush_task.cancel()
         with suppress(asyncio.CancelledError):
             await flush_task
-        buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
+        buffer_logs(log_queue, write_queue, force_flush=True)
+        write_queue.put_nowait(None)
+        await write_task
 
 
 def commit_task_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -45,7 +45,6 @@ from tracker.database.models import (
 )
 from tracker.database.session import engine
 from tracker.exceptions import (
-    CloudWatchError,
     DependencySetupExhaustedError,
     OutputArtifactError,
     SandboxSetupError,
@@ -310,7 +309,7 @@ async def write_buffered_logs(
     while (message := await write_queue.get()) is not None:
         try:
             await asyncio.to_thread(write_benchmark_log_event, stream_key, message, aws, log_group)
-        except CloudWatchError:
+        except Exception:
             logger.exception("Failed to write task logs")
 
 

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -161,6 +161,22 @@ class TestWriteBenchmarkLogEvent:
         )
         assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
 
+    def test_splits_large_utf8_messages_below_cloudwatch_limit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_credentials: AWSCredentials,
+    ) -> None:
+        client = self._mock_client(monkeypatch)
+        max_event_bytes = 1_048_576 - 26
+        message = "a" * (max_event_bytes - 1) + "🧪tail"
+
+        write_benchmark_log_event("bench123:task", message, aws_credentials, "/valkyrie/worker")
+
+        chunks = [call.kwargs["logEvents"][0]["message"] for call in client.put_log_events.call_args_list]
+        assert len(chunks) == 2
+        assert "".join(chunks) == message
+        assert all(len(chunk.encode()) <= max_event_bytes for chunk in chunks)
+
     def test_create_stream_botocore_error_reports_sanitized_name(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -195,3 +195,23 @@ class TestWriteBenchmarkLogEvent:
 
         assert "provider/model_fast" in str(exc_info.value)
         client.put_log_events.assert_not_called()
+
+    def test_reports_partial_chunk_writes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_credentials: AWSCredentials,
+    ) -> None:
+        client = self._mock_client(monkeypatch)
+        max_event_bytes = 1_048_576 - 26
+        client.put_log_events.side_effect = [
+            None,
+            ClientError({"Error": {"Code": "500", "Message": "Error"}}, "PutLogEvents"),
+        ]
+
+        with pytest.raises(CloudWatchError, match="after 1 complete chunks"):
+            write_benchmark_log_event(
+                "bench123:task",
+                "a" * (max_event_bytes + 1),
+                aws_credentials,
+                "/valkyrie/worker",
+            )

--- a/services/tracker/tests/unit/utils/test_task_execution.py
+++ b/services/tracker/tests/unit/utils/test_task_execution.py
@@ -63,6 +63,31 @@ class TestTaskExecution:
         await asyncio.wait_for(writer, timeout=1)
         assert calls == ["first", "second"]
 
+    async def test_buffered_log_writer_keeps_cloudwatch_failures_non_fatal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[str] = []
+
+        def write(_stream_key: str, message: str, _aws: AWSCredentials, _log_group: str) -> None:
+            calls.append(message)
+            if message == "first":
+                raise RuntimeError("CloudWatch unavailable")
+
+        monkeypatch.setattr(task_execution, "write_benchmark_log_event", write)
+        write_queue: asyncio.Queue[str | None] = asyncio.Queue()
+        for message in ["first", "second", None]:
+            write_queue.put_nowait(message)
+
+        await task_execution.write_buffered_logs(
+            write_queue,
+            "run:task",
+            Mock(spec=AWSCredentials),
+            "/valkyrie/worker",
+        )
+
+        assert calls == ["first", "second"]
+
     async def test_resizable_limiter_increase_wakes_waiting_admission(self) -> None:
         limiter = ResizableLimiter(limit=1)
         first_started = asyncio.Event()

--- a/services/tracker/tests/unit/utils/test_task_execution.py
+++ b/services/tracker/tests/unit/utils/test_task_execution.py
@@ -4,14 +4,17 @@ Run: uv run pytest tests/unit/utils/test_task_execution.py
 """
 
 import asyncio
+import threading
 from typing import Any
 from unittest.mock import MagicMock, Mock
 
 import pytest
 from sqlmodel import Session
 
+import tracker.utils.task_execution as task_execution
 from tests.utils import TEST_ORG_ID
 from tracker.database.models import Benchmark, Org, Task, TaskStatus
+from tracker.types import AWSCredentials
 from tracker.utils import ResizableLimiter, TaskMonitor, TrackedTask, TrackedTaskStatus
 
 
@@ -19,6 +22,46 @@ class TestTaskExecution:
     """Task monitoring and tracked task state transitions."""
 
     _test_org = Org(id=TEST_ORG_ID, name="default")
+
+    async def test_buffered_log_writer_orders_and_drains_final_messages(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[str] = []
+        first_started = threading.Event()
+        release_first = threading.Event()
+
+        def write(_stream_key: str, message: str, _aws: AWSCredentials, _log_group: str) -> None:
+            calls.append(message)
+            if message == "first":
+                first_started.set()
+                release_first.wait(timeout=1)
+
+        monkeypatch.setattr(task_execution, "write_benchmark_log_event", write)
+        log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
+        write_queue: asyncio.Queue[str | None] = asyncio.Queue()
+        aws = Mock(spec=AWSCredentials)
+        for message in ["first", "second"]:
+            log_queue.put_nowait(message)
+            task_execution.buffer_logs(log_queue, write_queue, force_flush=True)
+        write_queue.put_nowait(None)
+
+        writer = asyncio.create_task(
+            task_execution.write_buffered_logs(
+                write_queue,
+                "run:task",
+                aws,
+                "/valkyrie/worker",
+            )
+        )
+        while not first_started.is_set():
+            await asyncio.sleep(0)
+        await asyncio.sleep(0.01)
+        assert calls == ["first"]
+
+        release_first.set()
+        await asyncio.wait_for(writer, timeout=1)
+        assert calls == ["first", "second"]
 
     async def test_resizable_limiter_increase_wakes_waiting_admission(self) -> None:
         limiter = ResizableLimiter(limit=1)


### PR DESCRIPTION
## Summary

- split oversized UTF-8 messages at the current CloudWatch Logs 1 MB event/batch boundary
- serialize task log writes through one background writer
- force the final buffer into that writer and await its drain before task completion
- keep log transport failures non-fatal to task execution
- report how many chunks completed before a partial write failed

## Scope

This is a generic Tracker reliability fix extracted from closed #614. It changes no API, authentication, database schema, managed runtime, Dashboard behavior, or infrastructure.

## Verification

- 22 focused CloudWatch and task-execution tests
- full Tracker unit CI
- live Tracker integration CI
- Ruff format/check
- basedpyright
- `git diff --check`

Current AWS quota reference: https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
