### PR TITLE
change: self provision tls

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -13,8 +13,9 @@ AWS CDK infrastructure for the Agentic Harness benchmark platform.
 physical CloudFormation name remains `WorkerStack` so deployments update the
 existing stack and retained resources in place.
 
-Production imports the existing `vals.ai` hosted zone. Development imports the
-account-local `benchmark-tracker-dev.vals.ai` child zone and certificate.
+Production imports the existing `vals.ai` hosted zone. Development imports only
+the account-local `benchmark-tracker-dev.vals.ai` child zone. Each production
+and development Tracker stack creates and owns its ACM certificate.
 
 ## Prerequisites
 
@@ -24,11 +25,14 @@ account-local `benchmark-tracker-dev.vals.ai` child zone and certificate.
 - AWS CDK CLI
 
 The deployment account must be bootstrapped before deploying this application.
-Account setup owns the GitHub OIDC provider and deploy role, child hosted zone,
-and certificate. Configure the protected `dev` GitHub Environment with
-`DEV_ACCOUNT_ID`, `AWS_DEPLOY_ROLE_ARN`, `AWS_REGION=us-east-1`, and
-`DESCOPE_PROJECT_ID`. To enable Sentry in dev, also set `SENTRY_DSN_SECRET_NAME`
-to the name of an account-local Secrets Manager secret containing the DSN.
+Account setup owns the GitHub OIDC provider and deploy role and the child hosted
+zone. Before deploying the development Tracker, the production root zone must
+delegate `benchmark-tracker-dev.vals.ai` to the account-local child hosted zone
+so CDK DNS validation can complete. Configure the protected `dev` GitHub
+Environment with `DEV_ACCOUNT_ID`, `AWS_DEPLOY_ROLE_ARN`,
+`AWS_REGION=us-east-1`, and `DESCOPE_PROJECT_ID`. To enable Sentry in dev, also
+set `SENTRY_DSN_SECRET_NAME` to the name of an account-local Secrets Manager
+secret containing the DSN.
 
 Before production executor activation, configure the protected `prod` GitHub
 Environment used by the production executor job. Both AWS accounts must already
@@ -40,7 +44,6 @@ provider.
 The application imports these account-local values:
 
 - `/valkyrie/dev/dns/tracker/hosted-zone-id`
-- `/valkyrie/dev/dns/tracker/certificate-arn`
 - Secrets Manager secret `devEvalInfraDescopeManagementKey`
 
 ## Setup

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -96,7 +96,6 @@ def stage_parameter_name(dev_parameter: str, stage_name: str) -> str:
 
 
 # Dev account prerequisites
