### PR TITLE
Pass agent environment to sandbox commands

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -208,7 +208,7 @@ Omit this field, or set it to an empty list, to keep unrestricted sandbox egress
 
 ### `secrets: dict`
 
-Secrets required by the agent. Maps environment variable names to AWS Secrets Manager secret names. Tracker resolves them and injects them only during agent dependency installation and execution. Raw values are never stored.
+Secrets specified in the contract or CLI are used when installing dependencies and running the agent. Contract entries map environment variable names to AWS Secrets Manager secret names. Raw values are never stored.
 
 ```yaml
 secrets:

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -208,7 +208,7 @@ Omit this field, or set it to an empty list, to keep unrestricted sandbox egress
 
 ### `secrets: dict`
 
-Secrets required by the agent. Maps environment variable names to AWS Secrets Manager secret names. These are resolved at sandbox creation time - raw values are never stored.
+Secrets required by the agent. Maps environment variable names to AWS Secrets Manager secret names. Tracker resolves them and injects them only during agent dependency installation and execution. Raw values are never stored.
 
 ```yaml
 secrets:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -6,7 +6,7 @@ import time
 import uuid
 from asyncio import Semaphore
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import asynccontextmanager
 from enum import Enum
 from pathlib import PurePosixPath
@@ -342,6 +342,7 @@ async def _install_agent_dependencies_once(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
+    agent_env_vars: Mapping[str, str],
 ) -> None:
     """Run one bounded dependency installation attempt."""
     if not contract.install_cmd:
