### PR TITLE
refactor(logging): abstract run log access

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -38,7 +38,7 @@ from tracker.auth import (
     get_current_starter,
     resolve_descope_identity,
 )
-from tracker.aws.cloudwatch_logs import get_benchmark_log_url
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogLocations
 from tracker.aws.resolver import (
     resolve_aws_runtime_metadata,
     resolve_run_aws_runtime,
@@ -644,7 +644,7 @@ async def start_benchmark(
         concurrency=request.concurrency,
         started_at=benchmark_row.started_at,
         task_count=len(verify_response.task_ids),
-        cloudwatch_url=get_benchmark_log_url(str(benchmark_row.id), aws_runtime.resources),
+        cloudwatch_url=CloudWatchBenchmarkLogLocations(aws_runtime.resources).benchmark_location(str(benchmark_row.id)),
         s3_bucket_url=create_benchmark_url(str(benchmark_row.id), aws_runtime.resources),
         executor_release_id=benchmark_row.executor_release_id,
         current_execution_release_id=benchmark_row.current_execution_release_id,

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, col, desc, func, select
 from tracker.api.parsing import parse_csv
 from tracker.api.dependencies import TrackedBenchmarkId
 from tracker.auth import get_current_org
-from tracker.aws.cloudwatch_logs import get_benchmark_log_url
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogLocations
 from tracker.aws.resolver import resolve_run_metadata_aws_runtime
 from tracker.aws.s3 import create_benchmark_url
 from tracker.database.models import Benchmark, ErrorResult, Org, Task, TaskStatus
@@ -72,10 +72,7 @@ def get_single_benchmark(
         aws_resources = aws_runtime.resources
         s3_bucket_url = create_benchmark_url(str(benchmark.id), aws_resources)
         if aws_resources.log_group:
-            cloudwatch_url = get_benchmark_log_url(
-                benchmark_id=str(benchmark.id),
-                resources=aws_resources,
-            )
+            cloudwatch_url = CloudWatchBenchmarkLogLocations(aws_resources).benchmark_location(str(benchmark.id))
 
     return SingleBenchmarkResponse(
         id=benchmark.id,

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -10,7 +10,7 @@ from sqlmodel import Session, col, desc, select
 
 from tracker.api.dependencies import RunAWSDependency, TrackedBenchmarkId
 from tracker.auth import get_current_org
-from tracker.aws.cloudwatch_logs import get_benchmark_log_url
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogLocations
 from tracker.aws.s3 import S3_BENCHMARKS_PREFIX, create_presigned_url, s3_object_exists
 from tracker.database.models import (
     Benchmark,
@@ -127,10 +127,9 @@ async def get_task_artifacts(
     cloudwatch_url: str | None = None
     if aws_runtime.resources.log_group and aws_runtime.resources.region:
         log_stream_suffix = f"{int(task.started_at.timestamp() * 1_000_000):x}"
-        cloudwatch_url = get_benchmark_log_url(
-            benchmark_id=str(benchmark_id),
-            resources=aws_runtime.resources,
-            task_id=f"{task.task_id}_{log_stream_suffix}",
+        cloudwatch_url = CloudWatchBenchmarkLogLocations(aws_runtime.resources).task_location(
+            str(benchmark_id),
+            f"{task.task_id}_{log_stream_suffix}",
         )
 
     agent_output_url: str | None = None

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -8,8 +8,10 @@ from urllib.parse import quote
 import logfire
 from botocore.exceptions import BotoCoreError, ClientError
 
-from tracker.aws.runtime import AWSResources, AWSRuntime
+from tracker.aws.clients import AWSClientProvider
+from tracker.aws.runtime import AWSResources
 from tracker.exceptions import CloudWatchError
+from tracker.runtime.logs import BenchmarkLogLocations, BenchmarkLogSink
 
 _created_streams: set[str] = set()
 _P = ParamSpec("_P")
@@ -34,106 +36,88 @@ def handle_cloudwatch_error(message: str) -> Callable[[Callable[_P, _R]], Callab
         def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
             try:
                 return func(*args, **kwargs)
-            except (ClientError, BotoCoreError) as e:
-                raise CloudWatchError(f"{message}: {e}") from e
+            except (ClientError, BotoCoreError) as error:
+                raise CloudWatchError(f"{message}: {error}") from error
 
         return wrapper
 
     return decorator
 
 
-def get_benchmark_log_url(benchmark_id: str, resources: AWSResources, task_id: str | None = None) -> str:
-    """
-    Get the CloudWatch console URL for a benchmark or specific task.
+class CloudWatchBenchmarkLogLocations(BenchmarkLogLocations):
+    """CloudWatch console locations for resolved AWS resources."""
 
-    Args:
-        benchmark_id: The benchmark identifier
-        resources: AWS resource locations
-        task_id: Optional task identifier for task-specific logs
+    def __init__(self, resources: AWSResources) -> None:
+        self._resources = resources
 
-    Returns:
-        CloudWatch console URL
-    """
-    safe_region = quote(resources.region, safe="-")
-    safe_log_group = quote(resources.log_group, safe="-_")
-    safe_benchmark_id = quote(benchmark_id, safe="-_")
-    base = f"https://{safe_region}.console.aws.amazon.com/cloudwatch/home?region={safe_region}"
-    encoded_log_group = f"{safe_log_group}$252F{safe_benchmark_id}"
-    if task_id:
-        safe_task_id = quote(_sanitize_log_stream_name(task_id), safe="-_.")
-        return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{safe_task_id}"
+    def benchmark_location(self, benchmark_id: str) -> str:
+        return self._location(benchmark_id)
 
-    return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}"
+    def task_location(self, benchmark_id: str, task_stream_id: str) -> str:
+        return self._location(benchmark_id, task_stream_id)
 
-
-@handle_cloudwatch_error(message="Failed to create log group")
-@logfire.instrument("create_log_group", extract_args=("benchmark_id",))
-def create_benchmark_log_group(benchmark_id: str, runtime: AWSRuntime) -> str:
-    """
-    Create a log group for a benchmark.
-
-    Args:
-        benchmark_id: The benchmark identifier
-        runtime: AWS resources and clients for the operation
-
-    Returns:
-        The log group name
-    """
-    client = runtime.clients.cloudwatch_logs_client()
-    log_group_name: str = f"{runtime.resources.log_group}/{benchmark_id}"
-
-    try:
-        client.create_log_group(logGroupName=log_group_name)  # pyright: ignore[reportUnknownMemberType]
-        client.put_retention_policy(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group_name,
-            retentionInDays=runtime.resources.log_retention_days,
-        )
-    except ClientError as e:
-        if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
-            raise
-
-    return log_group_name
+    def _location(self, benchmark_id: str, task_stream_id: str | None = None) -> str:
+        safe_region = quote(self._resources.region, safe="-")
+        safe_log_group = quote(self._resources.log_group, safe="-_")
+        safe_benchmark_id = quote(benchmark_id, safe="-_")
+        base = f"https://{safe_region}.console.aws.amazon.com/cloudwatch/home?region={safe_region}"
+        encoded_log_group = f"{safe_log_group}$252F{safe_benchmark_id}"
+        if task_stream_id:
+            safe_task_id = quote(_sanitize_log_stream_name(task_stream_id), safe="-_.")
+            return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{safe_task_id}"
+        return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}"
 
 
-@handle_cloudwatch_error(message="Failed to create cloudwatch stream")
-def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime) -> None:
-    """
-    Stream a log message to CloudWatch.
+class CloudWatchBenchmarkLogSink(BenchmarkLogSink):
+    """CloudWatch transport using already-resolved AWS authority."""
 
-    Creates the log stream if it doesn't exist.
+    def __init__(self, clients: AWSClientProvider, log_group: str) -> None:
+        self._clients = clients
+        self._log_group = log_group
 
-    Args:
-        stream_key: The stream key (benchmark_id:task_id)
-        message: The log message
-        runtime: AWS resources and clients for the operation
-    """
-    if not message.strip():
-        return
-
-    benchmark_id, task_id = stream_key.split(":", 1)
-
-    if not benchmark_id or not task_id:
-        raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
-
-    client = runtime.clients.cloudwatch_logs_client()
-    log_group_name = f"{runtime.resources.log_group}/{benchmark_id}"
-    stream_name = _sanitize_log_stream_name(task_id)
-
-    if stream_key not in _created_streams:
+    @handle_cloudwatch_error(message="Failed to create log group")
+    @logfire.instrument("create_log_group", extract_args=("benchmark_id",))
+    def create_benchmark(self, benchmark_id: str, *, retention_days: int) -> None:
+        client = self._clients.cloudwatch_logs_client()
+        log_group_name = f"{self._log_group}/{benchmark_id}"
         try:
-            client.create_log_stream(logGroupName=log_group_name, logStreamName=stream_name)  # pyright: ignore[reportUnknownMemberType]
-        except ClientError as e:
-            if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
+            client.create_log_group(logGroupName=log_group_name)  # pyright: ignore[reportUnknownMemberType]
+            client.put_retention_policy(  # pyright: ignore[reportUnknownMemberType]
+                logGroupName=log_group_name,
+                retentionInDays=retention_days,
+            )
+        except ClientError as error:
+            if error.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
                 raise
-        except BotoCoreError as e:
-            raise CloudWatchError(f"Failed to create log stream '{stream_name}': {e}") from e
-        _created_streams.add(stream_key)
 
-    try:
-        client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group_name,
-            logStreamName=stream_name,
-            logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
-        )
-    except (ClientError, BotoCoreError) as e:
-        raise CloudWatchError(f"Failed to put log event: {e}") from e
+    @handle_cloudwatch_error(message="Failed to create cloudwatch stream")
+    def write(self, stream_key: str, message: str) -> None:
+        if not message.strip():
+            return
+
+        benchmark_id, task_id = stream_key.split(":", 1)
+        if not benchmark_id or not task_id:
+            raise CloudWatchError(f"Invalid stream key '{stream_key}', expected format 'benchmark_id:task_id'")
+
+        client = self._clients.cloudwatch_logs_client()
+        log_group_name = f"{self._log_group}/{benchmark_id}"
+        stream_name = _sanitize_log_stream_name(task_id)
+
+        if stream_key not in _created_streams:
+            try:
+                client.create_log_stream(logGroupName=log_group_name, logStreamName=stream_name)  # pyright: ignore[reportUnknownMemberType]
+            except ClientError as error:
+                if error.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
+                    raise
+            except BotoCoreError as error:
+                raise CloudWatchError(f"Failed to create log stream '{stream_name}': {error}") from error
+            _created_streams.add(stream_key)
+
+        try:
+            client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
+                logGroupName=log_group_name,
+                logStreamName=stream_name,
+                logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
+            )
+        except (ClientError, BotoCoreError) as error:
+            raise CloudWatchError(f"Failed to put log event: {error}") from error

--- a/services/tracker/src/tracker/runtime/logs.py
+++ b/services/tracker/src/tracker/runtime/logs.py
@@ -1,0 +1,25 @@
+"""Provider-neutral benchmark log capabilities."""
+
+from typing import Protocol
+
+
+class BenchmarkLogSink(Protocol):
+    """Create benchmark log destinations and write task log messages."""
+
+    def create_benchmark(self, benchmark_id: str, *, retention_days: int) -> None:
+        """Ensure a benchmark log destination exists."""
+        raise NotImplementedError
+
+    def write(self, stream_key: str, message: str) -> None:
+        """Write one message to the task stream identified by ``stream_key``."""
+        raise NotImplementedError
+
+
+class BenchmarkLogLocations(Protocol):
+    """Provider-native locations for benchmark and task logs."""
+
+    def benchmark_location(self, benchmark_id: str) -> str:
+        raise NotImplementedError
+
+    def task_location(self, benchmark_id: str, task_stream_id: str) -> str:
+        raise NotImplementedError

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -17,7 +17,7 @@ from pydantic import ValidationError
 from sqlmodel import Session, col, desc, func, select
 
 from tracker._lambda import dry_run_lambda, invoke_lambda
-from tracker.aws.cloudwatch_logs import create_benchmark_log_group
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogSink
 from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import SecretsManagerStore
@@ -396,7 +396,10 @@ def _preflight_managed_aws(
     runtime: AWSRuntime,
 ) -> SandboxProviderConfig:
     """Verify executor-owned AWS access before starting sandbox work."""
-    create_benchmark_log_group(str(execution.benchmark_id), runtime)
+    CloudWatchBenchmarkLogSink(runtime.clients, runtime.resources.log_group).create_benchmark(
+        str(execution.benchmark_id),
+        retention_days=runtime.resources.log_retention_days,
+    )
     request = execution.request
     provider_secret_name = request.sandbox_provider_secret_name
     if provider_secret_name is None:
@@ -514,7 +517,10 @@ async def process_benchmark(
             )
 
         if not execution.aws_managed:
-            create_benchmark_log_group(str(benchmark_id), aws_runtime)
+            CloudWatchBenchmarkLogSink(aws_runtime.clients, aws_runtime.resources.log_group).create_benchmark(
+                str(benchmark_id),
+                retention_days=aws_runtime.resources.log_retention_days,
+            )
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -28,10 +28,11 @@ from pydantic import ValidationError
 from sqlmodel import Session, col, select, update
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
-from tracker.aws.cloudwatch_logs import get_benchmark_log_url, write_benchmark_log_event
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogLocations, CloudWatchBenchmarkLogSink
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.s3 import S3ObjectStore
 from tracker.runtime.artifacts import task_artifact_key
+from tracker.runtime.logs import BenchmarkLogSink
 from tracker.aws.secrets import SecretsManagerStore
 from tracker.runtime.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
@@ -413,7 +414,7 @@ def handle_early_exit(task_row: Task, task_session: Session, authority: Executio
 def buffer_logs(
     log_queue: asyncio.Queue[str],
     stream_key: str,
-    aws_runtime: AWSRuntime,
+    log_sink: BenchmarkLogSink,
     force_flush: bool = False,
 ) -> None:
     """
@@ -428,7 +429,7 @@ def buffer_logs(
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+    loop.run_in_executor(None, log_sink.write, stream_key, message)
 
 
 def save_eval_resume_state(
@@ -643,6 +644,7 @@ async def _process_task_attempt(
     stream_suffix = f"{int(task_row.started_at.timestamp() * 1_000_000):x}"
     task_stream_name = f"{task_id}_{stream_suffix}"
     stream_key: str = f"{benchmark_id}:{task_stream_name}"
+    log_sink = CloudWatchBenchmarkLogSink(aws_runtime.clients, aws_runtime.resources.log_group)
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
 
     logger.info(
@@ -650,9 +652,8 @@ async def _process_task_attempt(
         extra={
             "benchmark_id": str(benchmark_id),
             "task_id": task_id,
-            "cloudwatch_log_url": get_benchmark_log_url(
+            "cloudwatch_log_url": CloudWatchBenchmarkLogLocations(aws_runtime.resources).task_location(
                 str(benchmark_id),
-                aws_runtime.resources,
                 task_stream_name,
             ),
         },
@@ -665,7 +666,7 @@ async def _process_task_attempt(
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        buffer_logs(log_queue, stream_key, aws_runtime)
+        buffer_logs(log_queue, stream_key, log_sink)
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -673,7 +674,7 @@ async def _process_task_attempt(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                buffer_logs(log_queue, stream_key, log_sink, force_flush=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
@@ -1005,7 +1006,7 @@ async def _process_task_attempt(
                 recovery_attempt.mark_replacement_ready()
 
                 # Force flush the logs if anything has been buffered
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                buffer_logs(log_queue, stream_key, log_sink, force_flush=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -1088,7 +1089,7 @@ async def _process_task_attempt(
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                buffer_logs(log_queue, stream_key, log_sink, force_flush=True)
 
                 # Save the evaluation result to the database with the task row
                 # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
@@ -1277,7 +1278,7 @@ async def _process_task_attempt(
         flush_task.cancel()
         with suppress(asyncio.CancelledError):
             await flush_task
-        buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+        buffer_logs(log_queue, stream_key, log_sink, force_flush=True)
 
 
 def commit_task_error(

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -21,6 +21,7 @@ from sqlmodel import Session, select
 
 import tracker.utils.run_control as run_control_module
 import tracker.utils.run_orchestration as run_orchestration_module
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogSink
 from tests.factories import make_benchmark, make_task
 from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import (
@@ -308,7 +309,7 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[scored_task.task_id], final_score=0.25, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
+        monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_retry_task)
@@ -421,7 +422,7 @@ class TestRunFinalization:
             await both_monitors_arrived.wait()
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
+        monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(TaskMonitor, "track_tasks", synchronized_track_tasks)
@@ -550,7 +551,7 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[task.task_id], final_score=1.0, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
+        monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", assert_upload_lock_held)
         monkeypatch.setattr(run_orchestration_module, "invoke_lambda", assert_lambda_lock_held)
@@ -650,7 +651,7 @@ class TestRunFinalization:
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
 
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
+        monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
 
         for benchmark, expected_summary in benchmarks:

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -16,6 +16,7 @@ from sqlmodel import Session
 
 import tracker.api.single_task as single_task_module
 from main import app
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogLocations
 from tests.factories import make_error_result, make_evaluation_result, make_task
 from tracker.database.models import (
     AgentCausedExitReason,
@@ -137,7 +138,7 @@ def test_task_artifacts_only_presign_existing_output(
     get_log_url = Mock(return_value="https://example.test/cloudwatch")
     monkeypatch.setattr(single_task_module, "s3_object_exists", object_exists)
     monkeypatch.setattr(single_task_module, "create_presigned_url", create_presigned_url)
-    monkeypatch.setattr(single_task_module, "get_benchmark_log_url", get_log_url)
+    monkeypatch.setattr(CloudWatchBenchmarkLogLocations, "task_location", get_log_url)
 
     found_response = _client.get(
         f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/artifacts",

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -18,11 +18,11 @@ from tracker.aws.clients import (
     ExplicitCredentialsAWSClientProvider,
 )
 from tracker.aws.cloudwatch_logs import (
-    get_benchmark_log_url,
+    CloudWatchBenchmarkLogLocations,
+    CloudWatchBenchmarkLogSink,
     handle_cloudwatch_error,
-    write_benchmark_log_event,
 )
-from tracker.aws.runtime import AWSResources, AWSRuntime
+from tracker.aws.runtime import AWSResources
 from tracker.aws.s3 import handle_s3_error
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.types import AWSCredentials
@@ -239,34 +239,41 @@ class TestGetBenchmarkLogUrl:
     """CloudWatch benchmark log URL construction."""
 
     def test_sanitizes_task_id_in_url(self) -> None:
-        url = get_benchmark_log_url("bench123", _AWS_RESOURCES, task_id="provider/model:fast")
+        url = CloudWatchBenchmarkLogLocations(_AWS_RESOURCES).task_location("bench123", "provider/model:fast")
+        # task id is sanitized before being URL-quoted into the log-events path.
         assert "provider%2Fmodel_fast" in url
         assert "model:fast" not in url
 
     def test_no_task_id_omits_log_events(self) -> None:
-        url = get_benchmark_log_url("bench123", _AWS_RESOURCES)
+        url = CloudWatchBenchmarkLogLocations(_AWS_RESOURCES).benchmark_location("bench123")
         assert "log-events" not in url
 
 
 class TestWriteBenchmarkLogEvent:
     """CloudWatch stream creation and benchmark log writes."""
 
-    def _runtime_with_mock_client(self, monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, AWSRuntime]:
+    def _sink_with_mock_client(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> tuple[MagicMock, MagicMock, CloudWatchBenchmarkLogSink]:
         client = MagicMock()
         client_provider = MagicMock(spec=AWSClientProvider)
         client_provider.cloudwatch_logs_client.return_value = client
         monkeypatch.setattr(cloudwatch_logs, "_created_streams", set[str]())
-        runtime = AWSRuntime(
-            resources=_AWS_RESOURCES,
-            clients=cast(AWSClientProvider, client_provider),
+        return (
+            client,
+            client_provider,
+            CloudWatchBenchmarkLogSink(
+                cast(AWSClientProvider, client_provider),
+                _AWS_RESOURCES.log_group,
+            ),
         )
-        return client, runtime
 
     def test_creates_stream_and_puts_event_with_sanitized_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        client, runtime = self._runtime_with_mock_client(monkeypatch)
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
 
         # stream_key splits on the first ':' -> task_id keeps its own ':'
-        write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
+        sink.write("bench123:provider/model:fast", "hello")
 
         client.create_log_stream.assert_called_once_with(
             logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
@@ -277,11 +284,91 @@ class TestWriteBenchmarkLogEvent:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        client, runtime = self._runtime_with_mock_client(monkeypatch)
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
         client.create_log_stream.side_effect = BotoCoreError()
 
         with pytest.raises(CloudWatchError) as exc_info:
-            write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
+            sink.write("bench123:provider/model:fast", "hello")
 
         assert "provider/model_fast" in str(exc_info.value)
         client.put_log_events.assert_not_called()
+
+    def test_create_benchmark_configures_group_retention(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
+
+        sink.create_benchmark("bench123", retention_days=30)
+
+        client.create_log_group.assert_called_once_with(logGroupName="/valkyrie/worker/bench123")
+        client.put_retention_policy.assert_called_once_with(
+            logGroupName="/valkyrie/worker/bench123",
+            retentionInDays=30,
+        )
+
+    def test_create_benchmark_ignores_existing_group(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
+        client.create_log_group.side_effect = ClientError(
+            {"Error": {"Code": "ResourceAlreadyExistsException"}},
+            "CreateLogGroup",
+        )
+
+        sink.create_benchmark("bench123", retention_days=30)
+
+        client.put_retention_policy.assert_not_called()
+
+    def test_create_benchmark_translates_non_existing_group_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
+        client.create_log_group.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}},
+            "CreateLogGroup",
+        )
+
+        with pytest.raises(CloudWatchError, match="Failed to create log group"):
+            sink.create_benchmark("bench123", retention_days=30)
+
+    def test_blank_message_does_not_create_client_or_stream(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, client_provider, sink = self._sink_with_mock_client(monkeypatch)
+
+        sink.write("bench123:task", " \n\t")
+
+        client_provider.cloudwatch_logs_client.assert_not_called()
+        client.assert_not_called()
+
+    def test_invalid_stream_key_is_rejected_before_client_access(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, client_provider, sink = self._sink_with_mock_client(monkeypatch)
+
+        with pytest.raises(CloudWatchError, match="Invalid stream key"):
+            sink.write("bench123:", "message")
+
+        client_provider.cloudwatch_logs_client.assert_not_called()
+        client.assert_not_called()
+
+    def test_reuses_created_stream_and_tolerates_existing_aws_stream(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
+        client.create_log_stream.side_effect = ClientError(
+            {"Error": {"Code": "ResourceAlreadyExistsException"}},
+            "CreateLogStream",
+        )
+
+        sink.write("bench123:task", "first")
+        sink.write("bench123:task", "second")
+
+        client.create_log_stream.assert_called_once_with(
+            logGroupName="/valkyrie/worker/bench123",
+            logStreamName="task",
+        )
+        assert client.put_log_events.call_count == 2
+
+    def test_non_existing_stream_error_and_put_error_are_translated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, _, sink = self._sink_with_mock_client(monkeypatch)
+        client.create_log_stream.side_effect = ClientError(
+            {"Error": {"Code": "AccessDeniedException"}},
+            "CreateLogStream",
+        )
+
+        with pytest.raises(CloudWatchError, match="Failed to create cloudwatch stream"):
+            sink.write("bench123:task", "message")
+
+        client.create_log_stream.side_effect = None
+        client.put_log_events.side_effect = BotoCoreError()
+        with pytest.raises(CloudWatchError, match="Failed to put log event"):
+            sink.write("bench123:other-task", "message")

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -3,7 +3,8 @@
 import os
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager
-from typing import Any
+from types import ModuleType
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 
 from benchmark_service.client import BenchmarkServiceClient
@@ -164,20 +165,23 @@ def mock_benchmark_service(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.fixture(autouse=True)
-def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
-    def _mock_create_benchmark_log_group(*_args: Any, **_kwargs: Any) -> str:
-        return "mock-group"
+def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest) -> None:
+    if cast(ModuleType, request.module).__name__ == "tests.unit.aws.test_clients":
+        return
 
-    def _mock_write_benchmark_log_event(*_args: Any, **_kwargs: Any) -> None:
+    def _mock_create_benchmark(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    def _mock_write(*_args: Any, **_kwargs: Any) -> None:
         return None
 
     async def _mock_upload_final_view(*_args: Any, **_kwargs: Any) -> None:
         return None
 
-    monkeypatch.setattr("tracker.aws.cloudwatch_logs.create_benchmark_log_group", _mock_create_benchmark_log_group)
-    monkeypatch.setattr("tracker.aws.cloudwatch_logs.write_benchmark_log_event", _mock_write_benchmark_log_event)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", _mock_create_benchmark_log_group)
-    monkeypatch.setattr("tracker.utils.task_execution.write_benchmark_log_event", _mock_write_benchmark_log_event)
+    monkeypatch.setattr(
+        "tracker.aws.cloudwatch_logs.CloudWatchBenchmarkLogSink.create_benchmark", _mock_create_benchmark
+    )
+    monkeypatch.setattr("tracker.aws.cloudwatch_logs.CloudWatchBenchmarkLogSink.write", _mock_write)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", _mock_upload_final_view)
 
 

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -13,6 +13,7 @@ from sqlmodel import Session
 
 from tests.conftest import TEST_ORG_ID
 from tracker.auth import RequestIdentity
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogSink
 from tracker.aws.resolver import ManagedAWSEligibilityError
 from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org
@@ -327,10 +328,9 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
 
-    def create_log_group(_benchmark_id: str, runtime: AWSRuntime) -> str:
-        assert runtime is aws_runtime
+    def create_log_group(_self: object, _benchmark_id: str, *, retention_days: int) -> None:
+        assert retention_days == aws_runtime.resources.log_retention_days
         calls.append("logs")
-        return "benchmark-log-group"
 
     def fetch_provider(_name: str, secret_store: object, _provider: str) -> SandboxProviderConfig:
         assert secret_store is not aws_runtime.clients
@@ -360,7 +360,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         return MagicMock()
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
+    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", resolve_agent_secrets)
@@ -421,7 +421,7 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     def dry_run(*_args: Any, **_kwargs: Any) -> None:
         calls.append("lambda")
 
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
+    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.aws.secrets.SecretsManagerStore.get", get_webhook_secret)
@@ -452,7 +452,7 @@ async def test_managed_preflight_failure_happens_before_sandbox(
         raise RuntimeError("managed log preflight failed")
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", fail_log_preflight)
+    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", fail_log_preflight)
     monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
 
     await process_benchmark(

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -26,6 +26,7 @@ from websockets.http11 import Response
 
 import tracker.sandbox as sandbox_module
 import tracker.utils.run_orchestration as run_orchestration_module
+from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogSink
 import tracker.utils.task_execution as utils_module
 from tests.unit.utils.task_execution_support import TEST_ORG, create_task_environment, run_process_task
 from tracker.aws.runtime import AWSRuntime
@@ -622,7 +623,7 @@ class TestBenchmarkServiceFailures:
                 return ExecResult(exit_code=1, output="")
             raise AssertionError(f"unexpected command: {command}")
 
-        def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
+        def _mock_write_benchmark_log_event(_self: Any, _stream_key: str, message: str) -> None:
             logged_messages.append(message)
             if expected_log in message:
                 event_loop.call_soon_threadsafe(expected_log_written.set)
@@ -635,7 +636,7 @@ class TestBenchmarkServiceFailures:
             _mock_stream_command_output,
         )
         monkeypatch.setattr(sandbox_module, "_exec", _mock_exec)
-        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
+        monkeypatch.setattr(CloudWatchBenchmarkLogSink, "write", _mock_write_benchmark_log_event)
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
         # Log writes are dispatched to an executor and never awaited, so the flush carrying the
@@ -709,11 +710,11 @@ class TestBenchmarkServiceFailures:
         async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
             raise httpx.ConnectTimeout("")
 
-        def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
+        def _mock_write_benchmark_log_event(_self: Any, _stream_key: str, message: str) -> None:
             logged_messages.append(message)
 
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
-        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
+        monkeypatch.setattr(CloudWatchBenchmarkLogSink, "write", _mock_write_benchmark_log_event)
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 


### PR DESCRIPTION
## Purpose

Make benchmark log writes and console locations replaceable while preserving current CloudWatch behavior. This PR intentionally keeps Tracker write-oriented: it does not introduce a provider-neutral log-reading or streaming product surface.

## What changes

- Introduces AWS-free `BenchmarkLogSink` and `BenchmarkLogLocations` contracts.
- Keeps CloudWatch implementations bound to the selected runtime AWS client and configured log resources.
- Routes buffered task-log writes through the sink and routes API console URLs through the location provider.
- Preserves retry/resume stream identity by retaining the persisted `started_at` suffix in stream keys.

## Behavior preserved

- Buffered writes, whitespace filtering, stream-name sanitization, stream-creation caching, and CloudWatch error translation.
- First-colon parsing of benchmark/task stream keys.
- Existing CloudWatch console URL shape and API endpoint behavior.
- Retry/resume behavior: a task continues to use the same persisted log-stream identity.

## Deliberate non-goals

- No log read, pagination, tailing, streaming, or provider-selection API.
- No new CloudWatch client creation path outside the selected runtime authority.
- No change to task payloads, logging semantics, or user-facing console URL contracts.

## Review guide

1. Start with the runtime log sink/location contracts.
2. Inspect the CloudWatch adapter's group/stream creation, error handling, and stream-key handling.
3. Trace task execution writes and API console-location consumers.
4. Review focused tests for blank/invalid no-ops, provider acquisition, stream caching, and AWS error translation.

## Stack and merge order

1. #656 Storage (`dev` ← `ok/runtime-storage`)
2. #657 Secrets (`ok/runtime-storage` ← `ok/runtime-secrets`)
3. **#658 Logging** (`ok/runtime-secrets` ← `ok/runtime-logs`)
4. #659 Executor artifacts (`ok/runtime-logs` ← `ok/executor-artifacts`)

Merge only after #657 merges; then continue to #659.

## Validation

- 690 Tracker unit tests passed (one existing Starlette/httpx warning).
- 45 executor-host and end-to-end telemetry tests passed.
- Basedpyright, Ruff, formatting, diff checks, targeted LSP, and independent review passed.
- Focused CloudWatch adapter behavior reached 100% local coverage; local executable diff-coverage estimate: **94.25%** (above Codecov's #658 patch target).

## Live validation scope

- The stack ran `uv run pytest tests/integration/live/api/test_s3_routes.py` against `ValkDevSharedStack`: **2 passed** (one existing Starlette/httpx warning).
- That probe validates the inherited S3 route path and CloudWatch console-location response shape only; it does not write or read CloudWatch events.
- CloudWatch writes, Secrets Manager retrieval, sandbox orchestration, and sealed executor-release activation remain covered by the green CI and unit contracts.