-DEV_TRACKER_CERTIFICATE_ARN_PARAMETER = "/valkyrie/dev/dns/tracker/certificate-arn"
 DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER = "/valkyrie/dev/dns/tracker/hosted-zone-id"
 
 # Dev shared-resource contract published for benchmark-service consumers.

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -20,7 +20,6 @@ from constants import (
     DEV_SHARED_PUBLIC_SUBNET_IDS_PARAMETER,
     DEV_SHARED_VPC_ID_PARAMETER,
     DEV_TRACKER_ALB_DNS_PARAMETER,
-    DEV_TRACKER_CERTIFICATE_ARN_PARAMETER,
     DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER,
     DEV_TRACKER_SECURITY_GROUP_PARAMETER,
     executor_release_launch_parameter,
@@ -204,14 +203,13 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         bucket = next(iter(buckets.values()))
         self.assertEqual(bucket["Properties"]["BucketName"], f"agentic-harness-release-test-{TEST_ACCOUNT}")
 
-    def test_dev_tracker_imports_account_local_dns_and_auth(self) -> None:
+    def test_dev_tracker_owns_certificate_in_account_local_hosted_zone(self) -> None:
         dev_auth = {"AUTH_REQUIRED": "false", "DESCOPE_PROJECT_ID": "dev-project"}
         with mock.patch.dict(os.environ, dev_auth, clear=True):
             tracker_template = dev_tracker_template()
 
         template = cast(Mapping[str, object], tracker_template.to_json())
         hosted_zone_parameter = ssm_parameter_id(template, DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER)
-        certificate_parameter = ssm_parameter_id(template, DEV_TRACKER_CERTIFICATE_ARN_PARAMETER)
         rendered = json.dumps(template)
         iam_policies = tracker_template.find_resources("AWS::IAM::Policy")
         rendered_policies = json.dumps(iam_policies)
@@ -219,10 +217,23 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         self.assertIn("devEvalInfraDescopeManagementKey", rendered)
         self.assertNotIn("/vals/dev/descope/project-id", rendered)
         self.assertNotIn("valkyrie/sentry-dsn", rendered)
-        self.assertFalse(tracker_template.find_resources("AWS::CertificateManager::Certificate"))
+        self.assertNotIn("/valkyrie/dev/dns/tracker/certificate-arn", rendered)
+        certificates = tracker_template.find_resources("AWS::CertificateManager::Certificate")
+        self.assertEqual(len(certificates), 1)
+        certificate_id, certificate = next(iter(certificates.items()))
+        self.assertEqual(certificate["Properties"]["DomainName"], "benchmark-tracker-dev.vals.ai")
+        self.assertEqual(
+            certificate["Properties"]["DomainValidationOptions"],
+            [
+                {
+                    "DomainName": "benchmark-tracker-dev.vals.ai",
+                    "HostedZoneId": {"Ref": hosted_zone_parameter},
+                }
+            ],
+        )
         tracker_template.has_resource_properties(
             "AWS::ElasticLoadBalancingV2::Listener",
-            {"Certificates": [{"CertificateArn": {"Ref": certificate_parameter}}]},
+            {"Certificates": [{"CertificateArn": {"Ref": certificate_id}}]},
         )
         tracker_template.has_resource_properties(
             "AWS::Route53::RecordSet",

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -213,6 +213,49 @@ class MonitoringStackTest(unittest.TestCase):
         self.assertEqual(stage.phys("AgenticHarnessCluster"), "AgenticHarnessCluster-release-test")
         self.assertEqual(stage.domain("benchmark-tracker.vals.ai"), "benchmark-tracker-release-test.vals.ai")
 
+    def test_tracker_transport_follows_stage_contract(self) -> None:
+        tracker_templates: dict[str, assertions.Template] = {}
+        for stage_name, environment in (
+            (PROD, {}),
+            (DEV, TEST_DEV_ENV),
+            (RELEASE_TEST, {"DESCOPE_PROJECT_ID": "release-test"}),
+        ):
+            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
+                tracker_templates[stage_name] = _service_templates(stage_name)[0]
+
+        for stage_name in (PROD, DEV):
+            listeners = {
+                (resource["Properties"]["Port"], resource["Properties"]["Protocol"]): resource
+                for resource in tracker_templates[stage_name]
+                .find_resources("AWS::ElasticLoadBalancingV2::Listener")
+                .values()
+            }
+            self.assertEqual(set(listeners), {(80, "HTTP"), (443, "HTTPS")})
+            self.assertTrue(listeners[(443, "HTTPS")]["Properties"]["Certificates"])
+            redirect = listeners[(80, "HTTP")]["Properties"]["DefaultActions"][0]
+            self.assertEqual(redirect["Type"], "redirect")
+            self.assertEqual(
+                redirect["RedirectConfig"],
+                {"Port": "443", "Protocol": "HTTPS", "StatusCode": "HTTP_301"},
+            )
+
+        for stage_name in (PROD, DEV):
+            self.assertEqual(
+                len(tracker_templates[stage_name].find_resources("AWS::CertificateManager::Certificate")),
+                1,
+            )
+
+        release_test_template = tracker_templates[RELEASE_TEST]
+        self.assertFalse(release_test_template.find_resources("AWS::CertificateManager::Certificate"))
+        release_test_template.has_resource_properties(
+            "AWS::ElasticLoadBalancingV2::Listener",
+            {"Port": 80, "Protocol": "HTTP"},
+        )
+        self.assertEqual(
+            len(release_test_template.find_resources("AWS::ElasticLoadBalancingV2::Listener")),
+            1,
+        )
+
     def test_release_test_owns_immutable_service_image_repositories(self) -> None:
         release_template = _shared_template(RELEASE_TEST)
         repositories = release_template.find_resources("AWS::ECR::Repository")

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -8,7 +8,6 @@ import aws_cdk as cdk
 from aws_cdk import (
     Duration,
     Stack,
-    aws_certificatemanager,
     aws_ec2,
     aws_ecr,
     aws_ecs,
@@ -31,7 +30,6 @@ from constants import (
     CONTAINER_HEALTH_START_PERIOD_SECONDS,
     CONTAINER_HEALTH_TIMEOUT_SECONDS,
     DEV_TRACKER_ALB_DNS_PARAMETER,
-    DEV_TRACKER_CERTIFICATE_ARN_PARAMETER,
     DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER,
     DEV_TRACKER_SECURITY_GROUP_PARAMETER,
     DOCKER_ASSET_EXCLUDES,
@@ -232,7 +230,6 @@ class TrackerStack(Stack):
 
         tracker_domain: str | None = None
         tracker_hosted_zone: aws_route53.IHostedZone | None = None
-        certificate: aws_certificatemanager.ICertificate | None = None
         if stage.is_prod:
             if hosted_zone is None:
                 raise ValueError("Production requires the vals.ai hosted zone")
@@ -249,14 +246,7 @@ class TrackerStack(Stack):
                 ),
                 zone_name=tracker_domain,
             )
-            certificate = aws_certificatemanager.Certificate.from_certificate_arn(
-                self,
-                "DevTrackerCertificate",
-                aws_ssm.StringParameter.value_for_string_parameter(
-                    self,
-                    DEV_TRACKER_CERTIFICATE_ARN_PARAMETER,
-                ),
-            )
+        tls_enabled = not stage.is_release_test
 
         self.service = aws_ecs_patterns.ApplicationLoadBalancedFargateService(
             self,
@@ -268,13 +258,12 @@ class TrackerStack(Stack):
             circuit_breaker=aws_ecs.DeploymentCircuitBreaker(rollback=True),
             domain_name=tracker_domain,
             domain_zone=tracker_hosted_zone,
-            certificate=certificate,
             protocol=(
                 aws_elasticloadbalancingv2.ApplicationProtocol.HTTPS
-                if certificate is not None
+                if tls_enabled
                 else aws_elasticloadbalancingv2.ApplicationProtocol.HTTP
             ),
-            redirect_http=certificate is not None,
+            redirect_http=tls_enabled,
             open_listener=False,
             assign_public_ip=True,
             public_load_balancer=not stage.is_release_test,


### PR DESCRIPTION
## What changed

Dev now provisions its Tracker certificate in CDK, the same way prod does. It only imports its hosted zone; the old certificate ARN parameter is no longer required.

`release-test` stays HTTP-only. I also updated the infra tests and README to cover the new ownership model.

## Why

Dev was the odd one out: prod owned its certificate in CDK, while dev depended on a separately provisioned certificate. This removes that special case.

## Rollout

The DNS work is already done. `benchmark-tracker-dev.vals.ai` is delegated to the dev account, and the child zone has the live ALB, TXT, and ACM validation records.

The current certificate, SSM parameter, and old parent-zone records are still in place for rollback. Nothing was deleted.

## Testing

- 23 affected infra tests passed
- Ruff and formatting passed
- BasedPyright passed with no errors or warnings
- The live dev CDK diff adds one certificate and switches the existing HTTPS listener without replacing the ALB or listener
- Google and Cloudflare resolve the delegated child zone
- Dev `/health` returns 200 and HTTP still redirects to HTTPS

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
