### PR TITLE
Scale generation sandbox lifetime with agent timeout

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,7 @@
 """Sandbox management utilities for the tracker service."""
 
 import asyncio
+import math
 import shlex
 import time
 import uuid
@@ -80,6 +81,7 @@ logger = get_logger(__name__)
 
 bundle_path = PurePosixPath("/bundle")
 SANDBOX_AUTO_STOP_INTERVAL = 10 * 60
+SANDBOX_AUTO_STOP_PADDING_MINUTES = 10
 SANDBOX_CREATE_TIMEOUT = 360
 AGENT_INSTALL_TIMEOUT_SECONDS = 10 * 60
 CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS = 24 * 60 * 60
@@ -160,6 +162,15 @@ def _set_sandbox_span_attributes(sandbox: Sandbox) -> None:
     span.set_attribute("valkyrie.sandbox_state", sandbox.state)
 
 
+def sandbox_auto_stop_interval(agent_timeout: float | None) -> int:
+    if agent_timeout is None:
+        return SANDBOX_AUTO_STOP_INTERVAL
+    return max(
+        SANDBOX_AUTO_STOP_INTERVAL,
+        math.ceil(agent_timeout / 60) + SANDBOX_AUTO_STOP_PADDING_MINUTES,
+    )
+
+
 @logfire.instrument("sandbox.create", extract_args=False)
 async def _create_sandbox(
     provider: SandboxProvider,
@@ -169,6 +180,7 @@ async def _create_sandbox(
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
     volumes: list[VolumeMount] | None = None,
+    auto_stop_interval: int = SANDBOX_AUTO_STOP_INTERVAL,
 ) -> Sandbox:
     """Create a sandbox through its provider."""
     provider_source = _provider_source(source)
@@ -181,7 +193,7 @@ async def _create_sandbox(
             labels=labels or {},
             env_vars=env_vars or {},
             volumes=volumes or [],
-            auto_stop_interval=SANDBOX_AUTO_STOP_INTERVAL,
+            auto_stop_interval=auto_stop_interval,
             create_timeout=SANDBOX_CREATE_TIMEOUT,
         )
     )
@@ -197,6 +209,7 @@ async def create_sandbox(
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
     volumes: list[VolumeMount] | None = None,
+    auto_stop_interval: int = SANDBOX_AUTO_STOP_INTERVAL,
 ) -> AsyncGenerator[Sandbox, Any]:
     """
     Yeild a sandbox to be used within a context manager.
@@ -224,7 +237,16 @@ async def create_sandbox(
         async with creation_semaphore:
             start = time.monotonic()
             creation_task = asyncio.create_task(
-                _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars, volumes)
+                _create_sandbox(
+                    provider,
+                    sandbox_name,
+                    source,
+                    resources,
+                    labels,
+                    env_vars,
+                    volumes,
+                    auto_stop_interval,
+                )
             )
             try:
                 sandbox = await asyncio.shield(creation_task)

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -55,7 +55,13 @@ from tracker.executor.execution_authority import ExecutionAuthority, lock_execut
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, retry_callback
-from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
+from tracker.sandbox import (
+    DependencySetupMode,
+    create_sandbox,
+    run_agent,
+    sandbox_auto_stop_interval,
+    upload_agent_artifacts,
+)
 from tracker.types import (
     AWSCredentials,
     HarnessConfig,
@@ -660,6 +666,7 @@ async def _process_task_attempt(
             env_vars=env_vars,
             resources=task_data.resources,
             volumes=task_data.volumes,
+            auto_stop_interval=sandbox_auto_stop_interval(task_data.agent_timeout),
             creation_semaphore=creation_semaphore,
         ) as sandbox:
             task_breakdown.sandbox_build_duration = time.perf_counter() - start_sandbox_build_time

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -65,6 +65,14 @@ _upload_agent_artifacts = getattr(sandbox_module, "upload_agent_artifacts")
 _upload_output_artifact = getattr(sandbox_module, "_upload_output_artifact")
 
 
+def test_sandbox_auto_stop_interval_defaults_without_agent_timeout() -> None:
+    assert sandbox_module.sandbox_auto_stop_interval(None) == sandbox_module.SANDBOX_AUTO_STOP_INTERVAL
+
+
+def test_sandbox_auto_stop_interval_tracks_agent_timeout() -> None:
+    assert sandbox_module.sandbox_auto_stop_interval(172_800.0) == 2_890
+
+
 class TestOutputArtifacts:
     """Declared output artifact collection and size validation."""
 
@@ -1000,6 +1008,7 @@ class TestSandboxLifecycle:
             resources,
             labels={"run-id": "run-123"},
             volumes=volumes,
+            auto_stop_interval=1234,
         )
 
         assert sandbox is mock_sandbox
@@ -1009,7 +1018,7 @@ class TestSandboxLifecycle:
         assert request.resources == resources
         assert request.labels == {"run-id": "run-123"}
         assert request.volumes == volumes
-        assert request.auto_stop_interval == sandbox_module.SANDBOX_AUTO_STOP_INTERVAL
+        assert request.auto_stop_interval == 1234
         assert request.create_timeout == sandbox_module.SANDBOX_CREATE_TIMEOUT
 
     async def test_create_sandbox_unwraps_compose_source_before_provider_create(


### PR DESCRIPTION
Long-horizon cyber-range runs set multi-day agent timeouts, but generation sandboxes used a fixed 600-minute auto-stop interval. This derives Daytona auto-stop from the task agent_timeout with a 10-minute pad while preserving the existing default for tasks without a timeout.\n\nThis does not fix every possible Daytona PTY loss, but it removes the hard cap that would kill official 48h cyber-range attempts.\n\nValidation:\n- uv run pytest -q services/tracker/tests/unit/test_sandbox.py services/tracker/tests/unit/utils/test_task_execution_retry.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->