### PR TITLE
refactor(secrets): abstract secret resolution

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -45,7 +45,7 @@ from tracker.aws.resolver import (
     resolve_run_aws_runtime_and_access_key_config,
     resolve_start_aws_runtime,
 )
-from tracker.aws.secrets import resolve_secrets
+from tracker.aws.secrets import SecretsManagerStore
 from tracker.agent.contract import get_contract_from_zip_bytes
 from tracker.aws.s3 import (
     S3_BENCHMARKS_PREFIX,
@@ -61,6 +61,7 @@ from tracker.runtime.artifacts import (
     benchmark_prefix as benchmark_artifact_prefix,
     copy_agent_to_benchmark,
 )
+from tracker.runtime.secrets import resolve_secrets
 from tracker.runtime.storage import ObjectStore, StoredObjectCopy
 from tracker.agent.schemas import AgentConfig
 from tracker.config import (
@@ -513,7 +514,7 @@ async def start_benchmark(
     if request.service_auth_header_name and request.service_auth_secret_name:
         resolved = resolve_secrets(
             {request.service_auth_header_name: request.service_auth_secret_name},
-            aws_runtime.clients,
+            SecretsManagerStore(aws_runtime.clients),
         )
         service_headers.update(resolved)
 

--- a/services/tracker/src/tracker/aws/secrets.py
+++ b/services/tracker/src/tracker/aws/secrets.py
@@ -1,4 +1,4 @@
-"""AWS Secrets Manager utilities."""
+"""AWS Secrets Manager adapters."""
 
 import json
 from typing import Any
@@ -7,69 +7,30 @@ from botocore.exceptions import ClientError
 
 from tracker.aws.clients import AWSClientProvider
 from tracker.exceptions import SecretsError
-from tracker.logging import get_logger
-
-logger = get_logger(__name__)
+from tracker.runtime.secrets import SecretValue
 
 
-def fetch_aws_secret(secret_name: str, client_provider: AWSClientProvider) -> dict[str, Any] | str:
-    """Fetch a JSON secret from AWS Secrets Manager by name.
+class SecretsManagerStore:
+    """Read named values through an already-selected AWS client provider."""
 
-    Args:
-        secret_name: The name of the secret to retrieve.
-        client_provider: AWS clients for the operation.
+    def __init__(self, clients: AWSClientProvider) -> None:
+        self._clients = clients
 
-    Returns:
-        Parsed JSON contents of the secret as a dict or the string value
+    def get(self, name: str) -> SecretValue:
+        """Fetch and decode one AWS Secrets Manager value."""
+        client = self._clients.secretsmanager_client()
+        try:
+            response: dict[str, Any] = client.get_secret_value(SecretId=name)  # pyright: ignore[reportUnknownMemberType]
+        except ClientError as error:
+            error_code = error.response.get("Error", {}).get("Code", "")
+            if error_code == "ResourceNotFoundException":
+                raise SecretsError(f"Secret '{name}' does not exist in AWS Secrets Manager") from error
+            if error_code == "AccessDeniedException":
+                raise SecretsError(f"Access denied when retrieving secret '{name}'") from error
+            raise SecretsError(f"Failed to retrieve secret '{name}': {error}") from error
 
-    Raises:
-        SecretsError: If the secret does not exist or cannot be retrieved.
-    """
-    client = client_provider.secretsmanager_client()
-    try:
-        response: dict[str, Any] = client.get_secret_value(SecretId=secret_name)  # pyright: ignore[reportUnknownMemberType]
-    except ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "")
-        if error_code == "ResourceNotFoundException":
-            raise SecretsError(f"Secret '{secret_name}' does not exist in AWS Secrets Manager") from e
-        if error_code == "AccessDeniedException":
-            raise SecretsError(f"Access denied when retrieving secret '{secret_name}'") from e
-        raise SecretsError(f"Failed to retrieve secret '{secret_name}': {e}") from e
-
-    secret_string = str(response["SecretString"])  # pyright: ignore[reportUnknownArgumentType]
-
-    try:
-        return json.loads(secret_string)  # pyright: ignore[reportUnknownVariableType]
-    except json.JSONDecodeError:
-        return secret_string
-
-
-def resolve_secrets(secrets: dict[str, str], client_provider: AWSClientProvider) -> dict[str, str]:
-    """Resolve AWS secret references to actual values
-
-    Args:
-        secrets: Mapping of {ENV_VAR_NAME: aws_secret_name}.
-        client_provider: AWS clients for the operation.
-
-    Returns:
-        Mapping of {ENV_VAR_NAME: actual_secret_value}.
-
-    Raises:
-        SecretsError: If a secret cannot be fetched or a key is missing.
-    """
-    if not secrets:
-        return {}
-
-    resolved: dict[str, str] = {}
-
-    for env_name, secret_name in secrets.items():
-        secret_value = fetch_aws_secret(secret_name, client_provider)
-
-        if isinstance(secret_value, dict):
-            if env_name not in secret_value:
-                raise SecretsError(f"Key '{env_name}' not found in JSON secret '{secret_name}'")
-            resolved[env_name] = str(secret_value[env_name])
-        else:
-            resolved[env_name] = secret_value
-
-    return resolved
+        secret_string = str(response["SecretString"])  # pyright: ignore[reportUnknownArgumentType]
+        try:
+            return json.loads(secret_string)  # pyright: ignore[reportUnknownVariableType]
+        except json.JSONDecodeError:
+            return secret_string

--- a/services/tracker/src/tracker/notifications.py
+++ b/services/tracker/src/tracker/notifications.py
@@ -9,8 +9,7 @@ from uuid import UUID
 import httpx
 from pydantic import BaseModel
 
-from tracker.aws.clients import AWSClientProvider
-from tracker.aws.secrets import fetch_aws_secret
+from tracker.runtime.secrets import SecretStore
 from tracker.database.models import BenchmarkStatus
 from tracker.exceptions import SecretsError
 from tracker.logging import get_logger
@@ -117,16 +116,16 @@ def _build_terminal_message(
 
 
 class SlackNotifier:
-    def __init__(self, secret_name: str, clients: AWSClientProvider, intervals: list[int]):
+    def __init__(self, secret_name: str, secret_store: SecretStore, intervals: list[int]):
         self._secret_name = secret_name
-        self._clients = clients
+        self._secret_store = secret_store
         self._intervals = set(intervals)
         self._fired: set[int] = set()
 
     async def _send_webhook(self, text: str) -> None:
         """Fire and forget — exceptions are caught and logged, never raised."""
         try:
-            secret_value = fetch_aws_secret(self._secret_name, self._clients)
+            secret_value = self._secret_store.get(self._secret_name)
             if not isinstance(secret_value, str):
                 logger.warning(
                     f"Webhook secret '{self._secret_name}' returned a dict, expected a plain string URL. Skipping notification."

--- a/services/tracker/src/tracker/runtime/secrets.py
+++ b/services/tracker/src/tracker/runtime/secrets.py
@@ -1,0 +1,35 @@
+"""Provider-neutral secret reads and reference resolution."""
+
+from typing import Protocol, TypeAlias
+
+from tracker.exceptions import SecretsError
+
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+SecretValue: TypeAlias = JsonValue
+
+
+class SecretStore(Protocol):
+    """Synchronous access to named secret values."""
+
+    def get(self, name: str) -> SecretValue:
+        """Return decoded JSON, or the raw string when the value is not JSON."""
+        raise NotImplementedError
+
+
+def resolve_secrets(secrets: dict[str, str], secret_store: SecretStore) -> dict[str, str]:
+    """Resolve environment-variable secret references to their current values."""
+    if not secrets:
+        return {}
+
+    resolved: dict[str, str] = {}
+    for env_name, secret_name in secrets.items():
+        secret_value = secret_store.get(secret_name)
+        if isinstance(secret_value, dict):
+            if env_name not in secret_value:
+                raise SecretsError(f"Key '{env_name}' not found in JSON secret '{secret_name}'")
+            resolved[env_name] = str(secret_value[env_name])
+        else:
+            resolved[env_name] = str(secret_value)
+    return resolved

--- a/services/tracker/src/tracker/sandbox_cleanup.py
+++ b/services/tracker/src/tracker/sandbox_cleanup.py
@@ -16,6 +16,9 @@ from benchmark_service import (
     SandboxQuery,
 )
 
+from tracker.aws.clients import DefaultChainAWSClientProvider
+from tracker.aws.secrets import SecretsManagerStore
+from tracker.config import AWS_DEPLOYMENT_REGION
 from tracker.logging import configure_logging, get_logger
 from tracker.sandbox import audit_sandbox_delete
 from tracker.utils.resources import fetch_sandbox_provider_config
@@ -157,9 +160,16 @@ async def run_cleanup(
         return await cleanup_old_sandboxes(provider, now=now or datetime.now(UTC))
 
 
+def _cleanup_secret_store() -> SecretsManagerStore:
+    """Build the cleanup Lambda's sole ambient default-chain secret authority."""
+    if AWS_DEPLOYMENT_REGION is None:
+        raise RuntimeError("Sandbox cleanup requires AWS_DEPLOYMENT_REGION")
+    return SecretsManagerStore(DefaultChainAWSClientProvider(AWS_DEPLOYMENT_REGION))
+
+
 def _load_provider_config(secret_name: str, provider_type: str) -> SandboxProviderConfig:
     try:
-        return fetch_sandbox_provider_config(secret_name, None, provider_type)
+        return fetch_sandbox_provider_config(secret_name, _cleanup_secret_store(), provider_type)
     except (TypeError, ValueError):
         # Provider validation may echo credentials, so do not expose or chain it.
         raise RuntimeError(f"Sandbox cleanup secret is invalid for provider {provider_type!r}") from None

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -11,8 +11,7 @@ from benchmark_service.client import BenchmarkServiceClient
 from sqlmodel import Session, select
 
 from tracker.auth import RequestIdentity
-from tracker.aws.clients import AWSClientProvider
-from tracker.aws.secrets import fetch_aws_secret
+from tracker.runtime.secrets import SecretStore
 from tracker.config import create_benchmark_service_url
 from tracker.database.models import (
     Benchmark,
@@ -37,11 +36,11 @@ class BenchmarkConcurrencyUpdate:
 
 def fetch_sandbox_provider_config(
     secret_name: str,
-    clients: AWSClientProvider,
+    secret_store: SecretStore,
     provider_type: str,
 ) -> SandboxProviderConfig:
     """Resolve sandbox provider config from the selected provider type and secret."""
-    secret = fetch_aws_secret(secret_name, clients)
+    secret = secret_store.get(secret_name)
     if not isinstance(secret, dict):
         raise TrackerServiceError("Expected sandbox provider secret to be a JSON object")
 

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -27,6 +27,7 @@ from tracker.exceptions import TrackerServiceError
 from tracker.logging import get_logger
 from tracker.sandbox import delete_sandbox
 from tracker.aws.runtime import AWSRuntime
+from tracker.aws.secrets import SecretsManagerStore
 
 from tracker.utils.resources import fetch_benchmark_row, fetch_sandbox_provider_config
 
@@ -137,7 +138,9 @@ async def force_stop_sandboxes(
     benchmark_service = benchmark_row.benchmark_service()
     try:
         provider = benchmark_service.get_sandbox_provider(
-            fetch_sandbox_provider_config(sandbox_provider_secret_name, aws_runtime.clients, sandbox_provider)
+            fetch_sandbox_provider_config(
+                sandbox_provider_secret_name, SecretsManagerStore(aws_runtime.clients), sandbox_provider
+            )
         )
         sandboxes = [sandbox async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids)]
         await asyncio.gather(*(stop_sandbox(sandbox, provider, org) for sandbox in sandboxes))

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -20,7 +20,8 @@ from tracker._lambda import dry_run_lambda, invoke_lambda
 from tracker.aws.cloudwatch_logs import create_benchmark_log_group
 from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.secrets import fetch_aws_secret, resolve_secrets
+from tracker.aws.secrets import SecretsManagerStore
+from tracker.runtime.secrets import resolve_secrets
 from tracker.config import AUTH_REQUIRED, broker
 from tracker.database.models import (
     Benchmark,
@@ -400,14 +401,15 @@ def _preflight_managed_aws(
     provider_secret_name = request.sandbox_provider_secret_name
     if provider_secret_name is None:
         raise ValueError("Queued managed benchmark request has no sandbox provider secret name.")
+    secret_store = SecretsManagerStore(runtime.clients)
     sandbox_provider_config = fetch_sandbox_provider_config(
         provider_secret_name,
-        runtime.clients,
+        secret_store,
         request.sandbox_provider,
     )
-    resolve_secrets(request.contract.secrets, runtime.clients)
+    resolve_secrets(request.contract.secrets, secret_store)
     if request.webhook_secret_name and request.webhook_intervals:
-        fetch_aws_secret(request.webhook_secret_name, runtime.clients)
+        secret_store.get(request.webhook_secret_name)
     if request.lambda_function:
         dry_run_lambda(runtime.clients, request.lambda_function)
     return sandbox_provider_config
@@ -499,7 +501,7 @@ async def process_benchmark(
             aws_runtime = AWSRuntime.from_harness_config(harness_config)
             sandbox_provider_config = fetch_sandbox_provider_config(
                 harness_config.sandbox_provider_secret_name,
-                aws_runtime.clients,
+                SecretsManagerStore(aws_runtime.clients),
                 start_benchmark_request.sandbox_provider,
             )
 
@@ -507,7 +509,7 @@ async def process_benchmark(
         if start_benchmark_request.webhook_secret_name and start_benchmark_request.webhook_intervals:
             notifier = SlackNotifier(
                 secret_name=start_benchmark_request.webhook_secret_name,
-                clients=aws_runtime.clients,
+                secret_store=SecretsManagerStore(aws_runtime.clients),
                 intervals=start_benchmark_request.webhook_intervals,
             )
 

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -32,7 +32,8 @@ from tracker.aws.cloudwatch_logs import get_benchmark_log_url, write_benchmark_l
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.s3 import S3ObjectStore
 from tracker.runtime.artifacts import task_artifact_key
-from tracker.aws.secrets import resolve_secrets
+from tracker.aws.secrets import SecretsManagerStore
+from tracker.runtime.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
 from tracker.database.models import (
     AgentCausedExitReason,
@@ -933,7 +934,7 @@ async def _process_task_attempt(
             identity["email"] = benchmark_started_by_email
 
         env_vars = {
-            **resolve_secrets(start_benchmark_request.contract.secrets, aws_runtime.clients),
+            **resolve_secrets(start_benchmark_request.contract.secrets, SecretsManagerStore(aws_runtime.clients)),
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
             **_attested_inference_settings(start_benchmark_request.contract),

--- a/services/tracker/tests/integration/conftest.py
+++ b/services/tracker/tests/integration/conftest.py
@@ -20,6 +20,7 @@ from tests.integration.seed_agent_artifacts import (
 from tests.utils import TEST_ORG_ID
 from tracker.aws.clients import ExplicitCredentialsAWSClientProvider
 from tracker.aws.s3 import get_contract_s3_key
+from tracker.aws.secrets import SecretsManagerStore
 from tracker.config import create_benchmark_service_url
 from tracker.database.models import DEFAULT_ORG_NAME, AgentContractRequest, Org
 from tracker.types import AWSCredentials, HarnessConfig
@@ -168,7 +169,7 @@ def sandbox_provider_config(
     """Return the real provider configuration used by live service calls."""
     return fetch_sandbox_provider_config(
         daytona_secret_name,
-        ExplicitCredentialsAWSClientProvider(live_aws_credentials),
+        SecretsManagerStore(ExplicitCredentialsAWSClientProvider(live_aws_credentials)),
         "daytona",
     )
 

--- a/services/tracker/tests/integration/live/sandbox/test_force_stop.py
+++ b/services/tracker/tests/integration/live/sandbox/test_force_stop.py
@@ -15,6 +15,7 @@ from sqlmodel import Session, col, select
 import tracker.utils as tracker_utils
 from tests.utils import TEST_ORG_ID, random_task_id
 from tracker.aws.runtime import AWSRuntime
+from tracker.aws.secrets import SecretsManagerStore
 from tracker.database.models import Benchmark, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.logging import get_logger
 from tracker.sandbox import create_sandbox
@@ -137,7 +138,9 @@ class TestForceStop:
             org=Org(id=TEST_ORG_ID, name="default"),
         )
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
-        provider_config = fetch_sandbox_provider_config(daytona_secret_name, aws_runtime.clients, "daytona")
+        provider_config = fetch_sandbox_provider_config(
+            daytona_secret_name, SecretsManagerStore(aws_runtime.clients), "daytona"
+        )
         provider = benchmark_service.get_sandbox_provider(provider_config)
         labels = {
             "Benchmark": example_benchmark_object.name,
@@ -217,7 +220,9 @@ class TestForceStop:
         database_session.add(example_benchmark_object)
         database_session.commit()
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
-        provider_config = fetch_sandbox_provider_config(daytona_secret_name, aws_runtime.clients, "daytona")
+        provider_config = fetch_sandbox_provider_config(
+            daytona_secret_name, SecretsManagerStore(aws_runtime.clients), "daytona"
+        )
         provider = benchmark_service.get_sandbox_provider(provider_config)
 
         labels = {"Benchmark": example_benchmark_object.name, "Id": str(example_benchmark_object.id)}
@@ -344,7 +349,9 @@ class TestForceStop:
                 )
             )
 
-            provider_config = fetch_sandbox_provider_config(daytona_secret_name, aws_runtime.clients, "daytona")
+            provider_config = fetch_sandbox_provider_config(
+                daytona_secret_name, SecretsManagerStore(aws_runtime.clients), "daytona"
+            )
             provider = benchmark_service.get_sandbox_provider(provider_config)
             await _wait_for_running_benchmark(example_benchmark_object, database_session, provider)
 

--- a/services/tracker/tests/unit/aws/test_secrets.py
+++ b/services/tracker/tests/unit/aws/test_secrets.py
@@ -1,0 +1,90 @@
+"""AWS Secrets Manager adapter tests."""
+
+from typing import Any, cast
+
+import pytest
+from botocore.exceptions import ClientError
+
+from tracker.aws.clients import AWSClientProvider
+from tracker.aws.secrets import SecretsManagerStore
+from tracker.exceptions import SecretsError
+
+
+_ORIGINAL_GET = SecretsManagerStore.get
+
+
+@pytest.fixture(autouse=True)
+def use_real_secret_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(SecretsManagerStore, "get", _ORIGINAL_GET)
+
+
+class FakeSecretsManagerClient:
+    def __init__(self, response: dict[str, Any] | None = None, error: ClientError | None = None) -> None:
+        self.response = response or {}
+        self.error = error
+        self.secret_ids: list[str] = []
+
+    def get_secret_value(self, *, SecretId: str) -> dict[str, Any]:
+        self.secret_ids.append(SecretId)
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+class FakeClientProvider:
+    def __init__(self, client: FakeSecretsManagerClient) -> None:
+        self.client = client
+        self.calls = 0
+
+    def secretsmanager_client(self) -> FakeSecretsManagerClient:
+        self.calls += 1
+        return self.client
+
+
+@pytest.mark.parametrize(
+    ("secret_string", "expected"),
+    [
+        ('{"key": "value"}', {"key": "value"}),
+        ('["value", 1]', ["value", 1]),
+        ('"json-string"', "json-string"),
+        ("42", 42),
+        ("true", True),
+        ("null", None),
+        ("plain-text", "plain-text"),
+    ],
+)
+def test_get_preserves_json_and_raw_string_domains(secret_string: str, expected: object) -> None:
+    client = FakeSecretsManagerClient({"SecretString": secret_string})
+    provider = FakeClientProvider(client)
+
+    assert SecretsManagerStore(cast(AWSClientProvider, provider)).get("named-secret") == expected
+    assert client.secret_ids == ["named-secret"]
+    assert provider.calls == 1
+
+
+@pytest.mark.parametrize(
+    ("code", "message"),
+    [
+        ("ResourceNotFoundException", "Secret 'named-secret' does not exist in AWS Secrets Manager"),
+        ("AccessDeniedException", "Access denied when retrieving secret 'named-secret'"),
+        ("ThrottlingException", ""),
+    ],
+)
+def test_get_preserves_client_error_translation_and_cause(code: str, message: str) -> None:
+    provider_error = ClientError({"Error": {"Code": code, "Message": "provider failure"}}, "GetSecretValue")
+    client = FakeSecretsManagerClient(error=provider_error)
+
+    with pytest.raises(SecretsError) as captured:
+        SecretsManagerStore(cast(AWSClientProvider, FakeClientProvider(client))).get("named-secret")
+
+    expected = message or f"Failed to retrieve secret 'named-secret': {provider_error}"
+    assert str(captured.value) == f"Secret error: {expected}"
+    assert captured.value.__cause__ is provider_error
+
+
+def test_store_constructs_without_accessing_the_client() -> None:
+    provider = FakeClientProvider(FakeSecretsManagerClient({"SecretString": "value"}))
+
+    SecretsManagerStore(cast(AWSClientProvider, provider))
+
+    assert provider.calls == 0

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -174,16 +174,19 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _mock_upload_final_view(*_args: Any, **_kwargs: Any) -> None:
         return None
 
-    def _mock_fetch_aws_secret(*_args: Any, **_kwargs: Any) -> dict[str, str]:
-        return {"DAYTONA_API_KEY": "test-key", "DAYTONA_API_URL": "http://localhost:8001", "DAYTONA_TARGET": "us"}
-
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.write_benchmark_log_event", _mock_write_benchmark_log_event)
     monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.utils.task_execution.write_benchmark_log_event", _mock_write_benchmark_log_event)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", _mock_upload_final_view)
-    monkeypatch.setattr("tracker.aws.secrets.fetch_aws_secret", _mock_fetch_aws_secret)
-    monkeypatch.setattr("tracker.utils.resources.fetch_aws_secret", _mock_fetch_aws_secret)
+
+
+@pytest.fixture(autouse=True)
+def mock_secret_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    def get(_self: object, _name: str) -> dict[str, str]:
+        return {"DAYTONA_API_KEY": "test-key", "DAYTONA_API_URL": "http://localhost:8001", "DAYTONA_TARGET": "us"}
+
+    monkeypatch.setattr("tracker.aws.secrets.SecretsManagerStore.get", get)
 
 
 @pytest.fixture(autouse=True)

--- a/services/tracker/tests/unit/runtime/test_secrets.py
+++ b/services/tracker/tests/unit/runtime/test_secrets.py
@@ -1,0 +1,50 @@
+"""Provider-neutral secret-reference resolution tests."""
+
+from collections.abc import Mapping
+
+import pytest
+
+from tracker.exceptions import SecretsError
+from tracker.runtime.secrets import SecretValue, resolve_secrets
+
+
+class RecordingSecretStore:
+    def __init__(self, values: Mapping[str, SecretValue]) -> None:
+        self._values = values
+        self.calls: list[str] = []
+
+    def get(self, name: str) -> SecretValue:
+        self.calls.append(name)
+        return self._values[name]
+
+
+def test_resolve_secrets_skips_store_for_empty_mapping() -> None:
+    store = RecordingSecretStore({})
+
+    assert resolve_secrets({}, store) == {}
+    assert store.calls == []
+
+
+def test_resolve_secrets_requires_and_stringifies_object_members() -> None:
+    store = RecordingSecretStore({"shared": {"TOKEN": "value", "COUNT": 7, "EMPTY": None}})
+
+    assert resolve_secrets({"TOKEN": "shared", "COUNT": "shared", "EMPTY": "shared"}, store) == {
+        "TOKEN": "value",
+        "COUNT": "7",
+        "EMPTY": "None",
+    }
+    assert store.calls == ["shared", "shared", "shared"]
+
+
+def test_resolve_secrets_preserves_missing_object_key_error() -> None:
+    store = RecordingSecretStore({"shared": {"OTHER": "value"}})
+
+    with pytest.raises(SecretsError, match="Key 'TOKEN' not found"):
+        resolve_secrets({"TOKEN": "shared"}, store)
+
+
+@pytest.mark.parametrize("value", [["array"], 7, 3.5, True, None, "plain"])
+def test_resolve_secrets_stringifies_non_object_values(value: SecretValue) -> None:
+    store = RecordingSecretStore({"shared": value})
+
+    assert resolve_secrets({"TOKEN": "shared"}, store)["TOKEN"] == str(value)

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -332,13 +332,13 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         calls.append("logs")
         return "benchmark-log-group"
 
-    def fetch_provider(_name: str, clients: object, _provider: str) -> SandboxProviderConfig:
-        assert clients is aws_runtime.clients
+    def fetch_provider(_name: str, secret_store: object, _provider: str) -> SandboxProviderConfig:
+        assert secret_store is not aws_runtime.clients
         calls.append("provider-secret")
         return provider_config
 
-    def resolve_agent_secrets(_secrets: object, clients: object) -> dict[str, str]:
-        assert clients is aws_runtime.clients
+    def resolve_agent_secrets(_secrets: object, secret_store: object) -> dict[str, str]:
+        assert secret_store is not aws_runtime.clients
         calls.append("agent-secrets")
         return {"MODEL_API_KEY": "resolved"}
 
@@ -414,7 +414,7 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
         calls.append("agent_secrets")
         return {"AGENT_TOKEN": "resolved"}
 
-    def fetch_webhook_secret(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+    def get_webhook_secret(_store: object, _name: str) -> dict[str, str]:
         calls.append("webhook_secret")
         return {"url": "https://example.com"}
 
@@ -424,7 +424,7 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
-    monkeypatch.setattr("tracker.utils.run_orchestration.fetch_aws_secret", fetch_webhook_secret)
+    monkeypatch.setattr("tracker.aws.secrets.SecretsManagerStore.get", get_webhook_secret)
     monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", dry_run)
 
     result = _preflight_managed_aws(execution, aws_runtime)

--- a/services/tracker/tests/unit/test_notifications.py
+++ b/services/tracker/tests/unit/test_notifications.py
@@ -13,6 +13,8 @@ import pytest
 
 import tracker.notifications as notifications_module
 from tracker.aws.runtime import AWSRuntime
+from tracker.aws.secrets import SecretsManagerStore
+from tracker.runtime.secrets import SecretStore
 from tracker.database.models import BenchmarkStatus
 from tracker.exceptions import SecretsError
 from tracker.notifications import NotificationContext, SlackNotifier
@@ -40,11 +42,12 @@ def _make_notifier(
     *,
     secret_name: str = "test/webhook",
     intervals: tuple[int, ...] = (50,),
+    secret_store: SecretStore | None = None,
 ) -> SlackNotifier:
-    """Build a notifier with deterministic credentials and thresholds."""
+    """Build a notifier with deterministic provider authority and thresholds."""
     return SlackNotifier(
         secret_name=secret_name,
-        clients=aws_runtime.clients,
+        secret_store=secret_store or SecretsManagerStore(aws_runtime.clients),
         intervals=list(intervals),
     )
 
@@ -70,7 +73,7 @@ def mock_http_client(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
     client = AsyncMock()
     client.__aenter__.return_value = client
     client.__aexit__.return_value = False
-    monkeypatch.setattr(notifications_module.httpx, "AsyncClient", MagicMock(return_value=client))
+    monkeypatch.setattr(httpx, "AsyncClient", MagicMock(return_value=client))
 
     return client
 
@@ -216,12 +219,10 @@ class TestSlackNotifierFireAndForget:
         - A connection failure is caught after the threshold is crossed.
         """
 
-        def fetch_secret(_secret_name: str, _clients: object) -> str:
-            return "https://hooks.slack.com/test"
-
-        notifier = _make_notifier(aws_runtime)
+        secret_store = MagicMock()
+        secret_store.get.return_value = "https://hooks.slack.com/test"
+        notifier = _make_notifier(aws_runtime, secret_store=secret_store)
         mock_http_client.post = AsyncMock(side_effect=webhook_error)
-        monkeypatch.setattr(notifications_module, "fetch_aws_secret", fetch_secret)
 
         await notifier.check_and_notify(_make_context(finished_tasks=50))
 
@@ -235,15 +236,15 @@ class TestSlackNotifierSecretResolution:
         monkeypatch: pytest.MonkeyPatch,
         mock_http_client: AsyncMock,
     ) -> None:
-        """SlackNotifier calls fetch_aws_secret to resolve the webhook URL."""
-        notifier = _make_notifier(aws_runtime, secret_name="my/webhook/secret")
-        mock_fetch = MagicMock(return_value="https://hooks.slack.com/resolved")
+        """SlackNotifier resolves the webhook URL through its secret store."""
+        secret_store = MagicMock()
+        secret_store.get.return_value = "https://hooks.slack.com/resolved"
+        notifier = _make_notifier(aws_runtime, secret_name="my/webhook/secret", secret_store=secret_store)
         mock_http_client.post = AsyncMock(return_value=MagicMock(status_code=200))
-        monkeypatch.setattr(notifications_module, "fetch_aws_secret", mock_fetch)
 
         await notifier.check_and_notify(_make_context(finished_tasks=50))
 
-        mock_fetch.assert_called_once_with("my/webhook/secret", aws_runtime.clients)
+        secret_store.get.assert_called_once_with("my/webhook/secret")
         mock_http_client.post.assert_called_once()
         call_args = mock_http_client.post.call_args
         assert call_args[0][0] == "https://hooks.slack.com/resolved"
@@ -266,13 +267,13 @@ class TestSlackNotifierSecretResolution:
         - Secret retrieval raises an expected service error.
         - Secret retrieval returns structured data instead of a URL string.
         """
-        notifier = _make_notifier(aws_runtime, secret_name="invalid/secret")
-        fetch_secret = (
+        secret_store = MagicMock()
+        secret_store.get = (
             MagicMock(side_effect=secret_result)
             if isinstance(secret_result, Exception)
             else MagicMock(return_value=secret_result)
         )
-        monkeypatch.setattr(notifications_module, "fetch_aws_secret", fetch_secret)
+        notifier = _make_notifier(aws_runtime, secret_name="invalid/secret", secret_store=secret_store)
 
         await notifier.check_and_notify(_make_context(finished_tasks=50))
 

--- a/services/tracker/tests/unit/test_sandbox_cleanup.py
+++ b/services/tracker/tests/unit/test_sandbox_cleanup.py
@@ -245,6 +245,7 @@ def test_lambda_handler_fails_for_each_unsuccessful_outcome(monkeypatch: pytest.
 
     monkeypatch.setenv("SANDBOX_CLEANUP_SECRET_NAME", "cleanup-secret")
     monkeypatch.setenv("SANDBOX_CLEANUP_PROVIDER", "daytona")
+    monkeypatch.setattr(cleanup_module, "AWS_DEPLOYMENT_REGION", "us-east-1")
     monkeypatch.setattr(cleanup_module, "configure_logging", lambda: None)
     monkeypatch.setattr(cleanup_module, "fetch_sandbox_provider_config", fake_fetch_config)
     monkeypatch.setattr(cleanup_module, "run_cleanup", fake_run_cleanup)
@@ -254,10 +255,39 @@ def test_lambda_handler_fails_for_each_unsuccessful_outcome(monkeypatch: pytest.
             cleanup_module.lambda_handler({}, FakeLambdaContext(840_000))
 
 
+def test_load_provider_config_builds_the_cleanup_default_chain_store(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected_provider = object()
+    expected_store = object()
+    expected_config = cast(SandboxProviderConfig, object())
+
+    def build_default_chain_provider(region: str) -> object:
+        assert region == "us-west-2"
+        return expected_provider
+
+    def build_secret_store(provider: object) -> object:
+        assert provider is expected_provider
+        return expected_store
+
+    def fetch_provider_config(secret_name: str, secret_store: object, provider_type: str) -> SandboxProviderConfig:
+        assert secret_name == "cleanup-secret"
+        assert secret_store is expected_store
+        assert provider_type == "daytona"
+        return expected_config
+
+    monkeypatch.setattr(cleanup_module, "AWS_DEPLOYMENT_REGION", "us-west-2")
+    monkeypatch.setattr(cleanup_module, "DefaultChainAWSClientProvider", build_default_chain_provider)
+    monkeypatch.setattr(cleanup_module, "SecretsManagerStore", build_secret_store)
+    monkeypatch.setattr(cleanup_module, "fetch_sandbox_provider_config", fetch_provider_config)
+
+    load_provider_config = getattr(cleanup_module, "_load_provider_config")
+    assert load_provider_config("cleanup-secret", "daytona") is expected_config
+
+
 def test_lambda_handler_preserves_shutdown_margin_around_config_loading(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(cleanup_module, "configure_logging", lambda: None)
     monkeypatch.setenv("SANDBOX_CLEANUP_SECRET_NAME", "cleanup-secret")
     monkeypatch.setenv("SANDBOX_CLEANUP_PROVIDER", "daytona")
+    monkeypatch.setattr(cleanup_module, "AWS_DEPLOYMENT_REGION", "us-east-1")
     load_calls = 0
 
     def fake_fetch_config(*_args: object, **_kwargs: object) -> SandboxProviderConfig:

--- a/services/tracker/tests/unit/utils/task_execution_support.py
+++ b/services/tracker/tests/unit/utils/task_execution_support.py
@@ -12,6 +12,7 @@ from sqlmodel import Session
 from tests.utils import TEST_ORG_ID
 from tracker.auth import RequestIdentity
 from tracker.aws.runtime import AWSRuntime
+from tracker.aws.secrets import SecretsManagerStore
 from tracker.database.models import (
     AgentContractRequest,
     BenchmarkStatus,
@@ -135,6 +136,9 @@ async def run_process_task(
     Returns
     - The task result mapping returned by process_task.
     """
+    harness_config = start_benchmark_request.harness_config
+    assert harness_config is not None
+
     return await process_task(
         task_row=task_row,
         start_benchmark_request=start_benchmark_request,
@@ -144,8 +148,8 @@ async def run_process_task(
         aws_runtime=aws_runtime,
         org=TEST_ORG,
         sandbox_provider_config=fetch_sandbox_provider_config(
-            start_benchmark_request.harness_config.sandbox_provider_secret_name,
-            aws_runtime.clients,
+            harness_config.sandbox_provider_secret_name,
+            SecretsManagerStore(aws_runtime.clients),
             start_benchmark_request.sandbox_provider,
         ),
         creation_semaphore=Semaphore(1),

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -4,7 +4,7 @@ Run: uv run pytest tests/unit/utils/test_run_state.py
 """
 
 from datetime import datetime
-from typing import Any, Sequence
+from typing import Any, Sequence, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
@@ -23,7 +23,7 @@ from main import app
 from tests.factories import make_benchmark
 from tests.utils import TEST_ORG_ID
 from tracker.auth import RequestIdentity
-from tracker.aws.runtime import AWSRuntime
+from tracker.runtime.secrets import SecretValue
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -86,7 +86,7 @@ class TestRunState:
     _test_starter = RequestIdentity(org=_test_org, access_key_id=None, email=None, name=None)
 
     def test_fetch_sandbox_provider_config_combines_provider_type_with_secret(
-        self, harness_config: HarnessConfig, monkeypatch: pytest.MonkeyPatch
+        self, harness_config: HarnessConfig
     ) -> None:
         """Sandbox provider config should combine client-selected type with the production secret shape.
 
@@ -101,16 +101,11 @@ class TestRunState:
             },
         }
 
-        def fetch_secret(name: str, _client_provider: object) -> dict[str, str]:
-            return secrets[name]
+        class TestSecretStore:
+            def get(self, name: str) -> SecretValue:
+                return cast(SecretValue, secrets[name])
 
-        monkeypatch.setattr("tracker.utils.resources.fetch_aws_secret", fetch_secret)
-
-        provider_config = fetch_sandbox_provider_config(
-            "provider-secret",
-            AWSRuntime.from_harness_config(harness_config).clients,
-            "daytona",
-        )
+        provider_config = fetch_sandbox_provider_config("provider-secret", TestSecretStore(), "daytona")
         assert provider_config.model_dump(mode="json") == {
             "type": "daytona",
             "DAYTONA_API_KEY": "key",


### PR DESCRIPTION
## Purpose

Make secret resolution replaceable while preserving Tracker's existing explicit-key, managed-IAM, and maintenance-cleanup authority rules. This PR builds on #656's storage boundary.

## What changes

- Introduces AWS-free `SecretStore` and secret-reference resolution contracts.
- Makes `SecretsManagerStore` a thin adapter over the already-selected `AWSClientProvider`.
- Routes request, worker, orchestration, notification, stop, and maintenance-cleanup paths through resolved runtime authority.
- Keeps the default-chain decision visible at the maintenance-cleanup composition root rather than hiding it behind a domain interface.

## Behavior preserved

- Explicit caller-provided credentials remain authoritative where they were before.
- Managed-IAM/runtime credential selection remains authoritative where it was before.
- Existing secret-reference names, Secrets Manager lookup behavior, and failure behavior remain unchanged.
- Notifications, stop/cleanup work, and orchestration retain their existing authorization flow.

## Deliberate non-goals

- No credential values or AWS client types are exposed through domain contracts.
- No generic provider registry, selector, factory, or capability bundle is added.
- No new secret backend is shipped; the seam enables a future local backend without making one a runtime requirement.

## Review guide

1. Read the runtime secret contract and `SecretsManagerStore` adapter.
2. Trace each authority decision from request or worker composition to the secret lookup.
3. Confirm maintenance cleanup is the only default-chain composition point.
4. Review tests for explicit credentials, managed runtime authority, notification, and cleanup paths.

## Stack and merge order

1. #656 Storage (`dev` ← `ok/runtime-storage`)
2. **#657 Secrets** (`ok/runtime-storage` ← `ok/runtime-secrets`)
3. #658 Logging (`ok/runtime-secrets` ← `ok/runtime-logs`)
4. #659 Executor artifacts (`ok/runtime-logs` ← `ok/executor-artifacts`)

Merge only after #656 merges; then continue in stack order.

## Validation

- 690 Tracker unit tests passed (one existing Starlette/httpx warning).
- 45 executor-host and end-to-end telemetry tests passed.
- Basedpyright, Ruff, formatting, diff checks, targeted LSP, and independent review passed.
- The final stack's Codecov-sensitive storage and logging changes have local executable diff-coverage estimates above their required patch targets.

## Live validation scope

- The stack ran `uv run pytest tests/integration/live/api/test_s3_routes.py` against `ValkDevSharedStack`: **2 passed** (one existing Starlette/httpx warning).
- That probe is direct evidence for the storage route inherited from #656; it is not a live Secrets Manager retrieval test.
- Secrets Manager retrieval, sandbox orchestration, CloudWatch writes, and sealed executor-release activation remain covered by the green CI and unit contracts.
