### PR TITLE
Fix retry after deleting final evaluation

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -810,6 +810,7 @@ async def retry_or_resume_benchmark(
         rerun_task_ids=task_ids,
         org=org,
     )
+    session.expire(benchmark_row, ["final_evaluation"])
 
     if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not verified_task_ids:
         return RetryOrResumeBenchmarkResponse(

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1303,6 +1303,37 @@ class TestRunRecovery:
             "task_finished": TaskStatus.FINISHED,
         }
 
+    async def test_retry_clears_loaded_final_evaluation(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        benchmark = example_benchmark_object
+        benchmark.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark)
+        database_session.flush()
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark.id, status=TaskStatus.ERROR)
+        )
+        database_session.add(FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark.id, final_score=1.0))
+        database_session.commit()
+        assert benchmark.final_evaluation is not None
+
+        async def verify(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify)
+
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark.id}?retry=true")
+
+        assert response.status_code == 200
+        assert mock_kicker.queued_calls[0]["verified_task_ids"] == ["task_0"]
+        reloaded_benchmark = database_session.get(Benchmark, benchmark.id)
+        assert reloaded_benchmark is not None
+        assert reloaded_benchmark.final_evaluation is None
+
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_running_retry_repairs_error_and_later_finalizes_same_run(
         self,


### PR DESCRIPTION
## Summary
- expire the loaded final-evaluation relationship after retry reset deletes it
- add a regression test for retrying a run whose final evaluation was already loaded

## Verification
- uv run pytest tests/unit/utils/test_run_recovery.py -q (25 passed)
- uv run ruff check services/tracker/main.py services/tracker/tests/unit/utils/test_run_recovery.py
- uv run ruff format --check services/tracker/main.py services/tracker/tests/unit/utils/test_run_recovery.py
- uv run basedpyright services/tracker/tests/unit/utils/test_run_recovery.py (0 errors)

Closes vals-ai/valkyrie-ticket-library#143
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/625" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->