### PR TITLE
Support task-targeted Daytona snapshots

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "tenacity>=9.0.0",
     "sentry-sdk[fastapi]==2.58.0",
     "python-json-logger>=3.2.1",
-    "create-benchmark-service>=0.11.0",
+    "create-benchmark-service>=0.20.0",
     "aioboto3>=7.0.0",
 ]
 
@@ -50,7 +50,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.17.3" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.20.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, assert_never
 
 import logfire
 import sentry_sdk
@@ -25,6 +25,7 @@ from benchmark_service import (
     SandboxProvider,
     SandboxSource,
     SnapshotSource,
+    TargetedSnapshotSource,
 )
 from benchmark_service import (
     Resources as TrackerResources,
@@ -106,8 +107,10 @@ def _source_name(source: SandboxSource) -> str:
             return _source_name(outer)
         case ImageSource(image=image):
             return image
-        case SnapshotSource():
+        case SnapshotSource() | TargetedSnapshotSource():
             return "snapshot"
+        case _:
+            assert_never(source)
 
 
 def _provider_source(source: SandboxSource) -> SandboxSource:

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -7,11 +7,20 @@ import asyncio
 import shlex
 from collections import deque
 from collections.abc import AsyncIterator, Mapping
-from typing import Any, Never
+from typing import Any, Never, cast
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
-from benchmark_service import ComposeSandbox, ComposeSource, ExecResult, ImageSource, Resources, SnapshotSource
+from benchmark_service import (
+    ComposeSandbox,
+    ComposeSource,
+    ExecResult,
+    ImageSource,
+    Resources,
+    SandboxSource,
+    SnapshotSource,
+    TargetedSnapshotSource,
+)
 from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxCommandError
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 
@@ -845,6 +854,8 @@ class TestSandboxLifecycle:
             == "public.ecr.aws/vals/harbor"
         )
         assert metric_source_name(SnapshotSource(snapshot="base-python")) == "snapshot"
+        with pytest.raises(AssertionError, match="Expected code to be unreachable"):
+            metric_source_name(cast(SandboxSource, object()))
 
     def test_compose_runtime_sandbox_wraps_only_compose_sources(self) -> None:
         """Compose sources should adapt only the runtime sandbox surface.
@@ -1030,6 +1041,33 @@ class TestSandboxLifecycle:
             )
         ]
         assert context_calls == [("sandbox-123", "ghcr.io/vals/swebench:latest")]
+
+    async def test_targeted_snapshot_is_measured_and_deleted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        provider = AsyncMock()
+        provider.create_sandbox.return_value = mock_sandbox
+        distribution = Mock()
+        set_sandbox_context = Mock()
+        monkeypatch.setattr(sandbox_module, "distribution", distribution)
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", set_sandbox_context)
+
+        source = TargetedSnapshotSource(snapshot="masscan-linux-vm", target="us-west-3")
+        async with create_sandbox(
+            provider=provider,
+            sandbox_name="task-alias",
+            source=source,
+            resources=Resources(vcpu=4, memory=16, disk=30),
+            creation_semaphore=asyncio.Semaphore(1),
+        ) as sandbox:
+            assert sandbox is mock_sandbox
+
+        request = provider.create_sandbox.await_args.args[0]
+        assert request.source == source
+        assert distribution.call_args.kwargs["tags"] == {"image": "snapshot"}
+        set_sandbox_context.assert_called_once_with(mock_sandbox, image="snapshot")
+        provider.delete_sandbox.assert_awaited_once_with(mock_sandbox.id)
 
     async def test_create_sandbox_emits_error_metric(self, monkeypatch: pytest.MonkeyPatch) -> None:
         create_error = RuntimeError("create failed")

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.17.3"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3#748a1a808ee1f75a3f361cc9053934d086f143e3" }
+version = "0.20.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.20.0#77d2d826a82d6af07f370afcc75660133fed423b" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2021,7 +2021,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.20.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.17.3"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3#748a1a808ee1f75a3f361cc9053934d086f143e3" }
+version = "0.20.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.20.0#77d2d826a82d6af07f370afcc75660133fed423b" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2217,7 +2217,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.17.3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.20.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
- consume CBS targeted snapshot sources without changing the run-level interface
- classify targeted snapshots consistently in tracker metrics and cleanup
- pin create-benchmark-service v0.20.0 at commit 77d2d826a82d6af07f370afcc75660133fed423b

## Verification
- 419 tracker tests passed; coverage 86.87%
- Ruff passed
- required Basedpyright surface passed with 0 errors
- root and tracker uv lock checks passed
- independent final review found no actionable issues

## Rollout
This is the consumer-first half of ProgramBench Masscan routing. ProgramBench will not emit targeted_snapshot until this is deployed to dev.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->