### PR TITLE
Fix executor preflight credential ownership

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -329,14 +329,14 @@ jobs:
             --output-directory "$GITHUB_WORKSPACE/executor-release" \
             --source-revision "$GITHUB_SHA"
 
-      - name: Configure dev deployment credentials
+      - name: Configure dev release preflight credentials
         if: steps.freshness.outputs.current == 'true'
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
+          role-to-assume: arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-dev
           aws-region: ${{ env.AWS_REGION }}
           allowed-account-ids: ${{ env.DEV_ACCOUNT_ID }}
-          role-session-name: valkyrie-dev-executor-deploy-${{ github.run_id }}
+          role-session-name: valkyrie-dev-release-preflight-${{ github.run_id }}
           unset-current-credentials: true
 
       - name: Require deployed dev release control
@@ -353,19 +353,6 @@ jobs:
             cat "$error_file" >&2
           fi
           exit 1
-
-      - name: Configure dev release credentials for maintenance
-        if: >-
-          steps.freshness.outputs.current == 'true' &&
-          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
-           needs.classify-deployment.outputs.database_maintenance_required == 'true')
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-dev
-          aws-region: ${{ env.AWS_REGION }}
-          allowed-account-ids: ${{ env.DEV_ACCOUNT_ID }}
-          role-session-name: valkyrie-dev-maintenance-${{ github.run_id }}
-          unset-current-credentials: true
 
       - name: Begin dev maintenance
         if: >-
@@ -561,14 +548,14 @@ jobs:
             --output-directory "$GITHUB_WORKSPACE/executor-release" \
             --source-revision "$GITHUB_SHA"
 
-      - name: Configure production deployment credentials
+      - name: Configure production release preflight credentials
         if: steps.freshness.outputs.current == 'true'
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy
+          role-to-assume: arn:aws:iam::613431292675:role/ValkyrieExecutorRelease
           aws-region: ${{ env.AWS_REGION }}
           allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
-          role-session-name: valkyrie-prod-executor-deploy-${{ github.run_id }}
+          role-session-name: valkyrie-prod-release-preflight-${{ github.run_id }}
           unset-current-credentials: true
 
       - name: Require deployed production release control
@@ -585,19 +572,6 @@ jobs:
             cat "$error_file" >&2
           fi
           exit 1
-
-      - name: Configure production release credentials for maintenance
-        if: >-
-          steps.freshness.outputs.current == 'true' &&
-          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
-           needs.classify-deployment.outputs.database_maintenance_required == 'true')
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
-        with:
-          role-to-assume: arn:aws:iam::613431292675:role/ValkyrieExecutorRelease
-          aws-region: ${{ env.AWS_REGION }}
-          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
-          role-session-name: valkyrie-prod-maintenance-${{ github.run_id }}
-          unset-current-credentials: true
 
       - name: Begin production maintenance
         if: >-

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -135,12 +135,67 @@ class DeployWorkflowTest(unittest.TestCase):
         )[0]
         prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
 