@@ -356,6 +357,7 @@ async def _install_agent_dependencies_once(
         sandbox,
         f"cd {shlex.quote(str(contract_path))} && {install_cmd}",
         log_output,
+        env_vars=agent_env_vars,
     )
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         raise SandboxError(
@@ -377,23 +379,25 @@ async def _install_agent_dependencies_with_retries(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
+    agent_env_vars: Mapping[str, str],
 ) -> None:
-    await _install_agent_dependencies_once(sandbox, contract, log_output)
+    await _install_agent_dependencies_once(sandbox, contract, log_output, agent_env_vars)
 
 
 async def install_agent_dependencies(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     log_output: Callable[[str], None],
+    agent_env_vars: Mapping[str, str],
     mode: DependencySetupMode = DependencySetupMode.IN_PLACE_RETRIES,
 ) -> None:
     """Install dependencies using the policy selected for this sandbox."""
     if mode is DependencySetupMode.FINAL_FRESH_SANDBOX:
-        await _install_agent_dependencies_once(sandbox, contract, log_output)
+        await _install_agent_dependencies_once(sandbox, contract, log_output, agent_env_vars)
         return
 
     try:
-        await _install_agent_dependencies_with_retries(sandbox, contract, log_output)
+        await _install_agent_dependencies_with_retries(sandbox, contract, log_output, agent_env_vars)
     except SandboxError as error:
         raise DependencySetupExhaustedError(
             f"Dependency installation for contract {contract.name} failed after 4 attempts"
@@ -457,14 +461,15 @@ async def _stream_command_output_with_egress_allowlist(
     command: str,
     on_output: Callable[[str], None],
     allowed_addresses: list[str],
+    agent_env_vars: Mapping[str, str],
 ) -> tuple[AgentCausedExitReason | None, float]:
     if not allowed_addresses:
-        return await stream_command_output(sandbox, command, on_output)
+        return await stream_command_output(sandbox, command, on_output, env_vars=agent_env_vars)
 
     command_completed = False
     try:
         await _apply_egress_allowlist(sandbox, allowed_addresses)
-        result = await stream_command_output(sandbox, command, on_output)
+        result = await stream_command_output(sandbox, command, on_output, env_vars=agent_env_vars)
         command_completed = True
         return result
     finally:
@@ -476,6 +481,8 @@ async def stream_command_output(
     sandbox: Sandbox,
     command: str,
     on_output: Callable[[str], None],
+    *,
+    env_vars: Mapping[str, str] | None = None,
 ) -> tuple[AgentCausedExitReason | None, float]:
     # Bounded tail of recent output, kept only for error messages; capped by characters
     # rather than chunk count since a single chunk can be arbitrarily large.
@@ -496,7 +503,7 @@ async def stream_command_output(
     exit_code = _SUCCESS_EXIT_CODE
     try:
         try:
-            async for data in sandbox.command(timed_command):
+            async for data in sandbox.command(timed_command, env_vars=env_vars):
                 on_output(data)
                 output.append(data)
                 output_chars += len(data)
@@ -740,6 +747,7 @@ async def run_agent(
     cwd: str,
     aws: AWSCredentials,
     s3_bucket: str,
+    agent_env_vars: Mapping[str, str],
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
     benchmark_id: str | None = None,
@@ -755,6 +763,7 @@ async def run_agent(
         problem_path: Path inside the sandbox where the problem statement file was written during setup
         log_output: Callback to log output
         cwd: Working directory to run the agent in
+        agent_env_vars: Resolved environment passed natively to agent setup and execution
         agent_output_s3_key: S3 key to where we will upload the final output archive to
         agent_timeout: Optional timeout in seconds to enforce on the agent command
         runtime_source: Optional source used to adapt agent commands to the task runtime
@@ -770,7 +779,7 @@ async def run_agent(
     if runtime_source is not None:
         sandbox = runtime_sandbox(sandbox, runtime_source)
 
-    await install_agent_dependencies(sandbox, contract, log_output, dependency_setup_mode)
+    await install_agent_dependencies(sandbox, contract, log_output, agent_env_vars, dependency_setup_mode)
 
     run_cmd = contract.run_cmd.replace("{problem_statement_path}", problem_path).replace("{task_id}", task_id)
 
@@ -790,6 +799,7 @@ async def run_agent(
         f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}",
         log_output,
         contract.egress_allowlist,
+        agent_env_vars=agent_env_vars,
     )
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -763,7 +763,7 @@ async def run_agent(
         problem_path: Path inside the sandbox where the problem statement file was written during setup
         log_output: Callback to log output
         cwd: Working directory to run the agent in
-        agent_env_vars: Resolved environment passed natively to agent setup and execution
+        agent_env_vars: Environment supplied to each fresh agent PTY
         agent_output_s3_key: S3 key to where we will upload the final output archive to
         agent_timeout: Optional timeout in seconds to enforce on the agent command
         runtime_source: Optional source used to adapt agent commands to the task runtime

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -569,11 +569,15 @@ async def _process_task_attempt(
         if benchmark_started_by_email:
             identity["email"] = benchmark_started_by_email
 
-        env_vars = {
-            **resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws),
+        agent_secrets = resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws)
+        agent_secrets.pop("DAYTONA_SANDBOX_OTEL_EXTRA_LABELS", None)
+        agent_env_vars = {
+            **agent_secrets,
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
             "IDENTITY": json.dumps(identity),
+        }
+        sandbox_env_vars = {
             # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
             # are filterable per benchmark run and separable from other environments sharing the
             # same Daytona account (sandbox OTLP export is account-level).
@@ -591,7 +595,7 @@ async def _process_task_attempt(
             sandbox_name=task_row.task_id,
             source=task_data.source,
             labels=labels,
-            env_vars=env_vars,
+            env_vars=sandbox_env_vars,
             resources=task_data.resources,
             creation_semaphore=creation_semaphore,
         ) as sandbox:
@@ -646,7 +650,7 @@ async def _process_task_attempt(
                         task_data.cwd,
                         aws=harness_config.aws,
                         s3_bucket=harness_config.s3_bucket,
-                        agent_env_vars=env_vars,
+                        agent_env_vars=agent_env_vars,
                         agent_output_s3_key=agent_output_s3_key,
                         agent_timeout=task_data.agent_timeout,
                         benchmark_id=str(benchmark_id),

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -569,10 +569,8 @@ async def _process_task_attempt(
         if benchmark_started_by_email:
             identity["email"] = benchmark_started_by_email
 
-        agent_secrets = resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws)
-        agent_secrets.pop("DAYTONA_SANDBOX_OTEL_EXTRA_LABELS", None)
         agent_env_vars = {
-            **agent_secrets,
+            **resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws),
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
             "IDENTITY": json.dumps(identity),
@@ -587,8 +585,10 @@ async def _process_task_attempt(
             sandbox_name=task_row.task_id,
             source=task_data.source,
             labels=labels,
-            # Sandbox telemetry is configuration; agent secrets stay command-scoped.
             env_vars={
+                # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
+                # are filterable per benchmark run and separable from other environments sharing the
+                # same Daytona account (sandbox OTLP export is account-level).
                 "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": (
                     f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
                 )

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -646,6 +646,7 @@ async def _process_task_attempt(
                         task_data.cwd,
                         aws=harness_config.aws,
                         s3_bucket=harness_config.s3_bucket,
+                        agent_env_vars=env_vars,
                         agent_output_s3_key=agent_output_s3_key,
                         agent_timeout=task_data.agent_timeout,
                         benchmark_id=str(benchmark_id),

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -577,14 +577,6 @@ async def _process_task_attempt(
             "TASK_ID": task_row.task_id,
             "IDENTITY": json.dumps(identity),
         }
-        sandbox_env_vars = {
-            # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
-            # are filterable per benchmark run and separable from other environments sharing the
-            # same Daytona account (sandbox OTLP export is account-level).
-            "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": (
-                f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
-            ),
-        }
 
         # We don't want to track the task until the sandbox is actually created.
         task_breakdown = TaskBreakdown()
@@ -595,7 +587,12 @@ async def _process_task_attempt(
             sandbox_name=task_row.task_id,
             source=task_data.source,
             labels=labels,
-            env_vars=sandbox_env_vars,
+            # Sandbox telemetry is configuration; agent secrets stay command-scoped.
+            env_vars={
+                "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": (
+                    f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
+                )
+            },
             resources=task_data.resources,
             creation_semaphore=creation_semaphore,
         ) as sandbox:

--- a/services/tracker/tests/integration/live/sandbox/test_compose.py
+++ b/services/tracker/tests/integration/live/sandbox/test_compose.py
@@ -210,6 +210,7 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
         task_data.cwd,
         aws=aws_credentials,
         s3_bucket="unused",
+        agent_env_vars={},
         runtime_source=task_data.source,
     )
 

--- a/services/tracker/tests/integration/live/sandbox/test_compose.py
+++ b/services/tracker/tests/integration/live/sandbox/test_compose.py
@@ -96,13 +96,6 @@ async def compose_sandbox(
     project_name = f"tracker-compose-{uuid.uuid4().hex[:8]}"
     compose_file = f"/tmp/{project_name}.compose.yaml"
     task_data = _compose_task_response(f"docker compose -p {project_name} -f {compose_file}")
-    env_vars = {
-        "RUN_ID": _COMPOSE_RUN_ID,
-        "TASK_ID": _COMPOSE_TASK_ID,
-        "IDENTITY": _COMPOSE_IDENTITY,
-        "TRACKER_COMPOSE_SECRET": _COMPOSE_SECRET,
-    }
-
     assert isinstance(task_data.source, ComposeSource)
     assert isinstance(task_data.source.outer, ImageSource)
 
@@ -113,7 +106,6 @@ async def compose_sandbox(
         task_data.source,
         task_data.resources,
         creation_semaphore,
-        env_vars=env_vars,
     ) as outer_sandbox:
         try:
             await _start_compose_runtime(outer_sandbox, task_data.source, compose_file)
@@ -210,7 +202,12 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
         task_data.cwd,
         aws=aws_credentials,
         s3_bucket="unused",
-        agent_env_vars={},
+        agent_env_vars={
+            "RUN_ID": _COMPOSE_RUN_ID,
+            "TASK_ID": _COMPOSE_TASK_ID,
+            "IDENTITY": _COMPOSE_IDENTITY,
+            "TRACKER_COMPOSE_SECRET": _COMPOSE_SECRET,
+        },
         runtime_source=task_data.source,
     )
 
@@ -223,6 +220,8 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
 
     run_proof = await sandbox.exec("cat /workspace/agent-run.txt", timeout=30)
     assert run_proof.stdout == "agent-run"
+    ambient_secret = await sandbox.exec('test -z "${TRACKER_COMPOSE_SECRET+x}"', timeout=30)
+    assert ambient_secret.exit_code == 0
 
     evaluation = await sandbox.exec(
         "test -s /workspace/agent-run.txt && printf '{\"score\":1}' > /workspace/evaluation.json",

--- a/services/tracker/tests/integration/live/sandbox/test_sandbox.py
+++ b/services/tracker/tests/integration/live/sandbox/test_sandbox.py
@@ -232,7 +232,7 @@ class TestSandboxOperations:
         await test_sandbox.exec(f"mkdir -p /bundle/{contract_name}")
         await test_sandbox.exec(f"echo '#!/bin/bash\necho hello world' > /bundle/{contract_name}/setup.sh")
 
-        await install_agent_dependencies(test_sandbox, contract, log_callback)
+        await install_agent_dependencies(test_sandbox, contract, log_callback, {})
 
         # Verify messages were logged
         output = "\n".join(logged_messages)
@@ -277,6 +277,7 @@ class TestSandboxOperations:
             cwd="/",
             aws=live_aws_credentials,
             s3_bucket=harness_config.s3_bucket,
+            agent_env_vars={},
         )
 
         output = "\n".join(logged_messages)
@@ -321,6 +322,7 @@ class TestSandboxOperations:
             cwd="/",
             aws=live_aws_credentials,
             s3_bucket=harness_config.s3_bucket,
+            agent_env_vars={},
         )
 
         output = "\n".join(logged_messages)

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -557,6 +557,7 @@ class TestRunAgent:
             "/testbed",
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
+            agent_env_vars={},
             benchmark_id="benchmark-123",
         )
 
@@ -612,6 +613,7 @@ class TestRunAgent:
             "/testbed",
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
+            agent_env_vars={},
             agent_output_s3_key="benchmarks/run/task/agent_output.tar.gz",
             benchmark_id="benchmark-123",
         )
@@ -640,9 +642,16 @@ class TestRunAgent:
             assert command == "mkdir -p /workspace"
             return ExecResult(exit_code=0)
 
-        async def fake_stream_command_output(sandbox: Any, command: str, _log_output: Any) -> tuple[None, float]:
+        async def fake_stream_command_output(
+            sandbox: Any,
+            command: str,
+            _log_output: Any,
+            *,
+            env_vars: Mapping[str, str] | None = None,
+        ) -> tuple[None, float]:
             observed_sandboxes.append(sandbox)
             assert command == "cd /workspace && PYTHONSAFEPATH=1 echo done"
+            assert env_vars == {}
             return None, 0.0
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
@@ -662,6 +671,7 @@ class TestRunAgent:
             "/workspace",
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
+            agent_env_vars={},
             runtime_source=ComposeSource(
                 outer=ImageSource(image="docker:28.3.3-dind"),
                 compose_command="docker compose -f /harbor/compose.yaml",
@@ -693,8 +703,15 @@ class TestRunAgent:
             assert command == "mkdir -p /workspace"
             return ExecResult(exit_code=0)
 
-        async def fake_stream_command_output(_sandbox: Any, command: str, _log_output: Any) -> tuple[None, float]:
+        async def fake_stream_command_output(
+            _sandbox: Any,
+            command: str,
+            _log_output: Any,
+            *,
+            env_vars: Mapping[str, str] | None = None,
+        ) -> tuple[None, float]:
             observed_commands.append(command)
+            assert env_vars == {}
             return None, 0.0
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
@@ -713,10 +730,46 @@ class TestRunAgent:
             "/workspace",
             aws=harness_config.aws,
             s3_bucket=harness_config.s3_bucket,
+            agent_env_vars={},
             agent_timeout=2.5,
         )
 
         assert observed_commands == [f"cd /workspace && PYTHONSAFEPATH=1 timeout 2.5 sh -c {shlex.quote(run_cmd)}"]
+
+    async def test_run_agent_passes_environment_to_install_and_execution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: Any,
+    ) -> None:
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="bash setup.sh",
+            run_cmd="echo done",
+        )
+        agent_env_vars = {"MODEL_PROXY_SSH_KEY": "sentinel-key"}
+        stream_output = AsyncMock(return_value=(None, 0.0))
+        monkeypatch.setattr(sandbox_module, "_exec", AsyncMock(return_value=ExecResult(exit_code=0)))
+        monkeypatch.setattr(sandbox_module, "stream_command_output", stream_output)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        await run_agent(
+            mock_sandbox,
+            contract,
+            "/tmp/problem.txt",
+            "task_0",
+            lambda _msg: None,
+            "/workspace",
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+            agent_env_vars=agent_env_vars,
+        )
+
+        assert stream_output.await_count == 2
+        assert all(call.kwargs["env_vars"] is agent_env_vars for call in stream_output.await_args_list)
+        assert all("sentinel-key" not in call.args[1] for call in stream_output.await_args_list)
 
 
 class TestSandboxRetry:
@@ -755,8 +808,11 @@ class TestSandboxRetry:
             _sandbox: Any,
             command: str,
             _log_output: Any,
+            *,
+            env_vars: Mapping[str, str] | None = None,
         ) -> tuple[AgentCausedExitReason | None, float]:
             observed_commands.append(command)
+            assert env_vars == {}
 
             return setup_results.popleft()
 
@@ -765,7 +821,7 @@ class TestSandboxRetry:
 
         monkeypatch.setattr(sandbox_module, "stream_command_output", fake_stream_command_output)
 
-        await _install_agent_dependencies(Mock(), contract, log_output)
+        await _install_agent_dependencies(Mock(), contract, log_output, {})
 
         expected_command = "cd /bundle/test-agent && timeout 600 sh -c 'apt-get update -qq && echo done'"
         assert observed_commands == [expected_command, expected_command]
@@ -791,7 +847,7 @@ class TestSandboxRetry:
         monkeypatch.setattr(sandbox_module, "stream_command_output", stream_command)
         monkeypatch.setattr(asyncio, "sleep", sleep)
 
-        await _install_agent_dependencies(Mock(), contract, _ignore_output)
+        await _install_agent_dependencies(Mock(), contract, _ignore_output, {})
 
         assert stream_command.await_count == 4
         assert [call.args[0] for call in sleep.await_args_list] == [0.0, 10.0, 60.0]
@@ -811,7 +867,7 @@ class TestSandboxRetry:
         monkeypatch.setattr(asyncio, "sleep", sleep)
 
         with pytest.raises(DependencySetupExhaustedError) as exc_info:
-            await _install_agent_dependencies(Mock(), contract, _ignore_output)
+            await _install_agent_dependencies(Mock(), contract, _ignore_output, {})
 
         assert isinstance(exc_info.value.__cause__, AgentRunFailedError)
         assert stream_command.await_count == 4
@@ -826,6 +882,7 @@ class TestSandboxRetry:
                 Mock(),
                 contract,
                 _ignore_output,
+                {},
                 mode=mode.FINAL_FRESH_SANDBOX,
             )
 
@@ -1252,6 +1309,7 @@ class TestEgressAllowlist:
             "run-agent.sh",
             on_output=ignore_output,
             allowed_addresses=["https://api.openai.com"],
+            agent_env_vars={},
         )
 
         assert result == (None, 2.5)
@@ -1285,6 +1343,7 @@ class TestEgressAllowlist:
             "run-agent.sh",
             on_output=ignore_output,
             allowed_addresses=[],
+            agent_env_vars={},
         )
 
         assert result == (None, 1.0)
@@ -1321,7 +1380,15 @@ class TestStreamCommandOutputAgentFailure:
     """Agent command failure cleanup and error classification."""
 
     async def test_stream_command_output_removes_timing_files(self) -> None:
-        async def stream_command(_command: str) -> AsyncIterator[str]:
+        observed_env_vars: Mapping[str, str] | None = None
+
+        async def stream_command(
+            _command: str,
+            *,
+            env_vars: Mapping[str, str] | None = None,
+        ) -> AsyncIterator[str]:
+            nonlocal observed_env_vars
+            observed_env_vars = env_vars
             yield "done\n"
 
         exec_commands: list[str] = []
@@ -1342,11 +1409,15 @@ class TestStreamCommandOutputAgentFailure:
         mock_sandbox.exec = exec_command
 
         exit_reason, duration = await sandbox_module.stream_command_output(
-            mock_sandbox, "run-agent.sh", on_output=lambda _: None
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=lambda _: None,
+            env_vars={"MODEL_PROXY_SSH_KEY": "sentinel-key"},
         )
 
         assert exit_reason is None
         assert duration == 2
+        assert observed_env_vars == {"MODEL_PROXY_SSH_KEY": "sentinel-key"}
         assert exec_commands[-1].startswith("rm -f ")
         assert ".start_ns" in exec_commands[-1]
         assert ".end_ns" in exec_commands[-1]
@@ -1355,7 +1426,12 @@ class TestStreamCommandOutputAgentFailure:
     async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(
         self, monkeypatch: pytest.MonkeyPatch, exit_code: int
     ) -> None:
-        async def stream_command(_command: str) -> AsyncIterator[str]:
+        async def stream_command(
+            _command: str,
+            *,
+            env_vars: Mapping[str, str] | None = None,
+        ) -> AsyncIterator[str]:
+            assert env_vars is None
             yield "last line\n"
             raise ProviderSandboxCommandError(exit_code)
 
@@ -1393,7 +1469,12 @@ class TestStreamCommandOutputAgentFailure:
         """
         tail_cap = getattr(sandbox_module, "_OUTPUT_TAIL_MAX_CHARS")
 
-        async def stream_command(_command: str) -> AsyncIterator[str]:
+        async def stream_command(
+            _command: str,
+            *,
+            env_vars: Mapping[str, str] | None = None,
+        ) -> AsyncIterator[str]:
+            assert env_vars is None
             yield "old-marker\n"
             yield "x" * (tail_cap + 1) + "\n"
             yield "new-marker\n"

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -31,6 +31,16 @@ async def _capture_sandbox_environment(
     yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
 
 
+async def _capture_agent_environment(
+    captured_env_vars: list[dict[str, str]],
+    *_args: Any,
+    agent_env_vars: dict[str, str],
+    **_kwargs: Any,
+) -> tuple[None, float]:
+    captured_env_vars.append(agent_env_vars)
+    return None, 0.0
+
+
 class TestProcessTaskEnvironment:
     """Tracker-owned environment variables passed to agent tasks."""
 
@@ -62,6 +72,7 @@ class TestProcessTaskEnvironment:
             }
         )
         captured_env_vars: list[dict[str, str]] = []
+        captured_agent_env_vars: list[dict[str, str]] = []
 
         def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
             return {
@@ -78,6 +89,11 @@ class TestProcessTaskEnvironment:
             utils_module,
             "create_sandbox",
             partial(_capture_sandbox_environment, captured_env_vars),
+        )
+        monkeypatch.setattr(
+            utils_module,
+            "run_agent",
+            partial(_capture_agent_environment, captured_agent_env_vars),
         )
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
@@ -96,6 +112,7 @@ class TestProcessTaskEnvironment:
         assert env_vars["UNRELATED_SECRET"] == "secret-value"
         assert env_vars["MODEL_GATEWAY_URL"] == "https://gateway.example.test"
         assert env_vars["MODEL_GATEWAY_API_KEY"] == "gateway-key"
+        assert captured_agent_env_vars == [env_vars]
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_task_omits_identity_email_when_unavailable(

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -71,7 +71,7 @@ class TestProcessTaskEnvironment:
                 "contract": contract.model_copy(update={"name": "transient-agent-name"}),
             }
         )
-        captured_env_vars: list[dict[str, str]] = []
+        captured_sandbox_env_vars: list[dict[str, str]] = []
         captured_agent_env_vars: list[dict[str, str]] = []
 
         def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
@@ -82,13 +82,14 @@ class TestProcessTaskEnvironment:
                 "UNRELATED_SECRET": "secret-value",
                 "MODEL_GATEWAY_URL": "https://gateway.example.test",
                 "MODEL_GATEWAY_API_KEY": "gateway-key",
+                "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": "secret-value",
             }
 
         monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_secrets)
         monkeypatch.setattr(
             utils_module,
             "create_sandbox",
-            partial(_capture_sandbox_environment, captured_env_vars),
+            partial(_capture_sandbox_environment, captured_sandbox_env_vars),
         )
         monkeypatch.setattr(
             utils_module,
@@ -99,20 +100,27 @@ class TestProcessTaskEnvironment:
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": {"status": "success", "score": 1.0}}
-        assert len(captured_env_vars) == 1
-        env_vars = captured_env_vars[0]
-        assert env_vars["RUN_ID"] == str(benchmark_id)
-        assert "QUESTION_ID" not in env_vars
-        assert env_vars["TASK_ID"] == "task_0"
-        assert json.loads(env_vars["IDENTITY"]) == {
+        assert captured_sandbox_env_vars == [
+            {
+                "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": (
+                    f"benchmark_id={benchmark_id},task_id=task_0,environment={utils_module.ENVIRONMENT}"
+                )
+            }
+        ]
+        assert len(captured_agent_env_vars) == 1
+        agent_env_vars = captured_agent_env_vars[0]
+        assert agent_env_vars["RUN_ID"] == str(benchmark_id)
+        assert "QUESTION_ID" not in agent_env_vars
+        assert agent_env_vars["TASK_ID"] == "task_0"
+        assert json.loads(agent_env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,
             "email": "starter@example.com",
         }
-        assert env_vars["UNRELATED_SECRET"] == "secret-value"
-        assert env_vars["MODEL_GATEWAY_URL"] == "https://gateway.example.test"
-        assert env_vars["MODEL_GATEWAY_API_KEY"] == "gateway-key"
-        assert captured_agent_env_vars == [env_vars]
+        assert agent_env_vars["UNRELATED_SECRET"] == "secret-value"
+        assert agent_env_vars["MODEL_GATEWAY_URL"] == "https://gateway.example.test"
+        assert agent_env_vars["MODEL_GATEWAY_API_KEY"] == "gateway-key"
+        assert "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS" not in agent_env_vars
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_task_omits_identity_email_when_unavailable(
@@ -127,7 +135,7 @@ class TestProcessTaskEnvironment:
             database_session,
             harness_config,
         )
-        captured_env_vars: list[dict[str, str]] = []
+        captured_agent_env_vars: list[dict[str, str]] = []
 
         def _mock_resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
             return {}
@@ -135,18 +143,18 @@ class TestProcessTaskEnvironment:
         monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_no_secrets)
         monkeypatch.setattr(
             utils_module,
-            "create_sandbox",
-            partial(_capture_sandbox_environment, captured_env_vars),
+            "run_agent",
+            partial(_capture_agent_environment, captured_agent_env_vars),
         )
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": {"status": "success", "score": 1.0}}
-        assert len(captured_env_vars) == 1
-        env_vars = captured_env_vars[0]
-        assert json.loads(env_vars["IDENTITY"]) == {
+        assert len(captured_agent_env_vars) == 1
+        agent_env_vars = captured_agent_env_vars[0]
+        assert json.loads(agent_env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,
         }
-        assert "MODEL_GATEWAY_URL" not in env_vars
-        assert "MODEL_GATEWAY_API_KEY" not in env_vars
+        assert "MODEL_GATEWAY_URL" not in agent_env_vars
+        assert "MODEL_GATEWAY_API_KEY" not in agent_env_vars

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -73,7 +73,6 @@ class TestProcessTaskEnvironment:
                 "UNRELATED_SECRET": "secret-value",
                 "MODEL_GATEWAY_URL": "https://gateway.example.test",
                 "MODEL_GATEWAY_API_KEY": "gateway-key",
-                "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": "secret-value",
             }
 
         monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_secrets)
@@ -107,7 +106,6 @@ class TestProcessTaskEnvironment:
         assert agent_env_vars["UNRELATED_SECRET"] == "secret-value"
         assert agent_env_vars["MODEL_GATEWAY_URL"] == "https://gateway.example.test"
         assert agent_env_vars["MODEL_GATEWAY_API_KEY"] == "gateway-key"
-        assert "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS" not in agent_env_vars
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_task_omits_identity_email_when_unavailable(

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlmodel import Session
@@ -29,16 +30,6 @@ async def _capture_sandbox_environment(
 ) -> AsyncGenerator[SimpleNamespace, None]:
     captured_env_vars.append(env_vars)
     yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
-
-
-async def _capture_agent_environment(
-    captured_env_vars: list[dict[str, str]],
-    *_args: Any,
-    agent_env_vars: dict[str, str],
-    **_kwargs: Any,
-) -> tuple[None, float]:
-    captured_env_vars.append(agent_env_vars)
-    return None, 0.0
 
 
 class TestProcessTaskEnvironment:
@@ -72,7 +63,7 @@ class TestProcessTaskEnvironment:
             }
         )
         captured_sandbox_env_vars: list[dict[str, str]] = []
-        captured_agent_env_vars: list[dict[str, str]] = []
+        run_agent = AsyncMock(return_value=(None, 0.0))
 
         def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
             return {
@@ -91,11 +82,7 @@ class TestProcessTaskEnvironment:
             "create_sandbox",
             partial(_capture_sandbox_environment, captured_sandbox_env_vars),
         )
-        monkeypatch.setattr(
-            utils_module,
-            "run_agent",
-            partial(_capture_agent_environment, captured_agent_env_vars),
-        )
+        monkeypatch.setattr(utils_module, "run_agent", run_agent)
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
@@ -107,8 +94,8 @@ class TestProcessTaskEnvironment:
                 )
             }
         ]
-        assert len(captured_agent_env_vars) == 1
-        agent_env_vars = captured_agent_env_vars[0]
+        run_agent.assert_awaited_once()
+        agent_env_vars = run_agent.call_args.kwargs["agent_env_vars"]
         assert agent_env_vars["RUN_ID"] == str(benchmark_id)
         assert "QUESTION_ID" not in agent_env_vars
         assert agent_env_vars["TASK_ID"] == "task_0"
@@ -135,23 +122,19 @@ class TestProcessTaskEnvironment:
             database_session,
             harness_config,
         )
-        captured_agent_env_vars: list[dict[str, str]] = []
+        run_agent = AsyncMock(return_value=(None, 0.0))
 
         def _mock_resolve_no_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
             return {}
 
         monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_no_secrets)
-        monkeypatch.setattr(
-            utils_module,
-            "run_agent",
-            partial(_capture_agent_environment, captured_agent_env_vars),
-        )
+        monkeypatch.setattr(utils_module, "run_agent", run_agent)
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config)
 
         assert result == {"task_0": {"status": "success", "score": 1.0}}
-        assert len(captured_agent_env_vars) == 1
-        agent_env_vars = captured_agent_env_vars[0]
+        run_agent.assert_awaited_once()
+        agent_env_vars = run_agent.call_args.kwargs["agent_env_vars"]
         assert json.loads(agent_env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,


### PR DESCRIPTION
## What changed

- Pass Tracker's already-resolved task environment to agent dependency installation and agent execution through the sandbox command API.
- Keep values out of shell command text.
- Add regression coverage for both command stages and the task-execution handoff.

## Why

Masscan is routed to a targeted Daytona Linux VM. Unlike container sandboxes, that VM does not expose `SandboxCreateRequest.env_vars` to newly created PTYs, so `setup.sh` failed with `MODEL_PROXY_SSH_KEY is required`.

CBS v0.22.1 attempted to restore sandbox-wide inheritance with `update_env`, but the required live smoke against the exact Masscan snapshot failed with `DaytonaNotFoundError: Failed to update environment: 404 page not found`. This PR uses the PTY command environment path that the runner actually supports and limits secret lifetime to dependency and agent commands.

## Validation

- Exact `us-west-3` Masscan snapshot live smoke: dependency setup and agent execution both received a surrogate variable; direct commands did not retain it; cross-target lookup passed; sandbox deleted.
- Local Docker Tracker API and worker built from this branch; `/health` returned `{"status":"ok"}`.
- `make test`: 420 passed, Alembic passed, 86.94% coverage.
- Ruff lint and format passed.
- Basedpyright reports only two pre-existing errors at unchanged `task_execution.py` lines 516 and 720.