### PR TITLE
fix(tracker): resume runs with final scores

### DIFF
--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -230,8 +230,10 @@ async def reset_to_in_progress_status(
             task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
         )
 
-        if benchmark_row.final_evaluation:
-            session.delete(benchmark_row.final_evaluation)
+        old_evaluation = benchmark_row.final_evaluation
+        if old_evaluation is not None:
+            benchmark_row.final_evaluation = None
+            session.delete(old_evaluation)
 
         # Retry/resume always starts a new active execution.
         if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1562,9 +1562,12 @@ class TestRunRecovery:
         benchmark_row = example_benchmark_object
         benchmark_row.status = BenchmarkStatus.IN_PROGRESS
         task = Task(org_id=TEST_ORG_ID, task_id="task_error", benchmark=benchmark_row.id, status=TaskStatus.ERROR)
+        old_evaluation = FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark_row.id, final_score=0.5)
         database_session.add(benchmark_row)
         database_session.add(task)
+        database_session.add(old_evaluation)
         database_session.commit()
+        old_evaluation_id = old_evaluation.id
 
         async def _verify_error_task(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
             return VerifyTaskIdsResponse(task_ids=[task.task_id])
@@ -1589,7 +1592,61 @@ class TestRunRecovery:
             assert persisted_benchmark.current_execution_release_id == "test-release"
             assert persisted_task is not None
             assert persisted_task.status == TaskStatus.ERROR
+            assert fresh_session.get(FinalEvaluation, old_evaluation_id) is not None
+            assert persisted_benchmark.final_evaluation is not None
+            assert persisted_benchmark.final_evaluation.id == old_evaluation_id
             assert fresh_session.exec(select(ExecutorDispatch)).all() == []
+
+    @pytest.mark.parametrize(
+        ("retry", "task_status", "dispatch_kind"),
+        [
+            (False, TaskStatus.STOPPED, ExecutorDispatchKind.RESUME),
+            (True, TaskStatus.ERROR, ExecutorDispatchKind.RETRY),
+        ],
+    )
+    async def test_recovery_removes_prior_final_evaluation_before_admitting_dispatch(
+        self,
+        retry: bool,
+        task_status: TaskStatus,
+        dispatch_kind: ExecutorDispatchKind,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: Any,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        task = Task(org_id=TEST_ORG_ID, task_id="recoverable-task", benchmark=benchmark_row.id, status=task_status)
+        old_evaluation = FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark_row.id, final_score=0.5)
+        database_session.add(benchmark_row)
+        database_session.add(task)
+        database_session.add(old_evaluation)
+        database_session.commit()
+        old_evaluation_id = old_evaluation.id
+
+        async def _verify_recoverable_task(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            return VerifyTaskIdsResponse(task_ids=[task.task_id])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_recoverable_task)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true"
+            if retry
+            else f"/retry-or-resume-benchmark/{benchmark_row.id}"
+        )
+
+        assert response.status_code == 200
+        dispatch_id = UUID(mock_kicker.queued_calls[0]["executor_dispatch_id"])
+        with Session(bind=database_session.get_bind()) as fresh_session:
+            persisted_benchmark = fresh_session.get(Benchmark, benchmark_row.id)
+            dispatch = fresh_session.get(ExecutorDispatch, dispatch_id)
+
+            assert persisted_benchmark is not None
+            assert persisted_benchmark.final_evaluation is None
+            assert fresh_session.get(FinalEvaluation, old_evaluation_id) is None
+            assert dispatch is not None
+            assert dispatch.status == ExecutorDispatchStatus.QUEUED
+            assert dispatch.kind == dispatch_kind
 
     async def test_terminal_resume_without_active_release_returns_503_without_mutation(
         self,

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1636,7 +1636,9 @@ class TestRunRecovery:
         )
 
         assert response.status_code == 200
+
         dispatch_id = UUID(mock_kicker.queued_calls[0]["executor_dispatch_id"])
+
         with Session(bind=database_session.get_bind()) as fresh_session:
             persisted_benchmark = fresh_session.get(Benchmark, benchmark_row.id)
             dispatch = fresh_session.get(ExecutorDispatch, dispatch_id)


### PR DESCRIPTION
## What changed

Runs can now be retried or resumed when they already have a saved final score.

Before this fix, Tracker deleted the old final-score record but kept an in-memory reference to it. When Tracker saved the resumed run, SQLAlchemy tried to save that deleted record again and returned a 500. The fix clears that reference before deleting the old score.

The tests cover both retry and resume, plus the rollback path when recovery cannot start.

## Why

This blocked runs that needed to continue after the outage. We observed 35 failed attempts across 9 runs, including six attempts for run `59912658-eb07-4c52-ba38-6f11676eb54d`.

The failed requests rolled back cleanly. Existing runs and final scores were not lost, so this change does not need a database migration or manual data repair.

## How tested

- All 35 Tracker recovery tests passed
- The PostgreSQL retry/finalization concurrency test passed
- All 20 PR checks passed
- Tracker live integration tests passed
- Ruff, formatting, BasedPyright, compatibility, Codecov, and security checks passed

## Rollout

1. Merge and deploy to dev
2. Promote the fix to production
3. Retry affected runs through the normal API
4. Confirm recovery requests no longer return this 500

Do not edit the affected runs directly in the database. Their failed retry attempts already rolled back, so they should resume normally after deployment.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