-        for executor_job in (dev_executor, prod_executor):
-            self.assertIn("aws ssm get-parameter", executor_job)
-            self.assertIn("ParameterNotFound", executor_job)
-            self.assertIn("physical WorkerStack bootstrap", executor_job)
-            self.assertNotIn("describe-stacks", executor_job)
-            self.assertNotIn("steps.executor-stack.outputs.exists", executor_job)
+        stages = (
+            (
+                dev_executor,
+                "dev",
+                "arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-dev",
+                "${{ env.AWS_DEPLOY_ROLE_ARN }}",
+            ),
+            (
+                prod_executor,
+                "production",
+                "arn:aws:iam::613431292675:role/ValkyrieExecutorRelease",
+                "arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy",
+            ),
+        )
+        for executor_job, stage, release_role, deployment_role in stages:
+            with self.subTest(stage=stage):
+                self.assertIn("aws ssm get-parameter", executor_job)
+                self.assertIn("ParameterNotFound", executor_job)
+                self.assertIn("physical WorkerStack bootstrap", executor_job)
+                self.assertNotIn("describe-stacks", executor_job)
+                self.assertNotIn("steps.executor-stack.outputs.exists", executor_job)
+
+                preflight = f"Require deployed {stage} release control"
+                maintenance = f"Begin {stage} maintenance"
+                release_credentials = f"Configure {stage} release preflight credentials"
+                restore_credentials = f"Restore {stage} deployment credentials"
+                core_deploy = f"Deploy {stage} core stacks under maintenance"
+                executor_deploy = f"Deploy {stage} executor stack"
+                final_release_credentials = f"- name: Configure {stage} release credentials\n"
+                activation = f"Publish and activate {stage} executor release"
+                finish = f"Finish {stage} maintenance"
+
+                self.assertIn(release_credentials, executor_job)
+                self.assertLess(executor_job.index(release_credentials), executor_job.index(preflight))
+                preflight_index = executor_job.index(preflight)
+                preflight_credentials = executor_job[executor_job.index(release_credentials) : preflight_index]
+                self.assertEqual(preflight_credentials.count("uses: aws-actions/configure-aws-credentials"), 1)
+                self.assertIn(f"role-to-assume: {release_role}", preflight_credentials)
+                self.assertNotIn(f"role-to-assume: {deployment_role}", preflight_credentials)
+                preflight_step = executor_job[preflight_index : executor_job.index(maintenance)]
+                self.assertIn("aws ssm get-parameter", preflight_step)
+                self.assertLess(preflight_index, executor_job.index(maintenance))
+                self.assertNotIn(f"Configure {stage} release credentials for maintenance", executor_job)
+
+                restore_index = executor_job.index(restore_credentials)
+                self.assertLess(restore_index, executor_job.index(core_deploy))
+                self.assertLess(restore_index, executor_job.index(executor_deploy))
+                deployment_credentials = executor_job[restore_index : executor_job.index(core_deploy)]
+                self.assertIn(f"role-to-assume: {deployment_role}", deployment_credentials)
+
+                final_release_index = executor_job.index(final_release_credentials)
+                activation_index = executor_job.index(activation)
+                self.assertLess(final_release_index, activation_index)
+                self.assertLess(final_release_index, executor_job.index(finish))
+                final_release = executor_job[final_release_index:activation_index]
+                self.assertIn(f"role-to-assume: {release_role}", final_release)
+                activation_step = executor_job[activation_index : executor_job.index(finish)]
+                self.assertIn(
+                    "needs.classify-deployment.outputs.executor_release_required == 'true'",
+                    activation_step,
+                )
 
         self.assertIn(
             "EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/dev/executor-release/launch-config",

--- a/infra/tests/test_maintenance_classifier.py
+++ b/infra/tests/test_maintenance_classifier.py
@@ -253,6 +253,17 @@ def upgrade() -> None:
         self.assertTrue(result.executor_stack_deploy_required)
         self.assertEqual(result.reasons, ["executor-core-change"])
 
+    def test_deploy_workflow_change_requires_stack_without_release(self) -> None:
+        head_sha = self._commit_file(".github/workflows/deploy.yaml", "changed\n")
+
+        result = self._classify(head_sha)
+
+        self.assertEqual(result.classification, "maintenance-required")
+        self.assertTrue(result.executor_stack_deploy_required)
+        self.assertFalse(result.executor_release_required)
+        self.assertFalse(result.core_maintenance_required)
+        self.assertFalse(result.database_maintenance_required)
+
     def test_shared_executor_input_requires_core_maintenance(self) -> None:
         head_sha = self._commit_file("infra/shared.py", "changed = True\n")
 


### PR DESCRIPTION
## What changed

- run dev and production executor release-control preflight under the dedicated release role
- reuse that role for maintenance entry, restoring deployment credentials only before CDK
- add regression coverage for role ownership and ordering across preflight, deployment, activation, and maintenance finish

## Why

The first dev cutover deployment failed before maintenance because the general deployment role intentionally cannot read the executor release launch parameter. The dedicated release role already owns that exact SSM permission.

## How tested

- `cd infra && uv run python -m unittest discover -s tests` — 75 passed
- `uv run ruff check infra/tests/test_deploy_workflow.py`
- `uv run ruff format --check infra/tests/test_deploy_workflow.py`
- `yq '.' .github/workflows/deploy.yaml`

## Rollout verification

After merge, the workflow-only change is classified as an ExecutorStack deployment. Verify the dev executor job runs with the current SHA and completes release-role preflight, maintenance begin, deployment-role ExecutorStack deployment, final release-role maintenance finish, and service recovery. Artifact activation is expected to skip because this PR does not change executor runtime artifacts.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/631" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->