### PR TITLE
refactor(executor): abstract artifact distribution

### DIFF
--- a/services/tracker/src/tracker/aws/executor_artifacts.py
+++ b/services/tracker/src/tracker/aws/executor_artifacts.py
@@ -1,0 +1,22 @@
+"""S3 adapter for immutable executor release artifacts."""
+
+from collections.abc import Mapping
+from contextlib import AbstractContextManager, closing
+from typing import BinaryIO, Protocol, cast
+
+
+class S3ExecutorArtifactClient(Protocol):
+    """The S3 operation needed to retrieve a sealed executor artifact."""
+
+    def get_object(self, *, Bucket: str, Key: str) -> Mapping[str, object]: ...
+
+
+class S3ExecutorArtifactReader:
+    """Read an artifact through an already-selected S3 client."""
+
+    def __init__(self, client: S3ExecutorArtifactClient) -> None:
+        self._client = client
+
+    def open(self, bucket: str, key: str) -> AbstractContextManager[BinaryIO]:
+        response = self._client.get_object(Bucket=bucket, Key=key)
+        return closing(cast(BinaryIO, response["Body"]))

--- a/services/tracker/src/tracker/executor/release_control.py
+++ b/services/tracker/src/tracker/executor/release_control.py
@@ -2,14 +2,11 @@
 
 import hashlib
 import logging
-from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, Protocol, cast
 from urllib.parse import urlparse
 from uuid import UUID
 
