### PR TITLE
feat(tracker): expose run outcome history

### DIFF
--- a/services/tracker/openapi.json
+++ b/services/tracker/openapi.json
@@ -384,6 +384,106 @@
         "title": "BenchmarkArguments",
         "type": "object"
       },
+      "BenchmarkErrorTaskAttempt": {
+        "properties": {
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "error_fingerprint": {
+            "pattern": "^[0-9a-f]{64}$",
+            "title": "Error Fingerprint",
+            "type": "string"
+          },
+          "error_message": {
+            "maxLength": 4000,
+            "title": "Error Message",
+            "type": "string"
+          },
+          "error_message_truncated": {
+            "title": "Error Message Truncated",
+            "type": "boolean"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "kind": {
+            "const": "error",
+            "default": "error",
+            "title": "Kind",
+            "type": "string"
+          },
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "error_message",
+          "error_message_truncated",
+          "error_fingerprint",
+          "task_id"
+        ],
+        "title": "BenchmarkErrorTaskAttempt",
+        "type": "object"
+      },
+      "BenchmarkEvaluationTaskAttempt": {
+        "properties": {
+          "agent_caused_exit_reason": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentCausedExitReason"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "created_at": {
+            "title": "Created At",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "instance_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Instance Id"
+          },
+          "kind": {
+            "const": "evaluation",
+            "default": "evaluation",
+            "title": "Kind",
+            "type": "string"
+          },
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "created_at",
+          "instance_id",
+          "agent_caused_exit_reason",
+          "task_id"
+        ],
+        "title": "BenchmarkEvaluationTaskAttempt",
+        "type": "object"
+      },
       "BenchmarkServiceCatalogResponse": {
         "properties": {
           "services": {
@@ -713,6 +813,41 @@
           "finished_tasks"
         ],
         "title": "BenchmarkTableRow",
+        "type": "object"
+      },
+      "BenchmarkTaskAttemptsResponse": {
+        "properties": {
+          "attempts": {
+            "items": {
+              "discriminator": {
+                "mapping": {
+                  "error": "#/components/schemas/BenchmarkErrorTaskAttempt",
+                  "evaluation": "#/components/schemas/BenchmarkEvaluationTaskAttempt"
+                },
+                "propertyName": "kind"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/BenchmarkErrorTaskAttempt"
+                },
+                {
+                  "$ref": "#/components/schemas/BenchmarkEvaluationTaskAttempt"
+                }
+              ]
+            },
+            "title": "Attempts",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "attempts",
+          "total_count"
+        ],
+        "title": "BenchmarkTaskAttemptsResponse",
         "type": "object"
       },
       "Body_retry_or_resume_benchmark": {
@@ -2286,6 +2421,71 @@
           }
         },
         "summary": "Get Single Benchmark"
