### PR TITLE
Require CBS and lockfile checks before prod deploy

### DIFF
--- a/.github/workflows/validate-cbs-latest-tag.yaml
+++ b/.github/workflows/validate-cbs-latest-tag.yaml
@@ -1,0 +1,15 @@
+name: validate-cbs-latest-tag
+
+on:
+  pull_request:
+    branches: [prod]
+  push:
+    branches: [prod]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cbs:
+    uses: vals-ai/.github/.github/workflows/validate-cbs-latest-tag.yaml@main

--- a/.github/workflows/validate-lockfile.yaml
+++ b/.github/workflows/validate-lockfile.yaml
@@ -1,0 +1,26 @@
+name: validate-lockfile
+
+on:
+  pull_request:
+    branches: [dev, prod]
+  push:
+    branches: [dev, prod]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lockfile:
+    strategy:
+      matrix:
+        project_path:
+          - "."
+          - services/tracker
+          - infra
+    uses: vals-ai/.github/.github/workflows/validate-lockfile.yaml@main
+    with:
+      project_path: ${{ matrix.project_path }}
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      SSH_PRIVATE_KEY: ${{ secrets.SUBMODULES_SSH_KEY }}


### PR DESCRIPTION
### Description

Gate the prod deploy job on the existing reusable CBS latest-tag and lockfile validation workflows.

The lockfile validation runs for the root project, tracker service, and infra project before production deploy proceeds.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/628" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->