### PR TITLE
Forward benchmark sandbox secret references to sandbox providers

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.23.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cfda9455d9e35533c023ed7f20980bb4c8358a78" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cfda9455d9e35533c023ed7f20980bb4c8358a78" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.26.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.25.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0#4e9574119cf5da0ca55d9251c5d11a97dc6ccdc4" }
+version = "0.25.1.dev1+gcfda9455d"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78#cfda9455d9e35533c023ed7f20980bb4c8358a78" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -744,9 +744,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/04/81bd731d6d1e3a469d9a4c36f5eb069bcf0cbb2d5d342c9fec22245b91fc/greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4", size = 295909, upload-time = "2026-07-22T11:38:09.261Z" },
     { url = "https://files.pythonhosted.org/packages/cc/dd/f5f22903a6ae70f5ea328ed0beaec92ad903f0e3b7d2845133b354abc4b8/greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17", size = 612011, upload-time = "2026-07-22T12:26:40.69Z" },
     { url = "https://files.pythonhosted.org/packages/8e/10/92a4a88d12b915d74ea5b6d288e4afefda4771647caa34442c156f7a454f/greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a", size = 624299, upload-time = "2026-07-22T12:29:02.089Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/f9/03e26be3487c5238e81f2b84714959a86ea8515a869828cf41f4fc54b34e/greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf", size = 629603, upload-time = "2026-07-22T12:43:43.456Z" },
     { url = "https://files.pythonhosted.org/packages/50/6d/0b14bb9db2989f32cd9fe7f76afedea01ee8bee3f87c07e69f24adfe7e63/greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f", size = 621541, upload-time = "2026-07-22T11:51:09.464Z" },
-    { url = "https://files.pythonhosted.org/packages/57/6b/7c55ca72ef80d57c16c4a55210f82582622462dc4485799a30f4ec6f3372/greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f", size = 432554, upload-time = "2026-07-22T12:39:51.379Z" },
     { url = "https://files.pythonhosted.org/packages/48/3d/25e9a2d9eb6b2e8b7ca4e80a3a26cb887cce6c8e0a87c921164f11bc5574/greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d", size = 1581444, upload-time = "2026-07-22T12:25:03.818Z" },
     { url = "https://files.pythonhosted.org/packages/b9/96/4c9bf2e2c408dcc0556edce69efa9f802e82223573c53240136a086821f1/greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9", size = 1645842, upload-time = "2026-07-22T11:51:12.295Z" },
     { url = "https://files.pythonhosted.org/packages/b5/41/303ecb26a3a56122c0f4d4073ee078881847bd6b6f463ae0ec57ec20223b/greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3", size = 247169, upload-time = "2026-07-22T11:38:19.893Z" },
@@ -1835,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.25.1.dev1+gcfda9455d"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78#cfda9455d9e35533c023ed7f20980bb4c8358a78" }
+version = "0.26.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.26.0#888b92f89c38294b668a362972bde1b7f7614c5d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1833,7 +1833,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.26.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cfda9455d9e35533c023ed7f20980bb4c8358a78" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.26.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -51,7 +51,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.25.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "cfda9455d9e35533c023ed7f20980bb4c8358a78" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -161,6 +161,18 @@ def _set_sandbox_span_attributes(sandbox: Sandbox) -> None:
     span.set_attribute("valkyrie.sandbox_state", sandbox.state)
 
 