+      }
+    },
+    "/benchmarks/{benchmark_id}/attempts": {
+      "get": {
+        "description": "Return persisted task outcomes across a benchmark, newest first.",
+        "operationId": "get_benchmark_task_attempts",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "maximum": 10000,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BenchmarkTaskAttemptsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Benchmark Task Attempts"
       }
     },
     "/benchmarks/{benchmark_id}/concurrency": {

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from datetime import datetime
 import hashlib
-from typing import cast
+from typing import Literal, TypeAlias, assert_never, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import inspect, literal, null, select as sa_select, union_all
 from sqlalchemy.orm import defer
 from sqlmodel import Session, col, desc, func, select
 
@@ -14,6 +17,7 @@ from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.s3 import S3_BENCHMARKS_PREFIX, create_presigned_url, s3_object_exists
 from tracker.database.models import (
+    AgentCausedExitReason,
     Benchmark,
     ErrorResult,
     EvaluationResult,
@@ -39,6 +43,16 @@ from tracker.types import (
 from tracker.utils import fetch_harness_config
 
 router = APIRouter(prefix="/benchmarks")
+
+BenchmarkAttemptRow: TypeAlias = tuple[
+    Literal["evaluation", "error"],
+    UUID,
+    str,
+    datetime,
+    str | None,
+    AgentCausedExitReason | None,
+    str | None,
+]
 
 
 def _summarize_attempt_error(message: str) -> tuple[str, bool, str]:
@@ -86,7 +100,6 @@ def get_benchmark_task_attempts(
     if benchmark is None:
         raise HTTPException(status_code=404, detail="Benchmark not found")
 
-    page_end = offset + limit
     task_filters = (
         col(Task.benchmark) == benchmark.id,
         col(Task.org_id) == org.id,
@@ -99,44 +112,87 @@ def get_benchmark_task_attempts(
         *task_filters,
         col(ErrorResult.org_id) == org.id,
     )
-    evaluation_rows = session.exec(
-        select(EvaluationResult, Task.task_id)
-        .join(Task, col(EvaluationResult.task) == col(Task.id))
+    evaluation_result_table = inspect(EvaluationResult).local_table
+    error_result_table = inspect(ErrorResult).local_table
+    task_table = inspect(Task).local_table
+    evaluation_attempts = (
+        sa_select(
+            literal("evaluation").label("kind"),
+            evaluation_result_table.c.id.label("id"),
+            task_table.c.task_id.label("task_id"),
+            evaluation_result_table.c.created_at.label("created_at"),
+            evaluation_result_table.c.instance_id.label("instance_id"),
+            evaluation_result_table.c.agent_caused_exit_reason.label("agent_caused_exit_reason"),
+            null().label("error_message"),
+        )
+        .join(task_table, evaluation_result_table.c.task == task_table.c.id)
         .where(*evaluation_filters)
-        .order_by(desc(EvaluationResult.created_at), desc(EvaluationResult.id))
-        .options(defer(EvaluationResult.result))  # pyright: ignore[reportArgumentType]
-        .limit(page_end)
-    ).all()
-    error_rows = session.exec(
-        select(ErrorResult, Task.task_id)
-        .join(Task, col(ErrorResult.task) == col(Task.id))
+    )
+    error_attempts = (
+        sa_select(
+            literal("error").label("kind"),
+            error_result_table.c.id.label("id"),
+            task_table.c.task_id.label("task_id"),
+            error_result_table.c.created_at.label("created_at"),
+            null().label("instance_id"),
+            null().label("agent_caused_exit_reason"),
+            error_result_table.c.error_message.label("error_message"),
+        )
+        .join(task_table, error_result_table.c.task == task_table.c.id)
         .where(*error_filters)
-        .order_by(desc(ErrorResult.created_at), desc(ErrorResult.id))
-        .limit(page_end)
-    ).all()
-    attempts: list[BenchmarkTaskAttempt] = [
-        BenchmarkEvaluationTaskAttempt(
-            id=row.id,
-            task_id=task_id,
-            created_at=row.created_at,
-            instance_id=row.instance_id,
-            agent_caused_exit_reason=row.agent_caused_exit_reason,
-        )
-        for row, task_id in evaluation_rows
-    ]
-    for row, task_id in error_rows:
-        message, truncated, fingerprint = _summarize_attempt_error(row.error_message)
-        attempts.append(
-            BenchmarkErrorTaskAttempt(
-                id=row.id,
-                task_id=task_id,
-                created_at=row.created_at,
-                error_message=message,
-                error_message_truncated=truncated,
-                error_fingerprint=fingerprint,
+    )
+    attempt_rows = union_all(evaluation_attempts, error_attempts).subquery()
+    rows = cast(
+        Sequence[BenchmarkAttemptRow],
+        session.execute(  # pyright: ignore[reportDeprecated]
+            sa_select(
+                attempt_rows.c.kind,
+                attempt_rows.c.id,
+                attempt_rows.c.task_id,
+                attempt_rows.c.created_at,
+                attempt_rows.c.instance_id,
+                attempt_rows.c.agent_caused_exit_reason,
+                attempt_rows.c.error_message,
             )
+            .order_by(
+                desc(attempt_rows.c.created_at),
+                desc(attempt_rows.c.id),
+                desc(attempt_rows.c.kind),
+            )
+            .offset(offset)
+            .limit(limit)
         )
-    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int), reverse=True)
+        .tuples()
+        .all(),
+    )
+    attempts: list[BenchmarkTaskAttempt] = []
+    for kind, attempt_id, task_id, created_at, instance_id, exit_reason, error_message in rows:
+        match kind:
+            case "evaluation":
+                attempts.append(
+                    BenchmarkEvaluationTaskAttempt(
+                        id=attempt_id,
+                        task_id=task_id,
+                        created_at=created_at,
+                        instance_id=instance_id,
+                        agent_caused_exit_reason=exit_reason,
+                    )
+                )
+            case "error":
+                assert error_message is not None
+                message, truncated, fingerprint = _summarize_attempt_error(error_message)
+                attempts.append(
+                    BenchmarkErrorTaskAttempt(
+                        id=attempt_id,
+                        task_id=task_id,
+                        created_at=created_at,
+                        error_message=message,
+                        error_message_truncated=truncated,
+                        error_fingerprint=fingerprint,
+                    )
+                )
+            case _:
+                assert_never(kind)
 
     evaluation_count = session.exec(
         select(func.count(col(EvaluationResult.id)))
@@ -147,7 +203,7 @@ def get_benchmark_task_attempts(
         select(func.count(col(ErrorResult.id))).join(Task, col(ErrorResult.task) == col(Task.id)).where(*error_filters)
     ).one()
     return BenchmarkTaskAttemptsResponse(
-        attempts=attempts[offset:page_end],
+        attempts=attempts,
         total_count=evaluation_count + error_count,
     )
 

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -136,7 +136,7 @@ def get_benchmark_task_attempts(
                 error_fingerprint=fingerprint,
             )
         )
-    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int, attempt.kind), reverse=True)
+    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int), reverse=True)
 
     evaluation_count = session.exec(
         select(func.count(col(EvaluationResult.id)))

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -23,6 +23,10 @@ from tracker.database.models import (
 )
 from tracker.database.session import get_session
 from tracker.types import (
+    BenchmarkErrorTaskAttempt,
+    BenchmarkEvaluationTaskAttempt,
+    BenchmarkTaskAttempt,
+    BenchmarkTaskAttemptsResponse,
     ErrorTaskAttempt,
     EvaluationTaskAttempt,
     HarnessConfig,
@@ -62,6 +66,90 @@ def _load_task_or_404(benchmark_id: UUID, task_id: str, org: Org, session: Sessi
         raise HTTPException(status_code=404, detail="Task not found")
 
     return benchmark, task
+
+
+@router.get(
+    "/{benchmark_id}/attempts",
+    response_model=BenchmarkTaskAttemptsResponse,
+)
+def get_benchmark_task_attempts(
+    benchmark_id: UUID,
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0, le=10_000),
+    org: Org = Depends(get_current_org),
+    session: Session = Depends(get_session),
+) -> BenchmarkTaskAttemptsResponse:
+    """Return persisted task outcomes across a benchmark, newest first."""
+    benchmark = session.exec(
+        select(Benchmark).where(Benchmark.id == benchmark_id).where(Benchmark.org_id == org.id)
+    ).first()
+    if benchmark is None:
+        raise HTTPException(status_code=404, detail="Benchmark not found")
+
+    page_end = offset + limit
+    task_filters = (
+        col(Task.benchmark) == benchmark.id,
+        col(Task.org_id) == org.id,
+    )
+    evaluation_filters = (
+        *task_filters,
+        col(EvaluationResult.org_id) == org.id,
+    )
+    error_filters = (
+        *task_filters,
+        col(ErrorResult.org_id) == org.id,
+    )
+    evaluation_rows = session.exec(
+        select(EvaluationResult, Task.task_id)
+        .join(Task, col(EvaluationResult.task) == col(Task.id))
+        .where(*evaluation_filters)
+        .order_by(desc(EvaluationResult.created_at), desc(EvaluationResult.id))
+        .options(defer(EvaluationResult.result))  # pyright: ignore[reportArgumentType]
+        .limit(page_end)
+    ).all()
+    error_rows = session.exec(
+        select(ErrorResult, Task.task_id)
+        .join(Task, col(ErrorResult.task) == col(Task.id))
+        .where(*error_filters)
+        .order_by(desc(ErrorResult.created_at), desc(ErrorResult.id))
+        .limit(page_end)
+    ).all()
+    attempts: list[BenchmarkTaskAttempt] = [
+        BenchmarkEvaluationTaskAttempt(
+            id=row.id,
+            task_id=task_id,
+            created_at=row.created_at,
+            instance_id=row.instance_id,
+            agent_caused_exit_reason=row.agent_caused_exit_reason,
+        )
+        for row, task_id in evaluation_rows
+    ]
+    for row, task_id in error_rows:
+        message, truncated, fingerprint = _summarize_attempt_error(row.error_message)
+        attempts.append(
+            BenchmarkErrorTaskAttempt(
+                id=row.id,
+                task_id=task_id,
+                created_at=row.created_at,
+                error_message=message,
+                error_message_truncated=truncated,
+                error_fingerprint=fingerprint,
+            )
+        )
+    attempts.sort(key=lambda attempt: (attempt.created_at, attempt.id.int, attempt.kind), reverse=True)
+
+    evaluation_count = session.exec(
+        select(func.count(col(EvaluationResult.id)))
+        .join(Task, col(EvaluationResult.task) == col(Task.id))
+        .where(*evaluation_filters)
+    ).one()
+    error_count = session.exec(
+        select(func.count(col(ErrorResult.id))).join(Task, col(ErrorResult.task) == col(Task.id)).where(*error_filters)
+    ).one()
+    return BenchmarkTaskAttemptsResponse(
+        attempts=attempts[offset:page_end],
+        total_count=evaluation_count + error_count,
+    )
 
 
 def _task_prefix(benchmark_id: UUID, task_id: str) -> str:

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -426,6 +426,25 @@ class TaskAttemptsResponse(BaseModel):
     total_count: int
 
 
+class BenchmarkErrorTaskAttempt(ErrorTaskAttempt):
+    task_id: str
+
+
+class BenchmarkEvaluationTaskAttempt(EvaluationTaskAttempt):
+    task_id: str
+
+
+BenchmarkTaskAttempt = Annotated[
+    BenchmarkErrorTaskAttempt | BenchmarkEvaluationTaskAttempt,
+    Field(discriminator="kind"),
+]
+
+
+class BenchmarkTaskAttemptsResponse(BaseModel):
+    attempts: list[BenchmarkTaskAttempt]
+    total_count: int
+
+
 class AgentEntry(BaseModel):
     name: str
     last_modified: str | None = None

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -162,6 +162,31 @@ def test_benchmark_attempts_enforce_org_scope_and_page_limit(
     assert distant_response.status_code == 422
 
 
+def test_benchmark_attempts_processes_only_the_requested_page(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    benchmark = example_benchmark_object
+    task = make_task(benchmark, "retried-task", status=TaskStatus.ERROR)
+    database_session.add_all([benchmark, task])
+    database_session.flush()
+    started_at = datetime(2026, 6, 24, 12, tzinfo=ZoneInfo("UTC"))
+    database_session.add_all(
+        [make_error_result(task, f"failure-{index}", started_at + timedelta(minutes=index)) for index in range(5)]
+    )
+    database_session.commit()
+
+    summarize = Mock(wraps=getattr(single_task_module, "_summarize_attempt_error"))
+    monkeypatch.setattr(single_task_module, "_summarize_attempt_error", summarize)
+
+    response = _client.get(f"/benchmarks/{benchmark.id}/attempts?limit=1&offset=3")
+
+    assert response.status_code == 200, response.text
+    assert [attempt["error_message"] for attempt in response.json()["attempts"]] == ["failure-1"]
+    assert summarize.call_count == 1
+
+
 def test_task_attempts_page_retry_history_newest_first(
     database_session: Session,
     example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -29,6 +29,139 @@ from tracker.database.models import (
 _client = TestClient(app)
 
 
+def test_benchmark_attempts_page_retry_history_across_tasks(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+) -> None:
+    benchmark = example_benchmark_object
+    first_task = make_task(benchmark, "first-task", status=TaskStatus.ERROR)
+    second_task = make_task(benchmark, "second-task", status=TaskStatus.FINISHED)
+    database_session.add_all([benchmark, first_task, second_task])
+    database_session.flush()
+
+    repeated_failure = "identical failure\n" * 500
+    newest_evaluation = make_evaluation_result(
+        second_task,
+        "evaluation-new",
+        {"large": "x" * 5_000},
+        datetime(2026, 6, 24, 16, tzinfo=ZoneInfo("UTC")),
+    )
+    repeated_error_new = make_error_result(
+        first_task,
+        repeated_failure,
+        datetime(2026, 6, 24, 15, tzinfo=ZoneInfo("UTC")),
+    )
+    repeated_error_old = make_error_result(
+        second_task,
+        repeated_failure,
+        datetime(2026, 6, 24, 15, tzinfo=ZoneInfo("UTC")),
+    )
+    older_evaluation = make_evaluation_result(
+        first_task,
+        "evaluation-old",
+        {"score": 0.25},
+        datetime(2026, 6, 24, 14, tzinfo=ZoneInfo("UTC")),
+        exit_reason=AgentCausedExitReason.TIMEOUT,
+    )
+    newest_evaluation.id = UUID("00000000-0000-0000-0000-000000000004")
+    repeated_error_new.id = UUID("00000000-0000-0000-0000-000000000003")
+    repeated_error_old.id = UUID("00000000-0000-0000-0000-000000000002")
+    older_evaluation.id = UUID("00000000-0000-0000-0000-000000000001")
+    database_session.add_all(
+        [
+            newest_evaluation,
+            repeated_error_new,
+            repeated_error_old,
+            older_evaluation,
+        ]
+    )
+    database_session.commit()
+
+    first_response = _client.get(f"/benchmarks/{benchmark.id}/attempts?limit=2")
+    second_response = _client.get(f"/benchmarks/{benchmark.id}/attempts?limit=2&offset=2")
+
+    fingerprint = sha256(repeated_failure.encode()).hexdigest()
+    assert first_response.status_code == 200, first_response.text
+    assert first_response.json() == {
+        "attempts": [
+            {
+                "kind": "evaluation",
+                "id": str(newest_evaluation.id),
+                "task_id": second_task.task_id,
+                "created_at": "2026-06-24T16:00:00+00:00",
+                "instance_id": "evaluation-new",
+                "agent_caused_exit_reason": None,
+            },
+            {
+                "kind": "error",
+                "id": str(repeated_error_new.id),
+                "task_id": first_task.task_id,
+                "created_at": "2026-06-24T15:00:00+00:00",
+                "error_message": repeated_failure[:4_000],
+                "error_message_truncated": True,
+                "error_fingerprint": fingerprint,
+            },
+        ],
+        "total_count": 4,
+    }
+    assert second_response.status_code == 200, second_response.text
+    assert second_response.json() == {
+        "attempts": [
+            {
+                "kind": "error",
+                "id": str(repeated_error_old.id),
+                "task_id": second_task.task_id,
+                "created_at": "2026-06-24T15:00:00+00:00",
+                "error_message": repeated_failure[:4_000],
+                "error_message_truncated": True,
+                "error_fingerprint": fingerprint,
+            },
+            {
+                "kind": "evaluation",
+                "id": str(older_evaluation.id),
+                "task_id": first_task.task_id,
+                "created_at": "2026-06-24T14:00:00+00:00",
+                "instance_id": "evaluation-old",
+                "agent_caused_exit_reason": "TIMEOUT",
+            },
+        ],
+        "total_count": 4,
+    }
+
+
+def test_benchmark_attempts_enforce_org_scope_and_page_limit(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+) -> None:
+    benchmark = example_benchmark_object
+    task = make_task(benchmark, "target", status=TaskStatus.ERROR)
+    other_org = Org(id=uuid4(), name="other-org")
+    other_benchmark = Benchmark(
+        org_id=other_org.id,
+        name=benchmark.name,
+        arguments=benchmark.arguments,
+    )
+    database_session.add_all([benchmark, task, other_org, other_benchmark])
+    database_session.flush()
+
+    target_error = make_error_result(task, "target failure", datetime.now(ZoneInfo("UTC")))
+    foreign_error = make_error_result(task, "foreign failure", datetime.now(ZoneInfo("UTC")))
+    foreign_error.org_id = other_org.id
+    database_session.add_all([target_error, foreign_error])
+    database_session.commit()
+
+    response = _client.get(f"/benchmarks/{benchmark.id}/attempts")
+    foreign_response = _client.get(f"/benchmarks/{other_benchmark.id}/attempts")
+    oversized_response = _client.get(f"/benchmarks/{benchmark.id}/attempts?limit=101")
+    distant_response = _client.get(f"/benchmarks/{benchmark.id}/attempts?offset=10001")
+
+    assert response.status_code == 200
+    assert [attempt["error_message"] for attempt in response.json()["attempts"]] == ["target failure"]
+    assert foreign_response.status_code == 404
+    assert oversized_response.status_code == 422
+    assert distant_response.status_code == 422
+
+
 def test_task_attempts_page_retry_history_newest_first(
     database_session: Session,
     example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/test_openapi.py
+++ b/services/tracker/tests/unit/test_openapi.py
@@ -80,3 +80,10 @@ def test_openapi_declares_required_harness_headers() -> None:
     assert schema["components"]["parameters"] == expected_parameters
     for operation in affected_operations:
         assert operation["parameters"][-4:] == expected_references
+
+
+def test_openapi_declares_run_and_task_attempt_routes() -> None:
+    paths = build_openapi()["paths"]
+
+    assert paths["/benchmarks/{benchmark_id}/attempts"]["get"]["operationId"] == "get_benchmark_task_attempts"
+    assert paths["/benchmarks/{benchmark_id}/tasks/{task_id}/attempts"]["get"]["operationId"] == "get_task_attempts"


### PR DESCRIPTION
## Summary

- add a paginated run-wide view of persisted task outcomes
- include task IDs on discriminated evaluation and error entries
- page a SQL `UNION ALL` across evaluation and error outcomes so only the requested rows reach Python
- preserve globally newest-first ordering and organization isolation
- bound pagination and error excerpts while fingerprinting full messages

## Why

Dashboards need to group repeated retry failures across every task in a run without fetching each task separately. Database-side paging keeps deep pages bounded for large runs.

## Stack

- depends on #621

## Verification

- full Tracker unit CI
- live Tracker integration CI
- focused task API and OpenAPI tests
- regression coverage that only the requested page is processed
- Ruff format/check
- basedpyright on changed Python files
- canonical OpenAPI check
- `git diff --check`
