### PR TITLE
refactor(storage): abstract object operations

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -45,24 +45,23 @@ from tracker.aws.resolver import (
     resolve_run_aws_runtime_and_access_key_config,
     resolve_start_aws_runtime,
 )
-from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import resolve_secrets
 from tracker.agent.contract import get_contract_from_zip_bytes
 from tracker.aws.s3 import (
     S3_BENCHMARKS_PREFIX,
-    S3ObjectCopy,
-    copy_agent_to_benchmark,
+    S3ObjectStore,
     create_benchmark_url,
-    delete_from_s3,
     create_console_url,
     create_presigned_url,
-    download_from_s3,
-    download_many_from_s3,
-    get_benchmark_contract_s3_key,
-    get_contract_s3_key,
-    list_s3_objects,
     s3_object_exists,
 )
+from tracker.runtime.artifacts import (
+    agent_bundle_key,
+    benchmark_agent_bundle_key,
+    benchmark_prefix as benchmark_artifact_prefix,
+    copy_agent_to_benchmark,
+)
+from tracker.runtime.storage import ObjectStore, StoredObjectCopy
 from tracker.agent.schemas import AgentConfig
 from tracker.config import (
     AUTH_REQUIRED,
@@ -277,18 +276,17 @@ async def _enqueue_executor_dispatch(
 
 async def _delete_uncommitted_agent_copy(
     *,
-    created_copy: S3ObjectCopy | None,
+    created_copy: StoredObjectCopy | None,
     benchmark_id: UUID,
     request: StartBenchmarkRequest,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
 ) -> None:
     if created_copy is None:
         return
     try:
-        await delete_from_s3(
-            get_benchmark_contract_s3_key(str(benchmark_id), request.contract.name),
-            aws_runtime,
-            version_id=created_copy.version_id,
+        await object_store.delete(
+            benchmark_agent_bundle_key(str(benchmark_id), request.contract.name),
+            deletion_token=created_copy.deletion_token,
         )
     except Exception:
         logger.exception(
@@ -322,9 +320,9 @@ async def _rollback_failed_start_admission(
     *,
     benchmark_id: UUID,
     dispatch_id: UUID,
-    created_copy: S3ObjectCopy | None,
+    created_copy: StoredObjectCopy | None,
     request: StartBenchmarkRequest,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
 ) -> None:
     try:
         session.rollback()
@@ -344,7 +342,7 @@ async def _rollback_failed_start_admission(
         created_copy=created_copy,
         benchmark_id=benchmark_id,
         request=request,
-        aws_runtime=aws_runtime,
+        object_store=object_store,
     )
 
 
@@ -427,12 +425,9 @@ def init_org(
     return {"org_name": org.name, "created": created, "email_claim_missing": identity.email is None}
 
 
-async def _resolve_contract_from_s3(request: StartBenchmarkRequest, aws_runtime: AWSRuntime) -> AgentContractRequest:
+async def _resolve_contract_from_s3(request: StartBenchmarkRequest, object_store: ObjectStore) -> AgentContractRequest:
     """Resolve install_cmd/run_cmd/etc by parsing the agent's contract file inside its S3 zip."""
-    zip_bytes = await download_from_s3(
-        get_contract_s3_key(request.contract.name),
-        aws_runtime,
-    )
+    zip_bytes = await object_store.get_bytes(agent_bundle_key(request.contract.name))
     agent_config = AgentConfig(model=request.contract.model, kwargs=dict(request.contract.kwargs))
     resolved = get_contract_from_zip_bytes(request.contract.name, zip_bytes, agent_config)
     if request.contract.secrets:
@@ -481,6 +476,7 @@ async def start_benchmark(
 
     runtime_resolution = resolve_start_aws_runtime(http_request, request.harness_config, run_starter.org.id)
     aws_runtime = runtime_resolution.runtime
+    object_store = S3ObjectStore(aws_runtime)
     effective_harness_config = runtime_resolution.access_key_harness_config
     aws_managed = runtime_resolution.aws_managed
 
@@ -547,13 +543,13 @@ async def start_benchmark(
     )
 
     if not request.contract.install_cmd and not request.contract.run_cmd:
-        request = request.model_copy(update={"contract": await _resolve_contract_from_s3(request, aws_runtime)})
+        request = request.model_copy(update={"contract": await _resolve_contract_from_s3(request, object_store)})
         if aws_managed:
             try:
                 validate_managed_execution_request(request)
             except ValueError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
-    elif aws_managed and not await s3_object_exists(get_contract_s3_key(request.contract.name), aws_runtime):
+    elif aws_managed and not await object_store.exists(agent_bundle_key(request.contract.name)):
         raise HTTPException(
             status_code=404,
             detail=f"Agent '{request.contract.name}' is not available in the deployment bucket.",
@@ -596,12 +592,12 @@ async def start_benchmark(
         aws_managed=aws_managed,
     )
     dispatch_id = uuid4()
-    created_agent_copy: S3ObjectCopy | None = None
+    created_agent_copy: StoredObjectCopy | None = None
     try:
         created_agent_copy = await copy_agent_to_benchmark(
+            object_store,
             str(benchmark_row.id),
             request.contract.name,
-            aws_runtime,
         )
         for task_id in verify_response.task_ids:
             session.add(Task(org_id=benchmark_row.org_id, benchmark=benchmark_row.id, task_id=task_id))
@@ -619,7 +615,7 @@ async def start_benchmark(
             dispatch_id=dispatch_id,
             created_copy=created_agent_copy,
             request=request,
-            aws_runtime=aws_runtime,
+            object_store=object_store,
         )
         if isinstance(exc, ReleaseControlError):
             raise HTTPException(status_code=503, detail=str(exc)) from exc
@@ -1381,16 +1377,16 @@ def _safe_output_tar_member(s3_key: str, benchmark_prefix: str) -> str | None:
 async def _output_keys(
     benchmark_prefix: str,
     task_ids: list[str] | None,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
     benchmark_id: TrackedBenchmarkId,
 ) -> AsyncIterator[str]:
     prefixes = [f"{benchmark_prefix}{task_id}/" for task_id in task_ids] if task_ids else [benchmark_prefix]
     for prefix in prefixes:
-        async for key in list_s3_objects(prefix, aws_runtime):
-            if _safe_output_tar_member(key, benchmark_prefix) is None:
+        async for stored_object in object_store.list_objects(prefix):
+            if _safe_output_tar_member(stored_object.key, benchmark_prefix) is None:
                 logger.warning("Skipping unsafe output archive member for benchmark %s", benchmark_id)
                 continue
-            yield key
+            yield stored_object.key
 
 
 async def _output_keys_with_first(first_key: str, keys: AsyncIterator[str]) -> AsyncIterator[str]:
@@ -1402,14 +1398,14 @@ async def _output_keys_with_first(first_key: str, keys: AsyncIterator[str]) -> A
 async def _tar_output_stream(
     keys: AsyncIterator[str],
     benchmark_prefix: str,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
 ) -> AsyncIterator[bytes]:
     writer: YieldingWriter = YieldingWriter()
 
-    # download_many_from_s3 reuses a single client/connection pool across all keys,
+    # ObjectStore.get_many reuses a provider-owned resource scope across all keys,
     # and reads one object into memory at a time (bounded by the largest object).
     with tarfile.open(fileobj=writer, mode="w|") as tar:
-        async for s3_key, data in download_many_from_s3(keys, aws_runtime):
+        async for s3_key, data in object_store.get_many(keys):
             relative_path = s3_key.removeprefix(benchmark_prefix)
             tarinfo = tarfile.TarInfo(name=relative_path)
             tarinfo.size = len(data)
@@ -1441,18 +1437,18 @@ async def fetch_run_outputs(
     Returns:
         StreamingResponse
     """
-    aws_runtime = run_context.aws_runtime
+    object_store = S3ObjectStore(run_context.aws_runtime)
 
-    benchmark_prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
+    benchmark_prefix = benchmark_artifact_prefix(str(benchmark_id))
 
     # Peek a single key so an empty result still returns 404 before the stream starts.
-    keys = _output_keys(benchmark_prefix, task_ids, aws_runtime, benchmark_id)
+    keys = _output_keys(benchmark_prefix, task_ids, object_store, benchmark_id)
     first_key = await anext(keys, None)
     if first_key is None:
         raise HTTPException(status_code=404, detail=f"No outputs found for run '{benchmark_id}'")
 
     return StreamingResponse(
-        _tar_output_stream(_output_keys_with_first(first_key, keys), benchmark_prefix, aws_runtime),
+        _tar_output_stream(_output_keys_with_first(first_key, keys), benchmark_prefix, object_store),
         media_type="application/x-tar",
         headers={"Content-Disposition": f"attachment; filename=benchmark_{benchmark_id}_outputs.tar"},
     )

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -1,7 +1,7 @@
 """S3 upload utilities for the tracker service."""
 
-from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable
-from contextlib import suppress
+from collections.abc import AsyncGenerator, AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
@@ -13,6 +13,7 @@ from botocore.exceptions import BotoCoreError, ClientError
 from tracker.aws.runtime import AWSResources, AWSRuntime
 from tracker.exceptions import S3Error
 from tracker.logging import get_logger
+from tracker.runtime.storage import ArtifactLocations, ObjectReadSession, StoredObject, StoredObjectCopy
 
 logger = get_logger(__name__)
 
@@ -387,3 +388,99 @@ async def list_agents(runtime: AWSRuntime) -> list[tuple[str, datetime | None]]:
                 agents.append((tail[: -len(".zip")], s3_object.get("LastModified")))
 
     return agents
+
+
+class _S3ObjectReadSession:
+    """S3 reads scoped to an already-open client."""
+
+    def __init__(self, client: Any, bucket: str) -> None:
+        self._client = client
+        self._bucket = bucket
+
+    @handle_s3_error(message="Failed to download from S3")
+    async def get_bytes(self, key: str) -> bytes:
+        response = await self._client.get_object(Bucket=self._bucket, Key=key)
+        async with response["Body"] as stream:
+            return await stream.read()
+
+    async def list_objects(self, prefix: str) -> AsyncIterator[StoredObject]:
+        try:
+            paginator = self._client.get_paginator("list_objects_v2")
+            async for page in paginator.paginate(Bucket=self._bucket, Prefix=prefix):
+                for stored_object in page.get("Contents", []):
+                    key = stored_object.get("Key")
+                    if key is not None:
+                        yield StoredObject(key=key, last_modified=stored_object.get("LastModified"))
+        except (ClientError, BotoCoreError) as error:
+            raise S3Error(f"Failed to list objects from S3: {error}") from error
+
+
+class S3ObjectStore:
+    """Object-store adapter using already-resolved AWS authority."""
+
+    def __init__(self, runtime: AWSRuntime) -> None:
+        self._runtime = runtime
+
+    @asynccontextmanager
+    async def read_session(self) -> AsyncGenerator[ObjectReadSession, None]:
+        async with self._runtime.clients.s3_client() as client:
+            yield _S3ObjectReadSession(client, self._runtime.resources.s3_bucket)
+
+    async def put_bytes(self, key: str, content: bytes) -> None:
+        await upload_to_s3(content, key, self._runtime)
+
+    async def put_stream(
+        self,
+        key: str,
+        chunks: AsyncIterable[bytes],
+        *,
+        should_continue: Callable[[], bool] | None = None,
+    ) -> int:
+        return await upload_stream_to_s3(chunks, key, self._runtime, should_continue=should_continue)
+
+    async def get_bytes(self, key: str) -> bytes:
+        async with self.read_session() as reader:
+            return await reader.get_bytes(key)
+
+    async def get_many(self, keys: AsyncIterable[str]) -> AsyncIterator[tuple[str, bytes]]:
+        async with self._runtime.clients.s3_client() as client:
+            async for key in keys:
+                try:
+                    response = await client.get_object(Bucket=self._runtime.resources.s3_bucket, Key=key)
+                    async with response["Body"] as stream:
+                        yield key, await stream.read()
+                except (ClientError, BotoCoreError) as error:
+                    logger.warning(f"Failed to download {key} from S3: {error}")
+
+    async def delete(self, key: str, *, deletion_token: str | None = None) -> None:
+        await delete_from_s3(key, self._runtime, version_id=deletion_token)
+
+    async def copy(self, source_key: str, destination_key: str) -> StoredObjectCopy:
+        return StoredObjectCopy(deletion_token=await copy_s3_object(source_key, destination_key, self._runtime))
+
+    async def exists(self, key: str) -> bool:
+        return await s3_object_exists(key, self._runtime)
+
+    async def list_objects(self, prefix: str) -> AsyncIterator[StoredObject]:
+        async with self.read_session() as reader:
+            async for stored_object in reader.list_objects(prefix):
+                yield stored_object
+
+    async def temporary_download_url(self, key: str, *, expires_in: int) -> str:
+        return await create_presigned_url(key, self._runtime, expiration=expires_in)
+
+
+class S3ArtifactLocations(ArtifactLocations):
+    """AWS-console artifact locations for resolved S3 resources."""
+
+    def __init__(self, resources: AWSResources) -> None:
+        self._resources = resources
+
+    def object_location(self, key: str) -> str:
+        return create_console_url(key, self._resources)
+
+    def prefix_location(self, prefix: str) -> str:
+        return (
+            f"https://{self._resources.region}.console.aws.amazon.com/s3/buckets/{self._resources.s3_bucket}"
+            f"?region={self._resources.region}&prefix={prefix}"
+        )

--- a/services/tracker/src/tracker/runtime/__init__.py
+++ b/services/tracker/src/tracker/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Provider-neutral runtime contracts."""

--- a/services/tracker/src/tracker/runtime/artifacts.py
+++ b/services/tracker/src/tracker/runtime/artifacts.py
@@ -1,0 +1,43 @@
+"""Artifact key and lifecycle policy."""
+
+from datetime import datetime
+
+from tracker.runtime.storage import ObjectStore, StoredObjectCopy
+
+AGENTS_PREFIX = "agents"
+BENCHMARKS_PREFIX = "benchmarks"
+
+
+def agent_bundle_key(agent_name: str) -> str:
+    return f"{AGENTS_PREFIX}/{agent_name}.zip"
+
+
+def benchmark_prefix(benchmark_id: str) -> str:
+    return f"{BENCHMARKS_PREFIX}/{benchmark_id}/"
+
+
+def benchmark_agent_bundle_key(benchmark_id: str, agent_name: str) -> str:
+    return f"{benchmark_prefix(benchmark_id)}{agent_name}.zip"
+
+
+def task_artifact_key(benchmark_id: str, task_id: str, output_name: str) -> str:
+    return f"{benchmark_prefix(benchmark_id)}{task_id}/{output_name}"
+
+
+async def copy_agent_to_benchmark(store: ObjectStore, benchmark_id: str, agent_name: str) -> StoredObjectCopy | None:
+    """Freeze an agent bundle for a benchmark unless it already exists."""
+    source_key = agent_bundle_key(agent_name)
+    destination_key = benchmark_agent_bundle_key(benchmark_id, agent_name)
+    if await store.exists(destination_key):
+        return None
+    return await store.copy(source_key, destination_key)
+
+
+async def list_agents(store: ObjectStore) -> list[tuple[str, datetime | None]]:
+    agents: list[tuple[str, datetime | None]] = []
+    prefix = f"{AGENTS_PREFIX}/"
+    async for stored_object in store.list_objects(prefix):
+        tail = stored_object.key.removeprefix(prefix)
+        if tail.endswith(".zip"):
+            agents.append((tail.removesuffix(".zip"), stored_object.last_modified))
+    return agents

--- a/services/tracker/src/tracker/runtime/storage.py
+++ b/services/tracker/src/tracker/runtime/storage.py
@@ -1,0 +1,84 @@
+"""Provider-neutral object storage capabilities used by Tracker and the CLI."""
+
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Coroutine
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True)
+class StoredObject:
+    """Metadata returned while listing stored objects."""
+
+    key: str
+    last_modified: datetime | None = None
+
+
+@dataclass(frozen=True)
+class StoredObjectCopy:
+    """Opaque provider identity for precisely deleting a copied object."""
+
+    deletion_token: str | None
+
+
+class ObjectReadSession(Protocol):
+    """Related object reads performed within one provider-owned resource scope."""
+
+    def get_bytes(self, key: str) -> Coroutine[Any, Any, bytes]:
+        raise NotImplementedError  # pragma: no cover
+
+    def list_objects(self, prefix: str) -> AsyncIterator[StoredObject]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class ObjectStore(Protocol):
+    """Object transfers using opaque, store-relative keys and prefixes."""
+
+    def read_session(self) -> AbstractAsyncContextManager[ObjectReadSession]:
+        """Open one resource scope for related listings and object reads."""
+        raise NotImplementedError  # pragma: no cover
+
+    async def put_bytes(self, key: str, content: bytes) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    async def put_stream(
+        self,
+        key: str,
+        chunks: AsyncIterable[bytes],
+        *,
+        should_continue: Callable[[], bool] | None = None,
+    ) -> int:
+        """Store all chunks and return their total byte count."""
+        raise NotImplementedError  # pragma: no cover
+
+    async def get_bytes(self, key: str) -> bytes:
+        raise NotImplementedError  # pragma: no cover
+
+    def get_many(self, keys: AsyncIterable[str]) -> AsyncIterator[tuple[str, bytes]]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def delete(self, key: str, *, deletion_token: str | None = None) -> None:
+        raise NotImplementedError  # pragma: no cover
+
+    async def copy(self, source_key: str, destination_key: str) -> StoredObjectCopy:
+        raise NotImplementedError  # pragma: no cover
+
+    async def exists(self, key: str) -> bool:
+        raise NotImplementedError  # pragma: no cover
+
+    def list_objects(self, prefix: str) -> AsyncIterator[StoredObject]:
+        raise NotImplementedError  # pragma: no cover
+
+    async def temporary_download_url(self, key: str, *, expires_in: int) -> str:
+        raise NotImplementedError  # pragma: no cover
+
+
+class ArtifactLocations(Protocol):
+    """Provider-native artifact locations for display or navigation."""
+
+    def object_location(self, key: str) -> str:
+        raise NotImplementedError  # pragma: no cover
+
+    def prefix_location(self, prefix: str) -> str:
+        raise NotImplementedError  # pragma: no cover

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -44,14 +44,8 @@ from tenacity import (
     wait_none,
 )
 
-from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import (
-    create_presigned_url,
-    get_agent_result_s3_key,
-    get_benchmark_contract_s3_key,
-    upload_stream_to_s3,
-    upload_to_s3,
-)
+from tracker.runtime.artifacts import benchmark_agent_bundle_key, task_artifact_key
+from tracker.runtime.storage import ObjectStore
 from tracker.database.models import (
     MAX_OUTPUT_ARTIFACT_BYTES,
     AgentCausedExitReason,
@@ -339,7 +333,7 @@ async def upload_agent_artifacts(
     sandbox: Sandbox,
     contract: AgentContractRequest,
     benchmark_id: str,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
 ) -> None:
     """
     Download and extract the agent contract zip directly inside the sandbox. We generate a presigned S3 URL and have the sandbox curl + unzip it directly.
@@ -350,18 +344,17 @@ async def upload_agent_artifacts(
         sandbox: The sandbox to download and extract files in
         contract: The agent contract configuration
         benchmark_id: The benchmark run id, used to locate the agent
-        aws_runtime: AWS resources and client provider
+        object_store: storage provider for the already-resolved run authority
 
     Raises:
         SandboxError: If download or extraction fails inside the sandbox
     """
     logger.info(f"Uploading contract {contract.name} to sandbox {sandbox.name}")
 
-    contract_s3_key = get_benchmark_contract_s3_key(benchmark_id, contract.name)
-    presigned_url = await create_presigned_url(
+    contract_s3_key = benchmark_agent_bundle_key(benchmark_id, contract.name)
+    presigned_url = await object_store.temporary_download_url(
         contract_s3_key,
-        aws_runtime,
-        expiration=CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS,
+        expires_in=CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS,
     )
 
     zip_path = shlex.quote(f"/tmp/{contract.name}.zip")
@@ -639,7 +632,7 @@ async def archive_and_upload_output(
     sandbox: Sandbox,
     output_path: str,
     agent_output_s3_key: str,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
     *,
     benchmark_id: str | None = None,
     task_id: str | None = None,
@@ -654,10 +647,9 @@ async def archive_and_upload_output(
         raise SandboxError(f"Failed to create archive from {output_path}")
 
     try:
-        archive_bytes = await upload_stream_to_s3(
-            sandbox.stream_download(archive_path),
+        archive_bytes = await object_store.put_stream(
             agent_output_s3_key,
-            aws_runtime,
+            sandbox.stream_download(archive_path),
             should_continue=execution_is_current,
         )
 
@@ -744,7 +736,7 @@ async def upload_output_artifacts(
     artifacts: list[OutputArtifactSpec],
     benchmark_id: str,
     task_id: str,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
     execution_is_current: Callable[[], bool] | None = None,
 ) -> None:
     """Upload declared small output artifacts from the sandbox directly to task S3 keys."""
@@ -760,7 +752,7 @@ async def upload_output_artifacts(
                 artifact,
                 benchmark_id,
                 task_id,
-                aws_runtime,
+                object_store,
                 total_bytes,
                 execution_is_current,
             )
@@ -788,7 +780,7 @@ async def _upload_output_artifact(
     artifact: OutputArtifactSpec,
     benchmark_id: str,
     task_id: str,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
     total_bytes: int,
     execution_is_current: Callable[[], bool] | None = None,
 ) -> int | None:
@@ -821,11 +813,11 @@ async def _upload_output_artifact(
     if execution_is_current is not None and not execution_is_current():
         return None
 
-    s3_key = get_agent_result_s3_key(benchmark_id, task_id, artifact_path)
+    s3_key = task_artifact_key(benchmark_id, task_id, artifact_path)
     file_content = await sandbox.download_file(sandbox_path)
     if execution_is_current is not None and not execution_is_current():
         return None
-    await upload_to_s3(file_content, s3_key, aws_runtime)
+    await object_store.put_bytes(s3_key, file_content)
 
     logger.info(
         "output_artifact.upload.complete",
@@ -849,7 +841,7 @@ async def run_agent(
     task_id: str,
     log_output: Callable[[str], None],
     cwd: str,
-    aws_runtime: AWSRuntime,
+    object_store: ObjectStore,
     agent_output_s3_key: str | None = None,
     agent_timeout: float | None = None,
     benchmark_id: str | None = None,
@@ -925,7 +917,7 @@ async def run_agent(
                 sandbox,
                 contract.final_output,
                 agent_output_s3_key,
-                aws_runtime,
+                object_store,
                 benchmark_id=benchmark_id,
                 task_id=task_id,
                 execution_is_current=execution_is_current,
@@ -939,7 +931,7 @@ async def run_agent(
             contract.output_artifacts,
             benchmark_id,
             task_id,
-            aws_runtime,
+            object_store,
             execution_is_current,
         )
 

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -30,9 +30,8 @@ from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url, write_benchmark_log_event
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import (
-    get_agent_result_s3_key,
-)
+from tracker.aws.s3 import S3ObjectStore
+from tracker.runtime.artifacts import task_artifact_key
 from tracker.aws.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
 from tracker.database.models import (
@@ -952,6 +951,7 @@ async def _process_task_attempt(
         task_breakdown = TaskBreakdown()
 
         start_sandbox_build_time = time.perf_counter()
+        object_store = S3ObjectStore(aws_runtime)
         async with create_sandbox(
             provider=sandbox_provider,
             sandbox_name=task_row.task_id,
@@ -984,7 +984,7 @@ async def _process_task_attempt(
                     sandbox,
                     start_benchmark_request.contract,
                     str(benchmark_id),
-                    aws_runtime,
+                    object_store,
                 )
 
                 # Reset timer to keep the last received message from the benchmarks service accurate
@@ -1009,7 +1009,7 @@ async def _process_task_attempt(
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
                 if start_benchmark_request.contract.final_output:
-                    agent_output_s3_key = get_agent_result_s3_key(str(benchmark_id), task_id, "agent_output.tar.gz")
+                    agent_output_s3_key = task_artifact_key(str(benchmark_id), task_id, "agent_output.tar.gz")
 
                 try:
                     exit_reason, agent_run_time = await run_agent(
@@ -1019,7 +1019,7 @@ async def _process_task_attempt(
                         task_id,
                         log_output,
                         task_data.cwd,
-                        aws_runtime=aws_runtime,
+                        object_store=object_store,
                         agent_output_s3_key=agent_output_s3_key,
                         agent_timeout=task_data.agent_timeout,
                         benchmark_id=str(benchmark_id),

--- a/services/tracker/tests/integration/live/sandbox/test_compose.py
+++ b/services/tracker/tests/integration/live/sandbox/test_compose.py
@@ -12,6 +12,7 @@ from benchmark_service import ComposeSource, ImageSource, Sandbox, SandboxProvid
 from benchmark_service.schemas import RetrieveTaskResponse
 
 from tracker.aws.runtime import AWSRuntime
+from tracker.aws.s3 import S3ObjectStore
 from tracker.database.models import AgentContractRequest
 from tracker.sandbox import create_sandbox, run_agent, runtime_sandbox
 from tracker.types import AWSCredentials, HarnessConfig
@@ -222,7 +223,7 @@ async def test_compose_sandbox_methods_use_daytona_outer_from_retrieve_task(
         _COMPOSE_TASK_ID,
         logs.append,
         task_data.cwd,
-        aws_runtime=aws_runtime,
+        S3ObjectStore(aws_runtime),
         runtime_source=task_data.source,
     )
 

--- a/services/tracker/tests/integration/live/sandbox/test_sandbox.py
+++ b/services/tracker/tests/integration/live/sandbox/test_sandbox.py
@@ -19,7 +19,7 @@ from benchmark_service import ImageSource, Resources, Sandbox, SandboxNotFoundEr
 
 from tests.utils import random_task_id
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import get_benchmark_contract_s3_key, get_contract_s3_key
+from tracker.aws.s3 import S3ObjectStore, get_benchmark_contract_s3_key, get_contract_s3_key
 from tracker.database.models import AgentContractRequest
 from tracker.exceptions import SandboxError
 from tracker.sandbox import (
@@ -157,6 +157,7 @@ class TestSandboxOperations:
             run_cmd="echo hello",
         )
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
+        object_store = S3ObjectStore(aws_runtime)
 
         agent_file = f"{contract_name}/{contract_name}/file.txt"
         setup_file = f"{contract_name}/setup.sh"
@@ -191,7 +192,7 @@ class TestSandboxOperations:
         )
 
         try:
-            await upload_agent_artifacts(test_sandbox, contract, benchmark_id, aws_runtime)
+            await upload_agent_artifacts(test_sandbox, contract, benchmark_id, object_store)
 
             # Verify files exist in sandbox
             result = await test_sandbox.exec(f"cat /bundle/{setup_file}")
@@ -260,6 +261,7 @@ class TestSandboxOperations:
             final_output="/tmp/agent_output.json",
         )
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
+        object_store = S3ObjectStore(aws_runtime)
 
         # Expecting bundle directory to exist
         await test_sandbox.exec("mkdir -p /bundle/test_agent")
@@ -271,7 +273,7 @@ class TestSandboxOperations:
             task_id=random_task_id(),
             log_output=log_callback,
             cwd="/",
-            aws_runtime=aws_runtime,
+            object_store=object_store,
         )
 
         output = "\n".join(logged_messages)
@@ -306,6 +308,7 @@ class TestSandboxOperations:
 
         await test_sandbox.exec("mkdir -p /bundle/test_agent")
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
+        object_store = S3ObjectStore(aws_runtime)
 
         await run_agent(
             test_sandbox,
@@ -314,7 +317,7 @@ class TestSandboxOperations:
             task_id=random_task_id(),
             log_output=log_callback,
             cwd="/",
-            aws_runtime=aws_runtime,
+            object_store=object_store,
         )
 
         output = "\n".join(logged_messages)

--- a/services/tracker/tests/integration/live/storage/test_upload_artifacts_images.py
+++ b/services/tracker/tests/integration/live/storage/test_upload_artifacts_images.py
@@ -11,7 +11,7 @@ from benchmark_service import ImageSource, Resources, SandboxProvider
 
 from tests.utils import random_task_id
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import get_benchmark_contract_s3_key, get_contract_s3_key
+from tracker.aws.s3 import S3ObjectStore, get_benchmark_contract_s3_key, get_contract_s3_key
 from tracker.database.models import AgentContractRequest
 from tracker.sandbox import create_sandbox, upload_agent_artifacts
 from tracker.types import HarnessConfig
@@ -60,6 +60,7 @@ class TestUploadArtifactsAcrossImages:
 
         benchmark_id = f"test-benchmark-{uuid4().hex[:5]}"
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
+        object_store = S3ObjectStore(aws_runtime)
         aws_credentials = harness_config.aws
 
         # Stage the per-benchmark frozen copy that upload_agent_artifacts will now read from.
@@ -91,7 +92,7 @@ class TestUploadArtifactsAcrossImages:
                     creation_semaphore,
                 ) as sandbox,
             ):
-                await upload_agent_artifacts(sandbox, contract, benchmark_id, aws_runtime)
+                await upload_agent_artifacts(sandbox, contract, benchmark_id, object_store)
 
                 dir_check = await sandbox.exec(f"test -d /bundle/{contract.name}")
                 assert dir_check.exit_code == 0, f"[{label}] contract dir /bundle/{contract.name} should exist"

--- a/services/tracker/tests/integration/live/storage/test_upload_to_s3.py
+++ b/services/tracker/tests/integration/live/storage/test_upload_to_s3.py
@@ -11,7 +11,7 @@ from benchmark_service import ImageSource, Resources, SandboxProvider
 
 from tests.utils import random_task_id
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import delete_from_s3, download_from_s3, get_agent_result_s3_key
+from tracker.aws.s3 import S3ObjectStore, delete_from_s3, download_from_s3, get_agent_result_s3_key
 from tracker.database.models import Benchmark
 from tracker.sandbox import archive_and_upload_output, create_sandbox
 from tracker.types import HarnessConfig
@@ -59,6 +59,7 @@ class TestUploadToS3:
         dir_path = "/tmp/test_output_dir"
         task_id = random_task_id()
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
+        object_store = S3ObjectStore(aws_runtime)
         file_s3_key = get_agent_result_s3_key(str(example_benchmark_object.id), task_id, "test_output.json")
         dir_s3_key = get_agent_result_s3_key(str(example_benchmark_object.id), task_id, "test_output_dir")
 
@@ -71,13 +72,13 @@ class TestUploadToS3:
                 creation_semaphore=creation_semaphore,
             ) as sandbox:
                 await sandbox.exec(f"echo '{file_content}' > {file_path}")
-                await archive_and_upload_output(sandbox, file_path, file_s3_key, aws_runtime)
+                await archive_and_upload_output(sandbox, file_path, file_s3_key, object_store)
 
                 await sandbox.exec(f"mkdir -p {dir_path}/nested")
                 await sandbox.exec(f"echo 'file1 content' > {dir_path}/file1.txt")
                 await sandbox.exec(f"echo 'file2 content' > {dir_path}/file2.txt")
                 await sandbox.exec(f"echo 'nested content' > {dir_path}/nested/file3.txt")
-                await archive_and_upload_output(sandbox, dir_path, dir_s3_key, aws_runtime)
+                await archive_and_upload_output(sandbox, dir_path, dir_s3_key, object_store)
 
                 file_members = _archive_members(await download_from_s3(file_s3_key, aws_runtime))
                 dir_members = _archive_members(await download_from_s3(dir_s3_key, aws_runtime))

--- a/services/tracker/tests/unit/aws/test_s3.py
+++ b/services/tracker/tests/unit/aws/test_s3.py
@@ -13,7 +13,14 @@ from botocore.exceptions import ClientError
 from tracker.aws import s3 as s3_module
 from tracker.aws.clients import DefaultChainAWSClientProvider
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import copy_s3_object, create_presigned_url, delete_from_s3, upload_stream_to_s3
+from tracker.aws.s3 import (
+    S3ObjectStore,
+    copy_s3_object,
+    create_presigned_url,
+    delete_from_s3,
+    download_many_from_s3,
+    upload_stream_to_s3,
+)
 from tracker.exceptions import S3Error
 
 
@@ -48,6 +55,113 @@ class MockS3Client:
 
     async def abort_multipart_upload(self, Bucket: str, Key: str, UploadId: str) -> None:
         self.aborted = True
+
+
+class DownloadBody:
+    def __init__(self, content: bytes) -> None:
+        self._content = content
+
+    async def __aenter__(self) -> "DownloadBody":
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        pass
+
+    async def read(self) -> bytes:
+        return self._content
+
+
+class DownloadClient:
+    def __init__(self, responses: dict[str, bytes | ClientError]) -> None:
+        self._responses = responses
+        self.keys: list[str] = []
+        self.entries = 0
+
+    async def __aenter__(self) -> "DownloadClient":
+        self.entries += 1
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        pass
+
+    async def get_object(self, *, Bucket: str, Key: str) -> dict[str, DownloadBody]:
+        self.keys.append(Key)
+        response = self._responses[Key]
+        if isinstance(response, ClientError):
+            raise response
+        return {"Body": DownloadBody(response)}
+
+
+async def test_download_many_reuses_one_client_and_skips_provider_failures(
+    monkeypatch: pytest.MonkeyPatch, aws_runtime: AWSRuntime
+) -> None:
+    missing = ClientError({"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "GetObject")
+    client = DownloadClient({"first": b"one", "missing": missing, "last": b"three"})
+    monkeypatch.setattr(type(aws_runtime.clients), "s3_client", lambda _provider: client)
+
+    downloaded = [item async for item in download_many_from_s3(["first", "missing", "last"], aws_runtime)]
+
+    assert downloaded == [("first", b"one"), ("last", b"three")]
+    assert client.keys == ["first", "missing", "last"]
+    assert client.entries == 1
+
+
+async def test_object_store_get_many_reuses_one_client_and_skips_provider_failures(
+    monkeypatch: pytest.MonkeyPatch, aws_runtime: AWSRuntime
+) -> None:
+    missing = ClientError({"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "GetObject")
+    client = DownloadClient({"first": b"one", "missing": missing, "last": b"three"})
+    monkeypatch.setattr(type(aws_runtime.clients), "s3_client", lambda _provider: client)
+
+    async def keys() -> AsyncIterator[str]:
+        yield "first"
+        yield "missing"
+        yield "last"
+
+    downloaded = [item async for item in S3ObjectStore(aws_runtime).get_many(keys())]
+
+    assert downloaded == [("first", b"one"), ("last", b"three")]
+    assert client.keys == ["first", "missing", "last"]
+    assert client.entries == 1
+
+
+class ObjectListPaginator:
+    def __init__(self, pages: list[dict[str, list[dict[str, object]]]]) -> None:
+        self._pages = pages
+        self.calls: list[dict[str, str]] = []
+
+    async def paginate(self, **kwargs: str) -> AsyncIterator[dict[str, list[dict[str, object]]]]:
+        self.calls.append(kwargs)
+        for page in self._pages:
+            yield page
+
+
+class ReadClient(DownloadClient):
+    def __init__(self, responses: dict[str, bytes | ClientError], paginator: ObjectListPaginator) -> None:
+        super().__init__(responses)
+        self._paginator = paginator
+
+    def get_paginator(self, name: str) -> ObjectListPaginator:
+        assert name == "list_objects_v2"
+        return self._paginator
+
+
+async def test_object_store_read_session_and_listing_preserve_object_metadata(
+    monkeypatch: pytest.MonkeyPatch, aws_runtime: AWSRuntime
+) -> None:
+    paginator = ObjectListPaginator(
+        [{"Contents": [{"Key": "agents/alpha.zip"}, {"LastModified": "ignored"}, {"Key": "agents/beta.zip"}]}]
+    )
+    client = ReadClient({"agents/alpha.zip": b"alpha"}, paginator)
+    monkeypatch.setattr(type(aws_runtime.clients), "s3_client", lambda _provider: client)
+
+    async with S3ObjectStore(aws_runtime).read_session() as reader:
+        assert await reader.get_bytes("agents/alpha.zip") == b"alpha"
+        listed = [stored_object async for stored_object in reader.list_objects("agents/")]
+
+    assert [stored_object.key for stored_object in listed] == ["agents/alpha.zip", "agents/beta.zip"]
+    assert paginator.calls == [{"Bucket": "test-bucket", "Prefix": "agents/"}]
+    assert client.entries == 1
 
 
 class TestCreatePresignedUrl:
@@ -146,12 +260,29 @@ class TestUploadStreamToS3:
         ]
         assert not mock_s3_client.aborted
 
-    async def test_aborts_multipart_upload_on_failure(
+    async def test_object_store_preserves_multipart_behavior(
+        self, mock_s3_client: MockS3Client, aws_runtime: AWSRuntime
+    ) -> None:
+        async def chunks() -> AsyncIterator[bytes]:
+            yield b"aaaa"
+            yield b"bbbb"
+            yield b"cc"
+
+        total = await S3ObjectStore(aws_runtime).put_stream("key", chunks())
+
+        assert total == 10
+        assert mock_s3_client.parts == [(1, b"aaaabbbb"), (2, b"cc")]
+        assert mock_s3_client.completed_parts == [
+            {"ETag": "etag-1", "PartNumber": 1},
+            {"ETag": "etag-2", "PartNumber": 2},
+        ]
+
+    async def test_object_store_translates_and_aborts_multipart_upload_on_failure(
         self, monkeypatch: pytest.MonkeyPatch, aws_runtime: AWSRuntime
     ) -> None:
         """
         Test cases:
-        - An upload failure aborts the multipart upload and surfaces as S3Error.
+        - An object-store upload failure aborts the multipart upload and surfaces as S3Error.
         """
         client = MockS3Client(fail_on_part=1)
 
@@ -165,7 +296,7 @@ class TestUploadStreamToS3:
             yield b"aaaabbbb"
 
         with pytest.raises(S3Error, match="Failed to upload stream to S3"):
-            await upload_stream_to_s3(chunks(), "key", aws_runtime)
+            await S3ObjectStore(aws_runtime).put_stream("key", chunks())
 
         assert client.aborted
         assert client.completed_parts is None

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -86,7 +86,7 @@ def empty_database_session() -> Generator[Session, None, None]:
 def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     """Replace S3 operations with deterministic in-process behavior."""
 
-    async def _mock_download_from_s3(*_args: Any, **_kwargs: Any) -> bytes:
+    async def _mock_get_bytes(*_args: Any, **_kwargs: Any) -> bytes:
         return b"mock-contract-content"
 
     def _mock_get_contract_s3_key(contract_name: str) -> str:
@@ -98,7 +98,7 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _mock_copy_agent_to_benchmark(*_args: Any, **_kwargs: Any) -> None:
         return None
 
-    monkeypatch.setattr("tracker.aws.s3.download_from_s3", _mock_download_from_s3)
+    monkeypatch.setattr("tracker.aws.s3.S3ObjectStore.get_bytes", _mock_get_bytes)
     monkeypatch.setattr("tracker.aws.s3.get_contract_s3_key", _mock_get_contract_s3_key)
     monkeypatch.setattr("tracker.utils.reporting.upload_to_s3", _mock_upload_to_s3)
     monkeypatch.setattr("main.copy_agent_to_benchmark", _mock_copy_agent_to_benchmark)

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -35,7 +35,7 @@ from main import app, tracker_service_error_handler
 from tests.utils import TEST_ORG_ID, async_iterator
 from tracker.auth import RequestIdentity, get_current_org, get_current_starter
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import S3ObjectCopy
+from tracker.runtime.storage import StoredObject, StoredObjectCopy
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -620,7 +620,7 @@ class TestTrackerAPI:
             monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_LOG_GROUP", "deployment-log-group")
             monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_LOG_RETENTION_DAYS", "30")
             monkeypatch.setattr("tracker.config.AWS_MANAGED_SUBMISSIONS_ENABLED", True)
-            monkeypatch.setattr(main_module, "s3_object_exists", AsyncMock(return_value=True))
+            monkeypatch.setattr(main_module.S3ObjectStore, "exists", AsyncMock(return_value=True))
             request = StartBenchmarkRequest(
                 contract=contract,
                 benchmark_name="swebench",
@@ -776,11 +776,11 @@ class TestTrackerAPI:
         assert admission is not None
         database_session.delete(admission)
         database_session.commit()
-        created_copy = S3ObjectCopy(version_id="copy-version") if agent_copy_created else None
+        created_copy = StoredObjectCopy(deletion_token="copy-version") if agent_copy_created else None
         copy_agent = AsyncMock(return_value=created_copy)
         delete_agent_copy = AsyncMock()
         monkeypatch.setattr("main.copy_agent_to_benchmark", copy_agent)
-        monkeypatch.setattr("main.delete_from_s3", delete_agent_copy)
+        monkeypatch.setattr(main_module.S3ObjectStore, "delete", delete_agent_copy)
 
         request = StartBenchmarkRequest(
             contract=contract,
@@ -798,11 +798,10 @@ class TestTrackerAPI:
         if agent_copy_created:
             copy_call = copy_agent.await_args
             assert copy_call is not None
-            copied_benchmark_id = copy_call.args[0]
+            copied_benchmark_id = copy_call.args[1]
             delete_agent_copy.assert_awaited_once_with(
                 f"benchmarks/{copied_benchmark_id}/{contract.name}.zip",
-                AWSRuntime.from_harness_config(harness_config),
-                version_id="copy-version",
+                deletion_token="copy-version",
             )
         else:
             delete_agent_copy.assert_not_awaited()
@@ -814,14 +813,14 @@ class TestTrackerAPI:
         harness_config: HarnessConfig,
         monkeypatch: MonkeyPatch,
     ) -> None:
-        copy_agent = AsyncMock(return_value=S3ObjectCopy(version_id="copy-version"))
+        copy_agent = AsyncMock(return_value=StoredObjectCopy(deletion_token="copy-version"))
         delete_agent_copy = AsyncMock()
 
         def fail_payload_build(*_args: Any, **_kwargs: Any) -> None:
             raise RuntimeError("payload validation failed")
 
         monkeypatch.setattr(main_module, "copy_agent_to_benchmark", copy_agent)
-        monkeypatch.setattr(main_module, "delete_from_s3", delete_agent_copy)
+        monkeypatch.setattr(main_module.S3ObjectStore, "delete", delete_agent_copy)
         monkeypatch.setattr(main_module, "_process_benchmark_kwargs", fail_payload_build)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_single_task_id)
         request = StartBenchmarkRequest(
@@ -843,11 +842,10 @@ class TestTrackerAPI:
         assert database_session.exec(select(ExecutorDispatch)).all() == []
         copy_call = copy_agent.await_args
         assert copy_call is not None
-        copied_benchmark_id = copy_call.args[0]
+        copied_benchmark_id = copy_call.args[1]
         delete_agent_copy.assert_awaited_once_with(
             f"benchmarks/{copied_benchmark_id}/{contract.name}.zip",
-            AWSRuntime.from_harness_config(harness_config),
-            version_id="copy-version",
+            deletion_token="copy-version",
         )
 
     async def test_start_commit_acknowledgement_failure_retains_durable_copy(
@@ -857,7 +855,7 @@ class TestTrackerAPI:
         harness_config: HarnessConfig,
         monkeypatch: MonkeyPatch,
     ) -> None:
-        copy_agent = AsyncMock(return_value=S3ObjectCopy(version_id="copy-version"))
+        copy_agent = AsyncMock(return_value=StoredObjectCopy(deletion_token="copy-version"))
         delete_agent_copy = AsyncMock()
         commit = database_session.commit
 
@@ -866,7 +864,7 @@ class TestTrackerAPI:
             raise RuntimeError("commit acknowledgement lost")
 
         monkeypatch.setattr(main_module, "copy_agent_to_benchmark", copy_agent)
-        monkeypatch.setattr(main_module, "delete_from_s3", delete_agent_copy)
+        monkeypatch.setattr(main_module.S3ObjectStore, "delete", delete_agent_copy)
         monkeypatch.setattr(database_session, "commit", commit_then_fail)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_single_task_id)
         request = StartBenchmarkRequest(
@@ -901,19 +899,19 @@ class TestTrackerAPI:
         delete_agent_copy = AsyncMock()
         monkeypatch.setattr(database_session, "rollback", rollback)
         monkeypatch.setattr(main_module, "_start_admission_is_absent", verify_absent)
-        monkeypatch.setattr(main_module, "delete_from_s3", delete_agent_copy)
+        monkeypatch.setattr(main_module.S3ObjectStore, "delete", delete_agent_copy)
 
-        await main_module._rollback_failed_start_admission(
+        await getattr(main_module, "_rollback_failed_start_admission")(
             database_session,
             benchmark_id=uuid4(),
             dispatch_id=uuid4(),
-            created_copy=S3ObjectCopy(version_id="copy-version"),
+            created_copy=StoredObjectCopy(deletion_token="copy-version"),
             request=StartBenchmarkRequest(
                 contract=contract,
                 benchmark_name="swebench",
                 harness_config=harness_config,
             ),
-            aws_runtime=AWSRuntime.from_harness_config(harness_config),
+            object_store=main_module.S3ObjectStore(AWSRuntime.from_harness_config(harness_config)),
         )
 
         rollback.assert_called_once_with()
@@ -2104,18 +2102,16 @@ class TestTrackerAPI:
 
         observed_prefixes: list[str] = []
 
-        async def _mock_list_s3_objects(prefix: str, *_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+        async def _mock_list_objects(_store: object, prefix: str) -> AsyncIterator[StoredObject]:
             observed_prefixes.append(prefix)
-            yield f"{prefix}output.txt"
+            yield StoredObject(key=f"{prefix}output.txt")
 
-        async def _mock_download_many_from_s3(
-            keys: AsyncIterator[str], *_args: Any, **_kwargs: Any
-        ) -> AsyncIterator[tuple[str, bytes]]:
+        async def _mock_get_many(_store: object, keys: AsyncIterator[str]) -> AsyncIterator[tuple[str, bytes]]:
             async for key in keys:
                 yield key, b"output contents"
 
-        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
-        monkeypatch.setattr("main.download_many_from_s3", _mock_download_many_from_s3)
+        monkeypatch.setattr(main_module.S3ObjectStore, "list_objects", _mock_list_objects)
+        monkeypatch.setattr(main_module.S3ObjectStore, "get_many", _mock_get_many)
 
         response = client.get(
             f"/fetch-run-outputs/{example_benchmark_object.id}",
@@ -2150,22 +2146,20 @@ class TestTrackerAPI:
         database_session.add(example_benchmark_object)
         database_session.commit()
 
-        async def _mock_list_s3_objects(prefix: str, *_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
-            yield f"{prefix}task/../../outside.txt"
-            yield f"{prefix}task/..\\outside.txt"
-            yield f"{prefix}C:/outside.txt"
-            yield f"{prefix}task//outside.txt"
-            yield f"{prefix}task/hidden\x00.txt"
-            yield f"{prefix}task/output.txt"
+        async def _mock_list_objects(_store: object, prefix: str) -> AsyncIterator[StoredObject]:
+            yield StoredObject(key=f"{prefix}task/../../outside.txt")
+            yield StoredObject(key=f"{prefix}task/..\\outside.txt")
+            yield StoredObject(key=f"{prefix}C:/outside.txt")
+            yield StoredObject(key=f"{prefix}task//outside.txt")
+            yield StoredObject(key=f"{prefix}task/hidden\x00.txt")
+            yield StoredObject(key=f"{prefix}task/output.txt")
 
-        async def _mock_download_many_from_s3(
-            keys: AsyncIterator[str], *_args: Any, **_kwargs: Any
-        ) -> AsyncIterator[tuple[str, bytes]]:
+        async def _mock_get_many(_store: object, keys: AsyncIterator[str]) -> AsyncIterator[tuple[str, bytes]]:
             async for key in keys:
                 yield key, b"output contents"
 
-        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
-        monkeypatch.setattr("main.download_many_from_s3", _mock_download_many_from_s3)
+        monkeypatch.setattr(main_module.S3ObjectStore, "list_objects", _mock_list_objects)
+        monkeypatch.setattr(main_module.S3ObjectStore, "get_many", _mock_get_many)
 
         response = client.get(
             f"/fetch-run-outputs/{example_benchmark_object.id}",
@@ -2187,13 +2181,13 @@ class TestTrackerAPI:
         database_session.add(example_benchmark_object)
         database_session.commit()
 
-        async def _mock_list_s3_objects(prefix: str, *_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
-            yield f"{prefix}task/../../outside.txt"
-            yield f"{prefix}task/hidden\x00.txt"
+        async def _mock_list_objects(_store: object, prefix: str) -> AsyncIterator[StoredObject]:
+            yield StoredObject(key=f"{prefix}task/../../outside.txt")
+            yield StoredObject(key=f"{prefix}task/hidden\x00.txt")
 
-        download_many_from_s3 = MagicMock()
-        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
-        monkeypatch.setattr("main.download_many_from_s3", download_many_from_s3)
+        get_many = MagicMock()
+        monkeypatch.setattr(main_module.S3ObjectStore, "list_objects", _mock_list_objects)
+        monkeypatch.setattr(main_module.S3ObjectStore, "get_many", get_many)
 
         response = client.get(
             f"/fetch-run-outputs/{example_benchmark_object.id}",
@@ -2202,7 +2196,7 @@ class TestTrackerAPI:
 
         assert response.status_code == 404
         assert response.json() == {"detail": f"No outputs found for run '{example_benchmark_object.id}'"}
-        download_many_from_s3.assert_not_called()
+        get_many.assert_not_called()
 
     async def test_fetch_run_outputs_returns_404_when_empty(
         self,
@@ -2214,10 +2208,10 @@ class TestTrackerAPI:
         database_session.add(example_benchmark_object)
         database_session.commit()
 
-        def _mock_list_s3_objects(*_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+        def _mock_list_objects(_store: object, _prefix: str) -> AsyncIterator[StoredObject]:
             return async_iterator(())
 
-        monkeypatch.setattr("main.list_s3_objects", _mock_list_s3_objects)
+        monkeypatch.setattr(main_module.S3ObjectStore, "list_objects", _mock_list_objects)
 
         response = client.get(
             f"/fetch-run-outputs/{example_benchmark_object.id}",

--- a/services/tracker/tests/unit/test_runtime_artifacts.py
+++ b/services/tracker/tests/unit/test_runtime_artifacts.py
@@ -1,0 +1,72 @@
+"""Behavioral tests for provider-neutral artifact policy."""
+
+from datetime import UTC, datetime
+from typing import cast
+
+from tracker.runtime.artifacts import copy_agent_to_benchmark, list_agents
+from tracker.runtime.storage import ObjectStore, StoredObject, StoredObjectCopy
+
+
+class RecordingStore:
+    """Small artifact-store double that exposes policy inputs and outputs."""
+
+    def __init__(self, *, exists: bool, objects: list[StoredObject] | None = None) -> None:
+        self._exists = exists
+        self._objects = objects or []
+        self.exists_keys: list[str] = []
+        self.copies: list[tuple[str, str]] = []
+        self.listed_prefixes: list[str] = []
+
+    async def exists(self, key: str) -> bool:
+        self.exists_keys.append(key)
+        return self._exists
+
+    async def copy(self, source_key: str, destination_key: str) -> StoredObjectCopy:
+        self.copies.append((source_key, destination_key))
+        return StoredObjectCopy(deletion_token="copied-version")
+
+    async def list_objects(self, prefix: str):  # type: ignore[no-untyped-def]
+        self.listed_prefixes.append(prefix)
+        for stored_object in self._objects:
+            yield stored_object
+
+
+async def test_copy_agent_to_benchmark_does_not_replace_existing_bundle() -> None:
+    recording_store = RecordingStore(exists=True)
+
+    copied = await copy_agent_to_benchmark(
+        cast(ObjectStore, recording_store), benchmark_id="benchmark-1", agent_name="agent-a"
+    )
+
+    assert copied is None
+    assert recording_store.exists_keys == ["benchmarks/benchmark-1/agent-a.zip"]
+    assert recording_store.copies == []
+
+
+async def test_copy_agent_to_benchmark_freezes_missing_bundle_with_provider_token() -> None:
+    recording_store = RecordingStore(exists=False)
+
+    copied = await copy_agent_to_benchmark(
+        cast(ObjectStore, recording_store), benchmark_id="benchmark-1", agent_name="agent-a"
+    )
+
+    assert copied == StoredObjectCopy(deletion_token="copied-version")
+    assert recording_store.exists_keys == ["benchmarks/benchmark-1/agent-a.zip"]
+    assert recording_store.copies == [("agents/agent-a.zip", "benchmarks/benchmark-1/agent-a.zip")]
+
+
+async def test_list_agents_keeps_zip_bundles_and_last_modified_metadata() -> None:
+    timestamp = datetime(2025, 1, 1, tzinfo=UTC)
+    recording_store = RecordingStore(
+        exists=False,
+        objects=[
+            StoredObject(key="agents/alpha.zip", last_modified=timestamp),
+            StoredObject(key="agents/notes.txt", last_modified=timestamp),
+            StoredObject(key="agents/nested/beta.zip"),
+        ],
+    )
+
+    agents = await list_agents(cast(ObjectStore, recording_store))
+
+    assert agents == [("alpha", timestamp), ("nested/beta", None)]
+    assert recording_store.listed_prefixes == ["agents/"]

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -29,6 +29,7 @@ from benchmark_service.sandbox import SandboxError as ProviderSandboxError
 
 from tracker import sandbox as sandbox_module
 from tracker.aws.runtime import AWSRuntime
+from tracker.runtime.storage import ObjectStore
 from tracker.database.models import (
     AgentCausedExitReason,
     AgentContractRequest,
@@ -57,6 +58,28 @@ def _ignore_output(_message: str) -> None:
     pass
 
 
+def _mock_object_store() -> Mock:
+    store = Mock(spec=ObjectStore)
+    store.put_bytes = AsyncMock()
+    store.put_stream = AsyncMock(return_value=0)
+    store.temporary_download_url = AsyncMock(return_value="https://example.com/presigned")
+    return store
+
+
+def _capture_put_bytes(store: Mock, upload: Callable[..., Any]) -> None:
+    async def put_bytes(key: str, content: bytes) -> None:
+        await upload(content, key, None)
+
+    store.put_bytes.side_effect = put_bytes
+
+
+def _capture_put_stream(store: Mock, upload: Callable[..., Any]) -> None:
+    async def put_stream(key: str, chunks: AsyncIterator[bytes], **kwargs: Any) -> int:
+        return await upload(chunks, key, None, **kwargs)
+
+    store.put_stream.side_effect = put_stream
+
+
 _create_sandbox = getattr(sandbox_module, "_create_sandbox")
 _delete_sandbox = getattr(sandbox_module, "delete_sandbox")
 _exec = getattr(sandbox_module, "_exec")
@@ -76,6 +99,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         """
         Verify artifact contents use the sandbox file-transfer API instead of command output.
 
@@ -98,7 +122,7 @@ class TestOutputArtifacts:
             uploaded.append((file_content, s3_key))
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+        _capture_put_bytes(store, fake_upload_to_s3)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -110,7 +134,7 @@ class TestOutputArtifacts:
             [artifact],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         assert uploaded == [(artifact_content, "benchmarks/benchmark-123/task_0/artifacts/turns.jsonl")]
@@ -120,6 +144,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         artifact = "artifacts/turns.jsonl"
         authority_checks = iter([True, False])
         uploaded: list[bytes] = []
@@ -135,7 +160,7 @@ class TestOutputArtifacts:
             uploaded.append(file_content)
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+        _capture_put_bytes(store, fake_upload_to_s3)
         mock_sandbox = Mock()
         mock_sandbox.download_file = AsyncMock(return_value=b"old")
 
@@ -144,7 +169,7 @@ class TestOutputArtifacts:
             [artifact],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
             execution_is_current=lambda: next(authority_checks),
         )
 
@@ -156,6 +181,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         uploaded: list[tuple[bytes, str]] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
@@ -173,7 +199,7 @@ class TestOutputArtifacts:
             uploaded.append((file_content, s3_key))
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+        _capture_put_bytes(store, fake_upload_to_s3)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -188,7 +214,7 @@ class TestOutputArtifacts:
             ],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         assert uploaded == [
@@ -201,6 +227,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         uploaded: list[tuple[bytes, str]] = []
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
@@ -214,7 +241,7 @@ class TestOutputArtifacts:
             uploaded.append((file_content, s3_key))
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+        _capture_put_bytes(store, fake_upload_to_s3)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -226,7 +253,7 @@ class TestOutputArtifacts:
             [OutputArtifact(path="artifacts/result.json", source="/logs/model-library-run/result.json")],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         assert uploaded == [(b'{"turns":[]}\n', "benchmarks/benchmark-123/task_0/artifacts/result.json")]
@@ -236,6 +263,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         artifact = "artifacts/missing.json"
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
@@ -245,13 +273,14 @@ class TestOutputArtifacts:
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
 
         with pytest.raises(OutputArtifactError, match="Required output artifact missing"):
-            await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", aws_runtime)
+            await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", store)
 
     async def test_upload_output_artifacts_skips_missing_optional_model_patch(
         self,
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         artifact = OutputArtifact(
             path="artifacts/model.patch",
             source="/logs/artifacts/model.patch",
@@ -262,14 +291,14 @@ class TestOutputArtifacts:
         exec_mock = AsyncMock(return_value=ExecResult(exit_code=1, output=""))
         upload_mock = AsyncMock()
         monkeypatch.setattr(sandbox_module, "_exec", exec_mock)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", upload_mock)
+        _capture_put_bytes(store, upload_mock)
 
         await upload_output_artifacts(
             sandbox,
             [artifact],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         exec_mock.assert_awaited_once_with(
@@ -290,6 +319,7 @@ class TestOutputArtifacts:
         required: bool,
         expected_uploads: list[bytes],
     ) -> None:
+        store = _mock_object_store()
         source = "/logs/symlink result.json"
         uploaded: list[bytes] = []
 
@@ -306,7 +336,7 @@ class TestOutputArtifacts:
             uploaded.append(file_content)
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+        _capture_put_bytes(store, fake_upload_to_s3)
 
         sandbox = Mock()
         sandbox.id = "sandbox-123"
@@ -319,7 +349,7 @@ class TestOutputArtifacts:
             [artifact],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         assert uploaded == expected_uploads
@@ -329,6 +359,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         optional_source = "/logs/optional.json"
         required_source = "/logs/required.json"
         uploaded: list[tuple[bytes, str]] = []
@@ -352,7 +383,7 @@ class TestOutputArtifacts:
             uploaded.append((file_content, s3_key))
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", fake_upload_to_s3)
+        _capture_put_bytes(store, fake_upload_to_s3)
 
         sandbox = Mock()
         sandbox.id = "sandbox-123"
@@ -367,7 +398,7 @@ class TestOutputArtifacts:
             ],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         assert uploaded == [
@@ -382,6 +413,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         artifact = "artifacts/large.json"
 
         async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
@@ -393,10 +425,10 @@ class TestOutputArtifacts:
 
         upload_mock = AsyncMock()
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", upload_mock)
+        _capture_put_bytes(store, upload_mock)
 
         with pytest.raises(OutputArtifactError, match="too large"):
-            await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", aws_runtime)
+            await upload_output_artifacts(Mock(), [artifact], "benchmark-123", "task_0", store)
 
         upload_mock.assert_not_awaited()
 
@@ -420,6 +452,7 @@ class TestOutputArtifacts:
         total_bytes: int,
         error: str,
     ) -> None:
+        store = _mock_object_store()
         sandbox = Mock()
         sandbox.download_file = AsyncMock()
         exec_mock = AsyncMock(
@@ -436,7 +469,7 @@ class TestOutputArtifacts:
                 "artifacts/result.json",
                 "benchmark-123",
                 "task_0",
-                aws_runtime,
+                store,
                 total_bytes,
             )
 
@@ -447,6 +480,7 @@ class TestOutputArtifacts:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         artifact = OutputArtifact(
             path="atif/trajectory.json",
             source="/logs/trajectory_atif.json",
@@ -462,14 +496,14 @@ class TestOutputArtifacts:
         )
         upload_mock = AsyncMock()
         monkeypatch.setattr(sandbox_module, "_exec", exec_mock)
-        monkeypatch.setattr(sandbox_module, "upload_to_s3", upload_mock)
+        _capture_put_bytes(store, upload_mock)
 
         await upload_output_artifacts(
             sandbox,
             [artifact],
             "benchmark-123",
             "task_0",
-            aws_runtime,
+            store,
         )
 
         assert exec_mock.await_args_list == [
@@ -490,6 +524,7 @@ class TestArchiveAndUploadOutput:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         """
         Test cases:
         - The tar.gz archive is streamed chunk-by-chunk to S3 without a full in-memory download.
@@ -522,7 +557,7 @@ class TestArchiveAndUploadOutput:
             return chunks()
 
         monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
-        monkeypatch.setattr(sandbox_module, "upload_stream_to_s3", fake_upload_stream_to_s3)
+        _capture_put_stream(store, fake_upload_stream_to_s3)
 
         mock_sandbox = Mock()
         mock_sandbox.id = "sandbox-123"
@@ -533,7 +568,7 @@ class TestArchiveAndUploadOutput:
             mock_sandbox,
             "/logs",
             "benchmarks/benchmark-123/task_0/output.tar.gz",
-            aws_runtime,
+            store,
         )
 
         assert uploaded == [(b"chunk-1chunk-2", "benchmarks/benchmark-123/task_0/output.tar.gz")]
@@ -549,6 +584,7 @@ class TestRunAgent:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         contract = AgentContractRequest(
             name="test-agent",
             install_cmd="",
@@ -591,7 +627,7 @@ class TestRunAgent:
             "task_0",
             lambda _msg: None,
             "/testbed",
-            aws_runtime=aws_runtime,
+            object_store=store,
             benchmark_id="benchmark-123",
         )
 
@@ -602,6 +638,7 @@ class TestRunAgent:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         contract = AgentContractRequest(
             name="test-agent",
             install_cmd="",
@@ -645,7 +682,7 @@ class TestRunAgent:
             "task_0",
             lambda _msg: None,
             "/testbed",
-            aws_runtime=aws_runtime,
+            object_store=store,
             agent_output_s3_key="benchmarks/run/task/agent_output.tar.gz",
             benchmark_id="benchmark-123",
         )
@@ -660,7 +697,7 @@ class TestRunAgent:
             "task_0",
             lambda _msg: None,
             "/testbed",
-            aws_runtime=aws_runtime,
+            object_store=store,
             agent_output_s3_key="benchmarks/run/task/agent_output.tar.gz",
             benchmark_id="benchmark-123",
             execution_is_current=lambda: False,
@@ -672,6 +709,7 @@ class TestRunAgent:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         """Compose runtime sources should route agent setup and execution through the wrapper.
 
         Test cases:
@@ -709,7 +747,7 @@ class TestRunAgent:
             "task_0",
             lambda _msg: None,
             "/workspace",
-            aws_runtime=aws_runtime,
+            object_store=store,
             runtime_source=ComposeSource(
                 outer=ImageSource(image="docker:28.3.3-dind"),
                 compose_command="docker compose -f /harbor/compose.yaml",
@@ -724,6 +762,7 @@ class TestRunAgent:
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
     ) -> None:
+        store = _mock_object_store()
         """Task timeouts should apply to the full shell-form agent command.
 
         Test cases:
@@ -759,7 +798,7 @@ class TestRunAgent:
             "task_0",
             lambda _msg: None,
             "/workspace",
-            aws_runtime=aws_runtime,
+            object_store=store,
             agent_timeout=2.5,
         )
 
@@ -1532,6 +1571,7 @@ class TestUploadAgentArtifacts:
         exit_code: int,
         retryable: bool,
     ) -> None:
+        store = _mock_object_store()
         """Exit code 35 (curl SSL/TLS) raises SandboxSetupError so process_task retries
         with a fresh sandbox. All other non-zero exit codes raise the base SandboxError,
         which marks the task as failed without a sandbox retry.
@@ -1548,14 +1588,11 @@ class TestUploadAgentArtifacts:
             "_exec",
             AsyncMock(return_value=ExecResult(exit_code=exit_code, output="error output")),
         )
-        monkeypatch.setattr(
-            "tracker.sandbox.create_presigned_url",
-            AsyncMock(return_value="https://example.com/presigned"),
-        )
+        store.temporary_download_url = AsyncMock(return_value="https://example.com/presigned")
 
         expected = SSLConnectionError if retryable else SandboxError
         with pytest.raises(expected) as exc_info:
-            await upload_agent_artifacts(mock_sandbox, contract, "bench-123", aws_runtime)
+            await upload_agent_artifacts(mock_sandbox, contract, "bench-123", store)
 
         if not retryable:
             assert not isinstance(exc_info.value, SandboxSetupError)

--- a/services/tracker/tests/unit/test_taskiq_producers.py
+++ b/services/tracker/tests/unit/test_taskiq_producers.py
@@ -28,8 +28,8 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
-from tracker.aws.runtime import AWSRuntime
 from tracker.executor.release_control import promote_release
+from tracker.runtime.storage import ObjectStore
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 
 
@@ -143,7 +143,7 @@ def test_managed_start_and_resume_emit_credential_free_v2(
         return True
 
     monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_task_ids)
-    monkeypatch.setattr("main.s3_object_exists", agent_exists)
+    monkeypatch.setattr("tracker.aws.s3.S3ObjectStore.exists", agent_exists)
     monkeypatch.setattr("main.copy_agent_to_benchmark", AsyncMock(return_value=True))
     reset_to_in_progress = AsyncMock(return_value=["task-2"])
     monkeypatch.setattr("main.reset_to_in_progress_status", reset_to_in_progress)
@@ -202,16 +202,18 @@ async def test_resolving_a_contract_from_s3_attests_its_inference_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Rebuilding from the bundle is what makes the settings trustworthy."""
-    monkeypatch.setattr("main.download_from_s3", AsyncMock(return_value=b"zip-bytes"))
+    object_store = AsyncMock()
+    object_store.get_bytes.return_value = b"zip-bytes"
     monkeypatch.setattr(
         "main.get_contract_from_zip_bytes",
         lambda *_args, **_kwargs: contract.model_copy(update={"kwargs": {"variant": "max"}}),
     )
 
-    resolved = await main._resolve_contract_from_s3(_start_request(contract, None), cast(AWSRuntime, None))
+    resolved = await main._resolve_contract_from_s3(_start_request(contract, None), cast(ObjectStore, object_store))
 
     assert resolved.inference_settings_attested is True
     assert resolved.kwargs == {"variant": "max"}
+    object_store.get_bytes.assert_awaited_once_with("agents/dummy.zip")
 
 
 def test_start_clears_a_caller_asserted_attestation(
@@ -231,7 +233,7 @@ def test_start_clears_a_caller_asserted_attestation(
         return True
 
     monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_task_ids)
-    monkeypatch.setattr("main.s3_object_exists", agent_exists)
+    monkeypatch.setattr("tracker.aws.s3.S3ObjectStore.exists", agent_exists)
     monkeypatch.setattr("main.copy_agent_to_benchmark", AsyncMock(return_value=True))
     resolve_from_s3 = AsyncMock()
     monkeypatch.setattr("main._resolve_contract_from_s3", resolve_from_s3)
@@ -270,7 +272,7 @@ def test_managed_start_rejects_aws_authority_before_persistence(
     async def agent_exists(*_args: Any, **_kwargs: Any) -> bool:
         raise AssertionError("invalid managed requests must be rejected before checking S3")
 
-    monkeypatch.setattr("main.s3_object_exists", agent_exists)
+    monkeypatch.setattr("tracker.aws.s3.S3ObjectStore.exists", agent_exists)
     request = _start_request(contract, None).model_copy(
         update={"service_headers": {"AWS_SECRET_ACCESS_KEY": "credential"}}
     )
@@ -331,7 +333,7 @@ def test_managed_resume_rolls_back_when_the_active_release_is_incompatible(
         "verify_task_ids",
         AsyncMock(return_value=VerifyTaskIdsResponse(task_ids=["task-1"])),
     )
-    monkeypatch.setattr("main.s3_object_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr("tracker.aws.s3.S3ObjectStore.exists", AsyncMock(return_value=True))
 
     response = client.post("/start-benchmark", json=_start_request(contract, None).model_dump(mode="json"))
     assert response.status_code == 200
@@ -383,7 +385,7 @@ def test_managed_resume_payload_failure_rolls_back_recovery_state(
         "verify_task_ids",
         AsyncMock(return_value=VerifyTaskIdsResponse(task_ids=["task-1"])),
     )
-    monkeypatch.setattr("main.s3_object_exists", AsyncMock(return_value=True))
+    monkeypatch.setattr("tracker.aws.s3.S3ObjectStore.exists", AsyncMock(return_value=True))
     monkeypatch.setattr("main.copy_agent_to_benchmark", AsyncMock(return_value=True))
 
     response = client.post("/start-benchmark", json=_start_request(contract, None).model_dump(mode="json"))


### PR DESCRIPTION
## Purpose

Make object storage replaceable without changing Tracker's current S3-backed behavior. This is the root PR of the stack: later PRs depend on its provider-neutral storage boundary.

## What changes

- Introduces AWS-free object-storage and artifact-location contracts in `tracker.runtime`.
- Moves artifact key construction, agent-bundle copy-if-absent behavior, and agent listing/filtering to provider-neutral helpers.
- Keeps `AWSRuntime` and its already-selected AWS client provider as the S3 composition authority.
- Adapts the existing S3 implementation to the new contracts; benchmark, task, sandbox, reporting, API, and CLI flows consume the boundary rather than constructing storage clients themselves.

## Behavior preserved

- Existing S3 key formats and artifact locations.
- Presigned URL expiry and download behavior.
- Multipart upload behavior, retry/error translation, and telemetry instrumentation.
- Existing AWS credential/runtime selection; no credential object moves onto domain interfaces.

## Deliberate non-goals

- No local storage provider is added in this PR.
- No generic provider registry, selector, or factory is introduced.
- No API payload, route, or user-visible artifact workflow changes.

## Review guide

1. Start with the `tracker.runtime` storage and artifact contracts/helpers.
2. Verify the S3 adapter remains a thin implementation behind the selected runtime client.
3. Follow the migrated artifact call sites to confirm existing behavior is reached through the new boundary.
4. Review the focused S3 and artifact-policy tests for copy/list/download semantics.

## Stack and merge order

1. **#656 Storage** (`dev` ← `ok/runtime-storage`)
2. #657 Secrets (`ok/runtime-storage` ← `ok/runtime-secrets`)
3. #658 Logging (`ok/runtime-secrets` ← `ok/runtime-logs`)
4. #659 Executor artifacts (`ok/runtime-logs` ← `ok/executor-artifacts`)

Merge in that order after #656's required approval.

## Validation

- 690 Tracker unit tests passed (one existing Starlette/httpx warning).
- 45 executor-host and end-to-end telemetry tests passed.
- Basedpyright, Ruff, formatting, diff checks, targeted LSP, and independent review passed.
- Local executable diff-coverage estimate: **89.51%** (above Codecov's #656 patch target).

## Live validation

- `uv run pytest tests/integration/live/api/test_s3_routes.py` against `ValkDevSharedStack`: **2 passed** (one existing Starlette/httpx warning).
- Exercised real S3 agent-artifact listing, presigned download, task-artifact signing, missing-output handling, and isolated S3 cleanup using short-lived SSO credentials.
- Not run live: sandbox orchestration, Secrets Manager retrieval, CloudWatch writes, and sealed executor-release activation. Those boundaries remain covered by the green CI and unit contracts.