+def _reject_plaintext_secret_collisions(
+    env_vars: dict[str, str] | None,
+    sandbox_secrets: dict[str, str] | None,
+) -> None:
+    overlapping_env_names = sorted(set(env_vars or {}) & set(sandbox_secrets or {}))
+    if overlapping_env_names:
+        raise InvalidSandboxConfigurationError(
+            "Sandbox environment variables cannot be both plaintext and provider-managed secrets: "
+            f"{', '.join(overlapping_env_names)}"
+        )
+
+
 @logfire.instrument("sandbox.create", extract_args=False)
 async def _create_sandbox(
     provider: SandboxProvider,
@@ -173,12 +185,7 @@ async def _create_sandbox(
     sandbox_secrets: dict[str, str] | None = None,
 ) -> Sandbox:
     """Create a sandbox through its provider."""
-    overlapping_env_names = sorted(set(env_vars or {}) & set(sandbox_secrets or {}))
-    if overlapping_env_names:
-        raise InvalidSandboxConfigurationError(
-            "Sandbox environment variables cannot be both plaintext and provider-managed secrets: "
-            f"{', '.join(overlapping_env_names)}"
-        )
+    _reject_plaintext_secret_collisions(env_vars, sandbox_secrets)
     provider_source = _provider_source(source)
     _set_sandbox_create_span_attributes(sandbox_name, provider_source, resources)
     return await provider.create_sandbox(

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -175,8 +175,6 @@ async def _create_sandbox(
     """Create a sandbox through its provider."""
     overlapping_env_names = sorted(set(env_vars or {}) & set(sandbox_secrets or {}))
     if overlapping_env_names:
-        # Deterministic misconfiguration: SandboxSetupError would trigger the
-        # fresh-sandbox retry in _process_task_attempt, which cannot help here.
         raise InvalidSandboxConfigurationError(
             "Sandbox environment variables cannot be both plaintext and provider-managed secrets: "
             f"{', '.join(overlapping_env_names)}"

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -253,10 +253,7 @@ async def create_sandbox(
                 await delete_sandbox(sandbox, provider)
                 raise
     except Exception as e:
-        # Deterministic config errors are caught before any provider call and
-        # would skew the infra-error signal this metric exists to track.
-        if not isinstance(e, InvalidSandboxConfigurationError):
-            incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
+        incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
         raise
 
     distribution(

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -255,7 +255,10 @@ async def create_sandbox(
                 await delete_sandbox(sandbox, provider)
                 raise
     except Exception as e:
-        incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
+        # Deterministic config errors are caught before any provider call and
+        # would skew the infra-error signal this metric exists to track.
+        if not isinstance(e, InvalidSandboxConfigurationError):
+            incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
         raise
 
     distribution(

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -60,6 +60,7 @@ from tracker.database.models import (
 from tracker.exceptions import (
     AgentRunFailedError,
     DependencySetupExhaustedError,
+    InvalidSandboxConfigurationError,
     OutputArtifactError,
     SandboxError,
     SandboxSetupError,
@@ -169,8 +170,17 @@ async def _create_sandbox(
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
     volumes: list[VolumeMount] | None = None,
+    sandbox_secrets: dict[str, str] | None = None,
 ) -> Sandbox:
     """Create a sandbox through its provider."""
+    overlapping_env_names = sorted(set(env_vars or {}) & set(sandbox_secrets or {}))
+    if overlapping_env_names:
+        # Deterministic misconfiguration: SandboxSetupError would trigger the
+        # fresh-sandbox retry in _process_task_attempt, which cannot help here.
+        raise InvalidSandboxConfigurationError(
+            "Sandbox environment variables cannot be both plaintext and provider-managed secrets: "
+            f"{', '.join(overlapping_env_names)}"
+        )
     provider_source = _provider_source(source)
     _set_sandbox_create_span_attributes(sandbox_name, provider_source, resources)
     return await provider.create_sandbox(
@@ -180,6 +190,7 @@ async def _create_sandbox(
             name=sandbox_name,
             labels=labels or {},
             env_vars=env_vars or {},
+            sandbox_secrets=sandbox_secrets or {},
             volumes=volumes or [],
             auto_stop_interval=SANDBOX_AUTO_STOP_INTERVAL,
             create_timeout=SANDBOX_CREATE_TIMEOUT,
@@ -197,6 +208,7 @@ async def create_sandbox(
     labels: dict[str, str] | None = None,
     env_vars: dict[str, str] | None = None,
     volumes: list[VolumeMount] | None = None,
+    sandbox_secrets: dict[str, str] | None = None,
 ) -> AsyncGenerator[Sandbox, Any]:
     """
     Yeild a sandbox to be used within a context manager.
@@ -209,6 +221,7 @@ async def create_sandbox(
         labels: The labels to use for the sandbox
         env_vars: The environment variables to use for the sandbox
         volumes: Persistent volumes to mount in the sandbox
+        sandbox_secrets: Provider-managed secret references keyed by environment variable name
         creation_semaphore: Per-benchmark semaphore to limit concurrent sandbox creation.
 
     Returns:
@@ -224,7 +237,16 @@ async def create_sandbox(
         async with creation_semaphore:
             start = time.monotonic()
             creation_task = asyncio.create_task(
-                _create_sandbox(provider, sandbox_name, source, resources, labels, env_vars, volumes)
+                _create_sandbox(
+                    provider,
+                    sandbox_name,
+                    source,
+                    resources,
+                    labels=labels,
+                    env_vars=env_vars,
+                    volumes=volumes,
+                    sandbox_secrets=sandbox_secrets,
+                )
             )
             try:
                 sandbox = await asyncio.shield(creation_task)

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -658,6 +658,7 @@ async def _process_task_attempt(
             source=task_data.source,
             labels=labels,
             env_vars=env_vars,
+            sandbox_secrets=task_data.sandbox_secrets,
             resources=task_data.resources,
             volumes=task_data.volumes,
             creation_semaphore=creation_semaphore,

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -47,6 +47,7 @@ from tracker.database.session import engine
 from tracker.exceptions import (
     DependencySetupExhaustedError,
     ExecutionAuthorityRevoked,
+    InvalidSandboxConfigurationError,
     OutputArtifactError,
     SandboxSetupError,
     TrackerServiceError,
@@ -823,6 +824,20 @@ async def _process_task_attempt(
             return {task_id: None}
         log_output(f"\n[ERROR] {_exception_message(e)}")
         raise
+    except InvalidSandboxConfigurationError as e:
+        if task_is_stopped():
+            return {task_id: None}
+        error_message = _exception_message(e)
+        logger.warning(error_message)
+        log_output(f"\n[ERROR] {error_message}")
+
+        with Session(bind=engine) as task_session:
+            task = fetch_task_row(task_row.id, task_session, org)
+            commit_task_error(
+                task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
+            )
+
+        return {task_id: None}
     except OutputArtifactError as e:
         if task_is_stopped():
             return {task_id: None}

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -47,7 +47,6 @@ from tracker.database.session import engine
 from tracker.exceptions import (
     DependencySetupExhaustedError,
     ExecutionAuthorityRevoked,
-    InvalidSandboxConfigurationError,
     OutputArtifactError,
     SandboxSetupError,
     TrackerServiceError,
@@ -824,20 +823,6 @@ async def _process_task_attempt(
             return {task_id: None}
         log_output(f"\n[ERROR] {_exception_message(e)}")
         raise
-    except InvalidSandboxConfigurationError as e:
-        if task_is_stopped():
-            return {task_id: None}
-        error_message = _exception_message(e)
-        logger.warning(error_message)
-        log_output(f"\n[ERROR] {error_message}")
-
-        with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(
-                task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
-            )
-
-        return {task_id: None}
     except OutputArtifactError as e:
         if task_is_stopped():
             return {task_id: None}

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -35,6 +35,7 @@ from tracker.database.models import (
 from tracker.exceptions import (
     AgentRunFailedError,
     DependencySetupExhaustedError,
+    InvalidSandboxConfigurationError,
     OutputArtifactError,
     SSLConnectionError,
     SandboxError,
@@ -993,12 +994,14 @@ class TestSandboxLifecycle:
                 subpath="{run_id}",
             )
         ]
+        sandbox_secrets = {"TAVILY_API_KEY": "daytona-tavily"}
         sandbox = await _create_sandbox(
             provider,
             "task-alias",
             ImageSource(image="ghcr.io/vals/swebench:latest"),
             resources,
             labels={"run-id": "run-123"},
+            sandbox_secrets=sandbox_secrets,
             volumes=volumes,
         )
 
@@ -1008,9 +1011,25 @@ class TestSandboxLifecycle:
         assert request.name == "task-alias"
         assert request.resources == resources
         assert request.labels == {"run-id": "run-123"}
+        assert request.sandbox_secrets == sandbox_secrets
         assert request.volumes == volumes
         assert request.auto_stop_interval == sandbox_module.SANDBOX_AUTO_STOP_INTERVAL
         assert request.create_timeout == sandbox_module.SANDBOX_CREATE_TIMEOUT
+
+    async def test_create_sandbox_rejects_plaintext_and_secret_environment_collision(self) -> None:
+        provider = AsyncMock()
+
+        with pytest.raises(InvalidSandboxConfigurationError, match="TAVILY_API_KEY"):
+            await _create_sandbox(
+                provider,
+                "task-alias",
+                ImageSource(image="ghcr.io/vals/swebench:latest"),
+                Resources(vcpu=1, memory=2, disk=3),
+                env_vars={"TAVILY_API_KEY": "plaintext-value"},
+                sandbox_secrets={"TAVILY_API_KEY": "daytona-tavily"},
+            )
+
+        provider.create_sandbox.assert_not_awaited()
 
     async def test_create_sandbox_unwraps_compose_source_before_provider_create(
         self, monkeypatch: pytest.MonkeyPatch

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -11,10 +11,16 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from benchmark_service.client import BenchmarkServiceClient
 from sqlmodel import Session
 
 import tracker.utils.task_execution as utils_module
-from tests.unit.utils.task_execution_support import TEST_ORG, create_task_environment, run_process_task
+from tests.unit.utils.task_execution_support import (
+    TEST_ORG,
+    create_task_environment,
+    make_retrieve_task_response,
+    run_process_task,
+)
 from tracker.auth import RequestIdentity
 from tracker.database.models import (
     AgentContractRequest,
@@ -139,6 +145,50 @@ class TestProcessTaskEnvironment:
         }
         assert "MODEL_GATEWAY_URL" not in env_vars
         assert "MODEL_GATEWAY_API_KEY" not in env_vars
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_process_task_forwards_native_secret_references_without_resolving_values(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        contract = contract.model_copy(update={"secrets": {"LEGACY_API_KEY": "aws-secret"}})
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        captured: dict[str, dict[str, str]] = {}
+        resolved_inputs: list[dict[str, str]] = []
+
+        def _mock_resolve_secrets(secrets: dict[str, str], *_args: Any, **_kwargs: Any) -> dict[str, str]:
+            resolved_inputs.append(secrets)
+            return {"LEGACY_API_KEY": "legacy-value"}
+
+        @asynccontextmanager
+        async def _capture_sandbox(*_args: Any, **kwargs: Any) -> AsyncGenerator[SimpleNamespace, None]:
+            captured["env_vars"] = kwargs["env_vars"]
+            captured["sandbox_secrets"] = kwargs["sandbox_secrets"]
+            yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> Any:
+            response = make_retrieve_task_response()
+            response.sandbox_secrets = {"TAVILY_API_KEY": "daytona-tavily"}
+            return response
+
+        monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_secrets)
+        monkeypatch.setattr(utils_module, "create_sandbox", _capture_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert resolved_inputs == [{"LEGACY_API_KEY": "aws-secret"}]
+        assert captured["sandbox_secrets"] == {"TAVILY_API_KEY": "daytona-tavily"}
+        assert captured["env_vars"]["LEGACY_API_KEY"] == "legacy-value"
+        assert "TAVILY_API_KEY" not in captured["env_vars"]
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_stopped_task_output_is_fenced_while_sibling_keeps_dispatch_active(

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.25.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0#4e9574119cf5da0ca55d9251c5d11a97dc6ccdc4" }
+version = "0.25.1.dev1+gcfda9455d"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78#cfda9455d9e35533c023ed7f20980bb4c8358a78" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -752,9 +752,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -2022,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -383,8 +383,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.25.1.dev1+gcfda9455d"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78#cfda9455d9e35533c023ed7f20980bb4c8358a78" }
+version = "0.26.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.26.0#888b92f89c38294b668a362972bde1b7f7614c5d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2020,7 +2020,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.26.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.25.1.dev1+gcfda9455d"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78#cfda9455d9e35533c023ed7f20980bb4c8358a78" }
+version = "0.26.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.26.0#888b92f89c38294b668a362972bde1b7f7614c5d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2216,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.26.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -414,8 +414,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.25.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0#4e9574119cf5da0ca55d9251c5d11a97dc6ccdc4" }
+version = "0.25.1.dev1+gcfda9455d"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78#cfda9455d9e35533c023ed7f20980bb4c8358a78" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -783,9 +783,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -2218,7 +2216,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.25.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=cfda9455d9e35533c023ed7f20980bb4c8358a78" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
- Plumbs `RetrieveTaskResponse.sandbox_secrets` (env var name -> Daytona org-secret name, reference-only) from task retrieval through `create_sandbox` into the provider `SandboxCreateRequest`
- Rejects env var names declared as both plaintext `env_vars` and provider-managed `sandbox_secrets`, raising `InvalidSandboxConfigurationError` — a deterministic config error that fails the attempt immediately rather than triggering the fresh-sandbox `SandboxSetupError` retry, which cannot help
- Companion to vals-ai/create-benchmark-service#127

## Depends on
Requires vals-ai/create-benchmark-service#127. The `create-benchmark-service` pin in `services/tracker` and `services/executor_artifact` (plus the lockfiles) currently points at that PR's commit so CI runs against the dependency this branch needs; swap it to the release tag once #127 merges and a release is cut, mirroring how #633 paired the volumes plumbing with its dependency bump.

## Test plan
- `test_create_sandbox_passes_request_to_provider` asserts secrets reach the provider request
- `test_create_sandbox_rejects_plaintext_and_secret_environment_collision` asserts the fail-fast path (passes today; raises before the request is built)
- `test_process_task_forwards_native_secret_references_without_resolving_values` asserts references are forwarded untouched while legacy contract secrets still resolve to plaintext, with no cross-contamination
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/642" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

## Test results
- `test_create_sandbox_rejects_plaintext_and_secret_environment_collision` passes locally (fail-fast path, raises before the provider request is built)
- The two forwarding tests fail as expected until the create-benchmark-service pin is bumped past vals-ai/create-benchmark-service#127
- Live Daytona validation of the provider-side reference path (tenant keys can attach native secret references at sandbox creation) is documented on vals-ai/create-benchmark-service#127

## Live end-to-end validation
With the tracker, executor artifact, and benchmark service all built against the vals-ai/create-benchmark-service#127 commit (pins temporarily overridden locally), a full `valk run start` against real Daytona created the generation sandbox with the task-declared secret reference, and the benchmark service verified in-sandbox injection of the env var as an opaque placeholder (observation: `PRESENT 27 OPAQUE`). The task finished and the run scored 100. With the pin now committed at that revision, the full tracker unit suite (465 tests) and the live integration suite pass in CI.