-import boto3
 from sqlmodel import Session, col, select
 
 from tracker.database.models import (
@@ -27,6 +24,7 @@ from executor_protocol import (
     validate_executor_artifact_uri,
     validate_executor_digest,
 )
+from tracker.runtime.executor_artifacts import ExecutorArtifactReader
 
 _ACTIVE_BENCHMARK_STATUSES = (BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.STOPPING)
 _ACTIVE_DISPATCH_STATUSES = (
@@ -51,16 +49,6 @@ class ActiveExecutorReleaseWork:
             + len(self.executions_by_release.get(release_id, []))
             for release_id in release_ids
         }
-
-
-class S3Body(Protocol):
-    def read(self, size: int = -1) -> bytes: ...
-
-    def close(self) -> None: ...
-
-
-class S3Client(Protocol):
-    def get_object(self, *, Bucket: str, Key: str) -> Mapping[str, object]: ...
 
 
 class ReleaseControlError(ValueError):
@@ -94,7 +82,7 @@ def activate_release(
     *,
     expected_bucket: str,
     expected_prefix: str,
-    s3_client: S3Client | None = None,
+    artifact_reader: ExecutorArtifactReader,
 ) -> ExecutorRelease:
     """Create-or-match, verify, promote, and assert one immutable release."""
     _validate_release_manifest(candidate)
@@ -116,7 +104,7 @@ def activate_release(
     if release.status in (ExecutorReleaseStatus.DRAINING, ExecutorReleaseStatus.RETIRED):
         raise ReleaseControlError(f"Executor release {release.id!r} cannot be activated from {release.status.value}")
 
-    verify_release_artifact(session, release.id, s3_client=s3_client)
+    verify_release_artifact(session, release.id, artifact_reader=artifact_reader)
     activated = promote_release(session, release.id)
     admission = _get_required_admission(session)
     if (
@@ -132,7 +120,7 @@ def verify_release_artifact(
     session: Session,
     release_id: str,
     *,
-    s3_client: S3Client | None = None,
+    artifact_reader: ExecutorArtifactReader,
 ) -> ExecutorRelease:
     """Verify a registered release artifact and mark it ready for promotion."""
     release = _get_release(session, release_id)
@@ -142,22 +130,12 @@ def verify_release_artifact(
     if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.lstrip("/"):
         raise ReleaseControlError("Executor artifact URI must use s3://bucket/key")
 
-    client: S3Client
-    if s3_client is None:
-        boto3_client: Any = boto3.client("s3")  # pyright: ignore
-        client = cast(S3Client, boto3_client)
-    else:
-        client = s3_client
-    response = client.get_object(Bucket=parsed.netloc, Key=parsed.path.lstrip("/"))
-    body = cast(S3Body, response["Body"])
     digest = hashlib.sha256()
     artifact_bytes = 0
-    try:
+    with artifact_reader.open(parsed.netloc, parsed.path.lstrip("/")) as body:
         while chunk := body.read(1024 * 1024):
             digest.update(chunk)
             artifact_bytes += len(chunk)
-    finally:
-        body.close()
     if digest.hexdigest() != release.artifact_digest:
         raise ReleaseControlError(f"Executor artifact digest mismatch for release {release_id!r}")
 

--- a/services/tracker/src/tracker/executor/release_entrypoint.py
+++ b/services/tracker/src/tracker/executor/release_entrypoint.py
@@ -66,6 +66,10 @@ class EcsClient(Protocol):
     def update_service(self, **kwargs: object) -> Mapping[str, object]: ...
 
 
+class S3ArtifactClient(Protocol):
+    def get_object(self, *, Bucket: str, Key: str) -> Mapping[str, object]: ...
+
+
 class DatabaseSecret(BaseModel):
     username: str
     password: str
@@ -110,6 +114,11 @@ def create_ecs_client() -> EcsClient:
     return cast(EcsClient, boto3.client("ecs"))  # pyright: ignore[reportUnknownMemberType]
 
 
+def create_s3_artifact_client() -> S3ArtifactClient:
+    """Select the sealed release task's ambient S3 authority at its root."""
+    return cast(S3ArtifactClient, boto3.client("s3"))  # pyright: ignore[reportUnknownMemberType]
+
+
 def _configure_database(task: ReleaseTaskConfig) -> None:
     for name in tuple(os.environ):
         if name in _CALLER_CONTROLLED_ENV or name.startswith("AWS_ENDPOINT_URL"):
@@ -131,6 +140,7 @@ def _configure_database(task: ReleaseTaskConfig) -> None:
 def _activate_sealed_release(task: ReleaseTaskConfig, release: ReleaseInput) -> None:
     from sqlmodel import Session
 
+    from tracker.aws.executor_artifacts import S3ExecutorArtifactReader
     from tracker.database.models import ExecutorRelease
     from tracker.database.session import engine
     from tracker.executor.release_control import ReleaseControlError, activate_release
@@ -147,6 +157,7 @@ def _activate_sealed_release(task: ReleaseTaskConfig, release: ReleaseInput) -> 
                 ),
                 expected_bucket=task.release_bucket,
                 expected_prefix=task.release_prefix,
+                artifact_reader=S3ExecutorArtifactReader(create_s3_artifact_client()),
             )
             session.commit()
     except ReleaseControlError as error:

--- a/services/tracker/src/tracker/runtime/executor_artifacts.py
+++ b/services/tracker/src/tracker/runtime/executor_artifacts.py
@@ -1,0 +1,12 @@
+"""Provider-neutral access to immutable executor artifacts."""
+
+from contextlib import AbstractContextManager
+from typing import BinaryIO, Protocol
+
+
+class ExecutorArtifactReader(Protocol):
+    """Open a release artifact as a closed-on-exit binary stream."""
+
+    def open(self, bucket: str, key: str) -> AbstractContextManager[BinaryIO]:
+        """Yield the complete artifact stream and close it on every exit."""
+        raise NotImplementedError

--- a/services/tracker/tests/integration/local/database/test_release_control.py
+++ b/services/tracker/tests/integration/local/database/test_release_control.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, select
 
+from tracker.aws.executor_artifacts import S3ExecutorArtifactReader
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -157,7 +158,7 @@ def test_concurrent_first_activation_serializes_create_or_match(
             _activation_candidate(),
             expected_bucket="artifacts",
             expected_prefix="releases",
-            s3_client=_S3Client(),
+            artifact_reader=S3ExecutorArtifactReader(_S3Client()),
         )
 
     outcomes = _run_while_first_transaction_holds_locks(

--- a/services/tracker/tests/unit/aws/test_executor_artifacts.py
+++ b/services/tracker/tests/unit/aws/test_executor_artifacts.py
@@ -1,0 +1,24 @@
+import io
+
+from tracker.aws.executor_artifacts import S3ExecutorArtifactReader
+
+
+class _S3Client:
+    def __init__(self, body: io.BytesIO) -> None:
+        self.body = body
+        self.calls: list[tuple[str, str]] = []
+
+    def get_object(self, *, Bucket: str, Key: str) -> dict[str, object]:
+        self.calls.append((Bucket, Key))
+        return {"Body": self.body}
+
+
+def test_s3_executor_artifact_reader_closes_stream_after_read() -> None:
+    body = io.BytesIO(b"sealed executor")
+    client = _S3Client(body)
+
+    with S3ExecutorArtifactReader(client).open("artifacts", "releases/v1/executor.pex") as stream:
+        assert stream.read() == b"sealed executor"
+
+    assert client.calls == [("artifacts", "releases/v1/executor.pex")]
+    assert body.closed

--- a/services/tracker/tests/unit/executor/test_release_control.py
+++ b/services/tracker/tests/unit/executor/test_release_control.py
@@ -17,6 +17,7 @@ from tracker.database.models import (
     ExecutorRelease,
     ExecutorReleaseStatus,
 )
+from tracker.aws.executor_artifacts import S3ExecutorArtifactReader
 from tracker.executor.release_control import (
     ReleaseControlError,
     activate_release,
@@ -80,7 +81,7 @@ def test_activate_release_registers_verifies_and_promotes_in_one_session(databas
         release,
         expected_bucket="artifacts",
         expected_prefix="releases",
-        s3_client=FakeS3Client(content, key="releases/git-abc123-def456/executor.pex"),
+        artifact_reader=S3ExecutorArtifactReader(FakeS3Client(content, key="releases/git-abc123-def456/executor.pex")),
     )
 
     admission = database_session.get(ExecutorAdmission, 1)
@@ -104,7 +105,7 @@ def test_activate_release_is_idempotent_for_exact_active_release(database_sessio
         release,
         expected_bucket="artifacts",
         expected_prefix="releases",
-        s3_client=client,
+        artifact_reader=S3ExecutorArtifactReader(client),
     )
     activated_at = first.activated_at
 
@@ -118,7 +119,7 @@ def test_activate_release_is_idempotent_for_exact_active_release(database_sessio
         ),
         expected_bucket="artifacts",
         expected_prefix="releases",
-        s3_client=client,
+        artifact_reader=S3ExecutorArtifactReader(client),
     )
 
     assert second.status == ExecutorReleaseStatus.ACTIVE
@@ -146,14 +147,14 @@ def test_activate_release_rejects_draining_release(database_session: Session) ->
         previous,
         expected_bucket="artifacts",
         expected_prefix="releases",
-        s3_client=FakeS3Client(content, key="releases/git-previous/executor.pex"),
+        artifact_reader=S3ExecutorArtifactReader(FakeS3Client(content, key="releases/git-previous/executor.pex")),
     )
     activate_release(
         database_session,
         current,
         expected_bucket="artifacts",
         expected_prefix="releases",
-        s3_client=FakeS3Client(content, key="releases/git-current/executor.pex"),
+        artifact_reader=S3ExecutorArtifactReader(FakeS3Client(content, key="releases/git-current/executor.pex")),
     )
 
     with pytest.raises(ReleaseControlError, match="cannot be activated from DRAINING"):
@@ -167,7 +168,7 @@ def test_activate_release_rejects_draining_release(database_session: Session) ->
             ),
             expected_bucket="artifacts",
             expected_prefix="releases",
-            s3_client=FakeS3Client(content, key="releases/git-previous/executor.pex"),
+            artifact_reader=S3ExecutorArtifactReader(FakeS3Client(content, key="releases/git-previous/executor.pex")),
         )
 
 
