### PR TITLE
Measure agent command duration in tracker process

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -405,6 +405,7 @@ async def install_agent_dependencies(
 _TIMEOUT_EXIT_CODE: int = 124
 _OS_KILL_EXIT_CODE: int = 137
 _SUCCESS_EXIT_CODE: int = 0
+_STATUS_DIR = "/tmp/.valkyrie"
 _OUTPUT_TAIL_MAX_CHARS = 64 * 1024
 _EGRESS_RETRY = retry(
     retry=retry_if_exception_type(ProviderSandboxError) & retry_if_not_exception_type(SandboxNotFoundError),
@@ -480,35 +481,72 @@ async def stream_command_output(
     # rather than chunk count since a single chunk can be arbitrarily large.
     output: deque[str] = deque()
     output_chars = 0
+    run_id = uuid.uuid4().hex
+    start_ns_path = f"{_STATUS_DIR}/{run_id}.start_ns"
+    end_ns_path = f"{_STATUS_DIR}/{run_id}.end_ns"
+    # Timing is embedded in the sandbox command so it excludes the tracker->sandbox
+    # request round-trip and program cold-start (~5-6s), keeping the measurement accurate.
+    timed_command = (
+        f"mkdir -p {shlex.quote(_STATUS_DIR)}"
+        f" && date +%s%N > {shlex.quote(start_ns_path)}"
+        f"; {command}"
+        f"; exit_code=$?"
+        f"; date +%s%N > {shlex.quote(end_ns_path)}"
+        f'; sh -c "exit $exit_code"'
+    )
 
     exit_code = _SUCCESS_EXIT_CODE
-    started_at = time.monotonic()
+    monotonic_start = time.monotonic()
     try:
-        async for data in sandbox.command(command):
-            on_output(data)
-            output.append(data)
-            output_chars += len(data)
-            while output_chars > _OUTPUT_TAIL_MAX_CHARS and len(output) > 1:
-                output_chars -= len(output.popleft())
-    except ProviderSandboxCommandError as e:
-        exit_code = e.exit_code
-    except SandboxNotFoundError:
-        raise
-    except ProviderSandboxError as e:
-        raise SandboxError(str(e)) from e
-    duration = time.monotonic() - started_at
+        try:
+            async for data in sandbox.command(timed_command):
+                on_output(data)
+                output.append(data)
+                output_chars += len(data)
+                while output_chars > _OUTPUT_TAIL_MAX_CHARS and len(output) > 1:
+                    output_chars -= len(output.popleft())
+        except ProviderSandboxCommandError as e:
+            exit_code = e.exit_code
+        except SandboxNotFoundError:
+            raise
+        except ProviderSandboxError as e:
+            raise SandboxError(str(e)) from e
 
-    if exit_code == _SUCCESS_EXIT_CODE:
-        return None, duration
-    if exit_code == _TIMEOUT_EXIT_CODE:
-        return AgentCausedExitReason.TIMEOUT, duration
-    if exit_code == _OS_KILL_EXIT_CODE:
-        return AgentCausedExitReason.OS_KILLED, duration
+        # Prefer the sandbox-measured duration; fall back to the tracker-side monotonic
+        # duration if the timing files are missing/unparseable (e.g. the agent removed
+        # /tmp/.valkyrie), rather than crashing on `int()` of a `cat` error string.
+        duration = await _read_sandbox_duration(
+            sandbox, start_ns_path, end_ns_path, fallback=time.monotonic() - monotonic_start
+        )
 
-    tail = "".join(output).strip().splitlines()
-    recent = "\n".join(tail[-10:]) if tail else "(no output)"
-    sentry_sdk.set_tag("agent_exit_code", str(exit_code))
-    raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
+        if exit_code == _SUCCESS_EXIT_CODE:
+            return None, duration
+        if exit_code == _TIMEOUT_EXIT_CODE:
+            return AgentCausedExitReason.TIMEOUT, duration
+        if exit_code == _OS_KILL_EXIT_CODE:
+            return AgentCausedExitReason.OS_KILLED, duration
+
+        tail = "".join(output).strip().splitlines()
+        recent = "\n".join(tail[-10:]) if tail else "(no output)"
+        sentry_sdk.set_tag("agent_exit_code", str(exit_code))
+        raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
+    finally:
+        try:
+            await _exec(sandbox, f"rm -f {shlex.quote(start_ns_path)} {shlex.quote(end_ns_path)}")
+        except Exception:
+            pass
+
+
+async def _read_sandbox_duration(sandbox: Sandbox, start_ns_path: str, end_ns_path: str, fallback: float) -> float:
+    """Read the sandbox-side command duration, degrading to ``fallback`` on any failure."""
+    start_result = await _exec(sandbox, f"cat {shlex.quote(start_ns_path)}")
+    end_result = await _exec(sandbox, f"cat {shlex.quote(end_ns_path)}")
+    if start_result.exit_code != _SUCCESS_EXIT_CODE or end_result.exit_code != _SUCCESS_EXIT_CODE:
+        return fallback
+    try:
+        return (int(end_result.stdout.strip()) - int(start_result.stdout.strip())) / 1e9
+    except ValueError:
+        return fallback
 
 
 @logfire.instrument(

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -405,7 +405,6 @@ async def install_agent_dependencies(
 _TIMEOUT_EXIT_CODE: int = 124
 _OS_KILL_EXIT_CODE: int = 137
 _SUCCESS_EXIT_CODE: int = 0
-_STATUS_DIR = "/tmp/.valkyrie"
 _OUTPUT_TAIL_MAX_CHARS = 64 * 1024
 _EGRESS_RETRY = retry(
     retry=retry_if_exception_type(ProviderSandboxError) & retry_if_not_exception_type(SandboxNotFoundError),
@@ -481,54 +480,35 @@ async def stream_command_output(
     # rather than chunk count since a single chunk can be arbitrarily large.
     output: deque[str] = deque()
     output_chars = 0
-    run_id = uuid.uuid4().hex
-    start_ns_path = f"{_STATUS_DIR}/{run_id}.start_ns"
-    end_ns_path = f"{_STATUS_DIR}/{run_id}.end_ns"
-    timed_command = (
-        f"mkdir -p {shlex.quote(_STATUS_DIR)}"
-        f" && date +%s%N > {shlex.quote(start_ns_path)}"
-        f"; {command}"
-        f"; exit_code=$?"
-        f"; date +%s%N > {shlex.quote(end_ns_path)}"
-        f'; sh -c "exit $exit_code"'
-    )
 
     exit_code = _SUCCESS_EXIT_CODE
+    started_at = time.monotonic()
     try:
-        try:
-            async for data in sandbox.command(timed_command):
-                on_output(data)
-                output.append(data)
-                output_chars += len(data)
-                while output_chars > _OUTPUT_TAIL_MAX_CHARS and len(output) > 1:
-                    output_chars -= len(output.popleft())
-        except ProviderSandboxCommandError as e:
-            exit_code = e.exit_code
-        except SandboxNotFoundError:
-            raise
-        except ProviderSandboxError as e:
-            raise SandboxError(str(e)) from e
+        async for data in sandbox.command(command):
+            on_output(data)
+            output.append(data)
+            output_chars += len(data)
+            while output_chars > _OUTPUT_TAIL_MAX_CHARS and len(output) > 1:
+                output_chars -= len(output.popleft())
+    except ProviderSandboxCommandError as e:
+        exit_code = e.exit_code
+    except SandboxNotFoundError:
+        raise
+    except ProviderSandboxError as e:
+        raise SandboxError(str(e)) from e
+    duration = time.monotonic() - started_at
 
-        start_ns = (await _exec(sandbox, f"cat {shlex.quote(start_ns_path)}")).stdout
-        end_ns = (await _exec(sandbox, f"cat {shlex.quote(end_ns_path)}")).stdout
-        duration = (int(end_ns.strip()) - int(start_ns.strip())) / 1e9
+    if exit_code == _SUCCESS_EXIT_CODE:
+        return None, duration
+    if exit_code == _TIMEOUT_EXIT_CODE:
+        return AgentCausedExitReason.TIMEOUT, duration
+    if exit_code == _OS_KILL_EXIT_CODE:
+        return AgentCausedExitReason.OS_KILLED, duration
 
-        if exit_code == _SUCCESS_EXIT_CODE:
-            return None, duration
-        if exit_code == _TIMEOUT_EXIT_CODE:
-            return AgentCausedExitReason.TIMEOUT, duration
-        if exit_code == _OS_KILL_EXIT_CODE:
-            return AgentCausedExitReason.OS_KILLED, duration
-
-        tail = "".join(output).strip().splitlines()
-        recent = "\n".join(tail[-10:]) if tail else "(no output)"
-        sentry_sdk.set_tag("agent_exit_code", str(exit_code))
-        raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
-    finally:
-        try:
-            await _exec(sandbox, f"rm -f {shlex.quote(start_ns_path)} {shlex.quote(end_ns_path)}")
-        except Exception:
-            pass
+    tail = "".join(output).strip().splitlines()
+    recent = "\n".join(tail[-10:]) if tail else "(no output)"
+    sentry_sdk.set_tag("agent_exit_code", str(exit_code))
+    raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
 
 
 @logfire.instrument(

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1320,36 +1320,28 @@ class TestEgressAllowlist:
 class TestStreamCommandOutputAgentFailure:
     """Agent command failure cleanup and error classification."""
 
-    async def test_stream_command_output_removes_timing_files(self) -> None:
-        async def stream_command(_command: str) -> AsyncIterator[str]:
+    async def test_stream_command_output_measures_duration_in_tracker(self) -> None:
+        observed_commands: list[str] = []
+
+        async def stream_command(command: str) -> AsyncIterator[str]:
+            observed_commands.append(command)
             yield "done\n"
-
-        exec_commands: list[str] = []
-
-        async def exec_command(command: str) -> ExecResult:
-            exec_commands.append(command)
-            if command.startswith("cat ") and command.endswith(".start_ns"):
-                return ExecResult(exit_code=0, output="1000000000")
-            if command.startswith("cat ") and command.endswith(".end_ns"):
-                return ExecResult(exit_code=0, output="3000000000")
-            return ExecResult(exit_code=0)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "test-sandbox"
         mock_sandbox.state = "started"
         mock_sandbox.command = stream_command
-        mock_sandbox.exec = exec_command
+        mock_sandbox.exec = AsyncMock()
 
         exit_reason, duration = await sandbox_module.stream_command_output(
             mock_sandbox, "run-agent.sh", on_output=lambda _: None
         )
 
         assert exit_reason is None
-        assert duration == 2
-        assert exec_commands[-1].startswith("rm -f ")
-        assert ".start_ns" in exec_commands[-1]
-        assert ".end_ns" in exec_commands[-1]
+        assert duration >= 0
+        assert observed_commands == ["run-agent.sh"]
+        mock_sandbox.exec.assert_not_awaited()
 
     @pytest.mark.parametrize("exit_code", [1, 2, 127])
     async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(
@@ -1364,12 +1356,7 @@ class TestStreamCommandOutputAgentFailure:
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "test-sandbox"
         mock_sandbox.command = stream_command
-        mock_sandbox.exec = AsyncMock(
-            side_effect=[
-                ExecResult(exit_code=0, output="1000000000"),
-                ExecResult(exit_code=0, output="3000000000"),
-            ]
-        )
+        mock_sandbox.exec = AsyncMock()
 
         def fake_set_tag(key: str, value: object) -> None:
             tagged[key] = str(value)
@@ -1403,13 +1390,7 @@ class TestStreamCommandOutputAgentFailure:
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "test-sandbox"
         mock_sandbox.command = stream_command
-        mock_sandbox.exec = AsyncMock(
-            side_effect=[
-                ExecResult(exit_code=0, output="1000000000"),
-                ExecResult(exit_code=0, output="3000000000"),
-                ExecResult(exit_code=0, output=""),
-            ]
-        )
+        mock_sandbox.exec = AsyncMock()
 
         def fake_set_tag(_key: str, _value: object) -> None:
             pass

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1320,28 +1320,70 @@ class TestEgressAllowlist:
 class TestStreamCommandOutputAgentFailure:
     """Agent command failure cleanup and error classification."""
 
-    async def test_stream_command_output_measures_duration_in_tracker(self) -> None:
+    async def test_stream_command_output_uses_sandbox_timing_and_removes_files(self) -> None:
         observed_commands: list[str] = []
 
         async def stream_command(command: str) -> AsyncIterator[str]:
             observed_commands.append(command)
             yield "done\n"
 
+        exec_commands: list[str] = []
+
+        async def exec_command(command: str) -> ExecResult:
+            exec_commands.append(command)
+            if command.startswith("cat ") and command.endswith(".start_ns"):
+                return ExecResult(exit_code=0, output="1000000000")
+            if command.startswith("cat ") and command.endswith(".end_ns"):
+                return ExecResult(exit_code=0, output="3000000000")
+            return ExecResult(exit_code=0)
+
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "test-sandbox"
         mock_sandbox.state = "started"
         mock_sandbox.command = stream_command
-        mock_sandbox.exec = AsyncMock()
+        mock_sandbox.exec = exec_command
 
         exit_reason, duration = await sandbox_module.stream_command_output(
             mock_sandbox, "run-agent.sh", on_output=lambda _: None
         )
 
         assert exit_reason is None
+        assert duration == 2
+        # Timing is embedded in the sandbox command, not run raw.
+        assert observed_commands and "run-agent.sh" in observed_commands[0]
+        assert ".start_ns" in observed_commands[0]
+        assert exec_commands[-1].startswith("rm -f ")
+        assert ".start_ns" in exec_commands[-1]
+        assert ".end_ns" in exec_commands[-1]
+
+    async def test_stream_command_output_falls_back_when_timing_files_missing(self) -> None:
+        async def stream_command(_command: str) -> AsyncIterator[str]:
+            yield "done\n"
+
+        async def exec_command(command: str) -> ExecResult:
+            if command.startswith("cat "):
+                # `cat` on a missing file: non-zero exit and an error string on stdout.
+                return ExecResult(
+                    exit_code=1,
+                    output="cat: /tmp/.valkyrie/abc.end_ns: No such file or directory",
+                )
+            return ExecResult(exit_code=0)
+
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "test-sandbox"
+        mock_sandbox.state = "started"
+        mock_sandbox.command = stream_command
+        mock_sandbox.exec = exec_command
+
+        exit_reason, duration = await sandbox_module.stream_command_output(
+            mock_sandbox, "run-agent.sh", on_output=lambda _: None
+        )
+
+        # No crash on int() of the cat error text; duration degrades to the monotonic fallback.
+        assert exit_reason is None
         assert duration >= 0
-        assert observed_commands == ["run-agent.sh"]
-        mock_sandbox.exec.assert_not_awaited()
 
     @pytest.mark.parametrize("exit_code", [1, 2, 127])
     async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(


### PR DESCRIPTION
## Summary
`stream_command_output` timed agent commands by wrapping them in the sandbox to write `date +%s%N` into `.start_ns`/`.end_ns` files under `/tmp/.valkyrie`, then `cat`-ing both files and doing `int(end_ns) - int(start_ns)`. It never checked that the `cat` succeeded, so when `end_ns` was absent, the `cat` error text (`cat: ...end_ns: No such file or directory`) was passed straight to `int()`, producing a misleading `ValueError` that surfaced as the task error.

This hit 4/200 tasks (all `revprotocol`). The failing task's live CloudWatch stream confirms it, ending with:
`[ERROR] invalid literal for int() with base 10: 'cat: /tmp/.valkyrie/8d0783cb97c542e1b2e4448e7d98a8fd.end_ns: No such file or directory'`
Because duration was computed before artifact upload, those tasks have no console/trajectory artifacts in S3. The temp files most likely disappeared due to the agent removing/replacing `/tmp/.valkyrie` or a command-session interruption near completion.

Fix: keep the in-sandbox `start_ns`/`end_ns` timing (it deliberately excludes the tracker→sandbox request round-trip and program cold-start, ~5-6s, so the measurement stays accurate), but make the read non-fatal — check the `cat` exit codes and only `int()` on success, degrading to a tracker-side `time.monotonic()` fallback when the files are missing/unparseable instead of crashing.

## Changes
- `services/tracker/src/tracker/sandbox.py`: extract the timing read into `_read_sandbox_duration`, which returns the sandbox-measured duration when both `cat`s succeed and parse, and otherwise returns the `time.monotonic()` fallback captured around the command stream. Timing files are still written/cleaned up as before.
- `services/tracker/tests/unit/test_sandbox.py`: assert the sandbox-embedded timing path (duration from files, temp files removed) and add a fallback test where a missing `end_ns` no longer raises `ValueError`.

## Related Issues
Closes #

## Type of Change
- [x] Bug fix

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

`uv run pytest tests/unit/test_sandbox.py` → 45 passed; ruff + basedpyright clean.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/6d4830d12fa44c64981b3080f5349545
Requested by: @nikil-ravi
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/630" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->