### PR TITLE
Fix prod deployment gates

### DIFF
--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -25,14 +25,17 @@ jobs:
         with:
           fetch-depth: 1
           persist-credentials: true
-          ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          ref: ${{ github.event.repository.default_branch }}
 
-      - name: Fetch candidate without executing it
+      - name: Fetch base and candidate without executing them
         env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -euo pipefail
+          git fetch --no-tags origin "${BASE_REF#refs/heads/}"
+          test "$(git rev-parse FETCH_HEAD)" = "$BASE_SHA"
           if [[ -n "$PR_NUMBER" ]]; then
             git fetch --no-tags origin "pull/$PR_NUMBER/head"
           else

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -29,12 +29,11 @@ jobs:
 
       - name: Fetch base and candidate without executing them
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin "${BASE_REF#refs/heads/}"
+          git fetch --no-tags origin "$BASE_SHA"
           test "$(git rev-parse FETCH_HEAD)" = "$BASE_SHA"
           if [[ -n "$PR_NUMBER" ]]; then
             git fetch --no-tags origin "pull/$PR_NUMBER/head"

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -239,12 +239,16 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("pull_request_target:", classification_workflow)
         trusted_checkout = classification_workflow.split("      - name: Checkout trusted classifier", maxsplit=1)[
             1
-        ].split("      - name: Fetch candidate without executing it", maxsplit=1)[0]
-        self.assertIn(
-            "ref: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}",
-            trusted_checkout,
-        )
+        ].split("      - name: Fetch base and candidate without executing them", maxsplit=1)[0]
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", trusted_checkout)
+        self.assertNotIn("github.event.pull_request.base.sha", trusted_checkout)
         self.assertNotIn("github.event.pull_request.head.sha", trusted_checkout)
+        self.assertIn(
+            "BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}",
+            classification_workflow,
+        )
+        self.assertIn('git fetch --no-tags origin "${BASE_REF#refs/heads/}"', classification_workflow)
+        self.assertIn('test "$(git rev-parse FETCH_HEAD)" = "$BASE_SHA"', classification_workflow)
         self.assertIn('git fetch --no-tags origin "pull/$PR_NUMBER/head"', classification_workflow)
         self.assertIn('git fetch --no-tags origin "${MERGE_GROUP_HEAD_REF#refs/heads/}"', classification_workflow)
         self.assertIn('test "$(git rev-parse FETCH_HEAD)" = "$HEAD_SHA"', classification_workflow)

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -243,11 +243,7 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("ref: ${{ github.event.repository.default_branch }}", trusted_checkout)
         self.assertNotIn("github.event.pull_request.base.sha", trusted_checkout)
         self.assertNotIn("github.event.pull_request.head.sha", trusted_checkout)
-        self.assertIn(
-            "BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}",
-            classification_workflow,
-        )
-        self.assertIn('git fetch --no-tags origin "${BASE_REF#refs/heads/}"', classification_workflow)
+        self.assertIn('git fetch --no-tags origin "$BASE_SHA"', classification_workflow)
         self.assertIn('test "$(git rev-parse FETCH_HEAD)" = "$BASE_SHA"', classification_workflow)
         self.assertIn('git fetch --no-tags origin "pull/$PR_NUMBER/head"', classification_workflow)
         self.assertIn('git fetch --no-tags origin "${MERGE_GROUP_HEAD_REF#refs/heads/}"', classification_workflow)

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.22.3"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.3#8482fc4bd0737b7aa7d995620bd38895337d7126" }
+version = "0.22.4"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4#7016044a5e7ba41826ee44ec5b7e006eb24c077b" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "sentry-sdk[fastapi]==2.58.0",
   "python-json-logger>=3.2.1",
   "python-dotenv>=1.2.2",
-  "create-benchmark-service>=0.22.3",
+  "create-benchmark-service>=0.22.4",
   "aioboto3>=7.0.0",
 ]
 
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.22.3" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.22.4" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.22.3"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.3#8482fc4bd0737b7aa7d995620bd38895337d7126" }
+version = "0.22.4"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4#7016044a5e7ba41826ee44ec5b7e006eb24c077b" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.22.3"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.3#8482fc4bd0737b7aa7d995620bd38895337d7126" }
+version = "0.22.4"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4#7016044a5e7ba41826ee44ec5b7e006eb24c077b" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## What changed

- load the trusted maintenance classifier from the repository default branch, then fetch and verify the target base and candidate commits without executing candidate code
- update create-benchmark-service from v0.22.3 to v0.22.4 in the Tracker dependency pin and all affected lockfiles

## Why

The prod promotion check could not find the classifier because prod does not contain it yet. The CBS gate also rejected the stale v0.22.3 pin after v0.22.4 was released.

## Validation

- infrastructure suite: 75 passed
- Tracker unit suite: 462 passed
- all three lockfiles validated
- workflow YAML, Ruff, formatting, and focused diagnostics clean

This PR is intentionally left for manual merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/632" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->