@@ -195,7 +196,7 @@ def test_activate_release_rejects_retired_release(database_session: Session) -> 
             ),
             expected_bucket="artifacts",
             expected_prefix="releases",
-            s3_client=FakeS3Client(content, key="releases/git-retired/executor.pex"),
+            artifact_reader=S3ExecutorArtifactReader(FakeS3Client(content, key="releases/git-retired/executor.pex")),
         )
 
 
@@ -219,7 +220,7 @@ def test_activate_release_rejects_release_id_reuse_with_different_content(databa
             ),
             expected_bucket="artifacts",
             expected_prefix="releases",
-            s3_client=FakeS3Client(b"irrelevant"),
+            artifact_reader=S3ExecutorArtifactReader(FakeS3Client(b"irrelevant")),
         )
 
 
@@ -237,7 +238,9 @@ def test_activate_release_digest_failure_rolls_back_new_candidate(database_sessi
             release,
             expected_bucket="artifacts",
             expected_prefix="releases",
-            s3_client=FakeS3Client(b"different", key="releases/git-abc123-def456/executor.pex"),
+            artifact_reader=S3ExecutorArtifactReader(
+                FakeS3Client(b"different", key="releases/git-abc123-def456/executor.pex")
+            ),
         )
     database_session.rollback()
 
