### PR TITLE
Forward benchmark volume mounts to sandbox providers

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.17.3" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.23.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.22.4"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4#7016044a5e7ba41826ee44ec5b7e006eb24c077b" }
+version = "0.23.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0#96d535f4085a7606f6da2b82b0c6fbff25c1ce70" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.22.4" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.23.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -26,6 +26,7 @@ from benchmark_service import (
     SandboxSource,
     SnapshotSource,
     TargetedSnapshotSource,
+    VolumeMount,
 )
 from benchmark_service import (
     Resources as TrackerResources,
@@ -167,6 +168,7 @@ async def _create_sandbox(
     resources: TrackerResources,
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
+    volumes: list[VolumeMount] | None = None,
 ) -> Sandbox:
     """Create a sandbox through its provider."""
     provider_source = _provider_source(source)
@@ -178,6 +180,7 @@ async def _create_sandbox(
             name=sandbox_name,
             labels=labels or {},
             env_vars=env_vars or {},
+            volumes=volumes or [],
             auto_stop_interval=SANDBOX_AUTO_STOP_INTERVAL,
             create_timeout=SANDBOX_CREATE_TIMEOUT,
         )
@@ -193,6 +196,7 @@ async def create_sandbox(
     creation_semaphore: Semaphore,
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
+    volumes: list[VolumeMount] | None = None,
 ) -> AsyncGenerator[Sandbox, Any]:
     """
     Yeild a sandbox to be used within a context manager.
@@ -204,6 +208,7 @@ async def create_sandbox(
         resources: The resources to use for the sandbox
         labels: The labels to use for the sandbox
         env_vars: The environment variables to use for the sandbox
+        volumes: Persistent volumes to mount in the sandbox
         creation_semaphore: Per-benchmark semaphore to limit concurrent sandbox creation.
 
     Returns:
@@ -219,7 +224,7 @@ async def create_sandbox(
         async with creation_semaphore:
             start = time.monotonic()
             creation_task = asyncio.create_task(
-                _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars)
+                _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars, volumes)
             )
             try:
                 sandbox = await asyncio.shield(creation_task)

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -611,6 +611,9 @@ async def _process_task_attempt(
         labels = {
             "Benchmark": start_benchmark_request.benchmark_name,
             "Id": str(benchmark_id),
+            # CBS resolves VolumeMount's {run_id} placeholder from the
+            # "run-id" label and hard-fails if this isolation identity is absent.
+            "run-id": str(benchmark_id),
             "Task": task_row.task_id,
         }
 
@@ -656,6 +659,7 @@ async def _process_task_attempt(
             labels=labels,
             env_vars=env_vars,
             resources=task_data.resources,
+            volumes=task_data.volumes,
             creation_semaphore=creation_semaphore,
         ) as sandbox:
             task_breakdown.sandbox_build_duration = time.perf_counter() - start_sandbox_build_time

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -20,6 +20,7 @@ from benchmark_service import (
     SandboxSource,
     SnapshotSource,
     TargetedSnapshotSource,
+    VolumeMount,
 )
 from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxCommandError
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
@@ -984,11 +985,21 @@ class TestSandboxLifecycle:
         provider.create_sandbox = AsyncMock(return_value=mock_sandbox)
 
         resources = Resources(vcpu=2, memory=4, disk=5)
+        volumes = [
+            VolumeMount(
+                name="shared-fixtures",
+                mount_path="/fixtures",
+                read_only=True,
+                subpath="{run_id}",
+            )
+        ]
         sandbox = await _create_sandbox(
             provider,
             "task-alias",
             ImageSource(image="ghcr.io/vals/swebench:latest"),
             resources,
+            labels={"run-id": "run-123"},
+            volumes=volumes,
         )
 
         assert sandbox is mock_sandbox
@@ -996,6 +1007,8 @@ class TestSandboxLifecycle:
         request = provider.create_sandbox.await_args.args[0]
         assert request.name == "task-alias"
         assert request.resources == resources
+        assert request.labels == {"run-id": "run-123"}
+        assert request.volumes == volumes
         assert request.auto_stop_interval == sandbox_module.SANDBOX_AUTO_STOP_INTERVAL
         assert request.create_timeout == sandbox_module.SANDBOX_CREATE_TIMEOUT
 

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
-from benchmark_service.schemas import RetrieveTaskResponse
+from benchmark_service.schemas import RetrieveTaskResponse, VolumeMount
 from sqlmodel import Session
 from tenacity import wait_none
 
@@ -174,15 +174,27 @@ class TestTaskExecutionRetry:
             harness_config,
         )
 
+        create_sandbox_kwargs: dict[str, Any] = {}
+
         @asynccontextmanager
-        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+        async def _mock_create_sandbox(*_args: Any, **kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            create_sandbox_kwargs.update(kwargs)
             mock_sandbox = AsyncMock()
             mock_sandbox.id = "mock-sandbox-id"
             mock_sandbox.name = "mock-sandbox-name"
             yield mock_sandbox
 
         async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            return make_retrieve_task_response(problem_path="/tmp/problem.txt")
+            response = make_retrieve_task_response(problem_path="/tmp/problem.txt")
+            response.volumes = [
+                VolumeMount(
+                    name="shared-fixtures",
+                    mount_path="/fixtures",
+                    read_only=True,
+                    subpath="{run_id}",
+                )
+            ]
+            return response
 
         async def _mock_upload_agent_artifacts(*_args: Any, **_kwargs: Any) -> None:
             return None
@@ -243,6 +255,15 @@ class TestTaskExecutionRetry:
         assert all(record["entered"] and record["exited"] for record in transition_records)
         assert not any(record["message"].startswith("task.status_transition") for record in log_records)
         assert run_agent_kwargs["benchmark_id"] == str(benchmark_id)
+        assert create_sandbox_kwargs["labels"]["run-id"] == str(benchmark_id)
+        assert create_sandbox_kwargs["volumes"] == [
+            VolumeMount(
+                name="shared-fixtures",
+                mount_path="/fixtures",
+                read_only=True,
+                subpath="{run_id}",
+            )
+        ]
 
         event_names = [record["message"] for record in log_records]
         assert "agent.run.complete" in event_names

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.22.4"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4#7016044a5e7ba41826ee44ec5b7e006eb24c077b" }
+version = "0.23.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0#96d535f4085a7606f6da2b82b0c6fbff25c1ce70" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.22.4"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4#7016044a5e7ba41826ee44ec5b7e006eb24c077b" }
+version = "0.23.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0#96d535f4085a7606f6da2b82b0c6fbff25c1ce70" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.22.4" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
- pin create-benchmark-service v0.23.0 with safe Modal/Daytona volume support
- forward RetrieveTaskResponse volumes into SandboxCreateRequest
- attach an explicit run-id label for scoped volume subpaths
- reject non-object evaluation results at the tracker database boundary

## Verification
- 376 tracker unit tests passed
- tracker ruff passed
- configured tracker basedpyright passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/633" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->