### PR TITLE
Recover opted-in tasks after sandbox loss

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.24.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.23.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.24.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.25.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.23.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0#96d535f4085a7606f6da2b82b0c6fbff25c1ce70" }
+version = "0.23.1.dev1+g7b4b5eed2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33#7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.1.dev3+gcb167d20a"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3#cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
+version = "0.24.1.dev4+g2fd3b6250"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba#2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.1.dev4+g2fd3b6250"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba#2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
+version = "0.25.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0#4e9574119cf5da0ca55d9251c5d11a97dc6ccdc4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0#778da4d711ecf35eb744cd0e8d0a830bd092b23a" }
+version = "0.24.1.dev3+gcb167d20a"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3#cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.23.1.dev1+g7b4b5eed2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33#7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
+version = "0.24.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0#778da4d711ecf35eb744cd0e8d0a830bd092b23a" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.24.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.25.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.23.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.24.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -18,6 +18,7 @@ from zoneinfo import ZoneInfo
 import logfire
 import sentry_sdk
 from benchmark_service import (
+    SandboxNotFoundError,
     SandboxProviderConfig,
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
@@ -67,11 +68,38 @@ from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
 logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
+_SANDBOX_ATTEMPT_HARD_LIMIT: int = 20
 
 
 @dataclass
 class _DependencySetupRecoveryState:
     mode: DependencySetupMode = DependencySetupMode.IN_PLACE_RETRIES
+
+
+@dataclass
+class _SandboxRecoveryState:
+    attempts: int = 0
+    max_attempts: int | None = None
+    setup_retries: int = 0
+    outage_id: str | None = None
+    outage_started_epoch: float | None = None
+
+    def start_attempt(self) -> None:
+        self.attempts += 1
+
+    def record_loss(self, benchmark_id: UUID, task_id: str) -> None:
+        if self.outage_started_epoch is None:
+            self.outage_started_epoch = time.time()
+            self.outage_id = f"{benchmark_id}:{task_id}:{self.attempts}"
+        self.setup_retries = 0
+
+    def mark_replacement_ready(self) -> None:
+        self.outage_id = None
+        self.outage_started_epoch = None
+
+
+class _RetryTaskAttempt(Exception):
+    """Signal tenacity to replace the current sandbox without failing the task."""
 
 
 def _normalized_attempt_time(value: datetime) -> datetime:
@@ -454,13 +482,14 @@ async def process_task(
         sandbox_provider_config,
         creation_semaphore,
         dependency_setup_recovery=_DependencySetupRecoveryState(),
+        sandbox_recovery=_SandboxRecoveryState(),
         authority=authority,
     )
 
 
 @tenacity_retry(
-    retry=retry_if_exception_type(SandboxSetupError),
-    stop=stop_after_attempt(_PTY_TASK_RETRY_LIMIT + 1),
+    retry=retry_if_exception_type(_RetryTaskAttempt),
+    stop=stop_after_attempt(_SANDBOX_ATTEMPT_HARD_LIMIT),
     wait=wait_fixed(2),
     before_sleep=retry_callback("valkyrie.task"),
     reraise=True,
@@ -476,6 +505,7 @@ async def _process_task_attempt(
     sandbox_provider_config: SandboxProviderConfig,
     creation_semaphore: Semaphore,
     dependency_setup_recovery: _DependencySetupRecoveryState,
+    sandbox_recovery: _SandboxRecoveryState,
     authority: ExecutionAuthority,
 ) -> dict[str, dict[str, Any] | None]:
     """
@@ -485,6 +515,7 @@ async def _process_task_attempt(
     the evaluation will fail since the instance no longer exists. We handle this inside of the exception caught.
     """
     task_id_var.set(task_id)
+    sandbox_recovery.start_attempt()
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
     trace.get_current_span().set_attributes(
@@ -605,6 +636,9 @@ async def _process_task_attempt(
                 raise e from e
 
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
+        sandbox_recovery.max_attempts = (
+            task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
+        )
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
 
         # Labels that show up in the UI we can use to filter sandboxes
@@ -647,6 +681,10 @@ async def _process_task_attempt(
                 f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
             ),
         }
+        if sandbox_recovery.outage_started_epoch is not None:
+            env_vars["VALKYRIE_SANDBOX_OUTAGE_STARTED_EPOCH"] = str(sandbox_recovery.outage_started_epoch)
+        if sandbox_recovery.outage_id is not None:
+            env_vars["VALKYRIE_SANDBOX_OUTAGE_ID"] = sandbox_recovery.outage_id
 
         # We don't want to track the task until the sandbox is actually created.
         task_breakdown = TaskBreakdown()
@@ -695,6 +733,10 @@ async def _process_task_attempt(
                     dataset=start_benchmark_request.dataset,
                     sandbox_provider=sandbox_provider_config,
                 )
+                # The benchmark has now had an opportunity to persist the
+                # outage metadata in its restored volume. A later loss is a
+                # distinct outage and must receive a new identity.
+                sandbox_recovery.mark_replacement_ready()
 
                 # Force flush the logs if anything has been buffered
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
@@ -821,7 +863,41 @@ async def _process_task_attempt(
         if task_is_stopped():
             return {task_id: None}
         log_output(f"\n[ERROR] {_exception_message(e)}")
+        within_policy = (
+            sandbox_recovery.max_attempts is None
+            or sandbox_recovery.attempts < sandbox_recovery.max_attempts
+        )
+        if sandbox_recovery.setup_retries < _PTY_TASK_RETRY_LIMIT and within_policy:
+            sandbox_recovery.setup_retries += 1
+            raise _RetryTaskAttempt("retrying task in a fresh sandbox after setup failure") from e
         raise
+    except SandboxNotFoundError as e:
+        if task_is_stopped():
+            return {task_id: None}
+        max_attempts = sandbox_recovery.max_attempts
+        if max_attempts is not None and sandbox_recovery.attempts < max_attempts:
+            sandbox_recovery.record_loss(benchmark_id, task_row.task_id)
+            message = (
+                "Sandbox disappeared; restoring the task from its durable volume "
+                f"(attempt {sandbox_recovery.attempts + 1}/{max_attempts})"
+            )
+            logger.warning(message)
+            log_output(f"\n[WARNING] {message}\n")
+            raise _RetryTaskAttempt(message) from e
+
+        error_message = _exception_message(e)
+        logger.error(error_message)
+        log_output(f"\n[ERROR] {error_message}")
+        with Session(bind=engine) as task_session:
+            task = fetch_task_row(task_row.id, task_session, org)
+            commit_task_error(
+                task,
+                task_session,
+                error_message,
+                expected_started_at=attempt_started_at,
+                authority=authority,
+            )
+        return {task_id: None}
     except OutputArtifactError as e:
         if task_is_stopped():
             return {task_id: None}

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -20,13 +20,12 @@ import sentry_sdk
 from benchmark_service import (
     SandboxNotFoundError,
     SandboxProviderConfig,
+    SandboxRecoveryAttempt,
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from opentelemetry import trace
 from pydantic import ValidationError
 from sqlmodel import Session, col, select, update
-from tenacity import retry as tenacity_retry
-from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
 from tracker.aws.cloudwatch_logs import write_benchmark_log_event
@@ -55,7 +54,7 @@ from tracker.exceptions import (
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
-from tracker.observability import elapsed_ms, retry_callback
+from tracker.observability import elapsed_ms
 from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     AWSCredentials,
@@ -68,38 +67,12 @@ from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
 logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
-_SANDBOX_ATTEMPT_HARD_LIMIT: int = 20
+_SANDBOX_RETRY_DELAY_SECONDS: float = 2
 
 
 @dataclass
 class _DependencySetupRecoveryState:
     mode: DependencySetupMode = DependencySetupMode.IN_PLACE_RETRIES
-
-
-@dataclass
-class _SandboxRecoveryState:
-    attempts: int = 0
-    max_attempts: int | None = None
-    setup_retries: int = 0
-    outage_id: str | None = None
-    outage_started_epoch: float | None = None
-
-    def start_attempt(self) -> None:
-        self.attempts += 1
-
-    def record_loss(self, benchmark_id: UUID, task_id: str) -> None:
-        if self.outage_started_epoch is None:
-            self.outage_started_epoch = time.time()
-            self.outage_id = f"{benchmark_id}:{task_id}:{self.attempts}"
-        self.setup_retries = 0
-
-    def mark_replacement_ready(self) -> None:
-        self.outage_id = None
-        self.outage_started_epoch = None
-
-
-class _RetryTaskAttempt(Exception):
-    """Signal tenacity to replace the current sandbox without failing the task."""
 
 
 def _normalized_attempt_time(value: datetime) -> datetime:
@@ -471,29 +444,37 @@ async def process_task(
     authority: ExecutionAuthority,
 ) -> dict[str, dict[str, Any] | None]:
     """Process one task while retaining dependency recovery state across sandbox attempts."""
-    return await _process_task_attempt(
-        task_row,
-        start_benchmark_request,
-        benchmark_service,
-        benchmark_id,
-        task_id,
-        harness_config,
-        org,
-        sandbox_provider_config,
-        creation_semaphore,
-        dependency_setup_recovery=_DependencySetupRecoveryState(),
-        sandbox_recovery=_SandboxRecoveryState(),
-        authority=authority,
+    dependency_setup_recovery = _DependencySetupRecoveryState()
+
+    async def run_attempt(
+        recovery_attempt: SandboxRecoveryAttempt,
+    ) -> dict[str, dict[str, Any] | None]:
+        return await _process_task_attempt(
+            task_row,
+            start_benchmark_request,
+            benchmark_service,
+            benchmark_id,
+            task_id,
+            harness_config,
+            org,
+            sandbox_provider_config,
+            creation_semaphore,
+            dependency_setup_recovery=dependency_setup_recovery,
+            recovery_attempt=recovery_attempt,
+            authority=authority,
+        )
+
+    return await benchmark_service.run_with_sandbox_recovery(
+        task_id=task_id,
+        run_id=str(benchmark_id),
+        operation=run_attempt,
+        dataset=start_benchmark_request.dataset,
+        retryable_attempt_errors=(SandboxSetupError,),
+        default_max_attempts=_PTY_TASK_RETRY_LIMIT + 1,
+        retry_delay_s=_SANDBOX_RETRY_DELAY_SECONDS,
     )
 
 
-@tenacity_retry(
-    retry=retry_if_exception_type(_RetryTaskAttempt),
-    stop=stop_after_attempt(_SANDBOX_ATTEMPT_HARD_LIMIT),
-    wait=wait_fixed(2),
-    before_sleep=retry_callback("valkyrie.task"),
-    reraise=True,
-)
 async def _process_task_attempt(
     task_row: Task,
     start_benchmark_request: StartBenchmarkRequest,
@@ -505,7 +486,7 @@ async def _process_task_attempt(
     sandbox_provider_config: SandboxProviderConfig,
     creation_semaphore: Semaphore,
     dependency_setup_recovery: _DependencySetupRecoveryState,
-    sandbox_recovery: _SandboxRecoveryState,
+    recovery_attempt: SandboxRecoveryAttempt,
     authority: ExecutionAuthority,
 ) -> dict[str, dict[str, Any] | None]:
     """
@@ -515,7 +496,6 @@ async def _process_task_attempt(
     the evaluation will fail since the instance no longer exists. We handle this inside of the exception caught.
     """
     task_id_var.set(task_id)
-    sandbox_recovery.start_attempt()
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
     trace.get_current_span().set_attributes(
@@ -632,17 +612,7 @@ async def _process_task_attempt(
                     task = fetch_task_row(task_row.id, task_session, org)
                     if task.status == TaskStatus.STOPPED:
                         return {task_id: None}
-
-                # Successful durable evaluation resumes do not need the task
-                # payload or a generation sandbox. Fetch the opt-in policy only
-                # after provider loss so that fast resume remains independent
-                # of retrieve_task availability.
-                task_data = await benchmark_service.retrieve_task(
-                    task_id=task_id, dataset=start_benchmark_request.dataset
-                )
-                sandbox_recovery.max_attempts = (
-                    task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
-                )
+                await recovery_attempt.retrieve_task()
                 raise
             except Exception as e:
                 with Session(bind=engine) as task_session:
@@ -652,10 +622,7 @@ async def _process_task_attempt(
 
                 raise e from e
 
-        task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
-        sandbox_recovery.max_attempts = (
-            task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
-        )
+        task_data = await recovery_attempt.retrieve_task()
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
 
         # Labels that show up in the UI we can use to filter sandboxes
@@ -697,11 +664,8 @@ async def _process_task_attempt(
             "DAYTONA_SANDBOX_OTEL_EXTRA_LABELS": (
                 f"benchmark_id={benchmark_id},task_id={task_row.task_id},environment={ENVIRONMENT}"
             ),
+            **recovery_attempt.environment,
         }
-        if sandbox_recovery.outage_started_epoch is not None:
-            env_vars["VALKYRIE_SANDBOX_OUTAGE_STARTED_EPOCH"] = str(sandbox_recovery.outage_started_epoch)
-        if sandbox_recovery.outage_id is not None:
-            env_vars["VALKYRIE_SANDBOX_OUTAGE_ID"] = sandbox_recovery.outage_id
 
         # We don't want to track the task until the sandbox is actually created.
         task_breakdown = TaskBreakdown()
@@ -753,7 +717,7 @@ async def _process_task_attempt(
                 # The benchmark has now had an opportunity to persist the
                 # outage metadata in its restored volume. A later loss is a
                 # distinct outage and must receive a new identity.
-                sandbox_recovery.mark_replacement_ready()
+                recovery_attempt.mark_replacement_ready()
 
                 # Force flush the logs if anything has been buffered
                 buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
@@ -880,26 +844,18 @@ async def _process_task_attempt(
         if task_is_stopped():
             return {task_id: None}
         log_output(f"\n[ERROR] {_exception_message(e)}")
-        within_policy = (
-            sandbox_recovery.max_attempts is None or sandbox_recovery.attempts < sandbox_recovery.max_attempts
-        )
-        if sandbox_recovery.setup_retries < _PTY_TASK_RETRY_LIMIT and within_policy:
-            sandbox_recovery.setup_retries += 1
-            raise _RetryTaskAttempt("retrying task in a fresh sandbox after setup failure") from e
         raise
     except SandboxNotFoundError as e:
         if task_is_stopped():
             return {task_id: None}
-        max_attempts = sandbox_recovery.max_attempts
-        if max_attempts is not None and sandbox_recovery.attempts < max_attempts:
-            sandbox_recovery.record_loss(benchmark_id, task_row.task_id)
+        if recovery_attempt.sandbox_loss_retry_available:
             message = (
                 "Sandbox disappeared; restoring the task from its durable volume "
-                f"(attempt {sandbox_recovery.attempts + 1}/{max_attempts})"
+                f"(attempt {recovery_attempt.number + 1}/{recovery_attempt.max_attempts})"
             )
             logger.warning(message)
             log_output(f"\n[WARNING] {message}\n")
-            raise _RetryTaskAttempt(message) from e
+            raise
 
         error_message = _exception_message(e)
         logger.error(error_message)

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -586,11 +586,6 @@ async def _process_task_attempt(
         return not execution_is_current()
 
     try:
-        task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
-        sandbox_recovery.max_attempts = (
-            task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
-        )
-
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
@@ -632,6 +627,25 @@ async def _process_task_attempt(
                         return {task_id: None}
 
                     return {task_id: evaluation_result_row.result}
+            except SandboxNotFoundError:
+                with Session(bind=engine) as task_session:
+                    task = fetch_task_row(task_row.id, task_session, org)
+                    if task.status == TaskStatus.STOPPED:
+                        return {task_id: None}
+
+                # Successful durable evaluation resumes do not need the task
+                # payload or a generation sandbox. Fetch the opt-in policy only
+                # after provider loss so that fast resume remains independent
+                # of retrieve_task availability.
+                task_data = await benchmark_service.retrieve_task(
+                    task_id=task_id, dataset=start_benchmark_request.dataset
+                )
+                sandbox_recovery.max_attempts = (
+                    task_data.sandbox_recovery.max_sandbox_attempts
+                    if task_data.sandbox_recovery is not None
+                    else None
+                )
+                raise
             except Exception as e:
                 with Session(bind=engine) as task_session:
                     task = fetch_task_row(task_row.id, task_session, org)
@@ -640,6 +654,10 @@ async def _process_task_attempt(
 
                 raise e from e
 
+        task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
+        sandbox_recovery.max_attempts = (
+            task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
+        )
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
 
         # Labels that show up in the UI we can use to filter sandboxes

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -586,6 +586,11 @@ async def _process_task_attempt(
         return not execution_is_current()
 
     try:
+        task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
+        sandbox_recovery.max_attempts = (
+            task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
+        )
+
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
                 log_output("Resuming evaluation from durable benchmark state\n")
@@ -635,10 +640,6 @@ async def _process_task_attempt(
 
                 raise e from e
 
-        task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
-        sandbox_recovery.max_attempts = (
-            task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
-        )
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
 
         # Labels that show up in the UI we can use to filter sandboxes

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -864,8 +864,7 @@ async def _process_task_attempt(
             return {task_id: None}
         log_output(f"\n[ERROR] {_exception_message(e)}")
         within_policy = (
-            sandbox_recovery.max_attempts is None
-            or sandbox_recovery.attempts < sandbox_recovery.max_attempts
+            sandbox_recovery.max_attempts is None or sandbox_recovery.attempts < sandbox_recovery.max_attempts
         )
         if sandbox_recovery.setup_retries < _PTY_TASK_RETRY_LIMIT and within_policy:
             sandbox_recovery.setup_retries += 1

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -641,9 +641,7 @@ async def _process_task_attempt(
                     task_id=task_id, dataset=start_benchmark_request.dataset
                 )
                 sandbox_recovery.max_attempts = (
-                    task_data.sandbox_recovery.max_sandbox_attempts
-                    if task_data.sandbox_recovery is not None
-                    else None
+                    task_data.sandbox_recovery.max_sandbox_attempts if task_data.sandbox_recovery is not None else None
                 )
                 raise
             except Exception as e:

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -182,6 +182,7 @@ class TestBenchmarkServiceFailures:
         logged_messages: list[str] = []
         log_written = asyncio.Event()
         event_loop = asyncio.get_running_loop()
+        expected_error = "Output artifact error: Required output artifact missing: /tmp/valkyrie/artifacts/missing.json"
 
         async def _mock_install_agent_dependencies(*_args: Any, **_kwargs: Any) -> None:
             return None
@@ -198,7 +199,8 @@ class TestBenchmarkServiceFailures:
 
         def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
             logged_messages.append(message)
-            event_loop.call_soon_threadsafe(log_written.set)
+            if f"[ERROR] {expected_error}" in message:
+                event_loop.call_soon_threadsafe(log_written.set)
 
         monkeypatch.setattr(utils_module, "run_agent", sandbox_module.run_agent)
         monkeypatch.setattr(sandbox_module, "install_agent_dependencies", _mock_install_agent_dependencies)
@@ -218,7 +220,6 @@ class TestBenchmarkServiceFailures:
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
-        expected_error = "Output artifact error: Required output artifact missing: /tmp/valkyrie/artifacts/missing.json"
         assert error_message == expected_error
         assert any(f"[ERROR] {expected_error}" in message for message in logged_messages)
 

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from benchmark_service import SandboxNotFoundError, SandboxRecoveryPolicy
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import RetrieveTaskResponse, VolumeMount
 from sqlmodel import Session
@@ -157,6 +158,85 @@ class TestTaskExecutionRetry:
         assert sandbox_entry_count == 2
         assert call_count == 2
         assert dependency_modes == expected_dependency_modes
+
+        database_session.refresh(task_row)
+        assert task_row.status == expected_status
+
+    @pytest.mark.parametrize(
+        "max_attempts,failures,expected_attempts,expected_status",
+        [
+            (3, 1, 2, TaskStatus.FINISHED),
+            (3, 2, 3, TaskStatus.FINISHED),
+            (2, 2, 2, TaskStatus.ERROR),
+            (None, 1, 1, TaskStatus.ERROR),
+        ],
+    )
+    async def test_lost_sandbox_recovery_is_opt_in_and_bounded(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        max_attempts: int | None,
+        failures: int,
+        expected_attempts: int,
+        expected_status: TaskStatus,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        retryable_process_task = getattr(task_execution_module, "_process_task_attempt")
+        monkeypatch.setattr(retryable_process_task.retry, "wait", wait_none())
+        monkeypatch.setattr("tracker.utils.task_execution.time.time", lambda: 1_234.5)
+
+        sandbox_envs: list[dict[str, str]] = []
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            sandbox_envs.append(kwargs["env_vars"])
+            sandbox = AsyncMock()
+            sandbox.id = f"mock-sandbox-{len(sandbox_envs)}"
+            sandbox.name = sandbox.id
+            yield sandbox
+
+        run_count = 0
+
+        async def _mock_run_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            nonlocal run_count
+            run_count += 1
+            if run_count <= failures:
+                raise SandboxNotFoundError("sandbox was preempted")
+            return None, 0.0
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            response = make_retrieve_task_response(problem_path="/tmp/problem.txt")
+            if max_attempts is not None:
+                response.sandbox_recovery = SandboxRecoveryPolicy(max_sandbox_attempts=max_attempts)
+            return response
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(task_execution_module, "run_agent", _mock_run_agent)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
+
+        expected_result = None if expected_status is TaskStatus.ERROR else {"status": "success", "score": 1.0}
+        assert result == {"task_0": expected_result}
+        assert len(sandbox_envs) == expected_attempts
+        assert all(env["RUN_ID"] == str(benchmark_id) for env in sandbox_envs)
+        assert "VALKYRIE_SANDBOX_OUTAGE_ID" not in sandbox_envs[0]
+        for lost_attempt, env in enumerate(sandbox_envs[1:], start=1):
+            assert env["VALKYRIE_SANDBOX_OUTAGE_STARTED_EPOCH"] == "1234.5"
+            assert env["VALKYRIE_SANDBOX_OUTAGE_ID"] == f"{benchmark_id}:task_0:{lost_attempt}"
 
         database_session.refresh(task_row)
         assert task_row.status == expected_status

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -241,6 +241,59 @@ class TestTaskExecutionRetry:
         database_session.refresh(task_row)
         assert task_row.status == expected_status
 
+    async def test_eval_resume_loads_recovery_policy_before_handling_sandbox_loss(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        task_row.status = TaskStatus.EVALUATING
+        task_row.eval_resume_state = {"artifact_prefix": "s3://bucket/run"}
+        database_session.add(task_row)
+        database_session.commit()
+
+        retryable_process_task = getattr(task_execution_module, "_process_task_attempt")
+        monkeypatch.setattr(retryable_process_task.retry, "wait", wait_none())
+        monkeypatch.setattr("tracker.utils.task_execution.time.time", lambda: 1_234.5)
+
+        retrieve_count = 0
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            nonlocal retrieve_count
+            retrieve_count += 1
+            response = make_retrieve_task_response(problem_path="/tmp/problem.txt")
+            response.sandbox_recovery = SandboxRecoveryPolicy(max_sandbox_attempts=2)
+            return response
+
+        resume_count = 0
+
+        async def _mock_resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            nonlocal resume_count
+            resume_count += 1
+            if resume_count == 1:
+                raise SandboxNotFoundError("grading sandbox was preempted")
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert retrieve_count == 2
+        assert resume_count == 2
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+
     async def test_process_task_spans_timed_status_transitions(
         self,
         contract: AgentContractRequest,

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -13,7 +13,6 @@ from benchmark_service import SandboxNotFoundError, SandboxRecoveryPolicy
 from benchmark_service.client import BenchmarkServiceClient
 from benchmark_service.schemas import RetrieveTaskResponse, VolumeMount
 from sqlmodel import Session
-from tenacity import wait_none
 
 from tests.unit.utils.task_execution_support import (
     create_task_environment,
@@ -29,13 +28,6 @@ from tracker.utils import task_execution as task_execution_module
 
 class TestTaskExecutionRetry:
     """Task execution retries, callbacks, and transition spans."""
-
-    def test_process_task_retry_decorator_uses_observability_retry_callback(self) -> None:
-        retryable_process_task = getattr(task_execution_module, "_process_task_attempt")
-        before_sleep = retryable_process_task.retry.before_sleep
-
-        assert before_sleep is not None
-        assert callable(before_sleep)
 
     @pytest.mark.parametrize(
         "fail_target,error,second_error,expected_dependency_modes,expected_status",
@@ -97,8 +89,7 @@ class TestTaskExecutionRetry:
             harness_config,
         )
 
-        retryable_process_task = getattr(task_execution_module, "_process_task_attempt")
-        monkeypatch.setattr(retryable_process_task.retry, "wait", wait_none())
+        monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
 
         sandbox_entry_count = 0
 
@@ -187,9 +178,8 @@ class TestTaskExecutionRetry:
             database_session,
             harness_config,
         )
-        retryable_process_task = getattr(task_execution_module, "_process_task_attempt")
-        monkeypatch.setattr(retryable_process_task.retry, "wait", wait_none())
-        monkeypatch.setattr("tracker.utils.task_execution.time.time", lambda: 1_234.5)
+        monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr("benchmark_service.client.time.time", lambda: 1_234.5)
 
         sandbox_envs: list[dict[str, str]] = []
 
@@ -258,9 +248,8 @@ class TestTaskExecutionRetry:
         database_session.add(task_row)
         database_session.commit()
 
-        retryable_process_task = getattr(task_execution_module, "_process_task_attempt")
-        monkeypatch.setattr(retryable_process_task.retry, "wait", wait_none())
-        monkeypatch.setattr("tracker.utils.task_execution.time.time", lambda: 1_234.5)
+        monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr("benchmark_service.client.time.time", lambda: 1_234.5)
 
         retrieve_count = 0
 

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -289,7 +289,7 @@ class TestTaskExecutionRetry:
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
 
         assert result == {"task_0": {"status": "success", "score": 1.0}}
-        assert retrieve_count == 2
+        assert retrieve_count == 1
         assert resume_count == 2
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.FINISHED

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any
 from unittest.mock import AsyncMock, Mock
+from uuid import UUID
 
 import pytest
 from benchmark_service import SandboxNotFoundError, SandboxRecoveryPolicy
@@ -180,6 +181,7 @@ class TestTaskExecutionRetry:
         )
         monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
         monkeypatch.setattr("benchmark_service.client.time.time", lambda: 1_234.5)
+        monkeypatch.setattr("benchmark_service.client.uuid4", lambda: UUID(int=1))
 
         sandbox_envs: list[dict[str, str]] = []
 
@@ -226,7 +228,9 @@ class TestTaskExecutionRetry:
         assert "VALKYRIE_SANDBOX_OUTAGE_ID" not in sandbox_envs[0]
         for lost_attempt, env in enumerate(sandbox_envs[1:], start=1):
             assert env["VALKYRIE_SANDBOX_OUTAGE_STARTED_EPOCH"] == "1234.5"
-            assert env["VALKYRIE_SANDBOX_OUTAGE_ID"] == f"{benchmark_id}:task_0:{lost_attempt}"
+            assert env["VALKYRIE_SANDBOX_OUTAGE_ID"] == (
+                f"{benchmark_id}:task_0:{lost_attempt}:00000000000000000000000000000001"
+            )
 
         database_session.refresh(task_row)
         assert task_row.status == expected_status

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.23.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0#96d535f4085a7606f6da2b82b0c6fbff25c1ce70" }
+version = "0.23.1.dev1+g7b4b5eed2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33#7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0#778da4d711ecf35eb744cd0e8d0a830bd092b23a" }
+version = "0.24.1.dev3+gcb167d20a"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3#cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.1.dev3+gcb167d20a"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3#cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
+version = "0.24.1.dev4+g2fd3b6250"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba#2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.23.1.dev1+g7b4b5eed2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33#7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
+version = "0.24.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0#778da4d711ecf35eb744cd0e8d0a830bd092b23a" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.1.dev4+g2fd3b6250"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba#2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
+version = "0.25.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0#4e9574119cf5da0ca55d9251c5d11a97dc6ccdc4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.1.dev3+gcb167d20a"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3#cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
+version = "0.24.1.dev4+g2fd3b6250"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba#2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.1.dev4+g2fd3b6250"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba#2fd3b62504c0eab56d7434ab965d9ebc6f302fba" }
+version = "0.25.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0#4e9574119cf5da0ca55d9251c5d11a97dc6ccdc4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=2fd3b62504c0eab56d7434ab965d9ebc6f302fba" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.23.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0#96d535f4085a7606f6da2b82b0c6fbff25c1ce70" }
+version = "0.23.1.dev1+g7b4b5eed2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33#7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.23.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.23.1.dev1+g7b4b5eed2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33#7b4b5eed20049a2b9b6514e77c42fe2613e89d33" }
+version = "0.24.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0#778da4d711ecf35eb744cd0e8d0a830bd092b23a" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=7b4b5eed20049a2b9b6514e77c42fe2613e89d33" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.24.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0#778da4d711ecf35eb744cd0e8d0a830bd092b23a" }
+version = "0.24.1.dev3+gcb167d20a"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3#cb167d20a7244f2b52ec0289e8b5f564d6e493c3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.24.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cb167d20a7244f2b52ec0289e8b5f564d6e493c3" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## WHY

Valkyrie normally treats a provider SandboxNotFoundError as terminal. Explicitly durable workloads such as KSP's 120-hour full ladder need to cross Modal's 24-hour sandbox lifetime without granting retries to ordinary or non-idempotent benchmarks.

The recovery state machine now belongs to the CBS client, not Valkyrie's main task service.

## HOW

- Delegate policy loading, attempt counting, typed-loss retries, outage identity, retry delay, and setup-retry bounds to BenchmarkServiceClient.run_with_sandbox_recovery.
- Keep Valkyrie limited to its runner-specific work: create the sandbox, merge client-provided recovery metadata, acknowledge durable benchmark setup, and persist the existing terminal task error.
- Preserve lazy evaluation resume: a successful durable resume does not call retrieve_task or create a sandbox.
- Recreate opted-in tasks with the same RUN_ID, task identity, and volume mounts.
- Preserve fail-fast behavior when the benchmark does not return SandboxRecoveryPolicy.

~~~mermaid
flowchart LR
    V["Valkyrie task adapter"] --> C["CBS recovery client"]
    C --> P["Lazy cached benchmark policy"]
    C --> A["Bounded attempt + outage metadata"]
    A --> V
    V --> S["Provider sandbox + same RUN_ID/volume"]
    S --> K["Benchmark persists recovery marker"]
    K -->|"ready"| C
~~~

## VALIDATION

- Full tracker unit suite — 467 passed
- Tracker unit + local API suites — 503 passed
- Recovery/error/resume regression subset — 52 passed
- Simulated one loss, consecutive losses, cap exhaustion, failed replacement setup, no-opt-in behavior, and evaluation-resume loss
- Full ruff check . — passed
- Full basedpyright — 0 errors
- Root, tracker, and executor-artifact lockfiles resolve CBS v0.25.0 to merged commit 4e957411
- Final live-provider workflow — 27 passed in 290.14s against the same recovery implementation before the release-tag-only repin (the first PR attempt intentionally fails with “Check must be run manually on PRs”)
- Release repin regression subset — 19 passed

## DEPENDENCIES / MERGE ORDER

1. CBS vals-ai/create-benchmark-service#126 is merged and released as v0.25.0.
2. Merge this PR to dev after its refreshed checks and required review pass.
3. Deploy the already-merged KSP recovery build through vals-ai/benchmark-services-registry#517.
4. Force-delete a short dev Modal sandbox and verify same-run continuation plus exact outage credit before porting to prod.

## REVIEW NOTES

Recovery remains limited to the provider's typed not-found signal. WebSocket failures, agent failures, invalid responses, and benchmarks without an opt-in policy retain their existing behavior.