@@ -253,7 +256,7 @@ def test_activate_release_rejects_artifact_outside_configured_location(database_
             release,
             expected_bucket="release-artifacts",
             expected_prefix="releases",
-            s3_client=FakeS3Client(b"irrelevant"),
+            artifact_reader=S3ExecutorArtifactReader(FakeS3Client(b"irrelevant")),
         )
 
 
@@ -263,7 +266,9 @@ def test_verify_release_artifact_marks_candidate_ready(database_session: Session
     release.artifact_digest = hashlib.sha256(content).hexdigest()
     register_release(database_session, release)
 
-    verified = verify_release_artifact(database_session, "v1", s3_client=FakeS3Client(content))
+    verified = verify_release_artifact(
+        database_session, "v1", artifact_reader=S3ExecutorArtifactReader(FakeS3Client(content))
+    )
 
     assert verified.readiness_verified
     assert verified.readiness_metadata["artifact_bytes"] == len(content)
@@ -275,7 +280,11 @@ def test_verify_release_artifact_rejects_digest_mismatch(database_session: Sessi
     register_release(database_session, release)
 
     with pytest.raises(ReleaseControlError, match="digest mismatch"):
-        verify_release_artifact(database_session, "v1", s3_client=FakeS3Client(b"different artifact"))
+        verify_release_artifact(
+            database_session,
+            "v1",
+            artifact_reader=S3ExecutorArtifactReader(FakeS3Client(b"different artifact")),
+        )
 
     stored = database_session.get(ExecutorRelease, "v1")
     assert stored is not None


### PR DESCRIPTION
## Purpose

Make release-control artifact verification provider-neutral while preserving immutable release identity and the existing executor wire contract. This is the final PR in the stack.

## What changes

- Introduces an AWS-free `ExecutorArtifactReader` capability.
- Adds an S3 reader implementation that receives an injected client and closes artifact streams on exit.
- Removes direct boto client construction from release-control.
- Keeps the sealed release entrypoint as the explicit default-chain S3 composition root.

## Behavior preserved

- Release URI and digest verification.
- Readiness metadata, PostgreSQL admission, benchmark pinning, dispatch pinning, and executor payload shape.
- Executor artifact stream lifecycle and telemetry propagation.
- Immutable release identity: release-control still verifies the selected artifact rather than substituting an alternate provider or fallback.

## Deliberate non-goals

- No release-provider selector, compatibility layer, or fallback artifact source.
- No new executor protocol, payload field, admission policy, or release activation flow.
- No local executor artifact implementation is added; the capability permits a future one without changing the current sealed-entrypoint contract.

## Review guide

1. Read the artifact-reader capability and the injected S3 reader lifecycle.
2. Follow release-control verification from artifact retrieval through digest/readiness checks.
3. Confirm the sealed release entrypoint remains the sole default-chain composition point.
4. Review tests for stream closing, release identity, persisted admission, dispatch pinning, and telemetry propagation.

## Stack and merge order

1. #656 Storage (`dev` ← `ok/runtime-storage`)
2. #657 Secrets (`ok/runtime-storage` ← `ok/runtime-secrets`)
3. #658 Logging (`ok/runtime-secrets` ← `ok/runtime-logs`)
4. **#659 Executor artifacts** (`ok/runtime-logs` ← `ok/executor-artifacts`)

Merge only after #658 merges.

## Validation

- 690 Tracker unit tests passed (one existing Starlette/httpx warning).
- 45 executor-host and end-to-end telemetry tests passed.
- Basedpyright, Ruff, formatting, diff checks, targeted LSP, and independent review passed.
- The final stack's Codecov-sensitive storage and logging changes have local executable diff-coverage estimates above their required patch targets.

## Live validation scope

- The stack ran `uv run pytest tests/integration/live/api/test_s3_routes.py` against `ValkDevSharedStack`: **2 passed** (one existing Starlette/httpx warning).
- That probe is direct evidence for the inherited S3 API route only; it does not activate or admit a sealed executor release.
- Sealed executor-release activation, sandbox orchestration, Secrets Manager retrieval, and CloudWatch writes remain covered by the green CI and unit contracts.
