### PR TITLE
refactor: consolidate tracker persistence repositories

### DIFF
--- a/.agents/repository-design-pattern/SKILL.md
+++ b/.agents/repository-design-pattern/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: repository-design-pattern
+description: Use when adding, changing, or reviewing tracker database persistence; choose the right repository, preserve tenant and transaction boundaries, and test repository behavior.
+---
+
+# Tracker Repository Design Pattern
+
+Tracker repositories own database queries and persistence rules for one domain area. They receive a caller-owned `sqlmodel.Session` and expose domain operations instead of leaking SQL into routes, orchestration helpers, or workers.
+
+## Use a repository when
+
+Use a repository when code:
+
+- Reads or mutates tracker database rows.
+- Must enforce organization (`org_id`) isolation.
+- Combines several database writes into one domain operation.
+- Depends on compare-and-set (CAS) predicates, execution authority, or row locks.
+- Is used by more than one route, helper, or worker boundary.
+
+Do not use a repository for provider, sandbox, benchmark-service, broker, dispatch-admission, or other external operations. Keep those operations in the caller-owned orchestration layer.
+
+## Choose the repository
+
+| Operation                                                         | Repository                |
+| ----------------------------------------------------------------- | ------------------------- |
+| Organization lookup or idempotent creation                        | `OrgRepository`           |
+| Benchmark lookup, task selection, filters, or task counts         | `BenchmarkRepository`     |
+| Task lookup, creation, runnable selection, or terminal results    | `TaskRepository`          |
+| Evaluation results, score inputs, reporting, or pagination        | `ReportingRepository`     |
+| Stop, retry, resume, or benchmark row locking                     | `RunControlRepository`    |
+| Authority-fenced task status, errors, evaluation, or resume state | `TaskExecutionRepository` |
+
+Import repositories from `tracker.database.repositories`. Add a method to the existing repository for its domain before creating another repository.
+
+## Session and transaction ownership
+
+Repositories never commit. The caller owns the session lifetime, transaction boundary, commit, and final rollback.
+
+FastAPI routes should use the request-scoped providers in `tracker.database.dependencies`:
+
+```python
+from tracker.database.dependencies import BenchmarkRepositoryDep
+
+
+def route(repository: BenchmarkRepositoryDep) -> None:
+    ...
+```
+
+The providers depend on `get_session`. FastAPI caches that dependency per request, so multiple repository dependencies share one `Session`. Worker code should construct repositories from the worker's session at that session boundary.
+
+Pass repositories explicitly into helpers. Do not construct a repository from a hidden global, create a second session inside a helper, or make a helper silently fall back to repository construction.
+
+Inject a raw `Session` only when the route or helper directly uses it for a transaction, commit, rollback, lock, or fresh-session stream. Remove dead `session: Session = Depends(get_session)` parameters from routes that use repository dependencies instead. Run Ruff's `ARG` checks to catch unused session parameters.
+
+A repository may roll back its current transaction when an authority fence, CAS predicate, or required row check rejects a write. Callers must treat a `False` result as a rejected operation and re-establish the intended transaction state before continuing.
+
+The SSE results stream is an intentional exception to ordinary request scoping. It opens a fresh `Session`, `BenchmarkRepository`, and `ReportingRepository` for each poll so each event observes committed state without reusing a stale identity map.
+
+## Preserve database invariants
+
+Every organization-owned query and write must include the relevant `org_id` predicate. Do not trust a row loaded without scope for a tenant-owned operation.
+
+Keep concurrency guards in the repository operation:
+
+- Preserve `rowcount` checks for CAS updates.
+- Preserve execution-authority locks and benchmark row locks.
+- Keep force-stop and retry state changes in the same caller-controlled transaction phase.
+- Return an explicit result such as `None`, `False`, a count, or a selection when the operation was not accepted.
+
+A repository method should stage all writes for its domain operation. The caller decides when to flush, commit, retry, or hand control to an external operation.
+
+## External-operation boundaries
+
+Keep database persistence separate from external work. The caller should:
+
+1. Use a repository to load or lock the required rows.
+2. Commit any phase whose state must survive an external operation.
+3. Perform provider, sandbox, benchmark-service, broker, or dispatch work.
+4. Reacquire rows through the appropriate repository before finalizing state.
+
+Do not add network calls, sandbox cleanup, broker enqueueing, or dispatch admission to a repository method.
+
+## Adding a repository method
+
+1. Identify the domain owner from the table above.
+2. Read the existing repository and its callers before editing.
+3. Define the method around an observable domain operation, not a generic SQL wrapper.
+4. Pass `org_id` explicitly for organization-owned data.
+5. Preserve existing status, authority, lock, and CAS predicates.
+6. Do not commit inside the method.
+7. Pass the repository explicitly through routes and helpers.
+8. Add focused tests for the behavior and its failure or isolation path.
+
+## Testing repository behavior
+
+Keep repository unit tests together under:
+
+```text
+services/tracker/tests/unit/database/repositories/
+```
+
+Run the repository unit tests with:
+
+From `services/tracker`, run:
+
+```bash
+uv run pytest tests/unit/database/repositories/test_repositories.py tests/unit/database/repositories/test_run_control_repository.py tests/unit/database/repositories/test_task_execution_repository.py -q
+```
+
+Test outcomes rather than mocked call wiring. Repository tests should cover the relevant risks:
+
+- Organization isolation hides foreign rows.
+- A caller rollback removes staged repository writes.
+- A rejected authority or stale-attempt CAS leaves no partial terminal result.
+- A dangling breakdown rolls back the evaluation and status changes together.
+- Explicit empty task selections do not become whole-run operations.
+- PostgreSQL row locks serialize concurrent run-control operations.
+
+Use local integration tests under `services/tracker/tests/integration/local/database/` when the behavior depends on PostgreSQL locking, transaction isolation, or multiple sessions. Keep credentialed provider and sandbox coverage in the existing live integration locations.
+
+## Avoid these patterns
+
+- Calling `session.commit()` from a repository.
+- Passing an unscoped model into a tenant-owned write without checking `org_id`.
+- Replacing a CAS or authority predicate with a read-then-write sequence.
+- Moving provider or sandbox calls into a repository to simplify a caller.
+- Creating one repository per endpoint instead of grouping operations by domain.
+- Adding a test that asserts only which collaborator was called.

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -17,9 +17,7 @@ from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from fastapi.routing import APIRoute
 from opentelemetry.propagate import inject
-from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.orm import joinedload
-from sqlmodel import Session, col, select
+from sqlmodel import Session
 
 from tracker.api.agents import router as agents_router
 from tracker.api.benchmark_services import router as benchmark_services_router
@@ -30,7 +28,6 @@ from tracker.api.single_task import router as single_task_router
 from tracker.auth import (
     RequestIdentity,
     extract_api_key,
-    find_org_by_tenant,
     forward_tracker_api_key,
     get_current_org,
     get_current_starter,
@@ -55,6 +52,13 @@ from tracker.aws.s3 import (
 )
 from tracker.agent.schemas import AgentConfig
 from tracker.config import AUTH_REQUIRED, ENVIRONMENT, broker, create_benchmark_service_url
+from tracker.database.dependencies import (
+    BenchmarkRepositoryDep,
+    OrgRepositoryDep,
+    ReportingRepositoryDep,
+    RunControlRepositoryDep,
+    TaskRepositoryDep,
+)
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -65,9 +69,9 @@ from tracker.database.models import (
     FinalEvaluation,
     Org,
     RetryMode,
-    Task,
 )
-from tracker.database.scoping import assert_org, get_scoped
+from tracker.database.repositories import BenchmarkRepository, TaskRepository
+from tracker.database.scoping import assert_org
 from tracker.executor.dispatch_control import (
     EnqueueFailureResolution,
     admit_recovery_dispatch,
@@ -311,6 +315,7 @@ def health_check() -> dict[str, str]:
 
 @app.post("/init")
 def init_org(
+    org_repository: OrgRepositoryDep,
     request: Request,
     session: Session = Depends(get_session),
 ) -> dict[str, str | bool]:
@@ -321,12 +326,9 @@ def init_org(
     api_key = extract_api_key(request)
     identity = resolve_descope_identity(api_key, include_user_profile=True)
 
-    stmt = pg_insert(Org).values(name=identity.tenant_name).on_conflict_do_nothing(index_elements=["name"])
-    result = session.exec(stmt)
-    created = result.rowcount > 0
+    org, created = org_repository.ensure_by_name(identity.tenant_name)
     session.commit()
 
-    org = find_org_by_tenant(identity.tenant_name, session)
     if not org:
         raise HTTPException(status_code=500, detail="Internal error during org creation")
 
@@ -349,6 +351,7 @@ async def _resolve_contract_from_s3(request: StartBenchmarkRequest) -> AgentCont
 
 @app.post("/start-benchmark")
 async def start_benchmark(
+    task_repository: TaskRepositoryDep,
     http_request: Request,
     request: StartBenchmarkRequest,
     session: Session = Depends(get_session),
@@ -444,8 +447,13 @@ async def start_benchmark(
                 request.harness_config.s3_bucket,
             )
         )
-        for task_id in verify_response.task_ids:
-            session.add(Task(org_id=benchmark_row.org_id, benchmark=benchmark_row.id, task_id=task_id))
+        session.add(benchmark_row)
+        session.flush()
+        task_repository.create_missing_task_rows(
+            benchmark_row.id,
+            verify_response.task_ids,
+            benchmark_row.org_id,
+        )
         executor_dispatch = admit_start_dispatch(
             session,
             benchmark=benchmark_row,
@@ -534,6 +542,8 @@ async def fetch_benchmark_tasks(
 
 @app.get("/fetch-benchmark", response_model=None)
 async def fetch_benchmark(
+    benchmark_repository: BenchmarkRepositoryDep,
+    reporting_repository: ReportingRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     connect: bool = Query(default=False),
     session: Session = Depends(get_session),
@@ -553,7 +563,7 @@ async def fetch_benchmark(
     - 200 OK if benchmark is found
     - 404 Not Found if benchmark is not found
     """
-    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark_row = assert_org(benchmark_repository.get_for_org_with_final_evaluation(benchmark_id, org.id), org)
 
     # When we connect to the client every 60 seconds we send the latest benchmark status
     # and additional updates about the tasks completed
@@ -568,7 +578,7 @@ async def fetch_benchmark(
             },
         )
 
-    benchmark_context = BenchmarkContext(benchmark_row, session, org)
+    benchmark_context = BenchmarkContext(benchmark_row, reporting_repository, org)
 
     return FetchBenchmarkResponse(
         benchmark_name=benchmark_row.name,
@@ -589,6 +599,7 @@ async def fetch_benchmark(
 
 @app.post("/analyze-benchmark/{benchmark_id}", response_model=None)
 async def analyze_benchmark(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     body: AnalyzeBenchmarkRequest,
     session: Session = Depends(get_session),
@@ -603,7 +614,7 @@ async def analyze_benchmark(
     Cache short-circuit: when the benchmark already has docent_reading_status=DONE and
     no_cache=false, returns the existing reading_plan_url without invoking the Lambda.
     """
-    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark_row = assert_org(benchmark_repository.get_for_org(benchmark_id, org.id), org)
 
     if benchmark_row.status != BenchmarkStatus.FINISHED:
         raise HTTPException(
@@ -656,6 +667,8 @@ async def analyze_benchmark(
 
 @app.get("/retrieve-results")
 async def retrieve_results(
+    benchmark_repository: BenchmarkRepositoryDep,
+    reporting_repository: ReportingRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     http_request: Request,
     s3: bool = Query(default=False),
@@ -677,12 +690,14 @@ async def retrieve_results(
     curl -X GET http://<endpoint>/retrieve-results?benchmark_id=<uuid>&s3=false
     curl -X GET 'http://<endpoint>/retrieve-results?benchmark_id=<uuid>&task_ids=task_1&task_ids=task_2'
     """
-    benchmark_row = session.get(Benchmark, benchmark_id, options=[joinedload(Benchmark.final_evaluation)])
+    benchmark_row = benchmark_repository.get_for_org_with_final_evaluation(benchmark_id, org.id)
     if benchmark_row is None:
+        # Keep the legacy distinction between a missing run and a run owned by another org.
+        if benchmark_repository.get_by_id(benchmark_id) is not None:
+            raise HTTPException(status_code=404, detail="Not found")
         raise HTTPException(status_code=404, detail=f"Run {benchmark_id} not found")
-    assert_org(benchmark_row, org)
 
-    final_view = create_final_view(benchmark_row, session, org)
+    final_view = create_final_view(benchmark_row, reporting_repository, org)
 
     if task_ids:
         task_ids_set = set(task_ids)
@@ -697,7 +712,7 @@ async def retrieve_results(
         # (e.g. stopped/errored) still count toward the denominator instead of being dropped.
         scored_results = {
             task_id: result
-            for task_id, result in fetch_final_score_inputs(session, benchmark_row, org).items()
+            for task_id, result in fetch_final_score_inputs(reporting_repository, benchmark_row, org).items()
             if task_id in task_ids_set
         }
 
@@ -733,6 +748,7 @@ async def retrieve_results(
 
 @app.get("/check-results-exist")
 async def check_results_exist(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
@@ -747,7 +763,7 @@ async def check_results_exist(
     Returns:
         {"exists": true/false}
     """
-    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark_row = assert_org(benchmark_repository.get_for_org(benchmark_id, org.id), org)
 
     s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{benchmark_row.name}.json"
     exists = await s3_object_exists(s3_key, harness_config.aws, harness_config.s3_bucket)
@@ -757,7 +773,7 @@ async def check_results_exist(
 async def validate_tasks_exist(
     benchmark_row: Benchmark,
     task_ids: list[str],
-    session: Session,
+    task_repository: TaskRepository,
     org: Org,
 ) -> list[str]:
     """Validate that selected tasks belong to the run."""
@@ -765,14 +781,7 @@ async def validate_tasks_exist(
         raise HTTPException(status_code=400, detail="task_ids cannot be empty")
 
     requested_task_ids = list(dict.fromkeys(task_ids))
-    existing_task_ids = set(
-        session.exec(
-            select(Task.task_id)
-            .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.org_id) == org.id)
-            .where(col(Task.task_id).in_(requested_task_ids))
-        ).all()
-    )
+    existing_task_ids = task_repository.get_existing_task_ids(benchmark_row.id, requested_task_ids, org.id)
     missing_task_ids = [task_id for task_id in requested_task_ids if task_id not in existing_task_ids]
     if missing_task_ids:
         raise HTTPException(
@@ -785,6 +794,9 @@ async def validate_tasks_exist(
 
 @app.post("/stop-benchmark/{benchmark_id}")
 async def stop_benchmark(
+    benchmark_repository: BenchmarkRepositoryDep,
+    task_repository: TaskRepositoryDep,
+    run_control_repository: RunControlRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     force: bool = Query(default=False),
     task_ids: list[str] | None = Body(default=None, embed=True),
@@ -802,7 +814,7 @@ async def stop_benchmark(
     Returns:
         StopBenchmarkResponse
     """
-    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark_row = assert_org(benchmark_repository.get_for_org(benchmark_id, org.id), org)
 
     valid_stop_states = [BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPING]
 
@@ -813,17 +825,24 @@ async def stop_benchmark(
         )
 
     selected_task_ids = (
-        await validate_tasks_exist(benchmark_row, task_ids, session, org) if task_ids is not None else None
+        await validate_tasks_exist(benchmark_row, task_ids, task_repository, org) if task_ids is not None else None
     )
 
-    benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+    benchmark_row = fetch_benchmark_row(benchmark_id, benchmark_repository, org, for_update=True)
     if benchmark_row.status not in valid_stop_states:
         raise HTTPException(
             status_code=400,
             detail=f"Run {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress or error run.",
         )
 
-    await initiate_stop_benchmark(benchmark_row, session, force, org, task_ids=selected_task_ids)
+    await initiate_stop_benchmark(
+        benchmark_row,
+        session,
+        force,
+        org,
+        task_ids=selected_task_ids,
+        repository=run_control_repository,
+    )
 
     if force:
         # TODO: Drop the row fallback after legacy benchmark rows have aged out.
@@ -838,6 +857,8 @@ async def stop_benchmark(
             org,
             sandbox_provider=benchmark_row.arguments.sandbox_provider,
             task_ids=selected_task_ids,
+            repository=run_control_repository,
+            benchmark_repository=benchmark_repository,
         )
 
     return StopBenchmarkResponse(
@@ -849,34 +870,56 @@ def _update_benchmark_concurrency(
     benchmark_id: UUID,
     concurrency: int,
     session: Session,
+    benchmark_repository: BenchmarkRepository,
     org: Org,
 ) -> BenchmarkConcurrencyUpdate:
     try:
         with session.no_autoflush:
             lock_executor_admission(session)
-        benchmark_row = update_benchmark_concurrency(benchmark_id, concurrency, session, org)
+        benchmark_row = update_benchmark_concurrency(
+            benchmark_id,
+            concurrency,
+            session,
+            benchmark_repository,
+            org,
+        )
+        if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+            status = benchmark_row.status
+            raise HTTPException(
+                status_code=409,
+                detail=f"Run {benchmark_id} is currently in the {status} state.",
+            )
+        session.commit()
+        return benchmark_row
     except MaintenanceModeError as exc:
         session.rollback()
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except ValueError as exc:
+        session.rollback()
         raise HTTPException(status_code=404, detail="Not found") from exc
-
-    if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
-        raise HTTPException(
-            status_code=409,
-            detail=f"Run {benchmark_id} is currently in the {benchmark_row.status} state.",
-        )
-    return benchmark_row
+    except HTTPException:
+        session.rollback()
+        raise
+    except Exception:
+        session.rollback()
+        raise
 
 
 @app.patch("/benchmarks/{benchmark_id}/concurrency")
 def patch_benchmark_concurrency(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     request: UpdateBenchmarkConcurrencyRequest,
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
 ) -> UpdateBenchmarkConcurrencyResponse:
-    benchmark_row = _update_benchmark_concurrency(benchmark_id, request.concurrency, session, org)
+    benchmark_row = _update_benchmark_concurrency(
+        benchmark_id,
+        request.concurrency,
+        session,
+        benchmark_repository,
+        org,
+    )
     return UpdateBenchmarkConcurrencyResponse(
         benchmark_id=benchmark_row.benchmark_id,
         status=benchmark_row.status,
@@ -886,6 +929,8 @@ def patch_benchmark_concurrency(
 
 @app.post("/retry-or-resume-benchmark/{benchmark_id}")
 async def retry_or_resume_benchmark(
+    benchmark_repository: BenchmarkRepositoryDep,
+    run_control_repository: RunControlRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     http_request: Request,
     retry: bool = Query(default=False),
@@ -917,7 +962,7 @@ async def retry_or_resume_benchmark(
     Returns:
         RetryOrResumeBenchmarkResponse
     """
-    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark_row = assert_org(benchmark_repository.get_for_org(benchmark_id, org.id), org)
 
     if benchmark_row.status == BenchmarkStatus.STOPPING:
         raise HTTPException(
@@ -936,10 +981,11 @@ async def retry_or_resume_benchmark(
 
     if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and not retry:
         if concurrency is not None:
-            _update_benchmark_concurrency(benchmark_id, concurrency, session, org)
+            _update_benchmark_concurrency(benchmark_id, concurrency, session, benchmark_repository, org)
         if secrets or benchmark_url is not None:
             update_benchmark_resume_arguments(
                 benchmark_id,
+                benchmark_repository,
                 session,
                 org,
                 secrets=secrets,
@@ -959,7 +1005,7 @@ async def retry_or_resume_benchmark(
     try:
         with session.no_autoflush:
             lock_executor_admission(session)
-        benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+        benchmark_row = fetch_benchmark_row(benchmark_id, benchmark_repository, org, for_update=True)
         if benchmark_row.status == BenchmarkStatus.STOPPING:
             raise HTTPException(
                 status_code=400,
@@ -967,23 +1013,33 @@ async def retry_or_resume_benchmark(
             )
         pre_action_status = benchmark_row.status
 
-        verified_task_ids = await reset_to_in_progress_status(
-            benchmark_row=benchmark_row,
-            session=session,
-            benchmark_service=benchmark_row.benchmark_service(
-                service_headers=effective_service_headers,
-                benchmark_url=benchmark_url,
-            ),
-            retry=retry,
-            retry_mode=retry_mode,
-            rerun_task_ids=task_ids,
-            org=org,
+        benchmark_service = benchmark_row.benchmark_service(
+            service_headers=effective_service_headers,
+            benchmark_url=benchmark_url,
         )
+        try:
+            verified_task_ids = await reset_to_in_progress_status(
+                benchmark_row=benchmark_row,
+                session=session,
+                repository=run_control_repository,
+                benchmark_repository=benchmark_repository,
+                benchmark_service=benchmark_service,
+                retry=retry,
+                retry_mode=retry_mode,
+                rerun_task_ids=task_ids,
+                org=org,
+            )
+        finally:
+            try:
+                await benchmark_service.close()
+            except Exception:
+                logger.exception("Failed to close benchmark service client for %s", benchmark_row.name)
 
         if pre_action_status == BenchmarkStatus.IN_PROGRESS and not verified_task_ids:
             if secrets or concurrency is not None or benchmark_url is not None:
                 update_benchmark_resume_arguments(
                     benchmark_id,
+                    benchmark_repository,
                     session,
                     org,
                     secrets=secrets,
@@ -998,6 +1054,7 @@ async def retry_or_resume_benchmark(
         if secrets or concurrency is not None or benchmark_url is not None:
             benchmark_row = update_benchmark_resume_arguments(
                 benchmark_id,
+                benchmark_repository,
                 session,
                 org,
                 secrets=secrets,
@@ -1041,6 +1098,8 @@ async def retry_or_resume_benchmark(
 
 @app.get("/fetch-benchmarks")
 async def fetch_benchmarks(
+    reporting_repository: ReportingRepositoryDep,
+    benchmark_repository: BenchmarkRepositoryDep,
     agent_name: list[str] | None = Query(default=None),
     benchmark_name: list[str] | None = Query(default=None),
     status: list[BenchmarkStatus] | None = Query(default=None),
@@ -1081,10 +1140,10 @@ async def fetch_benchmarks(
         offset=offset,
     )
 
-    benchmark_rows, total_count, next_cursor = fetch_filtered_benchmark_rows(request, session, org)
+    benchmark_rows, total_count, next_cursor = fetch_filtered_benchmark_rows(request, reporting_repository, org)
 
     return FetchBenchmarksResponse(
-        benchmarks=build_benchmark_table_rows(benchmark_rows, session),
+        benchmarks=build_benchmark_table_rows(benchmark_rows, benchmark_repository),
         total_count=total_count,
         next_cursor=next_cursor,
     )
@@ -1092,6 +1151,7 @@ async def fetch_benchmarks(
 
 @app.get("/fetch-benchmark-metadata/{benchmark_id}")
 async def fetch_benchmark_metadata(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
@@ -1105,7 +1165,7 @@ async def fetch_benchmark_metadata(
     Returns:
         FetchBenchmarkMetadataResponse
     """
-    benchmark_row = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark_row = assert_org(benchmark_repository.get_for_org(benchmark_id, org.id), org)
 
     return benchmark_row.benchmark_metadata
 
@@ -1177,6 +1237,7 @@ async def _tar_output_stream(
 
 @app.get("/fetch-run-outputs/{benchmark_id}", response_model=None)
 async def fetch_run_outputs(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
@@ -1192,7 +1253,7 @@ async def fetch_run_outputs(
     Returns:
         StreamingResponse
     """
-    get_scoped(Benchmark, benchmark_id, session, org)
+    assert_org(benchmark_repository.get_for_org(benchmark_id, org.id), org)
 
     benchmark_prefix = f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/"
 

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -602,7 +602,6 @@ async def analyze_benchmark(
     benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
     body: AnalyzeBenchmarkRequest,
-    session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
 ) -> dict[str, str] | StreamingResponse:
@@ -673,7 +672,6 @@ async def retrieve_results(
     http_request: Request,
     s3: bool = Query(default=False),
     task_ids: list[str] | None = Query(default=None),
-    session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
 ) -> RetrieveResultsResponse:
@@ -750,7 +748,6 @@ async def retrieve_results(
 async def check_results_exist(
     benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
-    session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
 ) -> dict[str, bool]:
@@ -1020,7 +1017,6 @@ async def retry_or_resume_benchmark(
         try:
             verified_task_ids = await reset_to_in_progress_status(
                 benchmark_row=benchmark_row,
-                session=session,
                 repository=run_control_repository,
                 benchmark_repository=benchmark_repository,
                 benchmark_service=benchmark_service,
@@ -1113,7 +1109,6 @@ async def fetch_benchmarks(
     cursor: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
-    session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
 ) -> FetchBenchmarksResponse:
     """
@@ -1153,7 +1148,6 @@ async def fetch_benchmarks(
 async def fetch_benchmark_metadata(
     benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
-    session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
 ) -> FetchBenchmarkMetadataResponse:
     """
@@ -1239,7 +1233,6 @@ async def _tar_output_stream(
 async def fetch_run_outputs(
     benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: TrackedBenchmarkId,
-    session: Session = Depends(get_session),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
     org: Org = Depends(get_current_org),
     task_ids: list[str] | None = Query(default=None),

--- a/services/tracker/src/tracker/api/benchmarks_status.py
+++ b/services/tracker/src/tracker/api/benchmarks_status.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
-from sqlmodel import Session, col, func, select
 
 from tracker.api.parsing import parse_csv
 from tracker.auth import get_current_org
-from tracker.database.models import Benchmark, Org, Task, TaskStatus
-from tracker.database.session import get_session
+from tracker.database.dependencies import BenchmarkRepositoryDep
+from tracker.database.models import Org, TaskStatus
 from tracker.types import BenchmarkStatusEntry, BenchmarkStatusResponse
 
 router = APIRouter(prefix="/benchmarks")
@@ -18,27 +17,20 @@ router = APIRouter(prefix="/benchmarks")
 
 @router.get("/status", response_model=BenchmarkStatusResponse)
 def get_benchmarks_status(
+    benchmark_repository: BenchmarkRepositoryDep,
     ids: str = Query(default=""),
     org: Org = Depends(get_current_org),
-    session: Session = Depends(get_session),
 ) -> BenchmarkStatusResponse:
     """Return status + task-count breakdown for the listed benchmark ids."""
     parsed_ids = parse_csv(ids, UUID)
     if not parsed_ids:
         return BenchmarkStatusResponse(entries=[])
 
-    benchmarks = session.exec(
-        select(Benchmark).where(Benchmark.org_id == org.id).where(col(Benchmark.id).in_(parsed_ids))
-    ).all()
-
-    count_rows = session.exec(
-        select(Task.benchmark, Task.status, func.count())
-        .where(col(Task.benchmark).in_([benchmark.id for benchmark in benchmarks]))
-        .group_by(col(Task.benchmark), col(Task.status))
-    ).all()
-    counts_by_benchmark_id: dict[UUID, dict[TaskStatus, int]] = {}
-    for benchmark_id, status, count in count_rows:
-        counts_by_benchmark_id.setdefault(benchmark_id, {})[TaskStatus(status)] = count
+    benchmarks = benchmark_repository.get_for_ids(parsed_ids, org.id)
+    counts_by_benchmark_id = benchmark_repository.get_task_status_counts(
+        [benchmark.id for benchmark in benchmarks],
+        org.id,
+    )
 
     entries: list[BenchmarkStatusEntry] = []
     for benchmark in benchmarks:

--- a/services/tracker/src/tracker/api/filter_options.py
+++ b/services/tracker/src/tracker/api/filter_options.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
-from sqlmodel import Session, select
 
 from tracker.auth import get_current_org
-from tracker.database.models import Benchmark, Org
-from tracker.database.session import get_session
+from tracker.database.dependencies import BenchmarkRepositoryDep
+from tracker.database.models import Org
 
 router = APIRouter(prefix="/benchmarks")
 
@@ -20,17 +19,12 @@ class FilterOptionsResponse(BaseModel):
 
 @router.get("/filter-options", response_model=FilterOptionsResponse)
 def get_filter_options(
+    benchmark_repository: BenchmarkRepositoryDep,
     org: Org = Depends(get_current_org),
-    session: Session = Depends(get_session),
 ) -> FilterOptionsResponse:
     """Distinct benchmark + agent names in this org, for the runs-list filter dropdowns."""
 
-    benchmark_names = sorted(
-        set(session.exec(select(Benchmark.name).where(Benchmark.org_id == org.id).distinct()).all())
-    )
-
-    rows = session.exec(select(Benchmark.arguments).where(Benchmark.org_id == org.id)).all()
-    agent_names = sorted({row.contract.name for row in rows if row and row.contract.name})
+    benchmark_names, agent_names = benchmark_repository.get_filter_options(org.id)
 
     return FilterOptionsResponse(
         benchmark_names=benchmark_names,

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -5,17 +5,14 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy import case
-from sqlmodel import Session, col, desc, func, select
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from tracker.api.parsing import parse_csv
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.s3 import create_benchmark_url
-from tracker.database.models import Benchmark, ErrorResult, Org, Task, TaskStatus
-from tracker.database.scoping import get_scoped
-from tracker.database.session import get_session
+from tracker.database.dependencies import BenchmarkRepositoryDep
+from tracker.database.models import Org, TaskStatus
 from tracker.types import (
     HarnessConfig,
     SingleBenchmarkResponse,
@@ -27,39 +24,19 @@ from tracker.utils import try_fetch_harness_config
 router = APIRouter(prefix="/benchmarks")
 
 
-def _escape_sql_like_pattern(value: str) -> str:
-    """Escape \\, %, and _ so user input is treated as a literal in a LIKE clause."""
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-
-
-# Attention priority — higher is more urgent, so ORDER BY ... DESC surfaces
-# errors first, then abnormal/successful terminal, then active, then queued.
-_STATUS_SORT_PRIORITY = case(
-    {
-        TaskStatus.ERROR: 6,
-        TaskStatus.STOPPED: 5,
-        TaskStatus.FINISHED: 4,
-        TaskStatus.EVALUATING: 3,
-        TaskStatus.IN_PROGRESS: 2,
-        TaskStatus.BUILDING: 1,
-        TaskStatus.PENDING: 0,
-    },
-    value=col(Task.status),
-    else_=-1,
-)
-
-
 @router.get("/{benchmark_id}", response_model=SingleBenchmarkResponse)
 def get_single_benchmark(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: UUID,
     org: Org = Depends(get_current_org),
     harness_config: HarnessConfig | None = Depends(try_fetch_harness_config),
-    session: Session = Depends(get_session),
 ) -> SingleBenchmarkResponse:
     """Fetch a single benchmark with task counts + final score for the SingleRun page."""
-    benchmark = get_scoped(Benchmark, benchmark_id, session, org)
+    benchmark = benchmark_repository.get_for_org(benchmark_id, org.id)
+    if benchmark is None:
+        raise HTTPException(status_code=404, detail="Not found")
 
-    task_state_counts = benchmark.fetch_task_state_counts(session)
+    task_state_counts = benchmark_repository.get_task_state_counts(benchmark.id, org.id)
     total = sum(task_state_counts.values())
     finished = (
         task_state_counts.get(TaskStatus.FINISHED, 0)
@@ -97,7 +74,7 @@ def get_single_benchmark(
         finished_tasks=finished,
         task_state_counts={status.value: count for status, count in task_state_counts.items()},
         started_by_email=benchmark.started_by_email,
-        final_score=benchmark.fetch_final_score(session),
+        final_score=benchmark_repository.get_final_score(benchmark.id, org.id),
         error_message=benchmark.error_message,
         cloudwatch_url=cloudwatch_url,
         s3_bucket_url=s3_bucket_url,
@@ -106,6 +83,7 @@ def get_single_benchmark(
 
 @router.get("/{benchmark_id}/tasks", response_model=TasksResponse)
 def get_benchmark_tasks(
+    benchmark_repository: BenchmarkRepositoryDep,
     benchmark_id: UUID,
     status: str = Query(default=""),
     task_id_search: str | None = None,
@@ -114,47 +92,24 @@ def get_benchmark_tasks(
     limit: int = Query(default=50, ge=1, le=500),
     offset: int = Query(default=0, ge=0),
     org: Org = Depends(get_current_org),
-    session: Session = Depends(get_session),
 ) -> TasksResponse:
     """Paginated tasks for a benchmark, with optional status filter + task-id search.
 
     sort=status desc surfaces errors first (attention priority). Default: started_at desc."""
-    get_scoped(Benchmark, benchmark_id, session, org)
+    if benchmark_repository.get_for_org(benchmark_id, org.id) is None:
+        raise HTTPException(status_code=404, detail="Not found")
 
     statuses = parse_csv(status, TaskStatus)
-    base_filters = [
-        col(Task.benchmark) == benchmark_id,
-        col(Task.org_id) == org.id,
-    ]
-    if statuses:
-        base_filters.append(col(Task.status).in_(statuses))
-
-    if task_id_search:
-        escaped_search = _escape_sql_like_pattern(task_id_search)
-        base_filters.append(col(Task.task_id).ilike(f"%{escaped_search}%", escape="\\"))
-
-    latest_error_message = (
-        select(ErrorResult.error_message)
-        .where(ErrorResult.task == Task.id)
-        .where(ErrorResult.org_id == org.id)
-        .order_by(desc(ErrorResult.created_at))
-        .limit(1)
-        .scalar_subquery()
+    page = benchmark_repository.list_tasks(
+        benchmark_id,
+        org.id,
+        statuses=statuses,
+        task_id_search=task_id_search,
+        sort=sort,
+        sort_dir=sort_dir,
+        limit=limit,
+        offset=offset,
     )
-    sort_expr = {
-        "task_id": col(Task.task_id),
-        "started_at": col(Task.started_at),
-        "duration": func.coalesce(col(Task.finished_at), func.now()) - col(Task.started_at),
-        "status": _STATUS_SORT_PRIORITY,
-    }[sort]
-    primary = sort_expr.asc() if sort_dir == "asc" else sort_expr.desc()
-    # Tie-break newest-first for stable ordering within equal keys.
-    order_by = [primary, col(Task.started_at).desc()]
-
-    rows = session.exec(
-        select(Task, latest_error_message).where(*base_filters).order_by(*order_by).limit(limit).offset(offset)
-    ).all()
-    total = session.exec(select(func.count(col(Task.id))).where(*base_filters)).one()
 
     return TasksResponse(
         tasks=[
@@ -166,7 +121,7 @@ def get_benchmark_tasks(
                 finished_at=task.finished_at,
                 error_message=error_message if task.status == TaskStatus.ERROR else None,
             )
-            for task, error_message in rows
+            for task, error_message in page.rows
         ],
-        total_count=total,
+        total_count=page.total_count,
     )

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -2,43 +2,35 @@
 
 from __future__ import annotations
 
-from typing import cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlmodel import Session, desc, select
 
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.s3 import S3_BENCHMARKS_PREFIX, create_presigned_url, s3_object_exists
-from tracker.database.models import (
-    Benchmark,
-    ErrorResult,
-    EvaluationResult,
-    Org,
-    Task,
-    TaskStatus,
-)
-from tracker.database.session import get_session
+from tracker.database.dependencies import BenchmarkRepositoryDep, TaskRepositoryDep
+from tracker.database.models import Benchmark, EvaluationResult, Org, Task
+from tracker.database.repositories import BenchmarkRepository, TaskRepository
 from tracker.types import HarnessConfig, SingleTaskResponse, TaskArtifactsResponse
 from tracker.utils import fetch_harness_config
 
 router = APIRouter(prefix="/benchmarks")
 
 
-def _load_task_or_404(benchmark_id: UUID, task_id: str, org: Org, session: Session) -> tuple[Benchmark, Task]:
+def _load_task_or_404(
+    benchmark_id: UUID,
+    task_id: str,
+    org: Org,
+    benchmark_repository: BenchmarkRepository,
+    task_repository: TaskRepository,
+) -> tuple[Benchmark, Task]:
     """Return (benchmark, task) scoped to org, 404 if either is missing."""
-    benchmark = session.exec(
-        select(Benchmark).where(Benchmark.id == benchmark_id).where(Benchmark.org_id == org.id)
-    ).first()
-
+    benchmark = benchmark_repository.get_for_org(benchmark_id, org.id)
     if benchmark is None:
         raise HTTPException(status_code=404, detail="Benchmark not found")
 
-    task = session.exec(
-        select(Task).where(Task.benchmark == benchmark.id).where(Task.org_id == org.id).where(Task.task_id == task_id)
-    ).first()
-
+    task = task_repository.get_for_benchmark(benchmark.id, task_id, org.id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
 
@@ -50,29 +42,13 @@ def _task_prefix(benchmark_id: UUID, task_id: str) -> str:
     return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{task_id}/"
 
 
-def _fetch_result_objects(session: Session, task: Task, org: Org) -> tuple[EvaluationResult | None, str | None]:
-    """Fetches a task's evaluation result or error message depending on its status."""
-    if task.status not in (TaskStatus.FINISHED, TaskStatus.ERROR):
-        return None, None
-
-    result_model = EvaluationResult if task.status == TaskStatus.FINISHED else ErrorResult
-    result_filters = (
-        result_model.task == task.id,
-        result_model.org_id == org.id,
-    )
-    result_order = desc(result_model.created_at)
-
-    if task.status == TaskStatus.FINISHED:
-        result_select = select(EvaluationResult)
-    else:
-        result_select = select(ErrorResult.error_message)
-
-    result = session.exec(result_select.where(*result_filters).order_by(result_order)).first()
-
-    if task.status == TaskStatus.FINISHED:
-        return cast(EvaluationResult | None, result), None
-
-    return None, cast(str | None, result)
+def _fetch_result_objects(
+    task_repository: TaskRepository,
+    task: Task,
+    org: Org,
+) -> tuple[EvaluationResult | None, str | None]:
+    """Fetch a task's evaluation result or error message depending on its status."""
+    return task_repository.get_terminal_result(task, org.id)
 
 
 @router.get(
@@ -80,15 +56,16 @@ def _fetch_result_objects(session: Session, task: Task, org: Org) -> tuple[Evalu
     response_model=SingleTaskResponse,
 )
 def get_single_task(
+    benchmark_repository: BenchmarkRepositoryDep,
+    task_repository: TaskRepositoryDep,
     benchmark_id: UUID,
     task_id: str,
     org: Org = Depends(get_current_org),
-    session: Session = Depends(get_session),
 ) -> SingleTaskResponse:
     """Fetch a single task's status + evaluation result for the SingleTask page."""
-    _, task = _load_task_or_404(benchmark_id, task_id, org, session)
+    _, task = _load_task_or_404(benchmark_id, task_id, org, benchmark_repository, task_repository)
 
-    eval_row, error_message = _fetch_result_objects(session, task, org)
+    eval_row, error_message = _fetch_result_objects(task_repository, task, org)
 
     return SingleTaskResponse(
         id=task.id,
@@ -109,14 +86,15 @@ def get_single_task(
     response_model=TaskArtifactsResponse,
 )
 async def get_task_artifacts(
+    benchmark_repository: BenchmarkRepositoryDep,
+    task_repository: TaskRepositoryDep,
     benchmark_id: UUID,
     task_id: str,
     org: Org = Depends(get_current_org),
     harness_config: HarnessConfig = Depends(fetch_harness_config),
-    session: Session = Depends(get_session),
 ) -> TaskArtifactsResponse:
     """CloudWatch URL + presigned URL for the agent's output tarball, for the SingleTask page."""
-    _, task = _load_task_or_404(benchmark_id, task_id, org, session)
+    _, task = _load_task_or_404(benchmark_id, task_id, org, benchmark_repository, task_repository)
 
     cloudwatch_url: str | None = None
     if harness_config.log_group and harness_config.aws.aws_default_region:

--- a/services/tracker/src/tracker/auth.py
+++ b/services/tracker/src/tracker/auth.py
@@ -7,15 +7,15 @@ from dataclasses import dataclass
 from typing import Any
 
 from descope import AuthException, DescopeClient
-from fastapi import Depends, HTTPException, Request
+from fastapi import HTTPException, Request
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
-from sqlmodel import Session, select
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from tracker.config import AUTH_REQUIRED, DESCOPE_MANAGEMENT_KEY, DESCOPE_PROJECT_ID
-from tracker.database.models import DEFAULT_ORG_NAME, Org
-from tracker.database.session import get_session
+from tracker.database.models import Org
+from tracker.database.dependencies import OrgRepositoryDep
+from tracker.database.repositories import OrgRepository
 from tracker.logging import get_logger
 from tracker.outbound_security import validate_service_headers
 
@@ -135,12 +135,12 @@ def _load_descope_user_profile(user_id: str) -> DescopeUserProfile:
     return DescopeUserProfile(email=email, name=name)
 
 
-def get_default_org(session: Session) -> Org:
+def get_default_org(org_repository: OrgRepository) -> Org:
     """Fetch the default org, cached after first load. Used in self-hosted mode."""
     global _cached_default_org
     if _cached_default_org is not None:
         return _cached_default_org
-    org = session.exec(select(Org).where(Org.name == DEFAULT_ORG_NAME)).first()
+    org = org_repository.get_default()
     if not org:
         raise RuntimeError("Default org not found — run the migration")
     _cached_default_org = org
@@ -219,9 +219,9 @@ def resolve_descope_identity(api_key: str, *, include_user_profile: bool = False
     return DescopeIdentity(tenant_name=tenants[0], access_key_id=access_key_id, email=email, name=name)
 
 
-def find_org_by_tenant(tenant_name: str, session: Session) -> Org | None:
+def find_org_by_tenant(tenant_name: str, org_repository: OrgRepository) -> Org | None:
     """Look up an org by Descope tenant name. Returns None if not found."""
-    return session.exec(select(Org).where(Org.name == tenant_name)).first()
+    return org_repository.find_by_name(tenant_name)
 
 
 def forward_tracker_api_key(
@@ -258,7 +258,7 @@ def _extract_bearer_token(request: Request) -> str | None:
     return parts[1]
 
 
-def resolve_bearer_session(jwt: str, session: Session) -> Org:
+def resolve_bearer_session(jwt: str, org_repository: OrgRepository) -> Org:
     """Validate a Descope session JWT and resolve the org."""
     if not _descope_client:
         raise RuntimeError("Descope client not initialized — check DESCOPE_PROJECT_ID and AUTH_REQUIRED")
@@ -274,17 +274,17 @@ def resolve_bearer_session(jwt: str, session: Session) -> Org:
         raise HTTPException(status_code=400, detail="Session token has no tenant")
     tenant_name = tenants[0]
 
-    org = find_org_by_tenant(tenant_name, session)
+    org = find_org_by_tenant(tenant_name, org_repository)
     if not org:
         raise HTTPException(status_code=404, detail=f"Organization '{tenant_name}' not configured")
 
     return org
 
 
-def get_current_org(request: Request, session: Session = Depends(get_session)) -> Org:
+def get_current_org(request: Request, org_repository: OrgRepositoryDep) -> Org:
     """Resolve the current org from either an Authorization: Bearer or x-api-key header."""
     if not AUTH_REQUIRED:
-        return get_default_org(session)
+        return get_default_org(org_repository)
 
     bearer = _extract_bearer_token(request)
     api_key = request.headers.get("x-api-key") or ""
@@ -295,28 +295,28 @@ def get_current_org(request: Request, session: Session = Depends(get_session)) -
         raise HTTPException(status_code=401, detail="Missing Authorization or x-api-key header")
 
     if bearer:
-        return resolve_bearer_session(bearer, session)
+        return resolve_bearer_session(bearer, org_repository)
 
     identity = resolve_descope_identity(api_key)
-    org = find_org_by_tenant(identity.tenant_name, session)
+    org = find_org_by_tenant(identity.tenant_name, org_repository)
     if not org:
         raise HTTPException(status_code=404, detail=f"Organization '{identity.tenant_name}' not configured")
 
     return org
 
 
-def get_current_starter(request: Request, session: Session = Depends(get_session)) -> RequestIdentity:
+def get_current_starter(request: Request, org_repository: OrgRepositoryDep) -> RequestIdentity:
     """FastAPI dependency that returns the full identity behind the current request.
 
     Self-hosted (AUTH_REQUIRED=False): returns RequestIdentity with default org and Nones.
     Hosted (AUTH_REQUIRED=True): validates Descope API key and resolves org + identity.
     """
     if not AUTH_REQUIRED:
-        return RequestIdentity(org=get_default_org(session), access_key_id=None, email=None, name=None)
+        return RequestIdentity(org=get_default_org(org_repository), access_key_id=None, email=None, name=None)
 
     api_key = extract_api_key(request)
     identity = resolve_descope_identity(api_key, include_user_profile=True)
-    org = find_org_by_tenant(identity.tenant_name, session)
+    org = find_org_by_tenant(identity.tenant_name, org_repository)
     if not org:
         raise HTTPException(
             status_code=404,

--- a/services/tracker/src/tracker/database/dependencies.py
+++ b/services/tracker/src/tracker/database/dependencies.py
@@ -1,0 +1,47 @@
+"""FastAPI dependencies for request-scoped tracker repositories."""
+
+from typing import Annotated
+
+from fastapi import Depends
+from sqlmodel import Session
+
+from tracker.database.repositories import (
+    BenchmarkRepository,
+    OrgRepository,
+    ReportingRepository,
+    RunControlRepository,
+    TaskRepository,
+)
+from tracker.database.session import get_session
+
+
+def get_org_repository(session: Session = Depends(get_session)) -> OrgRepository:
+    """Provide an organization repository bound to the request session."""
+    return OrgRepository(session)
+
+
+def get_benchmark_repository(session: Session = Depends(get_session)) -> BenchmarkRepository:
+    """Provide a benchmark repository bound to the request session."""
+    return BenchmarkRepository(session)
+
+
+def get_task_repository(session: Session = Depends(get_session)) -> TaskRepository:
+    """Provide a task repository bound to the request session."""
+    return TaskRepository(session)
+
+
+def get_reporting_repository(session: Session = Depends(get_session)) -> ReportingRepository:
+    """Provide a reporting repository bound to the request session."""
+    return ReportingRepository(session)
+
+
+def get_run_control_repository(session: Session = Depends(get_session)) -> RunControlRepository:
+    """Provide a run-control repository bound to the request session."""
+    return RunControlRepository(session)
+
+
+OrgRepositoryDep = Annotated[OrgRepository, Depends(get_org_repository)]
+BenchmarkRepositoryDep = Annotated[BenchmarkRepository, Depends(get_benchmark_repository)]
+TaskRepositoryDep = Annotated[TaskRepository, Depends(get_task_repository)]
+ReportingRepositoryDep = Annotated[ReportingRepository, Depends(get_reporting_repository)]
+RunControlRepositoryDep = Annotated[RunControlRepository, Depends(get_run_control_repository)]

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -14,13 +14,9 @@ from sqlmodel import (
     Column,
     Field,
     Relationship,
-    Session,
     SQLModel,
     TypeDecorator,
     UniqueConstraint,
-    col,
-    func,
-    select,
 )
 
 from tracker.database.utils import has_field_changed
@@ -30,7 +26,6 @@ if TYPE_CHECKING:
     from benchmark_service.client import BenchmarkServiceClient
 
     from tracker.types import (
-        BenchmarkTableRow,
         FetchBenchmarkMetadataResponse,
         HarnessConfig,
         StartBenchmarkRequest,
@@ -205,11 +200,6 @@ class FinalEvaluation(SQLModel, table=True):
     def serialize_uuid(self, value: UUID | str) -> str:
         return str(value)
 
-    def fetch_evaluation_results(self, session: Session) -> dict[str, dict[str, Any]]:
-        from tracker.utils import fetch_evaluation_results
-
-        return fetch_evaluation_results(self.benchmark, session, self.org_id)
-
 
 class BenchmarkArgumentsType(TypeDecorator[BenchmarkArguments]):
     """
@@ -329,30 +319,6 @@ class Benchmark(SQLModel, table=True):
         sa_relationship_kwargs={"foreign_keys": "[FinalEvaluation.benchmark]"}
     )
 
-    def fetch_evaluation_results(self, session: Session) -> dict[str, dict[str, Any]]:
-        from tracker.utils import fetch_evaluation_results
-
-        return fetch_evaluation_results(self.id, session, self.org_id)
-
-    def fetch_tasks_with_errors(self, session: Session) -> dict[str, str] | None:
-        error_rows = session.exec(
-            select(Task.task_id, ErrorResult.error_message)
-            .outerjoin(ErrorResult, col(ErrorResult.task) == col(Task.id))
-            .where(Task.benchmark == self.id)
-            .where(Task.org_id == self.org_id)
-            .where(Task.status == TaskStatus.ERROR)
-            .order_by(col(Task.id), col(ErrorResult.created_at).desc())
-        ).all()
-
-        if not error_rows:
-            return None
-
-        errors_by_task_id: dict[str, str] = {}
-        for task_id, error_message in error_rows:
-            errors_by_task_id.setdefault(task_id, error_message or "No error message was provided")
-
-        return errors_by_task_id
-
     def start_benchmark_request(
         self, harness_config: "HarnessConfig", service_headers: dict[str, str] | None = None
     ) -> "StartBenchmarkRequest":
@@ -411,67 +377,6 @@ class Benchmark(SQLModel, table=True):
             executor_artifact_digest=self.executor_artifact_digest,
             executor_protocol_version=self.executor_protocol_version,
         )
-
-    def create_benchmark_table_row(self, session: Session) -> "BenchmarkTableRow":
-        """
-        Creates a benchmark table row object used to display the current data from this benchmark row.
-        Used in a table like feature amongst other benchmarks rows.
-
-        Args:
-            session: Session to use to fetch the total and finished tasks
-
-        Returns:
-            BenchmarkTableRow
-        """
-        from tracker.types import BenchmarkTableRow
-
-        task_state_counts = self.fetch_task_state_counts(session)
-        total_tasks = sum(task_state_counts.values())
-        finished_tasks = (
-            task_state_counts.get(TaskStatus.FINISHED, 0)
-            + task_state_counts.get(TaskStatus.ERROR, 0)
-            + task_state_counts.get(TaskStatus.STOPPED, 0)
-        )
-
-        return BenchmarkTableRow(
-            id=self.id,
-            name=self.name,
-            agent_name=self.arguments.contract.name,
-            model=self.arguments.contract.model,
-            dataset=self.arguments.dataset or "default",
-            executor_release_id=self.executor_release_id,
-            current_execution_release_id=self.current_execution_release_id,
-            executor_artifact_digest=self.executor_artifact_digest,
-            executor_protocol_version=self.executor_protocol_version,
-            started_by_email=self.started_by_email,
-            started_at=self.started_at,
-            finished_at=self.finished_at,
-            status=self.status,
-            total_tasks=total_tasks,
-            finished_tasks=finished_tasks,
-            task_state_counts={k.value: v for k, v in task_state_counts.items()},
-            final_score=(self.final_evaluation.final_score if self.final_evaluation else None),
-            label=self.label,
-        )
-
-    def fetch_task_state_counts(self, session: Session) -> dict[TaskStatus, int]:
-        """Count this benchmark's tasks grouped by TaskStatus."""
-        rows = session.exec(
-            select(col(Task.status), func.count(col(Task.task_id)))
-            .where(col(Task.benchmark) == self.id)
-            .where(col(Task.org_id) == self.org_id)
-            .group_by(col(Task.status))
-        ).all()
-        return {status: count for status, count in rows}
-
-    def fetch_final_score(self, session: Session) -> float | None:
-        """Return the FinalEvaluation.final_score for this benchmark, or None if no row exists."""
-        row = session.exec(
-            select(FinalEvaluation.final_score)
-            .where(col(FinalEvaluation.benchmark) == self.id)
-            .where(col(FinalEvaluation.org_id) == self.org_id)
-        ).first()
-        return row if row is not None else None
 
 
 @event.listens_for(Benchmark, "before_insert")

--- a/services/tracker/src/tracker/database/repositories/__init__.py
+++ b/services/tracker/src/tracker/database/repositories/__init__.py
@@ -1,0 +1,21 @@
+"""Named persistence repositories for tracker application operations."""
+
+from tracker.database.repositories.benchmark import BenchmarkRepository, TaskPage
+from tracker.database.repositories.org import OrgRepository
+from tracker.database.repositories.reporting import BenchmarkPage, BenchmarkTaskCounts, ReportingRepository
+from tracker.database.repositories.run_control import RetrySelection, RunControlRepository
+from tracker.database.repositories.task import TaskRepository
+from tracker.database.repositories.task_execution import TaskExecutionRepository
+
+__all__ = [
+    "BenchmarkPage",
+    "BenchmarkRepository",
+    "BenchmarkTaskCounts",
+    "OrgRepository",
+    "ReportingRepository",
+    "RetrySelection",
+    "RunControlRepository",
+    "TaskPage",
+    "TaskExecutionRepository",
+    "TaskRepository",
+]

--- a/services/tracker/src/tracker/database/repositories/benchmark.py
+++ b/services/tracker/src/tracker/database/repositories/benchmark.py
@@ -1,0 +1,183 @@
+"""Benchmark and benchmark-task read operations."""
+
+from dataclasses import dataclass
+from typing import Literal
+from uuid import UUID
+
+from sqlalchemy import case
+from sqlalchemy.orm import contains_eager
+from sqlmodel import Session, col, desc, func, select
+
+from tracker.database.models import (
+    Benchmark,
+    ErrorResult,
+    FinalEvaluation,
+    Task,
+    TaskStatus,
+)
+
+_STATUS_SORT_PRIORITY = case(
+    {
+        TaskStatus.ERROR: 6,
+        TaskStatus.STOPPED: 5,
+        TaskStatus.FINISHED: 4,
+        TaskStatus.EVALUATING: 3,
+        TaskStatus.IN_PROGRESS: 2,
+        TaskStatus.BUILDING: 1,
+        TaskStatus.PENDING: 0,
+    },
+    value=col(Task.status),
+    else_=-1,
+)
+
+
+@dataclass(frozen=True)
+class TaskPage:
+    """A page of tasks with the newest error message for each row."""
+
+    rows: list[tuple[Task, str | None]]
+    total_count: int
+
+
+class BenchmarkRepository:
+    """Read benchmark data through named, organization-scoped operations."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def get_by_id(self, benchmark_id: UUID) -> Benchmark | None:
+        """Return a benchmark by primary key without applying organization scope."""
+        return self._session.get(Benchmark, benchmark_id)
+
+    def get_for_org(self, benchmark_id: UUID, org_id: UUID, *, for_update: bool = False) -> Benchmark | None:
+        """Return a benchmark only when it belongs to the requested organization."""
+        statement = select(Benchmark).where(Benchmark.id == benchmark_id).where(Benchmark.org_id == org_id)
+        if for_update:
+            statement = statement.with_for_update().execution_options(populate_existing=True)
+        return self._session.exec(statement).one_or_none()
+
+    def get_for_org_with_final_evaluation(self, benchmark_id: UUID, org_id: UUID) -> Benchmark | None:
+        """Return an organization-owned benchmark with its scoped final evaluation eagerly loaded."""
+        statement = (
+            select(Benchmark)
+            .outerjoin(
+                FinalEvaluation,
+                (col(FinalEvaluation.benchmark) == col(Benchmark.id)) & (col(FinalEvaluation.org_id) == org_id),
+            )
+            .options(contains_eager(Benchmark.final_evaluation))
+            .where(Benchmark.id == benchmark_id)
+            .where(Benchmark.org_id == org_id)
+            .execution_options(populate_existing=True)
+        )
+        return self._session.exec(statement).unique().one_or_none()
+
+    def get_for_ids(self, benchmark_ids: list[UUID], org_id: UUID) -> list[Benchmark]:
+        """Return matching organization-owned benchmarks for status polling."""
+        if not benchmark_ids:
+            return []
+        return list(
+            self._session.exec(
+                select(Benchmark).where(Benchmark.org_id == org_id).where(col(Benchmark.id).in_(benchmark_ids))
+            ).all()
+        )
+
+    def get_task_state_counts(self, benchmark_id: UUID, org_id: UUID) -> dict[TaskStatus, int]:
+        """Count tasks by status for an organization-owned benchmark."""
+        rows = self._session.exec(
+            select(col(Task.status), func.count(col(Task.id)))
+            .where(col(Task.benchmark) == benchmark_id)
+            .where(col(Task.org_id) == org_id)
+            .group_by(col(Task.status))
+        ).all()
+        return {status: count for status, count in rows}
+
+    def get_final_score(self, benchmark_id: UUID, org_id: UUID) -> float | None:
+        """Return the final score for an organization-owned benchmark."""
+        score = self._session.exec(
+            select(FinalEvaluation.final_score)
+            .where(FinalEvaluation.benchmark == benchmark_id)
+            .where(FinalEvaluation.org_id == org_id)
+        ).first()
+        return score if score is not None else None
+
+    def list_tasks(
+        self,
+        benchmark_id: UUID,
+        org_id: UUID,
+        *,
+        statuses: list[TaskStatus],
+        task_id_search: str | None,
+        sort: Literal["task_id", "started_at", "duration", "status"],
+        sort_dir: Literal["asc", "desc"],
+        limit: int,
+        offset: int,
+    ) -> TaskPage:
+        """Return a filtered, sorted page of tasks and their newest error messages."""
+        filters = [col(Task.benchmark) == benchmark_id, col(Task.org_id) == org_id]
+        if statuses:
+            filters.append(col(Task.status).in_(statuses))
+        if task_id_search:
+            escaped_search = _escape_sql_like_pattern(task_id_search)
+            filters.append(col(Task.task_id).ilike(f"%{escaped_search}%", escape="\\"))
+
+        latest_error_message = (
+            select(ErrorResult.error_message)
+            .where(ErrorResult.task == Task.id)
+            .where(ErrorResult.org_id == org_id)
+            .order_by(desc(ErrorResult.created_at))
+            .limit(1)
+            .scalar_subquery()
+        )
+        sort_expression = {
+            "task_id": col(Task.task_id),
+            "started_at": col(Task.started_at),
+            "duration": func.coalesce(col(Task.finished_at), func.now()) - col(Task.started_at),
+            "status": _STATUS_SORT_PRIORITY,
+        }[sort]
+        primary_order = sort_expression.asc() if sort_dir == "asc" else sort_expression.desc()
+        order_by = [primary_order, col(Task.started_at).desc()]
+
+        rows = self._session.exec(
+            select(Task, latest_error_message).where(*filters).order_by(*order_by).limit(limit).offset(offset)
+        ).all()
+        total_count = self._session.exec(select(func.count(col(Task.id))).where(*filters)).one()
+        return TaskPage(rows=list(rows), total_count=total_count)
+
+    def get_filter_options(self, org_id: UUID) -> tuple[list[str], list[str]]:
+        """Return distinct benchmark and agent names for an organization."""
+        benchmark_names = sorted(
+            set(self._session.exec(select(Benchmark.name).where(Benchmark.org_id == org_id).distinct()).all())
+        )
+        benchmarks = self._session.exec(select(Benchmark).where(Benchmark.org_id == org_id)).all()
+        agent_names = sorted(
+            {
+                benchmark.arguments.contract.name
+                for benchmark in benchmarks
+                if benchmark.arguments and benchmark.arguments.contract.name
+            }
+        )
+        return benchmark_names, agent_names
+
+    def get_task_status_counts(
+        self,
+        benchmark_ids: list[UUID],
+        org_id: UUID,
+    ) -> dict[UUID, dict[TaskStatus, int]]:
+        """Return task status counts grouped by organization-owned benchmark."""
+        if not benchmark_ids:
+            return {}
+        rows = self._session.exec(
+            select(Task.benchmark, Task.status, func.count())
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.benchmark).in_(benchmark_ids))
+            .group_by(col(Task.benchmark), col(Task.status))
+        ).all()
+        counts: dict[UUID, dict[TaskStatus, int]] = {}
+        for benchmark_id, status, count in rows:
+            counts.setdefault(benchmark_id, {})[TaskStatus(status)] = count
+        return counts
+
+
+def _escape_sql_like_pattern(value: str) -> str:
+    """Escape SQL LIKE wildcards so search input is treated literally."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/services/tracker/src/tracker/database/repositories/org.py
+++ b/services/tracker/src/tracker/database/repositories/org.py
@@ -1,0 +1,31 @@
+"""Organization persistence operations."""
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import Session, select
+
+from tracker.database.models import DEFAULT_ORG_NAME, Org
+
+
+class OrgRepository:
+    """Load organizations without exposing query construction to callers."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def get_default(self) -> Org | None:
+        """Return the configured default organization, if it exists."""
+        return self._session.exec(select(Org).where(Org.name == DEFAULT_ORG_NAME)).first()
+
+    def find_by_name(self, name: str) -> Org | None:
+        """Return the organization with the given tenant name, if it exists."""
+        return self._session.exec(select(Org).where(Org.name == name)).first()
+
+    def ensure_by_name(self, name: str) -> tuple[Org | None, bool]:
+        """Ensure an organization exists and return it with whether this call created it.
+
+        The insert participates in the caller's transaction; this method never commits.
+        """
+        statement = pg_insert(Org).values(name=name).on_conflict_do_nothing(index_elements=["name"])
+        result = self._session.exec(statement)
+        created = result.rowcount > 0
+        return self.find_by_name(name), created

--- a/services/tracker/src/tracker/database/repositories/reporting.py
+++ b/services/tracker/src/tracker/database/repositories/reporting.py
@@ -1,0 +1,339 @@
+"""Read-model queries for benchmark reporting and listings."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Sequence, cast
+from uuid import UUID
+
+from sqlalchemy import JSON, literal, tuple_, type_coerce
+from sqlalchemy.orm import selectinload, with_loader_criteria
+from sqlmodel import Session, asc, col, desc, func, or_, select
+
+from tracker.database.models import (
+    Benchmark,
+    ErrorResult,
+    EvaluationResult,
+    FinalEvaluation,
+    Task,
+    TaskBreakdown,
+    TaskStatus,
+)
+from tracker.types import AverageTaskBreakdown, FetchBenchmarksRequest, Order
+
+
+@dataclass(frozen=True)
+class BenchmarkPage:
+    """A page of organization-scoped benchmarks and pagination metadata."""
+
+    rows: Sequence[Benchmark]
+    total_count: int | None
+    has_next_page: bool
+
+
+@dataclass(frozen=True)
+class BenchmarkTaskCounts:
+    """Task totals and status counts for an organization-owned benchmark."""
+
+    total_tasks: int
+    finished_tasks: int
+    failed_tasks: int
+    status_counts: dict[TaskStatus, int]
+
+
+class ReportingRepository:
+    """Read benchmark reporting data through named organization-scoped queries."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def fetch_evaluation_results(self, benchmark_id: UUID, org_id: UUID) -> dict[str, dict[str, Any]]:
+        """Select the latest successful evaluation result and history for each finished task."""
+        statement = (
+            select(EvaluationResult, Task.id, Task.task_id, TaskBreakdown)
+            .join(Task, col(EvaluationResult.task) == col(Task.id))
+            .outerjoin(TaskBreakdown, col(Task.task_breakdown) == col(TaskBreakdown.id))
+            .where(Task.benchmark == benchmark_id)
+            .where(Task.org_id == org_id)
+            .where(EvaluationResult.org_id == org_id)
+            .where(Task.status == TaskStatus.FINISHED)
+            .order_by(desc(EvaluationResult.created_at), desc(EvaluationResult.id))
+        )
+
+        results = cast(
+            Sequence[tuple[EvaluationResult, UUID, str, TaskBreakdown | None]],
+            self._session.exec(statement).all(),  # pyright: ignore[reportUnknownArgumentType]
+        )
+
+        latest_results: list[tuple[EvaluationResult, UUID, str, TaskBreakdown | None]] = []
+        seen_task_row_ids: set[UUID] = set()
+        for row in results:
+            task_row_id = row[1]
+            if task_row_id not in seen_task_row_ids:
+                latest_results.append(row)
+                seen_task_row_ids.add(task_row_id)
+
+        histories = self._fetch_result_histories(
+            list(seen_task_row_ids),
+            {evaluation_result.id for evaluation_result, _task_row_id, _task_id, _breakdown in latest_results},
+            org_id,
+        )
+
+        evaluation_results: dict[str, dict[str, Any]] = {}
+        for evaluation_result, task_row_id, task_id, task_breakdown in latest_results:
+            result_data = dict(evaluation_result.result)
+            result_data["agent_caused_exit_reason"] = evaluation_result.agent_caused_exit_reason
+            if task_breakdown is not None:
+                result_data["task_breakdown"] = task_breakdown.model_dump()
+            task_history = histories.get(task_row_id, [])
+            result_data["attempts"] = len(task_history) + 1
+            if task_history:
+                result_data["history"] = task_history
+            evaluation_results[task_id] = result_data
+
+        return evaluation_results
+
+    def _fetch_result_histories(
+        self,
+        task_row_ids: Sequence[UUID],
+        current_evaluation_result_ids: set[UUID],
+        org_id: UUID,
+    ) -> dict[UUID, list[dict[str, Any]]]:
+        """Fetch prior evaluation and error attempts for a set of tasks."""
+        evaluation_statement = cast(
+            Any,
+            select(EvaluationResult.id, EvaluationResult.task, EvaluationResult.created_at, EvaluationResult.result)
+            .where(col(EvaluationResult.task).in_(task_row_ids))
+            .where(col(EvaluationResult.org_id) == org_id),
+        )
+        if current_evaluation_result_ids:
+            evaluation_statement = evaluation_statement.where(
+                col(EvaluationResult.id).notin_(current_evaluation_result_ids)
+            )
+
+        evaluation_rows = cast(
+            Sequence[tuple[UUID, UUID, datetime, dict[str, Any]]],
+            cast(Any, self._session.exec(evaluation_statement)).all(),
+        )
+        error_rows = self._session.exec(
+            select(ErrorResult.task, ErrorResult.created_at, ErrorResult.error_message)
+            .where(col(ErrorResult.task).in_(task_row_ids))
+            .where(col(ErrorResult.org_id) == org_id)
+        ).all()
+
+        histories: dict[UUID, list[dict[str, Any]]] = {}
+        for _result_id, task_row_id, created_at, result in evaluation_rows:
+            histories.setdefault(task_row_id, []).append({"created_at": created_at.isoformat(), "result": dict(result)})
+        for task_row_id, created_at, error_message in error_rows:
+            histories.setdefault(task_row_id, []).append(
+                {"created_at": created_at.isoformat(), "error_message": error_message}
+            )
+
+        return {
+            task_row_id: sorted(entries, key=lambda entry: entry["created_at"], reverse=True)
+            for task_row_id, entries in histories.items()
+            if entries
+        }
+
+    def get_benchmark_task_counts(self, benchmark_id: UUID, org_id: UUID) -> BenchmarkTaskCounts:
+        """Count tasks by status for an organization-owned benchmark."""
+        rows = self._session.exec(
+            select(Task.status, func.count(col(Task.id)))
+            .where(Task.benchmark == benchmark_id)
+            .where(Task.org_id == org_id)
+            .group_by(Task.status)
+        ).all()
+        status_counts = {TaskStatus(status): count for status, count in rows}
+
+        return BenchmarkTaskCounts(
+            total_tasks=sum(status_counts.values()),
+            finished_tasks=sum(
+                status_counts.get(status, 0) for status in (TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED)
+            ),
+            failed_tasks=status_counts.get(TaskStatus.ERROR, 0),
+            status_counts=status_counts,
+        )
+
+    def fetch_final_score_inputs(self, benchmark_id: UUID, org_id: UUID) -> dict[str, dict[str, Any] | None]:
+        """Return each task's latest evaluation result, or None when it is unfinished."""
+        task_rows = cast(
+            Sequence[tuple[UUID, str, TaskStatus]],
+            self._session.exec(
+                select(Task.id, Task.task_id, Task.status)
+                .where(Task.benchmark == benchmark_id)
+                .where(Task.org_id == org_id)
+            ).all(),
+        )
+        finished_task_ids = [
+            task_row_id for task_row_id, _task_id, status in task_rows if status == TaskStatus.FINISHED
+        ]
+        result_rows: Sequence[tuple[UUID, dict[str, Any]]] = []
+        if finished_task_ids:
+            result_statement = cast(
+                Any,
+                select(EvaluationResult.task, EvaluationResult.result)
+                .where(col(EvaluationResult.task).in_(finished_task_ids))
+                .where(EvaluationResult.org_id == org_id)
+                .order_by(desc(EvaluationResult.created_at), desc(EvaluationResult.id)),
+            )
+            result_rows = cast(
+                Sequence[tuple[UUID, dict[str, Any]]],
+                cast(Any, self._session.exec(result_statement)).all(),
+            )
+
+        latest_results: dict[UUID, dict[str, Any]] = {}
+        for task_row_id, result in result_rows:
+            latest_results.setdefault(task_row_id, result)
+
+        return {
+            task_id: latest_results.get(task_row_id) if status == TaskStatus.FINISHED else None
+            for task_row_id, task_id, status in task_rows
+        }
+
+    def fetch_average_task_breakdown(self, benchmark_id: UUID, org_id: UUID) -> AverageTaskBreakdown | None:
+        """Fetch average task metrics for an organization-owned benchmark."""
+        row = self._session.exec(
+            select(
+                func.avg(TaskBreakdown.sandbox_build_duration),
+                func.avg(TaskBreakdown.agent_run_duration),
+                func.avg(TaskBreakdown.evaluation_run_duration),
+                func.avg(TaskBreakdown.sandbox_run_duration),
+            )
+            .join(Task, col(Task.task_breakdown) == col(TaskBreakdown.id))
+            .where(Task.benchmark == benchmark_id)
+            .where(Task.org_id == org_id)
+        ).one()
+
+        if all(value is None for value in row):
+            return None
+
+        return AverageTaskBreakdown(
+            sandbox_build_duration=row[0],
+            agent_run_duration=row[1],
+            evaluation_run_duration=row[2],
+            sandbox_run_duration=row[3],
+        )
+
+    def fetch_filtered_benchmark_rows(
+        self,
+        request: FetchBenchmarksRequest,
+        org_id: UUID,
+        *,
+        cursor: tuple[datetime, UUID] | None,
+    ) -> BenchmarkPage:
+        """Fetch filtered benchmarks using the requested offset or keyset pagination mode."""
+        query = (
+            select(Benchmark)
+            .where(Benchmark.org_id == org_id)
+            .options(
+                selectinload(Benchmark.final_evaluation),
+                with_loader_criteria(FinalEvaluation, cast(Any, col(FinalEvaluation.org_id) == org_id)),
+            )
+            .execution_options(populate_existing=True)
+        )
+        arguments_json = type_coerce(col(Benchmark.arguments), JSON)
+
+        if request.agent_name:
+            if len(request.agent_name) == 1:
+                query = query.where(arguments_json["contract"]["name"].as_string() == request.agent_name[0])
+            else:
+                query = query.where(col(arguments_json["contract"]["name"].as_string()).in_(request.agent_name))
+
+        if request.model:
+            query = query.where(arguments_json["contract"]["model"].as_string() == request.model)
+
+        if request.dataset:
+            dataset_value = arguments_json["dataset"].as_string()
+            if request.dataset == "default":
+                query = query.where(or_(dataset_value == "default", dataset_value.is_(None)))
+            else:
+                query = query.where(dataset_value == request.dataset)
+
+        if request.label is not None:
+            query = query.where(func.lower(Benchmark.label) == request.label.lower())
+
+        if request.benchmark_name:
+            if len(request.benchmark_name) == 1:
+                query = query.where(Benchmark.name == request.benchmark_name[0])
+            else:
+                query = query.where(col(Benchmark.name).in_(request.benchmark_name))
+
+        if request.status:
+            if len(request.status) == 1:
+                query = query.where(Benchmark.status == request.status[0])
+            else:
+                query = query.where(col(Benchmark.status).in_(request.status))
+
+        if request.started_after is not None:
+            query = query.where(Benchmark.started_at > request.started_after)
+
+        if request.started_before is not None:
+            query = query.where(Benchmark.started_at < request.started_before)
+
+        if request.started_by:
+            normalized_emails = [email.strip().lower() for email in request.started_by if email and email.strip()]
+            if normalized_emails:
+                query = query.where(col(Benchmark.started_by_email).in_(normalized_emails))
+
+        if request.order_by == Order.DESC:
+            query = query.order_by(desc(Benchmark.started_at), desc(Benchmark.id))
+        else:
+            query = query.order_by(asc(Benchmark.started_at), asc(Benchmark.id))
+
+        if request.cursor is not None:
+            if cursor is not None:
+                cursor_started_at, cursor_id = cursor
+                if request.order_by == Order.DESC:
+                    query = query.where(
+                        tuple_(col(Benchmark.started_at), col(Benchmark.id))
+                        < tuple_(literal(cursor_started_at), literal(str(cursor_id)))
+                    )
+                else:
+                    query = query.where(
+                        tuple_(col(Benchmark.started_at), col(Benchmark.id))
+                        > tuple_(literal(cursor_started_at), literal(str(cursor_id)))
+                    )
+
+            rows = list(self._session.exec(query.limit(request.limit + 1)).all())
+            has_next_page = len(rows) > request.limit
+            if has_next_page:
+                rows = rows[: request.limit]
+
+            return BenchmarkPage(rows=rows, total_count=None, has_next_page=has_next_page)
+
+        total_count = self._session.exec(select(func.count()).select_from(query.subquery())).one()
+        if not total_count:
+            return BenchmarkPage(rows=[], total_count=0, has_next_page=False)
+
+        rows = list(self._session.exec(query.limit(request.limit).offset(request.offset)).all())
+        return BenchmarkPage(rows=rows, total_count=total_count, has_next_page=False)
+
+    def get_stopped_task_count(self, benchmark_id: UUID, org_id: UUID) -> int:
+        """Count stopped tasks for an organization-owned benchmark."""
+        return self._session.exec(
+            select(func.count(col(Task.id)))
+            .where(col(Task.benchmark) == benchmark_id)
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.status) == TaskStatus.STOPPED)
+        ).one()
+
+    def get_task_errors(self, benchmark_id: UUID, org_id: UUID) -> dict[str, str] | None:
+        """Return the newest error message for each errored task in a benchmark."""
+        error_rows = self._session.exec(
+            select(Task.task_id, ErrorResult.error_message)
+            .outerjoin(
+                ErrorResult,
+                (col(ErrorResult.task) == col(Task.id)) & (col(ErrorResult.org_id) == org_id),
+            )
+            .where(Task.benchmark == benchmark_id)
+            .where(Task.org_id == org_id)
+            .where(Task.status == TaskStatus.ERROR)
+            .order_by(col(Task.id), col(ErrorResult.created_at).desc())
+        ).all()
+        if not error_rows:
+            return None
+
+        errors_by_task_id: dict[str, str] = {}
+        for task_id, error_message in error_rows:
+            errors_by_task_id.setdefault(task_id, error_message or "No error message was provided")
+
+        return errors_by_task_id

--- a/services/tracker/src/tracker/database/repositories/run_control.py
+++ b/services/tracker/src/tracker/database/repositories/run_control.py
@@ -1,0 +1,205 @@
+"""Database-only stop, retry, and resume persistence operations."""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import inspect
+from sqlalchemy.orm.base import NO_VALUE
+from sqlmodel import Session, col, func, or_, select, update
+
+from tracker.database.models import (
+    Benchmark,
+    BenchmarkStatus,
+    FinalEvaluation,
+    RetryMode,
+    Task,
+    TaskStatus,
+)
+from tracker.database.repositories.benchmark import BenchmarkRepository
+from tracker.database.repositories.task import TaskRepository
+from tracker.exceptions import TrackerServiceError
+
+
+@dataclass(frozen=True)
+class RetrySelection:
+    """Locked benchmark and the task rows/IDs selected for a retry or resume."""
+
+    benchmark: Benchmark
+    existing_tasks: list[Task]
+    new_task_ids: list[str]
+
+
+class RunControlRepository:
+    """Persist run-control state transitions without owning the transaction."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._benchmarks = BenchmarkRepository(session)
+        self._tasks = TaskRepository(session)
+
+    def lock_benchmark(self, benchmark_id: UUID, org_id: UUID) -> Benchmark | None:
+        """Return an organization-owned benchmark while acquiring its row lock."""
+        return self._benchmarks.get_for_org(benchmark_id, org_id, for_update=True)
+
+    def apply_stop(
+        self,
+        benchmark: Benchmark,
+        org_id: UUID,
+        *,
+        force: bool,
+        task_ids: Sequence[str] | None,
+    ) -> int:
+        """Stop graceful-stop tasks and optionally transition the whole run to STOPPING."""
+        self._require_benchmark_owner(benchmark, org_id)
+        task_update = (
+            update(Task)
+            .where(col(Task.benchmark) == benchmark.id)
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]))
+        )
+        if task_ids is not None:
+            task_update = task_update.where(col(Task.task_id).in_(task_ids))
+
+        result = self._session.exec(task_update.values(status=TaskStatus.STOPPED))
+        affected = result.rowcount
+        if task_ids is None and (affected > 0 or force):
+            benchmark.status = BenchmarkStatus.STOPPING
+            self._session.add(benchmark)
+
+        return affected
+
+    def stop_active_tasks(
+        self,
+        benchmark_id: UUID,
+        org_id: UUID,
+        *,
+        task_ids: Sequence[str] | None,
+    ) -> int:
+        """Force-stop building, in-progress, and evaluating tasks in one benchmark."""
+        task_update = (
+            update(Task)
+            .where(col(Task.benchmark) == benchmark_id)
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
+        )
+        if task_ids is not None:
+            task_update = task_update.where(col(Task.task_id).in_(task_ids))
+        return self._session.exec(task_update.values(status=TaskStatus.STOPPED)).rowcount
+
+    def count_nonterminal_tasks(self, benchmark_id: UUID, org_id: UUID) -> int:
+        """Count tasks that are not finished, errored, or stopped."""
+        terminal_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+        return self._session.exec(
+            select(func.count(col(Task.id)))
+            .where(col(Task.benchmark) == benchmark_id)
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.status).notin_(terminal_statuses))
+        ).one()
+
+    def mark_stopped(self, benchmark: Benchmark) -> None:
+        """Mark a locked benchmark stopped without committing the transaction."""
+        benchmark.status = BenchmarkStatus.STOPPED
+        self._session.add(benchmark)
+
+    def select_retryable(
+        self,
+        benchmark: Benchmark,
+        org_id: UUID,
+        *,
+        retry: bool,
+        rerun_task_ids: Sequence[str],
+    ) -> RetrySelection:
+        """Select retryable tasks using the existing retry status matrix."""
+        self._require_benchmark_owner(benchmark, org_id)
+        filters = [
+            col(Task.benchmark) == benchmark.id,
+            col(Task.org_id) == org_id,
+        ]
+        requested_ids = list(rerun_task_ids)
+        if benchmark.status == BenchmarkStatus.IN_PROGRESS:
+            filters.append(col(Task.status) == TaskStatus.ERROR)
+            if requested_ids:
+                filters.append(col(Task.task_id).in_(requested_ids))
+        elif retry and requested_ids:
+            filters.append(col(Task.task_id).in_(requested_ids))
+        else:
+            retry_statuses = [TaskStatus.STOPPED]
+            if retry:
+                retry_statuses.append(TaskStatus.ERROR)
+            filters.append(or_(col(Task.status).in_(retry_statuses), col(Task.task_id).in_(requested_ids)))
+
+        existing_tasks = list(
+            self._session.exec(select(Task).where(*filters).order_by(col(Task.started_at), col(Task.task_id))).all()
+        )
+        existing_ids = {task.task_id for task in existing_tasks}
+        if benchmark.status == BenchmarkStatus.IN_PROGRESS:
+            missing_task_ids = [task_id for task_id in requested_ids if task_id not in existing_ids]
+            if missing_task_ids:
+                raise TrackerServiceError(
+                    f"{', '.join(missing_task_ids)} cannot be retried while run {benchmark.id} is in progress "
+                    "because they are not in ERROR status"
+                )
+            new_task_ids: list[str] = []
+        else:
+            new_task_ids = list(dict.fromkeys(task_id for task_id in requested_ids if task_id not in existing_ids))
+
+        return RetrySelection(benchmark, existing_tasks, new_task_ids)
+
+    def apply_retry(
+        self,
+        selection: RetrySelection,
+        org_id: UUID,
+        *,
+        retry_mode: RetryMode,
+    ) -> None:
+        """Apply retry state after the caller verifies task IDs externally."""
+        benchmark = selection.benchmark
+        self._require_benchmark_owner(benchmark, org_id)
+        if not selection.existing_tasks and not selection.new_task_ids:
+            return
+
+        evaluations = self._session.exec(
+            select(FinalEvaluation)
+            .where(FinalEvaluation.benchmark == benchmark.id)
+            .where(FinalEvaluation.org_id == org_id)
+        ).all()
+        for evaluation in evaluations:
+            self._session.delete(evaluation)
+        benchmark_state = inspect(benchmark)
+        loaded_evaluation = (
+            benchmark_state.attrs.final_evaluation.loaded_value if benchmark_state is not None else NO_VALUE
+        )
+        if evaluations and isinstance(loaded_evaluation, FinalEvaluation) and loaded_evaluation.org_id == org_id:
+            benchmark.final_evaluation = None
+
+        if benchmark.status != BenchmarkStatus.IN_PROGRESS:
+            benchmark.status = BenchmarkStatus.IN_PROGRESS
+        benchmark.finished_at = None
+        self._session.add(benchmark)
+
+        for task in selection.existing_tasks:
+            task.status = (
+                TaskStatus.EVALUATING
+                if retry_mode == RetryMode.AUTO and task.eval_resume_state is not None
+                else TaskStatus.PENDING
+            )
+            task.started_at = datetime.now(ZoneInfo("UTC"))
+            task.finished_at = None
+            if retry_mode == RetryMode.FROM_SCRATCH:
+                task.eval_resume_state = None
+            self._session.add(task)
+
+        self._tasks.create_missing_task_rows(
+            benchmark.id,
+            selection.new_task_ids,
+            org_id,
+            status=TaskStatus.PENDING,
+        )
+
+    @staticmethod
+    def _require_benchmark_owner(benchmark: Benchmark, org_id: UUID) -> None:
+        if benchmark.org_id != org_id:
+            raise TrackerServiceError(f"Benchmark {benchmark.id} does not belong to organization {org_id}")

--- a/services/tracker/src/tracker/database/repositories/task.py
+++ b/services/tracker/src/tracker/database/repositories/task.py
@@ -1,0 +1,141 @@
+"""Task and terminal-result persistence operations."""
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlmodel import Session, col, select
+
+from tracker.database.models import (
+    Benchmark,
+    ErrorResult,
+    EvaluationResult,
+    Task,
+    TaskStatus,
+)
+
+
+class TaskRepository:
+    """Read and write task data through named operations."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def get_by_id(self, task_id: UUID) -> Task | None:
+        """Return a task by primary key without applying organization scope."""
+        return self._session.get(Task, task_id)
+
+    def get_by_id_for_org(self, task_id: UUID, org_id: UUID) -> Task | None:
+        """Return a task by primary key only when it belongs to the organization."""
+        return self._session.exec(select(Task).where(Task.id == task_id).where(Task.org_id == org_id)).first()
+
+    def get_for_benchmark(self, benchmark_id: UUID, task_id: str, org_id: UUID) -> Task | None:
+        """Return a task only when its benchmark and organization both match."""
+        return self._session.exec(
+            select(Task)
+            .where(Task.benchmark == benchmark_id)
+            .where(Task.org_id == org_id)
+            .where(Task.task_id == task_id)
+        ).first()
+
+    def get_existing_task_ids(self, benchmark_id: UUID, task_ids: Sequence[str], org_id: UUID) -> set[str]:
+        """Return requested task IDs that belong to the organization-owned benchmark."""
+        if not task_ids:
+            return set()
+
+        return set(
+            self._session.exec(
+                select(Task.task_id)
+                .join(Benchmark)
+                .where(Task.benchmark == benchmark_id)
+                .where(Benchmark.org_id == org_id)
+                .where(Task.org_id == org_id)
+                .where(col(Task.task_id).in_(task_ids))
+            ).all()
+        )
+
+    def create_missing_task_rows(
+        self,
+        benchmark_id: UUID,
+        task_ids: Sequence[str],
+        org_id: UUID,
+        *,
+        status: TaskStatus = TaskStatus.PENDING,
+    ) -> list[Task]:
+        """Create missing rows for an organization-owned benchmark in request order."""
+        requested_task_ids = list(dict.fromkeys(task_ids))
+        if not requested_task_ids:
+            return []
+
+        benchmark_exists = self._session.exec(
+            select(Benchmark.id).where(Benchmark.id == benchmark_id).where(Benchmark.org_id == org_id).with_for_update()
+        ).first()
+        if benchmark_exists is None:
+            return []
+
+        existing_task_ids = self.get_existing_task_ids(benchmark_id, requested_task_ids, org_id)
+        existing_rows = self._session.exec(
+            select(Task)
+            .where(Task.benchmark == benchmark_id)
+            .where(Task.org_id == org_id)
+            .where(col(Task.task_id).in_(existing_task_ids))
+        ).all()
+
+        rows_by_task_id = {task.task_id: task for task in existing_rows}
+        for task_id in requested_task_ids:
+            if task_id not in existing_task_ids:
+                task = Task(org_id=org_id, task_id=task_id, benchmark=benchmark_id, status=status)
+                self._session.add(task)
+                rows_by_task_id[task_id] = task
+
+        self._session.flush()
+
+        return [rows_by_task_id[task_id] for task_id in requested_task_ids]
+
+    def get_runnable_for_benchmark(
+        self,
+        benchmark_id: UUID,
+        task_ids: Sequence[str],
+        org_id: UUID,
+        *,
+        statuses: Sequence[TaskStatus] = (TaskStatus.PENDING, TaskStatus.EVALUATING),
+    ) -> list[tuple[str, Task]]:
+        """Return requested runnable task rows in caller-provided order."""
+        requested_task_ids = list(dict.fromkeys(task_ids))
+        if not requested_task_ids or not statuses:
+            return []
+
+        task_rows = self._session.exec(
+            select(Task.task_id, Task)
+            .join(Benchmark)
+            .where(Task.benchmark == benchmark_id)
+            .where(Benchmark.org_id == org_id)
+            .where(Task.org_id == org_id)
+            .where(col(Task.task_id).in_(requested_task_ids))
+            .where(col(Task.status).in_(statuses))
+        ).all()
+
+        task_rows_by_id = {task_id: task_row for task_id, task_row in task_rows}
+        return [(task_id, task_rows_by_id[task_id]) for task_id in requested_task_ids if task_id in task_rows_by_id]
+
+    def get_terminal_result(self, task: Task, org_id: UUID) -> tuple[EvaluationResult | None, str | None]:
+        """Return the newest evaluation result or error message for a terminal task."""
+        if task.org_id != org_id or task.status not in (TaskStatus.FINISHED, TaskStatus.ERROR):
+            return None, None
+
+        if task.status == TaskStatus.FINISHED:
+            result = self._session.exec(
+                select(EvaluationResult)
+                .where(EvaluationResult.task == task.id)
+                .where(EvaluationResult.org_id == org_id)
+                .order_by(col(EvaluationResult.created_at).desc())
+            ).first()
+            return result, None
+
+        error_message = self._session.exec(
+            select(ErrorResult.error_message)
+            .where(ErrorResult.task == task.id)
+            .where(ErrorResult.org_id == org_id)
+            .order_by(col(ErrorResult.created_at).desc())
+        ).first()
+
+        return None, error_message

--- a/services/tracker/src/tracker/database/repositories/task_execution.py
+++ b/services/tracker/src/tracker/database/repositories/task_execution.py
@@ -1,0 +1,319 @@
+"""Authority-fenced task execution persistence operations."""
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.sql.dml import Update
+from sqlmodel import Session, col, select, update
+
+from tracker.database.models import (
+    ErrorResult,
+    EvaluationResult,
+    Task,
+    TaskBreakdown,
+    TaskStatus,
+)
+from tracker.exceptions import ExecutionAuthorityRevoked
+from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
+
+
+class TaskExecutionRepository:
+    """Persist executor task state within a caller-owned transaction."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def get_for_execution(self, task_id: UUID, org_id: UUID) -> Task | None:
+        """Return a task only when it belongs to the requested organization."""
+        return self._session.exec(select(Task).where(col(Task.id) == task_id).where(col(Task.org_id) == org_id)).first()
+
+    def get_for_benchmark(self, benchmark_id: UUID, task_id: str, org_id: UUID) -> Task | None:
+        """Return a task only when its benchmark and organization both match."""
+        return self._session.exec(
+            select(Task)
+            .where(col(Task.benchmark) == benchmark_id)
+            .where(col(Task.task_id) == task_id)
+            .where(col(Task.org_id) == org_id)
+        ).first()
+
+    def is_current(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        authority: ExecutionAuthority,
+        expected_started_at: datetime,
+    ) -> bool:
+        """Check authority and attempt identity without committing the read transaction."""
+        try:
+            lock_execution_authority(self._session, authority)
+            task = self.get_for_execution(task_id, org_id)
+            is_current = (
+                task is not None
+                and task.benchmark == authority.benchmark_id
+                and task.status != TaskStatus.STOPPED
+                and task.started_at == expected_started_at
+            )
+        except ExecutionAuthorityRevoked:
+            self._session.rollback()
+            return False
+
+        self._session.rollback()
+        return is_current
+
+    def save_eval_resume_state(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        state: dict[str, Any],
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime | None = None,
+    ) -> bool:
+        """Save resumable evaluator state if the task attempt is still writable."""
+        try:
+            lock_execution_authority(self._session, authority)
+        except ExecutionAuthorityRevoked:
+            self._session.rollback()
+            return False
+
+        task_update = (
+            update(Task)
+            .where(col(Task.id) == task_id)
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.benchmark) == authority.benchmark_id)
+            .where(col(Task.status) != TaskStatus.STOPPED)
+        )
+        if expected_started_at is not None:
+            task_update = task_update.where(col(Task.started_at) == expected_started_at)
+
+        result = self._session.exec(task_update.values(eval_resume_state=state))
+        if result.rowcount == 0:
+            self._session.rollback()
+            return False
+
+        return True
+
+    def transition_status(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        to_status: TaskStatus,
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime | None = None,
+        expected_status: TaskStatus | None = None,
+    ) -> bool:
+        """Transition a task status with authority and attempt compare-and-set guards."""
+        try:
+            lock_execution_authority(self._session, authority)
+        except ExecutionAuthorityRevoked:
+            self._session.rollback()
+            return False
+
+        task_update = (
+            update(Task)
+            .where(col(Task.id) == task_id)
+            .where(col(Task.org_id) == org_id)
+            .where(col(Task.benchmark) == authority.benchmark_id)
+        )
+        if to_status != TaskStatus.STOPPED:
+            task_update = task_update.where(col(Task.status) != TaskStatus.STOPPED)
+        if expected_status is not None:
+            task_update = task_update.where(col(Task.status) == expected_status)
+        if expected_started_at is not None:
+            task_update = task_update.where(col(Task.started_at) == expected_started_at)
+
+        values: dict[str, TaskStatus | datetime] = {"status": to_status}
+        if to_status in (TaskStatus.FINISHED, TaskStatus.ERROR):
+            values["finished_at"] = datetime.now(UTC)
+        result = self._session.exec(task_update.values(**values))
+        if result.rowcount == 0:
+            self._session.rollback()
+            return False
+
+        return True
+
+    def record_error(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        error_message: str,
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime | None = None,
+        expected_status: TaskStatus | None = None,
+    ) -> bool:
+        """Atomically record an error and transition its task to ``ERROR``."""
+        try:
+            lock_execution_authority(self._session, authority)
+        except ExecutionAuthorityRevoked:
+            self._session.rollback()
+            return False
+
+        task = self.get_for_execution(task_id, org_id)
+        if task is None or task.benchmark != authority.benchmark_id:
+            self._session.rollback()
+            return False
+        if not self._transition_without_authority_lock(
+            task_id,
+            org_id,
+            TaskStatus.ERROR,
+            authority,
+            expected_started_at=expected_started_at,
+            expected_status=expected_status,
+        ):
+            return False
+
+        self._session.add(ErrorResult(org_id=org_id, task=task_id, error_message=error_message))
+        return True
+
+    def attach_breakdown_and_transition(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        breakdown: TaskBreakdown,
+        to_status: TaskStatus,
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime,
+        expected_status: TaskStatus | None = None,
+    ) -> bool:
+        """Atomically attach a breakdown and transition the task."""
+        try:
+            lock_execution_authority(self._session, authority)
+        except ExecutionAuthorityRevoked:
+            self._session.rollback()
+            return False
+
+        self._session.add(breakdown)
+        self._session.flush()
+        task_update = self._task_update(
+            task_id,
+            org_id,
+            to_status,
+            authority,
+            expected_started_at=expected_started_at,
+            expected_status=expected_status,
+        ).values(task_breakdown=breakdown.id)
+        result = self._session.exec(task_update)
+        if result.rowcount == 0:
+            self._session.rollback()
+            return False
+
+        return True
+
+    def record_evaluation_and_finish(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        result: EvaluationResult,
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime,
+        evaluation_run_duration: float | None = None,
+        sandbox_run_duration: float | None = None,
+        expected_status: TaskStatus | None = TaskStatus.EVALUATING,
+    ) -> bool:
+        """Atomically record an evaluation, update durations, and finish the task."""
+        try:
+            lock_execution_authority(self._session, authority)
+        except ExecutionAuthorityRevoked:
+            self._session.rollback()
+            return False
+
+        task = self.get_for_execution(task_id, org_id)
+        if task is None or task.benchmark != authority.benchmark_id:
+            self._session.rollback()
+            return False
+
+        existing_breakdown = None
+        if task.task_breakdown is not None:
+            existing_breakdown = self._session.get(TaskBreakdown, task.task_breakdown)
+            if existing_breakdown is None:
+                self._session.rollback()
+                return False
+
+        if not self._transition_without_authority_lock(
+            task_id,
+            org_id,
+            TaskStatus.FINISHED,
+            authority,
+            expected_started_at=expected_started_at,
+            expected_status=expected_status,
+        ):
+            return False
+
+        result.org_id = org_id
+        result.task = task_id
+        self._session.add(result)
+        if existing_breakdown is not None:
+            duration_values: dict[str, float] = {}
+            if evaluation_run_duration is not None:
+                duration_values["evaluation_run_duration"] = evaluation_run_duration
+            if sandbox_run_duration is not None:
+                duration_values["sandbox_run_duration"] = sandbox_run_duration
+            if duration_values:
+                update_result = self._session.exec(
+                    update(TaskBreakdown)
+                    .where(col(TaskBreakdown.id) == existing_breakdown.id)
+                    .values(**duration_values)
+                )
+                if update_result.rowcount == 0:
+                    self._session.rollback()
+                    return False
+
+        return True
+
+    def _task_update(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        to_status: TaskStatus,
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime | None,
+        expected_status: TaskStatus | None,
+    ) -> Update:
+        """Build the shared task status compare-and-set statement."""
+        task_update = update(Task).where(col(Task.id) == task_id).where(col(Task.org_id) == org_id)
+        task_update = task_update.where(col(Task.benchmark) == authority.benchmark_id)
+        if to_status != TaskStatus.STOPPED:
+            task_update = task_update.where(col(Task.status) != TaskStatus.STOPPED)
+        if expected_status is not None:
+            task_update = task_update.where(col(Task.status) == expected_status)
+        if expected_started_at is not None:
+            task_update = task_update.where(col(Task.started_at) == expected_started_at)
+
+        values: dict[str, TaskStatus | datetime] = {"status": to_status}
+        if to_status in (TaskStatus.FINISHED, TaskStatus.ERROR):
+            values["finished_at"] = datetime.now(UTC)
+
+        return task_update.values(**values)
+
+    def _transition_without_authority_lock(
+        self,
+        task_id: UUID,
+        org_id: UUID,
+        to_status: TaskStatus,
+        authority: ExecutionAuthority,
+        *,
+        expected_started_at: datetime | None,
+        expected_status: TaskStatus | None,
+    ) -> bool:
+        """Apply a status CAS after the caller has acquired the authority fence."""
+        result = self._session.exec(
+            self._task_update(
+                task_id,
+                org_id,
+                to_status,
+                authority,
+                expected_started_at=expected_started_at,
+                expected_status=expected_status,
+            )
+        )
+        if result.rowcount == 0:
+            self._session.rollback()
+            return False
+
+        return True

--- a/services/tracker/src/tracker/database/scoping.py
+++ b/services/tracker/src/tracker/database/scoping.py
@@ -1,10 +1,8 @@
 """Org-scoped query helpers for multi-tenant data isolation."""
 
 from typing import TypeVar
-from uuid import UUID
-
 from fastapi import HTTPException
-from sqlmodel import SQLModel, Session, select
+from sqlmodel import SQLModel, select
 
 from tracker.database.models import Org
 
@@ -21,8 +19,3 @@ def assert_org(row: T | None, org: Org) -> T:
     if row is None or row.org_id != org.id:  # type: ignore[attr-defined]
         raise HTTPException(status_code=404, detail="Not found")
     return row
-
-
-def get_scoped(model: type[T], row_id: UUID, session: Session, org: Org) -> T:
-    """Fetch a row by PK and validate it belongs to the given org. Returns 404 if missing or wrong org."""
-    return assert_org(session.get(model, row_id), org)

--- a/services/tracker/src/tracker/notifications.py
+++ b/services/tracker/src/tracker/notifications.py
@@ -11,12 +11,12 @@ from pydantic import BaseModel
 
 from tracker.aws.secrets import fetch_aws_secret
 from tracker.database.models import BenchmarkStatus
+from tracker.database.repositories import ReportingRepository
 from tracker.exceptions import SecretsError
 from tracker.logging import get_logger
 
 if TYPE_CHECKING:
     from tracker.database.models import Benchmark, Org
-    from sqlmodel import Session
     from tracker.types import AWSCredentials
 
 logger = get_logger(__name__)
@@ -38,10 +38,12 @@ class NotificationContext(BaseModel):
     model: str | None = None
 
     @classmethod
-    def from_benchmark(cls, benchmark_row: "Benchmark", session: "Session", org: "Org") -> NotificationContext:
+    def from_benchmark(
+        cls, benchmark_row: "Benchmark", reporting_repository: ReportingRepository, org: "Org"
+    ) -> NotificationContext:
         from tracker.utils import BenchmarkContext
 
-        details = BenchmarkContext(benchmark_row, session, org).benchmark_details
+        details = BenchmarkContext(benchmark_row, reporting_repository, org).benchmark_details
         return cls(
             benchmark_name=benchmark_row.name,
             agent_name=benchmark_row.arguments.contract.name,

--- a/services/tracker/src/tracker/utils/reporting.py
+++ b/services/tracker/src/tracker/utils/reporting.py
@@ -9,29 +9,18 @@ import json
 from collections.abc import AsyncGenerator, Buffer
 from datetime import datetime
 from functools import cached_property
-from typing import Any, NamedTuple, Sequence, cast
+from typing import Any, NamedTuple, Sequence
 from uuid import UUID
 
-from sqlalchemy import JSON, literal, tuple_, type_coerce
-from sqlalchemy.orm import selectinload
-from sqlmodel import Session, asc, case, col, desc, func, or_, select
+from sqlmodel import Session
 
 from tracker.aws.s3 import (
     S3_BENCHMARKS_PREFIX,
     create_benchmark_url,
     upload_to_s3,
 )
-from tracker.database.models import (
-    Benchmark,
-    BenchmarkStatus,
-    ErrorResult,
-    EvaluationResult,
-    Org,
-    Task,
-    TaskBreakdown,
-    TaskStatus,
-)
-from tracker.database.scoping import scoped_select
+from tracker.database.models import Benchmark, BenchmarkStatus, Org, TaskStatus
+from tracker.database.repositories import BenchmarkRepository, BenchmarkTaskCounts, ReportingRepository
 from tracker.logging import get_logger
 from tracker.types import (
     AverageTaskBreakdown,
@@ -41,18 +30,9 @@ from tracker.types import (
     FetchBenchmarksRequest,
     FinalViewResponse,
     HarnessConfig,
-    Order,
 )
 
 logger = get_logger(__name__)
-
-
-def _history_result(created_at: datetime, result: dict[str, Any]) -> dict[str, Any]:
-    return {"created_at": created_at.isoformat(), "result": dict(result)}
-
-
-def _history_error(created_at: datetime, error_message: str) -> dict[str, Any]:
-    return {"created_at": created_at.isoformat(), "error_message": error_message}
 
 
 class TaskCounts(NamedTuple):
@@ -63,12 +43,12 @@ class TaskCounts(NamedTuple):
 
 class BenchmarkContext:
     _benchmark_row: Benchmark
-    _session: Session
+    _reporting_repository: ReportingRepository
     _org: Org
 
-    def __init__(self, benchmark_row: Benchmark, session: Session, org: Org):
+    def __init__(self, benchmark_row: Benchmark, reporting_repository: ReportingRepository, org: Org):
         self._benchmark_row = benchmark_row
-        self._session = session
+        self._reporting_repository = reporting_repository
         self._org = org
 
     @property
@@ -76,45 +56,23 @@ class BenchmarkContext:
         return self._benchmark_row.status
 
     @cached_property
+    def _task_counts_report(self) -> BenchmarkTaskCounts:
+        return self._reporting_repository.get_benchmark_task_counts(self._benchmark_row.id, self._org.id)
+
+    @property
     def _task_counts(self) -> TaskCounts:
-        finished_statuses = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
+        report = self._task_counts_report
 
-        statement = (
-            select(
-                func.count().label("total_tasks"),
-                func.count(case((col(Task.status).in_(finished_statuses), 1))).label("finished_tasks"),
-                func.count(case((Task.status == TaskStatus.ERROR, 1))).label("failed_tasks"),
-            )
-            .select_from(Task)
-            .where(Task.benchmark == self._benchmark_row.id)
-            .where(Task.org_id == self._org.id)
+        return TaskCounts(
+            total_tasks=report.total_tasks,
+            finished_tasks=report.finished_tasks,
+            failed_tasks=report.failed_tasks,
         )
-
-        result = self._session.exec(statement).one()
-
-        task_counts = TaskCounts(total_tasks=result[0], finished_tasks=result[1], failed_tasks=result[2])
-
-        return task_counts
 
     @property
     def _task_breakdown(self) -> dict[TaskStatus, int]:
-        """
-        Returns a mapping between the task status and the number of tasks in that status
-
-        Provides a breakdown of the benchmark.
-        """
-        statement = (
-            select(Task.status, func.count(col(Task.id)))
-            .select_from(Task)
-            .where(Task.benchmark == self._benchmark_row.id)
-            .where(Task.org_id == self._org.id)
-            .group_by(Task.status)
-            .having(func.count(col(Task.id)) > 0)  # Exclude all with count of 0
-        )
-
-        result = self._session.exec(statement).all()
-
-        return {TaskStatus(status): count for status, count in result}
+        """Return the benchmark's task counts grouped by status."""
+        return self._task_counts_report.status_counts
 
     @cached_property
     def benchmark_details(self) -> BenchmarkDetails:
@@ -129,129 +87,18 @@ class BenchmarkContext:
         )
 
 
-def _fetch_result_histories(
-    session: Session, task_row_ids: Sequence[UUID], current_evaluation_result_ids: set[UUID], org_id: UUID
-) -> dict[UUID, list[dict[str, Any]]]:
-    """
-    Fetch the history of evaluation + error results for the provided task ids, mixing them with the evaluation results we already have.
-    """
-    # Prep query to fetch all evaluation results for the given tasks
-    evaluation_statement = cast(
-        Any,
-        select(EvaluationResult.id, EvaluationResult.task, EvaluationResult.created_at, EvaluationResult.result)
-        .where(col(EvaluationResult.task).in_(task_row_ids))
-        .where(col(EvaluationResult.org_id) == org_id),
-    )
-
-    # Exclude evaluation results we have already collected
-    if current_evaluation_result_ids:
-        evaluation_statement = evaluation_statement.where(
-            col(EvaluationResult.id).notin_(current_evaluation_result_ids)
-        )
-
-    # Fetched evaluation results
-    evaluation_query_result = cast(Any, session.exec(evaluation_statement))
-    evaluation_rows = cast(
-        Sequence[tuple[UUID, UUID, datetime, dict[str, Any]]],
-        evaluation_query_result.all(),
-    )
-
-    # Fetch all of the error results from the provided task_rows (A task can have a error message and a evaluation result depending on if its been reran)
-    error_rows = session.exec(
-        select(ErrorResult.task, ErrorResult.created_at, ErrorResult.error_message)
-        .where(col(ErrorResult.task).in_(task_row_ids))
-        .where(col(ErrorResult.org_id) == org_id)
-    ).all()
-
-    # Create a mapping of the task row, time stamp of when the result for the row was created, and the resulting row
-    # We do this so that we can easily sort it downstream
-    histories: dict[UUID, list[dict[str, Any]]] = {}
-    for _result_id, task_row_id, created_at, result in evaluation_rows:
-        histories.setdefault(task_row_id, []).append(_history_result(created_at, result))
-    for task_row_id, created_at, error_message in error_rows:
-        histories.setdefault(task_row_id, []).append(_history_error(created_at, error_message))
-
-    return {
-        task_row_id: sorted(entries, key=lambda entry: entry["created_at"], reverse=True)
-        for task_row_id, entries in histories.items()
-        if entries
-    }
-
-
-def fetch_evaluation_results(benchmark_id: UUID, session: Session, org_id: UUID) -> dict[str, dict[str, Any]]:
+def fetch_evaluation_results(
+    benchmark_id: UUID, reporting_repository: ReportingRepository, org_id: UUID
+) -> dict[str, dict[str, Any]]:
     """Select the latest successful evaluation result for each finished task."""
-    statement = (
-        select(EvaluationResult, Task.id, Task.task_id, TaskBreakdown)
-        .join(Task, col(EvaluationResult.task) == col(Task.id))
-        .outerjoin(TaskBreakdown, col(Task.task_breakdown) == col(TaskBreakdown.id))
-        .where(Task.benchmark == benchmark_id)
-        .where(Task.org_id == org_id)
-        .where(Task.status == TaskStatus.FINISHED)
-        .order_by(desc(EvaluationResult.created_at))
-    )
-
-    results = cast(
-        Sequence[tuple[EvaluationResult, UUID, str, TaskBreakdown | None]],
-        session.exec(statement).all(),  # pyright: ignore[reportUnknownArgumentType]
-    )
-
-    latest_results: list[tuple[EvaluationResult, UUID, str, TaskBreakdown | None]] = []
-    seen_task_row_ids: set[UUID] = set()
-    for row in results:
-        task_row_id = row[1]
-        if task_row_id not in seen_task_row_ids:
-            latest_results.append(row)
-            seen_task_row_ids.add(task_row_id)
-
-    histories = _fetch_result_histories(
-        session,
-        list(seen_task_row_ids),
-        {evaluation_result.id for evaluation_result, _task_row_id, _task_id, _breakdown in latest_results},
-        org_id,
-    )
-
-    evaluation_results: dict[str, dict[str, Any]] = {}
-    for evaluation_result, task_row_id, task_id, task_breakdown in latest_results:
-        result_data = dict(evaluation_result.result)
-        result_data["agent_caused_exit_reason"] = evaluation_result.agent_caused_exit_reason
-        if task_breakdown is not None:
-            result_data["task_breakdown"] = task_breakdown.model_dump()
-        task_history = histories.get(task_row_id, [])
-        result_data["attempts"] = len(task_history) + 1
-        if task_history:
-            result_data["history"] = task_history
-        evaluation_results[task_id] = result_data
-
-    return evaluation_results
+    return reporting_repository.fetch_evaluation_results(benchmark_id, org_id)
 
 
-def fetch_average_task_breakdown(benchmark_id: UUID, session: Session, org_id: UUID) -> AverageTaskBreakdown | None:
-    """
-    Fetch the average task breakdown for a given benchmark.
-
-    Returns None if there are no task metrics available for the benchmark.
-    """
-    row = session.exec(
-        select(
-            func.avg(TaskBreakdown.sandbox_build_duration),
-            func.avg(TaskBreakdown.agent_run_duration),
-            func.avg(TaskBreakdown.evaluation_run_duration),
-            func.avg(TaskBreakdown.sandbox_run_duration),
-        )
-        .join(Task, col(Task.task_breakdown) == col(TaskBreakdown.id))
-        .where(Task.benchmark == benchmark_id)
-        .where(Task.org_id == org_id)
-    ).one()
-
-    if all(v is None for v in row):
-        return None
-
-    return AverageTaskBreakdown(
-        sandbox_build_duration=row[0],
-        agent_run_duration=row[1],
-        evaluation_run_duration=row[2],
-        sandbox_run_duration=row[3],
-    )
+def fetch_average_task_breakdown(
+    benchmark_id: UUID, reporting_repository: ReportingRepository, org_id: UUID
+) -> AverageTaskBreakdown | None:
+    """Fetch the average task breakdown for a given benchmark."""
+    return reporting_repository.fetch_average_task_breakdown(benchmark_id, org_id)
 
 
 async def stream_benchmark_results(
@@ -276,13 +123,14 @@ async def stream_benchmark_results(
     try:
         while True:
             with Session(bind=session.bind) as fresh_session:
-                fresh_benchmark = fresh_session.get(Benchmark, benchmark_id)
-                if not fresh_benchmark or fresh_benchmark.org_id != org.id:
+                benchmark_repository = BenchmarkRepository(fresh_session)
+                fresh_benchmark = benchmark_repository.get_for_org(benchmark_id, org.id)
+                if fresh_benchmark is None:
                     yield f"{EVENT_ERROR} {json.dumps({'error': 'Run not found'})}\n\n"
                     break
 
-                fresh_session.refresh(fresh_benchmark)
-                benchmark_context = BenchmarkContext(fresh_benchmark, fresh_session, org)
+                reporting_repository = ReportingRepository(fresh_session)
+                benchmark_context = BenchmarkContext(fresh_benchmark, reporting_repository, org)
 
                 response_data = FetchBenchmarkResponse(
                     benchmark_name=fresh_benchmark.name,
@@ -296,9 +144,7 @@ async def stream_benchmark_results(
                     current_execution_release_id=fresh_benchmark.current_execution_release_id,
                     executor_artifact_digest=fresh_benchmark.executor_artifact_digest,
                     executor_protocol_version=fresh_benchmark.executor_protocol_version,
-                    final_score=fresh_benchmark.final_evaluation.final_score
-                    if fresh_benchmark.final_evaluation
-                    else None,
+                    final_score=benchmark_repository.get_final_score(fresh_benchmark.id, org.id),
                     error_message=fresh_benchmark.error_message
                     if fresh_benchmark.status == BenchmarkStatus.ERROR
                     else None,
@@ -334,137 +180,32 @@ def decode_cursor(cursor: str) -> tuple[datetime, UUID]:
 
 
 def fetch_filtered_benchmark_rows(
-    request: FetchBenchmarksRequest, session: Session, org: Org
+    request: FetchBenchmarksRequest, reporting_repository: ReportingRepository, org: Org
 ) -> tuple[Sequence[Benchmark], int | None, str | None]:
-    """
-    Creates a query to fetch benchmark rows from the database based on the fetch benchmark request.
+    """Fetch filtered benchmark rows through the reporting repository."""
+    cursor = decode_cursor(request.cursor) if request.cursor else None
+    page = reporting_repository.fetch_filtered_benchmark_rows(request, org.id, cursor=cursor)
 
-    When request.cursor is a non-empty string, uses keyset pagination (tuple comparison on
-    started_at, id) and returns next_cursor. total_count is None in this path.
+    next_cursor: str | None = None
+    if page.has_next_page:
+        last_row = page.rows[-1]
+        next_cursor = encode_cursor(last_row.started_at, last_row.id)
 
-    When request.cursor is None or empty, uses legacy offset/limit pagination and returns
-    total_count. next_cursor is None in this path.
-
-    Args:
-        request: FetchBenchmarksRequest
-
-    Returns:
-        tuple[Sequence[Benchmark], int | None, str | None]
-        Sequence of benchmark rows, optional total count, optional next cursor
-
-    """
-
-    query = scoped_select(Benchmark, org).options(selectinload(Benchmark.final_evaluation))
-
-    arguments_json = type_coerce(col(Benchmark.arguments), JSON)
-
-    if request.agent_name:
-        if len(request.agent_name) == 1:
-            query = query.where(arguments_json["contract"]["name"].as_string() == request.agent_name[0])
-        else:
-            query = query.where(col(arguments_json["contract"]["name"].as_string()).in_(request.agent_name))
-
-    if request.model:
-        query = query.where(arguments_json["contract"]["model"].as_string() == request.model)
-
-    if request.dataset:
-        dataset_value = arguments_json["dataset"].as_string()
-        if request.dataset == "default":
-            query = query.where(or_(dataset_value == "default", dataset_value.is_(None)))
-        else:
-            query = query.where(dataset_value == request.dataset)
-
-    if request.label is not None:
-        query = query.where(func.lower(Benchmark.label) == request.label.lower())
-
-    if request.benchmark_name:
-        if len(request.benchmark_name) == 1:
-            query = query.where(Benchmark.name == request.benchmark_name[0])
-        else:
-            query = query.where(col(Benchmark.name).in_(request.benchmark_name))
-
-    if request.status:
-        if len(request.status) == 1:
-            query = query.where(Benchmark.status == request.status[0])
-        else:
-            query = query.where(col(Benchmark.status).in_(request.status))
-
-    if request.started_after is not None:
-        query = query.where(Benchmark.started_at > request.started_after)
-
-    if request.started_before is not None:
-        query = query.where(Benchmark.started_at < request.started_before)
-
-    if request.started_by:
-        normalized_emails = [s.strip().lower() for s in request.started_by if s and s.strip()]
-        if normalized_emails:
-            query = query.where(col(Benchmark.started_by_email).in_(normalized_emails))
-
-    if request.order_by == Order.DESC:
-        query = query.order_by(desc(Benchmark.started_at), desc(Benchmark.id))
-    else:
-        query = query.order_by(asc(Benchmark.started_at), asc(Benchmark.id))
-
-    # Keyset cursor path — skip offset/limit and total_count computation.
-    # cursor="" means first page of keyset mode; non-empty cursor means subsequent page.
-    if request.cursor is not None:
-        if request.cursor:
-            cursor_started_at, cursor_id = decode_cursor(request.cursor)
-
-            if request.order_by == Order.DESC:
-                query = query.where(
-                    tuple_(col(Benchmark.started_at), col(Benchmark.id))
-                    < tuple_(literal(cursor_started_at), literal(str(cursor_id)))
-                )
-            else:
-                query = query.where(
-                    tuple_(col(Benchmark.started_at), col(Benchmark.id))
-                    > tuple_(literal(cursor_started_at), literal(str(cursor_id)))
-                )
-
-        # Fetch one extra row to detect whether there is a next page
-        query = query.limit(request.limit + 1)
-        benchmark_rows: Sequence[Benchmark] = session.exec(query).all()
-
-        next_cursor: str | None = None
-        if len(benchmark_rows) > request.limit:
-            benchmark_rows = benchmark_rows[: request.limit]
-            last_row = benchmark_rows[-1]
-            next_cursor = encode_cursor(last_row.started_at, last_row.id)
-
-        return benchmark_rows, None, next_cursor
-
-    # Legacy offset/limit path — compute total_count for backward compat
-    total_count = session.exec(select(func.count()).select_from(query.subquery())).one()
-
-    if not total_count:
-        return [], 0, None
-
-    query = query.limit(request.limit).offset(request.offset)
-    benchmark_rows = session.exec(query).all()
-
-    return benchmark_rows, total_count, None
+    return page.rows, page.total_count, next_cursor
 
 
-def build_benchmark_table_rows(benchmarks: Sequence[Benchmark], session: Session) -> list[BenchmarkTableRow]:
+def build_benchmark_table_rows(
+    benchmarks: Sequence[Benchmark], benchmark_repository: BenchmarkRepository
+) -> list[BenchmarkTableRow]:
     """Batch-load task counts + run-by emails for a page of benchmarks.
 
-    Caller must have eager-loaded `final_evaluation`. Avoids the N+1 of
-    Benchmark.create_benchmark_table_row in a loop.
+    Caller must have eager-loaded `final_evaluation`.
     """
     if not benchmarks:
         return []
 
-    bench_ids = [b.id for b in benchmarks]
-
-    count_rows = session.exec(
-        select(Task.benchmark, Task.status, func.count())
-        .where(col(Task.benchmark).in_(bench_ids))
-        .group_by(col(Task.benchmark), col(Task.status))
-    ).all()
-    counts_by_bench: dict[UUID, dict[TaskStatus, int]] = {}
-    for bench_id, status, count in count_rows:
-        counts_by_bench.setdefault(bench_id, {})[TaskStatus(status)] = count
+    bench_ids = [benchmark.id for benchmark in benchmarks]
+    counts_by_bench = benchmark_repository.get_task_status_counts(bench_ids, benchmarks[0].org_id)
 
     rows: list[BenchmarkTableRow] = []
     for b in benchmarks:
@@ -527,16 +268,13 @@ class YieldingWriter(io.RawIOBase):
         return chunk
 
 
-def create_final_view(benchmark_row: Benchmark, session: Session, org: Org) -> FinalViewResponse:
-    """Creates final view of a benchmark that includes metadata about evaluations and score"""
-    tasks_stopped: int = session.exec(
-        select(func.count(col(Task.id)))
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status) == TaskStatus.STOPPED)
-    ).one()
+def create_final_view(
+    benchmark_row: Benchmark, reporting_repository: ReportingRepository, org: Org
+) -> FinalViewResponse:
+    """Create the final view of a benchmark with evaluation metadata and score."""
+    tasks_stopped = reporting_repository.get_stopped_task_count(benchmark_row.id, org.id)
 
-    final_view: FinalViewResponse = FinalViewResponse(
+    final_view = FinalViewResponse(
         benchmark_name=benchmark_row.name,
         status=benchmark_row.status,
         error_message=benchmark_row.error_message,
@@ -544,11 +282,11 @@ def create_final_view(benchmark_row: Benchmark, session: Session, org: Org) -> F
         benchmark_arguments=benchmark_row.arguments,
         started_at=benchmark_row.started_at,
         finished_at=benchmark_row.finished_at,
-        tasks_stopped=tasks_stopped or None,  # NOTE: Only include if we stopped the benchmark
+        tasks_stopped=tasks_stopped or None,
         final_evaluation=benchmark_row.final_evaluation,
-        evaluation_results=benchmark_row.fetch_evaluation_results(session),
-        task_errors=benchmark_row.fetch_tasks_with_errors(session),
-        average_task_breakdown=fetch_average_task_breakdown(benchmark_row.id, session, org.id),
+        evaluation_results=reporting_repository.fetch_evaluation_results(benchmark_row.id, org.id),
+        task_errors=reporting_repository.get_task_errors(benchmark_row.id, org.id),
+        average_task_breakdown=reporting_repository.fetch_average_task_breakdown(benchmark_row.id, org.id),
     )
 
     return final_view

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -8,18 +8,12 @@ from benchmark_service import (
     sandbox_provider_config_from_mapping,
 )
 from benchmark_service.client import BenchmarkServiceClient
-from sqlmodel import Session, select
-
+from sqlmodel import Session
 from tracker.auth import RequestIdentity
 from tracker.aws.secrets import fetch_aws_secret
 from tracker.config import create_benchmark_service_url
-from tracker.database.models import (
-    Benchmark,
-    BenchmarkArguments,
-    BenchmarkStatus,
-    Org,
-    Task,
-)
+from tracker.database.models import Benchmark, BenchmarkArguments, BenchmarkStatus, Org, Task
+from tracker.database.repositories import BenchmarkRepository, TaskRepository
 from tracker.exceptions import TrackerServiceError
 from tracker.outbound_security import validate_service_headers, validate_service_url_syntax
 from tracker.types import (
@@ -92,7 +86,7 @@ def start_benchmark_request_to_benchmark(request: StartBenchmarkRequest, run_sta
 
 def fetch_benchmark_row(
     benchmark_id: UUID,
-    session: Session,
+    benchmark_repository: BenchmarkRepository,
     org: Org,
     *,
     for_update: bool = False,
@@ -101,7 +95,7 @@ def fetch_benchmark_row(
 
     Arguments
     - benchmark_id: Run identifier to fetch.
-    - session: Database session used for the query.
+    - benchmark_repository: Repository bound to the caller's database session.
     - org: Organization expected to contain the run.
     - for_update: Lock and refresh the row until the transaction completes.
 
@@ -111,40 +105,25 @@ def fetch_benchmark_row(
     Raises
     - ValueError: The run is missing or belongs to another organization.
     """
-    benchmark_row = session.get(
-        Benchmark,
-        benchmark_id,
-        populate_existing=for_update,
-        with_for_update=for_update or None,
-    )
-    if not benchmark_row:
-        raise ValueError(f"Run with id {benchmark_id} not found")
-    if benchmark_row.org_id != org.id:
+    benchmark_row = benchmark_repository.get_for_org(benchmark_id, org.id, for_update=for_update)
+    if benchmark_row:
+        return benchmark_row
+
+    if benchmark_repository.get_by_id(benchmark_id) is not None:
         raise ValueError(f"Run {benchmark_id} does not belong to org {org.id}")
-    return benchmark_row
 
-
-def _fetch_locked_benchmark(benchmark_id: UUID, session: Session, org: Org) -> Benchmark:
-    benchmark_row = session.exec(
-        select(Benchmark)
-        .where(Benchmark.id == benchmark_id)
-        .where(Benchmark.org_id == org.id)
-        .with_for_update()
-        .execution_options(populate_existing=True)
-    ).one_or_none()
-    if benchmark_row is None:
-        raise ValueError(f"Run with id {benchmark_id} not found")
-    return benchmark_row
+    raise ValueError(f"Run with id {benchmark_id} not found")
 
 
 def update_benchmark_concurrency(
     benchmark_id: UUID,
     concurrency: int,
     session: Session,
+    benchmark_repository: BenchmarkRepository,
     org: Org,
 ) -> BenchmarkConcurrencyUpdate:
-    """Lock an org-scoped run and persist a new active-run concurrency limit."""
-    benchmark_row = _fetch_locked_benchmark(benchmark_id, session, org)
+    """Lock an org-scoped run and stage a new active-run concurrency limit for the caller to commit."""
+    benchmark_row = fetch_benchmark_row(benchmark_id, benchmark_repository, org, for_update=True)
     if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
         return BenchmarkConcurrencyUpdate(
             benchmark_id=benchmark_row.id,
@@ -153,17 +132,17 @@ def update_benchmark_concurrency(
         )
 
     benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"concurrency": concurrency})
-    result = BenchmarkConcurrencyUpdate(
+    session.add(benchmark_row)
+    return BenchmarkConcurrencyUpdate(
         benchmark_id=benchmark_row.id,
         status=benchmark_row.status,
         concurrency=benchmark_row.arguments.concurrency,
     )
-    session.commit()
-    return result
 
 
 def update_benchmark_resume_arguments(
     benchmark_id: UUID,
+    benchmark_repository: BenchmarkRepository,
     session: Session,
     org: Org,
     *,
@@ -172,7 +151,7 @@ def update_benchmark_resume_arguments(
     benchmark_url: str | None,
 ) -> Benchmark:
     """Lock and persist argument and service URL overrides used by resume and retry."""
-    benchmark_row = _fetch_locked_benchmark(benchmark_id, session, org)
+    benchmark_row = fetch_benchmark_row(benchmark_id, benchmark_repository, org, for_update=True)
     arguments = benchmark_row.arguments
 
     if secrets:
@@ -189,11 +168,13 @@ def update_benchmark_resume_arguments(
     return benchmark_row
 
 
-def fetch_task_row(task_id: UUID, session: Session, org: Org) -> Task:
+def fetch_task_row(task_id: UUID, task_repository: TaskRepository, org: Org) -> Task:
     """Fetch task row with org validation. Raises domain errors (not HTTPException) for use in background tasks."""
-    task_row = session.get(Task, task_id)
-    if not task_row:
-        raise TrackerServiceError(f"Task with id {task_id} not found")
-    if task_row.org_id != org.id:
+    task_row = task_repository.get_by_id_for_org(task_id, org.id)
+    if task_row:
+        return task_row
+
+    if task_repository.get_by_id(task_id) is not None:
         raise TrackerServiceError(f"Task {task_id} does not belong to org {org.id}")
-    return task_row
+
+    raise TrackerServiceError(f"Task with id {task_id} not found")

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -29,7 +29,6 @@ logger = get_logger(__name__)
 
 def apply_stop_benchmark(
     benchmark_row: Benchmark,
-    session: Session,
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
@@ -159,7 +158,6 @@ async def force_stop_sandboxes(
 
 async def reset_to_in_progress_status(
     benchmark_row: Benchmark,
-    session: Session,
     benchmark_service: BenchmarkServiceClient,
     retry: bool,
     retry_mode: RetryMode,

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -2,9 +2,6 @@
 
 import traceback
 from collections.abc import AsyncGenerator
-from datetime import datetime
-from typing import Any
-from zoneinfo import ZoneInfo
 
 from benchmark_service import (
     Sandbox,
@@ -13,16 +10,10 @@ from benchmark_service import (
     SandboxQuery,
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from sqlmodel import Session, asc, col, func, or_, select, update
+from sqlmodel import Session
 
-from tracker.database.models import (
-    Benchmark,
-    BenchmarkStatus,
-    Org,
-    RetryMode,
-    Task,
-    TaskStatus,
-)
+from tracker.database.models import Benchmark, Org, RetryMode
+from tracker.database.repositories import BenchmarkRepository, RunControlRepository
 from tracker.executor.dispatch_control import terminalize_active_dispatches
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import get_logger
@@ -42,22 +33,16 @@ def apply_stop_benchmark(
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
+    *,
+    repository: RunControlRepository,
 ) -> None:
     """Apply the Stop state transition without committing the transaction."""
-    task_update = (
-        update(Task)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]))
+    repository.apply_stop(
+        benchmark_row,
+        org.id,
+        force=force,
+        task_ids=task_ids,
     )
-    if task_ids:
-        task_update = task_update.where(col(Task.task_id).in_(task_ids))
-
-    result = session.exec(task_update.values(status=TaskStatus.STOPPED))
-
-    if task_ids is None and (result.rowcount > 0 or force):
-        benchmark_row.status = BenchmarkStatus.STOPPING
-        session.add(benchmark_row)
 
 
 async def initiate_stop_benchmark(
@@ -66,10 +51,17 @@ async def initiate_stop_benchmark(
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
+    *,
+    repository: RunControlRepository,
 ) -> None:
     """Initiate Stop without interrupting work that already started unless forced."""
     try:
-        apply_stop_benchmark(benchmark_row, session, force, org, task_ids)
+        repository.apply_stop(
+            benchmark_row,
+            org.id,
+            force=force,
+            task_ids=task_ids,
+        )
         session.commit()
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error stopping run {benchmark_row.id}: {str(e)}") from e
@@ -117,6 +109,9 @@ async def force_stop_sandboxes(
     org: Org,
     sandbox_provider: str = "daytona",
     task_ids: list[str] | None = None,
+    *,
+    repository: RunControlRepository,
+    benchmark_repository: BenchmarkRepository,
 ) -> None:
     """
     Stops and deletes all sandboxes which are in progress or evaluating.
@@ -125,28 +120,18 @@ async def force_stop_sandboxes(
     Raises:
         TrackerServiceError: If there are any errors stopping the sandboxes
     """
-    benchmark_service = benchmark_row.benchmark_service()
-    provider = benchmark_service.get_sandbox_provider(
-        fetch_sandbox_provider_config(sandbox_provider_secret_name, aws, sandbox_provider)
-    )
-
-    # Update all tasks being processed to stopped
-    task_update = (
-        update(Task)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
-    )
-    if task_ids:
-        task_update = task_update.where(col(Task.task_id).in_(task_ids))
-
-    session.exec(task_update.values(status=TaskStatus.STOPPED))
-
+    # Persist active-task STOPPED statuses before touching provider sandboxes.
+    repository.stop_active_tasks(benchmark_row.id, org.id, task_ids=task_ids)
     session.commit()
 
-    # Iterate through each running sandbox and stop it, collecting error messages
+    # Construct the service only after the stop phase is committed. Provider setup
+    # belongs in the cleanup try/finally so the service closes on setup failures too.
+    benchmark_service = benchmark_row.benchmark_service()
     results: dict[str, str | None] = {}
     try:
+        provider = benchmark_service.get_sandbox_provider(
+            fetch_sandbox_provider_config(sandbox_provider_secret_name, aws, sandbox_provider)
+        )
         async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids):
             result = await stop_sandbox(sandbox, provider)
             results[sandbox.name] = result
@@ -159,19 +144,13 @@ async def force_stop_sandboxes(
 
     # Sandbox teardown releases the request's original benchmark lock. Reacquire
     # it so Retry admission cannot land between the runnable check and revocation.
-    benchmark_row = fetch_benchmark_row(benchmark_row.id, session, org, for_update=True)
-    finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
-    tasks_still_running: int = session.exec(
-        select(func.count(col(Task.id)))
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).notin_(finished_statuses))
-    ).one()
-
-    if not tasks_still_running:
-        benchmark_row.status = BenchmarkStatus.STOPPED
-        terminalize_active_dispatches(session, benchmark_row.id)
-        session.add(benchmark_row)
+    locked_benchmark = repository.lock_benchmark(benchmark_row.id, org.id)
+    if locked_benchmark is None:
+        # Preserve the legacy distinction between a missing run and a wrong-org run.
+        locked_benchmark = fetch_benchmark_row(benchmark_row.id, benchmark_repository, org, for_update=True)
+    if repository.count_nonterminal_tasks(locked_benchmark.id, org.id) == 0:
+        repository.mark_stopped(locked_benchmark)
+        terminalize_active_dispatches(session, locked_benchmark.id)
     session.commit()
 
     if error_message:
@@ -186,6 +165,9 @@ async def reset_to_in_progress_status(
     retry_mode: RetryMode,
     rerun_task_ids: list[str],
     org: Org,
+    *,
+    repository: RunControlRepository,
+    benchmark_repository: BenchmarkRepository,
 ) -> list[str]:
     """
     Resets valid tasks to in progress and to allow for retrying or resuming the benchmark.
@@ -200,91 +182,37 @@ async def reset_to_in_progress_status(
     NOTE: Will raise if benchmark is in a stopped state with no stopped tasks.
     """
     try:
-        # Serialize retries with final-score persistence for this benchmark.
-        benchmark_row = fetch_benchmark_row(benchmark_row.id, session, org, for_update=True)
-        existing_rows = session.exec(
-            select(Task)
-            .where(*_retry_task_filters(benchmark_row, retry, rerun_task_ids, org))
-            .order_by(asc(Task.started_at))
-        ).all()
-        existing_by_task_id: dict[str, Task] = {task.task_id: task for task in existing_rows}
+        # Serialize retries with final-score persistence for this benchmark and keep
+        # the row lock while the service verifies IDs and the caller admits dispatch.
+        locked_benchmark = repository.lock_benchmark(benchmark_row.id, org.id)
+        if locked_benchmark is None:
+            # Preserve the legacy distinction between a missing run and a wrong-org run.
+            locked_benchmark = fetch_benchmark_row(benchmark_row.id, benchmark_repository, org, for_update=True)
 
-        if benchmark_row.status == BenchmarkStatus.IN_PROGRESS:
-            missing_task_ids = [task_id for task_id in rerun_task_ids if task_id not in existing_by_task_id]
-            if missing_task_ids:
-                raise TrackerServiceError(
-                    f"{', '.join(missing_task_ids)} cannot be retried while run {benchmark_row.id} is in progress because they are not in ERROR status"
-                )
-            new_task_ids = []
-        else:
-            new_task_ids = [tid for tid in rerun_task_ids if tid not in existing_by_task_id]
-
-        # Allow re-running the end of the benchmark without running any tasks
-        if not existing_rows and not new_task_ids:
-            return []
-
-        # Verify the task ids are still valid before priming to resume
-        # Raises if any task ids are invalid
-        all_requested_task_ids = [task.task_id for task in existing_rows] + new_task_ids
-        verify_response = await benchmark_service.verify_task_ids(
-            task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
+        selection = repository.select_retryable(
+            locked_benchmark,
+            org.id,
+            retry=retry,
+            rerun_task_ids=rerun_task_ids,
         )
 
-        old_evaluation = benchmark_row.final_evaluation
-        if old_evaluation is not None:
-            benchmark_row.final_evaluation = None
-            session.delete(old_evaluation)
+        # Allow re-running the end of the benchmark without running any tasks.
+        if not selection.existing_tasks and not selection.new_task_ids:
+            return []
 
-        # Retry/resume always starts a new active execution.
-        if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
-            benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        benchmark_row.finished_at = None
-        session.add(benchmark_row)
-
-        for task in existing_rows:
-            task.status = (
-                TaskStatus.EVALUATING
-                if retry_mode == RetryMode.AUTO and task.eval_resume_state is not None
-                else TaskStatus.PENDING
-            )
-            task.started_at = datetime.now(ZoneInfo("UTC"))
-            task.finished_at = None
-            if retry_mode == RetryMode.FROM_SCRATCH:
-                task.eval_resume_state = None
-            session.add(task)
-
-        for task_id in new_task_ids:
-            session.add(Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id, status=TaskStatus.PENDING))
-
+        # Verify the task ids are still valid before priming to resume.
+        verify_response = await benchmark_service.verify_task_ids(
+            task_ids=[task.task_id for task in selection.existing_tasks] + selection.new_task_ids,
+            slice_str=None,
+            dataset=locked_benchmark.arguments.dataset,
+        )
+        repository.apply_retry(
+            selection,
+            org.id,
+            retry_mode=retry_mode,
+        )
         return verify_response.task_ids
     except (TrackerServiceError, BenchmarkServiceError):
         raise
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error resuming run {benchmark_row.id}: {str(e)}") from e
-
-
-def _retry_task_filters(benchmark_row: Benchmark, retry: bool, rerun_task_ids: list[str], org: Org) -> list[Any]:
-    """Select retryable rows.
-
-    Active retries on in-progress runs are limited to ERROR tasks. Finished tasks must wait until the run is terminal.
-    """
-    filters = [
-        col(Task.benchmark) == benchmark_row.id,
-        col(Task.org_id) == org.id,
-    ]
-    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS:
-        filters.append(col(Task.status) == TaskStatus.ERROR)
-        if rerun_task_ids:
-            filters.append(col(Task.task_id).in_(rerun_task_ids))
-        return filters
-
-    if retry and rerun_task_ids:
-        filters.append(col(Task.task_id).in_(rerun_task_ids))
-        return filters
-
-    retry_statuses = [TaskStatus.STOPPED]
-    if retry:
-        retry_statuses.append(TaskStatus.ERROR)
-
-    filters.append(or_(col(Task.status).in_(retry_statuses), col(Task.task_id).in_(rerun_task_ids)))
-    return filters

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -3,23 +3,23 @@
 import asyncio
 import traceback
 from asyncio import Semaphore, gather
-from typing import Any, Sequence, cast
+from typing import Any, Sequence
 from uuid import UUID
 
 import logfire
 import sentry_sdk
 from benchmark_service.client import BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from opentelemetry import trace
-from sqlmodel import Session, col, desc, func, select
+from sqlmodel import Session, col, func, select
 
 from tracker._lambda import invoke_lambda, lambda_client
 from tracker.aws.cloudwatch_logs import create_benchmark_log_group
 from tracker.config import broker
+from tracker.database.repositories import BenchmarkRepository, ReportingRepository, TaskRepository
 from tracker.database.models import (
     Benchmark,
     BenchmarkStatus,
     DocentReadingStatus,
-    EvaluationResult,
     FinalEvaluation,
     Org,
     Task,
@@ -111,6 +111,7 @@ def create_task_rows(
     org: Org,
     *,
     authority: ExecutionAuthority,
+    task_repository: TaskRepository,
 ) -> Sequence[tuple[str, Task]]:
     """
     Create task_rows that do not already exist in the database for the benchmark row.
@@ -119,31 +120,14 @@ def create_task_rows(
     """
     lock_execution_authority(session, authority)
 
-    # Find task ids that already exist so that we can filter them out
-    existing_task_ids: Sequence[str] = session.exec(
-        select(Task.task_id).where(Task.benchmark == benchmark_row.id).where(col(Task.task_id).in_(verified_task_ids))
-    ).all()
-
-    # NOTE: Must maintain same order that was passed in
-    task_ids_to_create = [task_id for task_id in verified_task_ids if task_id not in existing_task_ids]
-
-    for task_id in task_ids_to_create:
-        task_row = Task(org_id=org.id, task_id=task_id, benchmark=benchmark_row.id)
-        session.add(task_row)
-
+    task_repository.create_missing_task_rows(
+        benchmark_row.id,
+        verified_task_ids,
+        org.id,
+    )
     session.commit()
-    session.expire_all()
 
-    task_rows = session.exec(
-        select(Task.task_id, Task)
-        .where(Task.benchmark == benchmark_row.id)
-        .where(Task.org_id == org.id)
-        .where(col(Task.task_id).in_(verified_task_ids))
-        .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.EVALUATING]))
-    ).all()
-
-    task_rows_by_id: dict[str, Task] = {task_id: task_row for task_id, task_row in task_rows}
-    return [(task_id, task_rows_by_id[task_id]) for task_id in verified_task_ids if task_id in task_rows_by_id]
+    return task_repository.get_runnable_for_benchmark(benchmark_row.id, verified_task_ids, org.id)
 
 
 def has_runnable_tasks(session: Session, benchmark_row: Benchmark, org: Org) -> bool:
@@ -170,42 +154,11 @@ def has_stopped_tasks(session: Session, benchmark_row: Benchmark, org: Org) -> b
     )
 
 
-def fetch_final_score_inputs(session: Session, benchmark_row: Benchmark, org: Org) -> dict[str, dict[str, Any] | None]:
-    """
-    Return a mapping of the task IDs to their latest evaluation results. If a task is not finished we default to None.
-    """
-    # Fetch task rows which belong to the benchmark we are running
-    task_rows = cast(
-        Sequence[tuple[UUID, str, TaskStatus]],
-        session.exec(
-            select(Task.id, Task.task_id, Task.status)
-            .where(col(Task.benchmark) == benchmark_row.id)
-            .where(col(Task.org_id) == org.id)
-        ).all(),
-    )
-
-    # Fetch all results from tasks that are finished
-    task_row_ids = [task_row_id for task_row_id, _task_id, status in task_rows if status == TaskStatus.FINISHED]
-    result_rows = cast(
-        Sequence[tuple[UUID, dict[str, Any]]],
-        session.exec(
-            select(EvaluationResult.task, EvaluationResult.result)  # pyright: ignore[reportUnknownArgumentType]
-            .where(col(EvaluationResult.task).in_(task_row_ids))
-            .where(col(EvaluationResult.org_id) == org.id)
-            .order_by(desc(EvaluationResult.created_at))
-        ).all(),
-    )
-
-    # Group results by task row ID
-    latest_results: dict[UUID, dict[str, Any]] = {}
-    for task_row_id, result in result_rows:
-        latest_results.setdefault(task_row_id, result)
-
-    # Return mapping between task IDs and their latest evaluation results
-    return {
-        task_id: latest_results.get(task_row_id) if status == TaskStatus.FINISHED else None
-        for task_row_id, task_id, status in task_rows
-    }
+def fetch_final_score_inputs(
+    reporting_repository: ReportingRepository, benchmark_row: Benchmark, org: Org
+) -> dict[str, dict[str, Any] | None]:
+    """Return each task's latest evaluation result, or None when it is unfinished."""
+    return reporting_repository.fetch_final_score_inputs(benchmark_row.id, org.id)
 
 
 async def finalize_all_error_run(
@@ -224,7 +177,7 @@ async def finalize_all_error_run(
     - True when a concurrent retry defers finalization, otherwise False.
     """
     with Session(bind=engine) as session:
-        benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+        benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org, for_update=True)
         lock_execution_authority(session, authority)
         if has_runnable_tasks(session, benchmark_row, org):
             return True
@@ -236,13 +189,13 @@ async def finalize_all_error_run(
         if has_stopped_tasks(session, benchmark_row, org):
             set_benchmark_final_status(benchmark_row, session, org, authority=authority)
             return False
-        task_errors = benchmark_row.fetch_tasks_with_errors(session) or {}
+        task_errors = ReportingRepository(session).get_task_errors(benchmark_id, org.id) or {}
         session.commit()
 
     error_message = await asyncio.to_thread(summarize_task_errors, task_errors)
 
     with Session(bind=engine) as session:
-        benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+        benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org, for_update=True)
         if has_runnable_tasks(session, benchmark_row, org):
             return True
         if has_stopped_tasks(session, benchmark_row, org):
@@ -332,13 +285,16 @@ async def process_benchmark(
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            benchmark_repository = BenchmarkRepository(session)
+            task_repository = TaskRepository(session)
+            benchmark_row = fetch_benchmark_row(benchmark_id, benchmark_repository, org)
             task_rows: Sequence[tuple[str, Task]] = create_task_rows(
                 verified_task_ids,
                 benchmark_row,
                 session,
                 org,
                 authority=authority,
+                task_repository=task_repository,
             )
             limiter = ResizableLimiter(benchmark_row.arguments.concurrency)
 
@@ -389,7 +345,7 @@ async def process_benchmark(
         await monitor_task
 
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org, for_update=True)
             lock_execution_authority(session, authority)
             if has_runnable_tasks(session, benchmark_row, org):
                 finalization_deferred = True
@@ -399,7 +355,7 @@ async def process_benchmark(
                 benchmark_id,
                 except_dispatch_id=authority.dispatch_id,
             )
-            evaluation_results = fetch_final_score_inputs(session, benchmark_row, org)
+            evaluation_results = fetch_final_score_inputs(ReportingRepository(session), benchmark_row, org)
             session.commit()
 
         if not any(result is not None for result in evaluation_results.values()):
@@ -412,7 +368,7 @@ async def process_benchmark(
         )
 
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org, for_update=True)
             lock_execution_authority(session, authority)
             # final_score is a network call; a concurrent retry can make tasks runnable before we write FinalEvaluation.
             if has_runnable_tasks(session, benchmark_row, org):
@@ -428,7 +384,7 @@ async def process_benchmark(
         )
 
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org, for_update=True)
             if has_runnable_tasks(session, benchmark_row, org):
                 finalization_deferred = True
                 return
@@ -447,7 +403,11 @@ async def process_benchmark(
             lock_execution_authority(session, authority, require_in_progress=False)
             session.commit()
 
-            final_view: FinalViewResponse = create_final_view(benchmark_row, session, org)
+            final_view: FinalViewResponse = create_final_view(
+                benchmark_row,
+                ReportingRepository(session),
+                org,
+            )
             final_view_benchmark = benchmark_row
             lambda_function = benchmark_row.arguments.lambda_function
             lambda_payload: dict[str, Any] | None = None
@@ -481,7 +441,7 @@ async def process_benchmark(
     except BenchmarkServiceUnauthenticatedError as e:
         logfire.warn("process_benchmark failed due to benchmark service auth error")
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"
             logger.warning(error_message)
             commit_benchmark_error(
@@ -493,7 +453,7 @@ async def process_benchmark(
             )
     except BenchmarkServiceError as e:
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org)
             error_message = str(e)
             commit_benchmark_error(
                 benchmark_row,
@@ -506,7 +466,7 @@ async def process_benchmark(
         logfire.exception("process_benchmark failed")
         sentry_sdk.capture_exception(e)
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"
             commit_benchmark_error(
                 benchmark_row,
@@ -526,6 +486,7 @@ async def process_benchmark(
                     org,
                     authority=authority,
                     task_ids=verified_task_ids,
+                    benchmark_repository=BenchmarkRepository(session),
                 )
 
         if notifier and not finalization_deferred and authority_current:
@@ -536,7 +497,9 @@ async def process_benchmark(
                         authority,
                         require_in_progress=False,
                     )
-                    notification_context = NotificationContext.from_benchmark(benchmark_row, session, org)
+                    notification_context = NotificationContext.from_benchmark(
+                        benchmark_row, ReportingRepository(session), org
+                    )
                     final_score = benchmark_row.final_evaluation.final_score if benchmark_row.final_evaluation else None
                     notification_status = benchmark_row.status
                     notification_error_message = benchmark_row.error_message
@@ -586,6 +549,7 @@ def catch_errors_during_cleanup(
     *,
     authority: ExecutionAuthority,
     task_ids: list[str] | None = None,
+    benchmark_repository: BenchmarkRepository,
 ) -> bool:
     """
     On task exit we must clean up any edge cases so that it does not affect the users experience.
@@ -596,7 +560,7 @@ def catch_errors_during_cleanup(
     """
     terminal_statuses = [BenchmarkStatus.FINISHED, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPED]
 
-    benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
+    benchmark_row = fetch_benchmark_row(benchmark_id, benchmark_repository, org)
     try:
         benchmark_row = lock_execution_authority(
             session,

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -23,7 +23,7 @@ from benchmark_service import (
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from opentelemetry import trace
 from pydantic import ValidationError
-from sqlmodel import Session, col, select, update
+from sqlmodel import Session, select
 from tenacity import retry as tenacity_retry
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_fixed
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
@@ -36,12 +36,17 @@ from tracker.aws.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
 from tracker.database.models import (
     BenchmarkStatus,
-    ErrorResult,
     EvaluationResult,
     Org,
     Task,
     TaskBreakdown,
     TaskStatus,
+)
+from tracker.database.repositories import (
+    BenchmarkRepository,
+    ReportingRepository,
+    TaskExecutionRepository,
+    TaskRepository,
 )
 from tracker.database.session import engine
 from tracker.exceptions import (
@@ -61,7 +66,6 @@ from tracker.types import (
     HarnessConfig,
     StartBenchmarkRequest,
 )
-
 from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
 
 logger = get_logger(__name__)
@@ -93,7 +97,7 @@ class TrackedTaskStatus(str, Enum):
 class ResizableLimiter:
     """A per-executor admission limit that can change without preempting admitted work."""
 
-    def __init__(self, limit: int):
+    def __init__(self, limit: int) -> None:
         if limit < 1:
             raise ValueError("Limit must be greater than 0")
         self._limit = limit
@@ -136,7 +140,7 @@ class TrackedTask:
         coro: Coroutine[Any, Any, Any],
         org: Org,
         authority: ExecutionAuthority,
-    ):
+    ) -> None:
         self._coro = coro
         self._org = org
         self._authority = authority
@@ -152,8 +156,9 @@ class TrackedTask:
         return self._task
 
     async def run(self, limiter: ResizableLimiter, task_row: Task) -> dict[str, dict[str, Any] | None]:
-        async def _wrap_coro():
-            """Need to have a task created even if we are not running the coroutine so that we can cancel it before its running"""
+        async def _wrap_coro() -> dict[str, dict[str, Any] | None]:
+            """Need to have a task created even if we are not running the coroutine so that we can
+            cancel it before its running"""
             async with limiter:
                 self._status = TrackedTaskStatus.RUNNING
                 return await self._coro
@@ -166,7 +171,8 @@ class TrackedTask:
             # Need to clean up the coroutine if we cancelled the task
             self._coro.close()
 
-            # When we cancel we return the task id still so that we can track the task when we create the final evaluation row
+            # When we cancel we return the task id still so that we can track the task when we
+            # create the final evaluation row
             return {task_row.task_id: None}
         except Exception as e:
             error_message = f"Task error was not handled: {_exception_message(e)}\n{traceback.format_exc()}"
@@ -174,7 +180,7 @@ class TrackedTask:
             logfire.exception("tracked_task_run failed")
             sentry_sdk.capture_exception(e)
             with Session(bind=engine) as session:
-                task = fetch_task_row(task_row.id, session, self._org)
+                task = fetch_task_row(task_row.id, TaskRepository(session), self._org)
                 commit_task_error(
                     task,
                     session,
@@ -206,7 +212,7 @@ class TaskMonitor:
         *,
         authority: ExecutionAuthority,
         notifier: SlackNotifier | None = None,
-    ):
+    ) -> None:
         self._benchmark_id = benchmark_id
         self._task_tracking = task_tracking
         self._org = org
@@ -216,7 +222,7 @@ class TaskMonitor:
 
     async def _refresh_concurrency(self) -> None:
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(self._benchmark_id, session, self._org)
+            benchmark_row = fetch_benchmark_row(self._benchmark_id, BenchmarkRepository(session), self._org)
             concurrency = benchmark_row.arguments.concurrency
         await self._limiter.resize(concurrency)
 
@@ -254,7 +260,7 @@ class TaskMonitor:
 
         """
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(self._benchmark_id, session, self._org)
+            benchmark_row = fetch_benchmark_row(self._benchmark_id, BenchmarkRepository(session), self._org)
             task_row = self._fetch_task_row(task_id)
 
             # If task has been stopped or benchmark has errored we need to exit
@@ -269,8 +275,10 @@ class TaskMonitor:
             return
 
         with Session(bind=engine) as session:
-            benchmark_row = fetch_benchmark_row(self._benchmark_id, session, self._org)
-            notification_context = NotificationContext.from_benchmark(benchmark_row, session, self._org)
+            benchmark_row = fetch_benchmark_row(self._benchmark_id, BenchmarkRepository(session), self._org)
+            notification_context = NotificationContext.from_benchmark(
+                benchmark_row, ReportingRepository(session), self._org
+            )
             await self._notifier.check_and_notify(notification_context)
 
     async def track_tasks(self) -> None:
@@ -343,23 +351,17 @@ def save_eval_resume_state(
     expected_started_at: datetime | None = None,
 ) -> bool:
     with Session(bind=engine) as session:
-        try:
-            lock_execution_authority(session, authority)
-        except ExecutionAuthorityRevoked:
-            session.rollback()
-            return False
-        task_update = (
-            update(Task)
-            .where(col(Task.id) == task_row_id)
-            .where(col(Task.org_id) == org.id)
-            .where(col(Task.status) != TaskStatus.STOPPED)
+        repository = TaskExecutionRepository(session)
+        saved = repository.save_eval_resume_state(
+            task_row_id,
+            org.id,
+            eval_resume_state,
+            authority,
+            expected_started_at=expected_started_at,
         )
-        if expected_started_at is not None:
-            task_update = task_update.where(col(Task.started_at) == expected_started_at)
-
-        result = session.exec(task_update.values(eval_resume_state=eval_resume_state))
-        session.commit()
-        return result.rowcount > 0
+        if saved:
+            session.commit()
+        return saved
 
 
 def _commit_task_status(
@@ -384,28 +386,26 @@ def _commit_task_status(
         span_attributes["has_error_message"] = True
 
     with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
-        try:
-            lock_execution_authority(session, authority)
-        except ExecutionAuthorityRevoked:
-            session.rollback()
-            return False
-        values: dict[str, TaskStatus | datetime] = {"status": to_status}
-        if to_status in [TaskStatus.FINISHED, TaskStatus.ERROR]:
-            values["finished_at"] = datetime.now(ZoneInfo("UTC"))
-
-        task_update = update(Task).where(col(Task.id) == task.id).where(col(Task.org_id) == task.org_id)
-        if to_status != TaskStatus.STOPPED:
-            task_update = task_update.where(col(Task.status) != TaskStatus.STOPPED)
-        if expected_started_at is not None:
-            task_update = task_update.where(col(Task.started_at) == expected_started_at)
-
-        result = session.exec(task_update.values(**values))
-        if result.rowcount == 0:
-            session.rollback()
-            return False
-
-        session.commit()
-        return True
+        repository = TaskExecutionRepository(session)
+        if error_message is not None:
+            transitioned = repository.record_error(
+                task.id,
+                task.org_id,
+                error_message,
+                authority,
+                expected_started_at=expected_started_at,
+            )
+        else:
+            transitioned = repository.transition_status(
+                task.id,
+                task.org_id,
+                to_status,
+                authority,
+                expected_started_at=expected_started_at,
+            )
+        if transitioned:
+            session.commit()
+        return transitioned
 
 
 def commit_task_status_transition(
@@ -418,7 +418,7 @@ def commit_task_status_transition(
     expected_started_at: datetime | None = None,
 ) -> bool:
     fetch_start = time.monotonic()
-    task = fetch_task_row(task_row_id, session, org)
+    task = fetch_task_row(task_row_id, TaskRepository(session), org)
     return _commit_task_status(
         task,
         session,
@@ -498,8 +498,8 @@ async def _process_task_attempt(
 
     requested_attempt_started_at = task_row.started_at
     with Session(bind=engine) as task_session:
-        benchmark_row = fetch_benchmark_row(benchmark_id, task_session, org)
-        task_row = fetch_task_row(task_row.id, task_session, org)
+        benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(task_session), org)
+        task_row = fetch_task_row(task_row.id, TaskRepository(task_session), org)
 
         if _normalized_attempt_time(task_row.started_at) != _normalized_attempt_time(requested_attempt_started_at):
             return {task_id: None}
@@ -541,15 +541,12 @@ async def _process_task_attempt(
 
     def execution_is_current() -> bool:
         with Session(bind=engine) as task_session:
-            try:
-                lock_execution_authority(task_session, authority)
-            except ExecutionAuthorityRevoked:
-                task_session.rollback()
-                return False
-            task = fetch_task_row(task_row.id, task_session, org)
-            is_current = task.status != TaskStatus.STOPPED and task.started_at == attempt_started_at
-            task_session.rollback()
-            return is_current
+            return TaskExecutionRepository(task_session).is_current(
+                task_row.id,
+                org.id,
+                authority,
+                attempt_started_at,
+            )
 
     def task_is_stopped() -> bool:
         return not execution_is_current()
@@ -579,26 +576,30 @@ async def _process_task_attempt(
                 )
 
                 with Session(bind=engine) as task_session:
-                    task_session.add(evaluation_result_row)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
-                    if task_in_session.task_breakdown:
-                        existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
-                        assert existing_breakdown is not None
-                        existing_breakdown.evaluation_run_duration = resume_eval_duration
-                    if not commit_task_status_transition(
-                        task_row.id,
-                        task_session,
-                        org,
-                        TaskStatus.FINISHED,
-                        expected_started_at=attempt_started_at,
-                        authority=authority,
-                    ):
-                        return {task_id: None}
-
+                    fetch_start = time.monotonic()
+                    task_in_session = fetch_task_row(task_row.id, TaskRepository(task_session), org)
+                    span_attributes = {
+                        "benchmark_id": str(task_in_session.benchmark),
+                        "task_id": task_in_session.task_id,
+                        "from_status": task_in_session.status.value,
+                        "to_status": TaskStatus.FINISHED.value,
+                        "fetch_duration_ms": elapsed_ms(fetch_start),
+                    }
+                    with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
+                        if not TaskExecutionRepository(task_session).record_evaluation_and_finish(
+                            task_row.id,
+                            org.id,
+                            evaluation_result_row,
+                            authority,
+                            expected_started_at=attempt_started_at,
+                            evaluation_run_duration=resume_eval_duration,
+                        ):
+                            return {task_id: None}
+                        task_session.commit()
                     return {task_id: evaluation_result_row.result}
             except Exception as e:
                 with Session(bind=engine) as task_session:
-                    task = fetch_task_row(task_row.id, task_session, org)
+                    task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
                     if task.status == TaskStatus.STOPPED:
                         return {task_id: None}
 
@@ -738,18 +739,27 @@ async def _process_task_attempt(
 
                 task_breakdown.agent_run_duration = agent_run_time
                 with Session(bind=engine) as task_session:
-                    task_session.add(task_breakdown)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
-                    task_in_session.task_breakdown = task_breakdown.id
-                    if not commit_task_status_transition(
-                        task_row.id,
-                        task_session,
-                        org,
-                        TaskStatus.EVALUATING,
-                        expected_started_at=attempt_started_at,
-                        authority=authority,
-                    ):
-                        return {task_id: None}
+                    fetch_start = time.monotonic()
+                    task_in_session = fetch_task_row(task_row.id, TaskRepository(task_session), org)
+                    span_attributes = {
+                        "benchmark_id": str(task_in_session.benchmark),
+                        "task_id": task_in_session.task_id,
+                        "from_status": task_in_session.status.value,
+                        "to_status": TaskStatus.EVALUATING.value,
+                        "fetch_duration_ms": elapsed_ms(fetch_start),
+                    }
+                    with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
+                        if not TaskExecutionRepository(task_session).attach_breakdown_and_transition(
+                            task_row.id,
+                            org.id,
+                            task_breakdown,
+                            TaskStatus.EVALUATING,
+                            authority,
+                            expected_started_at=attempt_started_at,
+                            expected_status=TaskStatus.IN_PROGRESS,
+                        ):
+                            return {task_id: None}
+                        task_session.commit()
 
                 # Evaluate the instance
                 evaluation_start_time = time.perf_counter()
@@ -792,27 +802,33 @@ async def _process_task_attempt(
                 )
 
                 with Session(bind=engine) as task_session:
-                    task_session.add(evaluation_result_row)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
-                    existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
-                    if existing_breakdown is None:
+                    fetch_start = time.monotonic()
+                    task_in_session = fetch_task_row(task_row.id, TaskRepository(task_session), org)
+                    if task_in_session.task_breakdown is None:
                         raise TrackerServiceError(f"Missing task breakdown for task {task_row.id}")
-                    existing_breakdown.evaluation_run_duration = task_breakdown.evaluation_run_duration
-                    existing_breakdown.sandbox_run_duration = task_breakdown.sandbox_run_duration
-                    if not commit_task_status_transition(
-                        task_row.id,
-                        task_session,
-                        org,
-                        TaskStatus.FINISHED,
-                        expected_started_at=attempt_started_at,
-                        authority=authority,
-                    ):
-                        return {task_id: None}
-
+                    span_attributes = {
+                        "benchmark_id": str(task_in_session.benchmark),
+                        "task_id": task_in_session.task_id,
+                        "from_status": task_in_session.status.value,
+                        "to_status": TaskStatus.FINISHED.value,
+                        "fetch_duration_ms": elapsed_ms(fetch_start),
+                    }
+                    with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
+                        if not TaskExecutionRepository(task_session).record_evaluation_and_finish(
+                            task_row.id,
+                            org.id,
+                            evaluation_result_row,
+                            authority,
+                            expected_started_at=attempt_started_at,
+                            evaluation_run_duration=task_breakdown.evaluation_run_duration,
+                            sandbox_run_duration=task_breakdown.sandbox_run_duration,
+                        ):
+                            return {task_id: None}
+                        task_session.commit()
                     return {task_id: evaluation_result_row.result}
             except Exception:
                 with Session(bind=engine) as task_session:
-                    task = fetch_task_row(task_row.id, task_session, org)
+                    task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
                     if task.status == TaskStatus.STOPPED:
                         return {task_id: None}
 
@@ -831,7 +847,7 @@ async def _process_task_attempt(
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
+            task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
             commit_task_error(
                 task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
             )
@@ -848,7 +864,7 @@ async def _process_task_attempt(
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
+            task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
             commit_task_error(
                 task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
             )
@@ -864,7 +880,7 @@ async def _process_task_attempt(
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
+            task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
             commit_task_error(
                 task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
             )
@@ -877,7 +893,7 @@ async def _process_task_attempt(
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
+            task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
             commit_task_error(
                 task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
             )
@@ -890,7 +906,7 @@ async def _process_task_attempt(
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
+            task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
             commit_task_error(
                 task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
             )
@@ -909,7 +925,7 @@ async def _process_task_attempt(
         log_output(f"\n[ERROR] {error_message}")
 
         with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
+            task = fetch_task_row(task_row.id, TaskRepository(task_session), org)
             commit_task_error(
                 task, task_session, error_message, expected_started_at=attempt_started_at, authority=authority
             )
@@ -930,7 +946,6 @@ def commit_task_error(
     authority: ExecutionAuthority,
     expected_started_at: datetime | None = None,
 ) -> bool:
-    session.add(ErrorResult(org_id=task_row.org_id, task=task_row.id, error_message=error_message))
     return _commit_task_status(
         task_row,
         session,

--- a/services/tracker/tests/integration/live/orchestration/test_database_flow.py
+++ b/services/tracker/tests/integration/live/orchestration/test_database_flow.py
@@ -16,6 +16,7 @@ from sqlmodel import Session, col, select
 
 from tests.utils import TEST_ORG_ID
 from tracker.database.models import Benchmark, EvaluationResult, FinalEvaluation, Task, TaskStatus
+from tracker.database.repositories import ReportingRepository
 from tracker.sandbox import create_sandbox
 
 pytestmark = pytest.mark.usefixtures("tracker_database")
@@ -152,7 +153,9 @@ async def test_live_results_round_trip_through_tracker_database(
 
     final_score_response = await benchmark_service.final_score(evaluation_results=evaluation_results)
     final_evaluation_row = create_final_evaluation(database_session, benchmark_row, final_score_response)
-    fetched_evaluation_results = benchmark_row.fetch_evaluation_results(database_session)
+    fetched_evaluation_results = ReportingRepository(database_session).fetch_evaluation_results(
+        benchmark_row.id, benchmark_row.org_id
+    )
 
     assert set(fetched_evaluation_results) == set(task_ids)
     for task_id, evaluation_result in fetched_evaluation_results.items():

--- a/services/tracker/tests/integration/live/orchestration/test_process_benchmark.py
+++ b/services/tracker/tests/integration/live/orchestration/test_process_benchmark.py
@@ -28,6 +28,7 @@ from tracker.database.models import (
     TaskBreakdown,
     TaskStatus,
 )
+from tracker.database.repositories import ReportingRepository
 from tracker.types import HarnessConfig, StartBenchmarkRequest
 from tracker.utils import start_benchmark_request_to_benchmark
 
@@ -91,7 +92,7 @@ def _task_rows(benchmark: Benchmark, session: Session) -> list[Task]:
 
 
 def _assert_no_task_errors(benchmark: Benchmark, session: Session) -> None:
-    assert benchmark.fetch_tasks_with_errors(session) is None
+    assert ReportingRepository(session).get_task_errors(benchmark.id, benchmark.org_id) is None
 
 
 def _assert_task_breakdown_complete(task_breakdown: TaskBreakdown) -> None:
@@ -144,7 +145,7 @@ class TestProcessBenchmark:
             assert task_breakdown is not None
             _assert_task_breakdown_complete(task_breakdown)
 
-        results = benchmark.fetch_evaluation_results(database_session)
+        results = ReportingRepository(database_session).fetch_evaluation_results(benchmark.id, benchmark.org_id)
         assert set(results.keys()) == set(_TASK_IDS)
 
         assert benchmark.final_evaluation is not None
@@ -258,7 +259,7 @@ class TestProcessBenchmark:
         ).all()
         assert len(error_tasks) == 1
         assert error_tasks[0].task_id == failing_task
-        task_errors = benchmark.fetch_tasks_with_errors(database_session)
+        task_errors = ReportingRepository(database_session).get_task_errors(benchmark.id, benchmark.org_id)
         assert task_errors is not None
         assert "Simulated setup failure" in task_errors[failing_task]
 
@@ -268,7 +269,7 @@ class TestProcessBenchmark:
         assert len(finished_tasks) == 1
         assert finished_tasks[0].task_id == _TASK_ID
 
-        results = benchmark.fetch_evaluation_results(database_session)
+        results = ReportingRepository(database_session).fetch_evaluation_results(benchmark.id, benchmark.org_id)
         assert len(results) == 1
         assert _TASK_ID in results
         assert failing_task not in results
@@ -311,10 +312,10 @@ class TestProcessBenchmark:
         tasks = _task_rows(benchmark, database_session)
         assert len(tasks) == 1
         assert tasks[0].status == TaskStatus.ERROR
-        task_errors = benchmark.fetch_tasks_with_errors(database_session)
+        task_errors = ReportingRepository(database_session).get_task_errors(benchmark.id, benchmark.org_id)
         assert task_errors is not None
         assert "Required output artifact missing" in task_errors[_TASK_ID]
-        assert benchmark.fetch_evaluation_results(database_session) == {}
+        assert ReportingRepository(database_session).fetch_evaluation_results(benchmark.id, benchmark.org_id) == {}
 
     async def test_concurrent_benchmarks_same_task(
         self,
@@ -370,7 +371,7 @@ class TestProcessBenchmark:
             assert len(tasks) == 1
             assert tasks[0].task_id == _TASK_ID
             assert tasks[0].status == TaskStatus.FINISHED
-            assert benchmark.fetch_tasks_with_errors(database_session) is None
+            assert ReportingRepository(database_session).get_task_errors(benchmark.id, benchmark.org_id) is None
 
-            results = benchmark.fetch_evaluation_results(database_session)
+            results = ReportingRepository(database_session).fetch_evaluation_results(benchmark.id, benchmark.org_id)
             assert set(results.keys()) == {_TASK_ID}

--- a/services/tracker/tests/integration/live/sandbox/test_force_stop.py
+++ b/services/tracker/tests/integration/live/sandbox/test_force_stop.py
@@ -15,6 +15,7 @@ from sqlmodel import Session, col, select
 import tracker.utils as tracker_utils
 from tests.utils import TEST_ORG_ID, random_task_id
 from tracker.database.models import Benchmark, BenchmarkStatus, Org, Task, TaskStatus
+from tracker.database.repositories import BenchmarkRepository, ReportingRepository, RunControlRepository
 from tracker.logging import get_logger
 from tracker.sandbox import create_sandbox
 from tracker.types import AWSCredentials, HarnessConfig
@@ -93,7 +94,7 @@ async def _wait_for_sandbox_setup(
 
 def _assert_no_task_errors(benchmark: Benchmark, database_session: Session) -> None:
     database_session.expire_all()
-    assert benchmark.fetch_tasks_with_errors(database_session) is None
+    assert ReportingRepository(database_session).get_task_errors(benchmark.id, benchmark.org_id) is None
 
 
 class TestForceStop:
@@ -150,6 +151,8 @@ class TestForceStop:
                     live_aws_credentials,
                     Org(id=TEST_ORG_ID, name="default"),
                     sandbox_provider="daytona",
+                    repository=RunControlRepository(database_session),
+                    benchmark_repository=BenchmarkRepository(database_session),
                 )
             finally:
                 release_sandbox.set()
@@ -264,6 +267,8 @@ class TestForceStop:
                 live_aws_credentials,
                 Org(id=TEST_ORG_ID, name="default"),
                 sandbox_provider="daytona",
+                repository=RunControlRepository(database_session),
+                benchmark_repository=BenchmarkRepository(database_session),
             )
         finally:
             release_sandboxes.set()
@@ -380,6 +385,8 @@ class TestForceStop:
                         live_aws_credentials,
                         Org(id=TEST_ORG_ID, name="default"),
                         sandbox_provider="daytona",
+                        repository=RunControlRepository(database_session),
+                        benchmark_repository=BenchmarkRepository(database_session),
                     )
                     await _wait_until_no_sandboxes(example_benchmark_object, provider)
             finally:

--- a/services/tracker/tests/integration/local/database/test_release_control.py
+++ b/services/tracker/tests/integration/local/database/test_release_control.py
@@ -621,7 +621,6 @@ def test_whole_stop_and_retry_serialize_on_the_benchmark_row(
             raise ReleaseControlError(f"Cannot stop benchmark from {benchmark.status}")
         apply_stop_benchmark(
             benchmark,
-            session,
             force=True,
             org=org,
             repository=RunControlRepository(session),

--- a/services/tracker/tests/integration/local/database/test_release_control.py
+++ b/services/tracker/tests/integration/local/database/test_release_control.py
@@ -29,6 +29,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
+from tracker.database.repositories import BenchmarkRepository, RunControlRepository
 from tracker.executor.dispatch_control import admit_recovery_dispatch, admit_start_dispatch
 from tracker.executor.maintenance_control import begin_maintenance
 from tracker.executor.release_control import (
@@ -548,6 +549,46 @@ def test_terminal_retry_after_retirement_uses_the_active_release(postgres_sessio
     assert dispatch.executor_release_id == "terminal-active"
 
 
+def test_run_control_repository_lock_serializes_whole_run_stop(
+    postgres_session: Session,
+    postgres_engine: Engine,
+) -> None:
+    org = Org(id=uuid4(), name="repository-stop-race-org")
+    postgres_session.add(org)
+    benchmark = Benchmark(
+        org_id=org.id,
+        name="repository-stop-race",
+        status=BenchmarkStatus.IN_PROGRESS,
+        arguments=BenchmarkArguments(
+            contract=AgentContractRequest(name="race-agent", install_cmd="true", run_cmd="true"),
+            concurrency=1,
+        ),
+    )
+    postgres_session.add(benchmark)
+    postgres_session.commit()
+
+    def stop(session: Session) -> None:
+        repository = RunControlRepository(session)
+        locked_benchmark = repository.lock_benchmark(benchmark.id, org.id)
+        assert locked_benchmark is not None
+        repository.apply_stop(locked_benchmark, org.id, force=True, task_ids=None)
+        session.flush()
+
+    def observe_stopped(session: Session) -> None:
+        repository = RunControlRepository(session)
+        locked_benchmark = repository.lock_benchmark(benchmark.id, org.id)
+        assert locked_benchmark is not None
+        assert locked_benchmark.status == BenchmarkStatus.STOPPING
+
+    outcomes = _run_while_first_transaction_holds_locks(stop, observe_stopped, postgres_engine)
+
+    assert sorted(outcomes) == ["first-committed", "second-committed"]
+    postgres_session.expire_all()
+    stored_benchmark = postgres_session.get(Benchmark, benchmark.id)
+    assert stored_benchmark is not None
+    assert stored_benchmark.status == BenchmarkStatus.STOPPING
+
+
 def test_whole_stop_and_retry_serialize_on_the_benchmark_row(
     postgres_session: Session,
     postgres_engine: Engine,
@@ -574,14 +615,21 @@ def test_whole_stop_and_retry_serialize_on_the_benchmark_row(
         return benchmark
 
     def whole_stop(session: Session, benchmark_id: UUID) -> None:
-        benchmark = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+        benchmark_repository = BenchmarkRepository(session)
+        benchmark = fetch_benchmark_row(benchmark_id, benchmark_repository, org, for_update=True)
         if benchmark.status not in (BenchmarkStatus.IN_PROGRESS, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPING):
             raise ReleaseControlError(f"Cannot stop benchmark from {benchmark.status}")
-        apply_stop_benchmark(benchmark, session, force=True, org=org)
+        apply_stop_benchmark(
+            benchmark,
+            session,
+            force=True,
+            org=org,
+            repository=RunControlRepository(session),
+        )
         session.flush()
 
     def retry(session: Session, benchmark_id: UUID) -> None:
-        benchmark = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+        benchmark = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), org, for_update=True)
         if benchmark.status == BenchmarkStatus.STOPPING:
             raise ReleaseControlError("Cannot retry a stopping benchmark")
         pre_action_status = benchmark.status

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -285,7 +285,6 @@ class TestRunFinalization:
                 try:
                     verified_task_ids = await reset_to_in_progress_status(
                         retry_benchmark,
-                        retry_session,
                         benchmark_service,
                         retry=True,
                         retry_mode=RetryMode.FROM_SCRATCH,

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -21,6 +21,7 @@ from sqlmodel import Session, select
 import tracker.utils.run_control as run_control_module
 import tracker.utils.run_orchestration as run_orchestration_module
 from tests.factories import make_benchmark, make_task
+from tracker.database.repositories import BenchmarkRepository, ReportingRepository, RunControlRepository
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -161,7 +162,7 @@ class TestRunFinalization:
             dispatch_id=UUID(str(authority_kwargs["executor_dispatch_id"])),
         )
         postgres_session.refresh(benchmark)
-        final_view = create_final_view(benchmark, postgres_session, org)
+        final_view = create_final_view(benchmark, ReportingRepository(postgres_session), org)
 
         stale_dispatch = postgres_session.get(ExecutorDispatch, authority.dispatch_id)
         assert stale_dispatch is not None
@@ -290,6 +291,8 @@ class TestRunFinalization:
                         retry_mode=RetryMode.FROM_SCRATCH,
                         rerun_task_ids=[task.task_id],
                         org=org,
+                        repository=RunControlRepository(retry_session),
+                        benchmark_repository=BenchmarkRepository(retry_session),
                     )
                 finally:
                     await benchmark_service.close()
@@ -604,7 +607,7 @@ class TestRunFinalization:
                     assert allow_retry_lock.wait(timeout=2)
                     retry_benchmark = fetch_benchmark_row(
                         benchmark.id,
-                        retry_session,
+                        BenchmarkRepository(retry_session),
                         org,
                         for_update=True,
                     )
@@ -662,6 +665,8 @@ class TestRunFinalization:
                 harness_config.sandbox_provider_secret_name,
                 harness_config.aws,
                 org,
+                repository=RunControlRepository(postgres_session),
+                benchmark_repository=BenchmarkRepository(postgres_session),
             )
         finally:
             allow_retry_lock.set()

--- a/services/tracker/tests/unit/database/repositories/test_repositories.py
+++ b/services/tracker/tests/unit/database/repositories/test_repositories.py
@@ -1,6 +1,6 @@
 """Tests for named tracker persistence repositories.
 
-Run: uv run pytest tests/unit/database/test_repositories.py
+Run: uv run pytest tests/unit/database/repositories/test_repositories.py
 
 Covers organization scope and representative benchmark/task read operations.
 """

--- a/services/tracker/tests/unit/database/repositories/test_run_control_repository.py
+++ b/services/tracker/tests/unit/database/repositories/test_run_control_repository.py
@@ -1,4 +1,7 @@
-"""Focused tests for database-only run-control persistence."""
+"""Focused tests for database-only run-control persistence.
+
+Run: uv run pytest tests/unit/database/repositories/test_run_control_repository.py
+"""
 
 from datetime import datetime, timedelta
 from uuid import uuid4

--- a/services/tracker/tests/unit/database/repositories/test_task_execution_repository.py
+++ b/services/tracker/tests/unit/database/repositories/test_task_execution_repository.py
@@ -1,4 +1,7 @@
-"""Focused transaction and authority tests for task execution persistence."""
+"""Focused transaction and authority tests for task execution persistence.
+
+Run: uv run pytest tests/unit/database/repositories/test_task_execution_repository.py
+"""
 
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta

--- a/services/tracker/tests/unit/database/test_models.py
+++ b/services/tracker/tests/unit/database/test_models.py
@@ -8,6 +8,7 @@ from pydantic import ValidationError
 from sqlmodel import Session
 
 from tests.utils import TEST_ORG_ID
+from tracker.database.repositories import BenchmarkRepository
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -16,6 +17,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
+from tracker.utils.reporting import build_benchmark_table_rows
 
 
 def test_required_output_artifact_omits_default_from_serialized_contract() -> None:
@@ -60,7 +62,7 @@ def test_agent_contract_rejects_duplicate_normalized_output_artifact_paths(
         AgentContractRequest(name="agent", output_artifacts=artifacts)
 
 
-def test_create_benchmark_table_row_counts_stopped_tasks_as_finished(database_session: Session) -> None:
+def test_build_benchmark_table_row_counts_stopped_tasks_as_finished(database_session: Session) -> None:
     benchmark = Benchmark(
         org_id=TEST_ORG_ID,
         name="swebench",
@@ -81,7 +83,7 @@ def test_create_benchmark_table_row_counts_stopped_tasks_as_finished(database_se
         database_session.add(Task(org_id=TEST_ORG_ID, benchmark=benchmark.id, task_id=task_id, status=status))
     database_session.commit()
 
-    row = benchmark.create_benchmark_table_row(database_session)
+    row = build_benchmark_table_rows([benchmark], BenchmarkRepository(database_session))[0]
 
     assert row.total_tasks == 4
     assert row.finished_tasks == 3

--- a/services/tracker/tests/unit/database/test_repositories.py
+++ b/services/tracker/tests/unit/database/test_repositories.py
@@ -1,0 +1,477 @@
+"""Tests for named tracker persistence repositories.
+
+Run: uv run pytest tests/unit/database/test_repositories.py
+
+Covers organization scope and representative benchmark/task read operations.
+"""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+from sqlalchemy import inspect
+from sqlmodel import Session
+
+from tests.factories import make_benchmark, make_error_result, make_evaluation_result, make_task
+from tracker.database.models import FinalEvaluation, Org, TaskStatus
+from tracker.database.repositories import (
+    BenchmarkRepository,
+    OrgRepository,
+    ReportingRepository,
+    TaskRepository,
+)
+from tracker.exceptions import TrackerServiceError
+from tracker.types import FetchBenchmarksRequest, Order
+from tracker.utils.reporting import BenchmarkContext
+from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
+
+
+class TestOrgRepository:
+    """Organization lookup behavior."""
+
+    def test_find_by_name_returns_matching_organization_only(self, empty_database_session: Session) -> None:
+        """Tenant lookup returns the matching organization and no result for an unknown name."""
+        first_org = Org(id=uuid4(), name="first-org")
+        second_org = Org(id=uuid4(), name="second-org")
+        empty_database_session.add_all([first_org, second_org])
+        empty_database_session.commit()
+
+        repository = OrgRepository(empty_database_session)
+
+        assert repository.find_by_name("first-org") == first_org
+        assert repository.find_by_name("missing-org") is None
+
+    def test_ensure_by_name_is_idempotent_and_reports_creation(self, empty_database_session: Session) -> None:
+        """Organization creation is conflict-safe and leaves commit ownership with the caller."""
+        repository = OrgRepository(empty_database_session)
+
+        first_org, first_created = repository.ensure_by_name("tenant")
+        assert first_org is not None
+        assert first_created is True
+        empty_database_session.rollback()
+        assert repository.find_by_name("tenant") is None
+
+        first_org, first_created = repository.ensure_by_name("tenant")
+        assert first_org is not None
+        assert first_created is True
+        empty_database_session.commit()
+
+        second_org, second_created = repository.ensure_by_name("tenant")
+        assert second_org is not None
+        assert second_org.id == first_org.id
+        assert second_created is False
+        empty_database_session.rollback()
+
+
+class TestBenchmarkRepository:
+    """Organization-scoped benchmark and task read behavior."""
+
+    def test_get_for_org_hides_benchmark_from_other_organization(self, empty_database_session: Session) -> None:
+        """Benchmark lookup returns no row when the requested organization does not own it."""
+        owner = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([owner, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+
+        repository = BenchmarkRepository(empty_database_session)
+
+        assert repository.get_for_org(benchmark.id, owner.id) == benchmark
+        assert repository.get_for_org(benchmark.id, other_org.id) is None
+
+    def test_get_for_org_with_final_evaluation_eagerly_loads_and_scopes(self, empty_database_session: Session) -> None:
+        """Eager final-evaluation lookup returns only an organization-owned benchmark."""
+        owner = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([owner, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+        evaluation = FinalEvaluation(org_id=owner.id, benchmark=benchmark.id, final_score=42.0, properties={})
+        foreign_evaluation = FinalEvaluation(
+            org_id=other_org.id, benchmark=benchmark.id, final_score=99.0, properties={}
+        )
+        empty_database_session.add_all([evaluation, foreign_evaluation])
+        empty_database_session.commit()
+        empty_database_session.expire_all()
+
+        repository = BenchmarkRepository(empty_database_session)
+        loaded = repository.get_for_org_with_final_evaluation(benchmark.id, owner.id)
+
+        assert loaded is not None
+        assert loaded.final_evaluation is not None
+        assert loaded.final_evaluation.final_score == 42.0
+        loaded_state = inspect(loaded)
+        assert loaded_state is not None
+        assert loaded_state.attrs.final_evaluation.loaded_value is loaded.final_evaluation
+        assert repository.get_for_org_with_final_evaluation(benchmark.id, other_org.id) is None
+
+    def test_scoped_eager_lookup_replaces_a_previously_loaded_foreign_evaluation(
+        self, empty_database_session: Session
+    ) -> None:
+        """Scoped eager loading replaces an already-loaded foreign final evaluation."""
+        owner = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([owner, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+        empty_database_session.add(
+            FinalEvaluation(org_id=other_org.id, benchmark=benchmark.id, final_score=99.0, properties={})
+        )
+        empty_database_session.commit()
+        empty_database_session.expire_all()
+
+        repository = BenchmarkRepository(empty_database_session)
+        previously_loaded = repository.get_by_id(benchmark.id)
+        assert previously_loaded is not None
+        assert previously_loaded.final_evaluation is not None
+        assert previously_loaded.final_evaluation.final_score == 99.0
+
+        scoped = repository.get_for_org_with_final_evaluation(benchmark.id, owner.id)
+
+        assert scoped is not None
+        assert scoped.final_evaluation is None
+
+    def test_get_final_score_scopes_evaluation_to_organization(self, empty_database_session: Session) -> None:
+        """Final-score lookup does not expose a result row owned by another organization."""
+        owner = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([owner, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+        empty_database_session.add(
+            FinalEvaluation(org_id=other_org.id, benchmark=benchmark.id, final_score=99.0, properties={})
+        )
+        empty_database_session.commit()
+
+        repository = BenchmarkRepository(empty_database_session)
+
+        assert repository.get_final_score(benchmark.id, owner.id) is None
+        assert repository.get_final_score(benchmark.id, other_org.id) == 99.0
+
+    def test_get_task_state_counts_scopes_tasks_and_groups_statuses(self, empty_database_session: Session) -> None:
+        """Task counts include only the requested benchmark and organization."""
+        owner = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([owner, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+        other_benchmark = make_benchmark(org_id=other_org.id, session=empty_database_session)
+        empty_database_session.add_all(
+            [
+                make_task(benchmark, "finished", status=TaskStatus.FINISHED),
+                make_task(benchmark, "pending"),
+                make_task(other_benchmark, "other"),
+            ]
+        )
+        empty_database_session.commit()
+
+        counts = BenchmarkRepository(empty_database_session).get_task_state_counts(benchmark.id, owner.id)
+
+        assert counts == {TaskStatus.FINISHED: 1, TaskStatus.PENDING: 1}
+
+    def test_get_task_status_counts_scopes_batch_to_organization(self, empty_database_session: Session) -> None:
+        """Batch task counts include only requested benchmarks and organization-owned tasks."""
+        owner = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([owner, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+        other_benchmark = make_benchmark(org_id=other_org.id, session=empty_database_session)
+        foreign_task = make_task(benchmark, "foreign", status=TaskStatus.ERROR)
+        foreign_task.org_id = other_org.id
+        empty_database_session.add_all(
+            [
+                make_task(benchmark, "finished", status=TaskStatus.FINISHED),
+                make_task(benchmark, "stopped", status=TaskStatus.STOPPED),
+                foreign_task,
+                make_task(other_benchmark, "other", status=TaskStatus.ERROR),
+            ]
+        )
+        empty_database_session.commit()
+
+        counts = BenchmarkRepository(empty_database_session).get_task_status_counts([benchmark.id], owner.id)
+
+        assert counts == {benchmark.id: {TaskStatus.FINISHED: 1, TaskStatus.STOPPED: 1}}
+
+
+class TestTaskRepository:
+    """Task and terminal-result lookup behavior."""
+
+    def test_task_operations_preserve_organization_scope(self, empty_database_session: Session) -> None:
+        """Task and terminal-result lookups hide rows requested through another organization."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        task = make_task(benchmark, "error", status=TaskStatus.ERROR)
+        empty_database_session.add(task)
+        empty_database_session.flush()
+        now = datetime.now(ZoneInfo("UTC"))
+        empty_database_session.add_all(
+            [
+                make_error_result(task, "old failure", now - timedelta(minutes=1)),
+                make_error_result(task, "new failure", now),
+            ]
+        )
+        empty_database_session.commit()
+
+        repository = TaskRepository(empty_database_session)
+
+        assert repository.get_for_benchmark(benchmark.id, task.task_id, other_org.id) is None
+        assert repository.get_terminal_result(task, other_org.id) == (None, None)
+        assert repository.get_terminal_result(task, org.id) == (None, "new failure")
+
+    def test_get_existing_task_ids_scopes_benchmark_and_organization(self, empty_database_session: Session) -> None:
+        """Task validation returns only IDs owned by the requested organization and benchmark."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        other_benchmark = make_benchmark(org_id=other_org.id, session=empty_database_session)
+        foreign_task = make_task(other_benchmark, "foreign")
+        foreign_task.org_id = org.id
+        empty_database_session.add_all([make_task(benchmark, "owned"), foreign_task])
+        empty_database_session.commit()
+
+        repository = TaskRepository(empty_database_session)
+
+        assert repository.get_existing_task_ids(benchmark.id, ["foreign", "owned"], org.id) == {"owned"}
+        assert repository.get_existing_task_ids(other_benchmark.id, ["foreign"], org.id) == set()
+        assert repository.get_existing_task_ids(benchmark.id, ["owned"], other_org.id) == set()
+
+    def test_task_creation_and_runnable_selection_preserve_order_and_are_idempotent(
+        self, empty_database_session: Session
+    ) -> None:
+        """Task creation preserves requested order, filters statuses, and does not duplicate rows."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        empty_database_session.add_all(
+            [
+                make_task(benchmark, "finished", status=TaskStatus.FINISHED),
+                make_task(benchmark, "pending"),
+            ]
+        )
+        empty_database_session.commit()
+        repository = TaskRepository(empty_database_session)
+
+        requested = ["new", "finished", "pending", "new"]
+        first_created = repository.create_missing_task_rows(benchmark.id, requested, org.id)
+        first_rows = repository.get_runnable_for_benchmark(benchmark.id, requested, org.id)
+        second_created = repository.create_missing_task_rows(benchmark.id, requested, org.id)
+        second_rows = repository.get_runnable_for_benchmark(benchmark.id, requested, org.id)
+
+        assert [task.task_id for task in first_created] == ["new", "finished", "pending"]
+        assert [task.task_id for task in second_created] == ["new", "finished", "pending"]
+        assert [task_id for task_id, _task in first_rows] == ["new", "pending"]
+        assert [task_id for task_id, _task in second_rows] == ["new", "pending"]
+        assert repository.get_existing_task_ids(benchmark.id, requested, org.id) == {"new", "finished", "pending"}
+        assert repository.create_missing_task_rows(benchmark.id, ["foreign"], other_org.id) == []
+        assert repository.get_runnable_for_benchmark(benchmark.id, ["foreign"], other_org.id) == []
+
+
+class TestReportingRepository:
+    """Reporting query behavior and organization isolation."""
+
+    def test_evaluation_results_include_latest_result_and_ordered_history(
+        self, empty_database_session: Session
+    ) -> None:
+        """Evaluation reporting selects the latest attempt and orders prior attempts newest first."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        finished_at = datetime(2026, 1, 1, tzinfo=ZoneInfo("UTC"))
+        task = make_task(benchmark, "finished", status=TaskStatus.FINISHED, finished_at=finished_at)
+        error_task = make_task(benchmark, "error", status=TaskStatus.ERROR, finished_at=finished_at)
+        empty_database_session.add_all([task, error_task])
+        empty_database_session.flush()
+        foreign_evaluation = make_evaluation_result(task, "foreign", {"score": 999}, finished_at + timedelta(minutes=1))
+        foreign_evaluation.org_id = other_org.id
+        foreign_error = make_error_result(error_task, "foreign failure", finished_at + timedelta(minutes=1))
+        foreign_error.org_id = other_org.id
+        empty_database_session.add_all(
+            [
+                make_evaluation_result(
+                    task,
+                    "old",
+                    {"score": 1},
+                    finished_at - timedelta(minutes=2),
+                ),
+                make_error_result(error_task, "failed", finished_at - timedelta(minutes=1)),
+                make_error_result(task, "retry failed", finished_at - timedelta(minutes=1)),
+                make_evaluation_result(task, "latest", {"score": 2}, finished_at),
+                foreign_evaluation,
+                foreign_error,
+            ]
+        )
+        empty_database_session.commit()
+
+        repository = ReportingRepository(empty_database_session)
+
+        results = repository.fetch_evaluation_results(benchmark.id, org.id)
+
+        assert results["finished"]["score"] == 2
+        assert results["finished"]["attempts"] == 3
+        history = results["finished"]["history"]
+        assert history[0]["error_message"] == "retry failed"
+        assert history[1]["result"] == {"score": 1}
+        assert history[0]["created_at"] > history[1]["created_at"]
+        assert repository.get_task_errors(benchmark.id, org.id) == {"error": "failed"}
+        assert repository.fetch_evaluation_results(benchmark.id, uuid4()) == {}
+
+    def test_benchmark_task_counts_preserve_context_shape_and_scope(self, empty_database_session: Session) -> None:
+        """Task aggregates preserve reporting totals and exclude rows from another organization."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        finished_at = datetime(2026, 1, 1, tzinfo=ZoneInfo("UTC"))
+        finished = make_task(benchmark, "finished", status=TaskStatus.FINISHED, finished_at=finished_at)
+        error = make_task(benchmark, "error", status=TaskStatus.ERROR, finished_at=finished_at)
+        stopped = make_task(benchmark, "stopped", status=TaskStatus.STOPPED)
+        pending = make_task(benchmark, "pending")
+        foreign = make_task(benchmark, "foreign", status=TaskStatus.ERROR, finished_at=finished_at)
+        foreign.org_id = other_org.id
+        empty_database_session.add_all([finished, error, stopped, pending, foreign])
+        empty_database_session.commit()
+
+        reporting_repository = ReportingRepository(empty_database_session)
+        counts = reporting_repository.get_benchmark_task_counts(benchmark.id, org.id)
+        details = BenchmarkContext(benchmark, reporting_repository, org).benchmark_details
+
+        assert counts.total_tasks == 4
+        assert counts.finished_tasks == 3
+        assert counts.failed_tasks == 1
+        assert counts.status_counts == {
+            TaskStatus.FINISHED: 1,
+            TaskStatus.ERROR: 1,
+            TaskStatus.STOPPED: 1,
+            TaskStatus.PENDING: 1,
+        }
+        assert details.total_tasks == counts.total_tasks
+        assert details.finished_tasks == counts.finished_tasks
+        assert details.task_breakdown == counts.status_counts
+        assert (
+            ReportingRepository(empty_database_session)
+            .get_benchmark_task_counts(benchmark.id, other_org.id)
+            .total_tasks
+            == 1
+        )
+
+    def test_final_score_inputs_select_latest_results_and_preserve_unfinished_tasks(
+        self, empty_database_session: Session
+    ) -> None:
+        """Final-score inputs select the newest tenant-owned result and map unfinished tasks to None."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        finished = make_task(
+            benchmark, "finished", status=TaskStatus.FINISHED, finished_at=datetime.now(ZoneInfo("UTC"))
+        )
+        pending = make_task(benchmark, "pending")
+        empty_database_session.add_all([finished, pending])
+        empty_database_session.flush()
+        created_at = datetime(2026, 1, 1, tzinfo=ZoneInfo("UTC"))
+        old_result = make_evaluation_result(finished, "old", {"score": 1}, created_at)
+        latest_result = make_evaluation_result(finished, "latest", {"score": 2}, created_at + timedelta(minutes=1))
+        foreign_result = make_evaluation_result(finished, "foreign", {"score": 999}, created_at + timedelta(minutes=2))
+        foreign_result.org_id = other_org.id
+        empty_database_session.add_all([old_result, latest_result, foreign_result])
+        empty_database_session.commit()
+
+        repository = ReportingRepository(empty_database_session)
+
+        assert repository.fetch_final_score_inputs(benchmark.id, org.id) == {
+            "finished": {"score": 2},
+            "pending": None,
+        }
+        assert repository.fetch_final_score_inputs(benchmark.id, other_org.id) == {}
+
+    def test_filtered_benchmarks_support_offset_and_keyset_pages(self, empty_database_session: Session) -> None:
+        """Filtered benchmark reporting preserves organization scope across pagination modes."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        started_at = datetime(2026, 1, 1, tzinfo=ZoneInfo("UTC"))
+        benchmarks = [
+            make_benchmark(
+                org_id=org.id,
+                name=f"benchmark-{index}",
+                started_at=started_at + timedelta(minutes=index),
+                session=empty_database_session,
+            )
+            for index in range(3)
+        ]
+        make_benchmark(org_id=other_org.id, started_at=started_at, session=empty_database_session)
+        empty_database_session.add(
+            FinalEvaluation(org_id=other_org.id, benchmark=benchmarks[0].id, final_score=99.0, properties={})
+        )
+        empty_database_session.commit()
+        loaded = BenchmarkRepository(empty_database_session).get_by_id(benchmarks[0].id)
+        assert loaded is not None
+        assert loaded.final_evaluation is not None
+        assert loaded.final_evaluation.final_score == 99.0
+        repository = ReportingRepository(empty_database_session)
+
+        ascending_page = repository.fetch_filtered_benchmark_rows(
+            FetchBenchmarksRequest(limit=3, order_by=Order.ASC), org.id, cursor=None
+        )
+        offset_page = repository.fetch_filtered_benchmark_rows(
+            FetchBenchmarksRequest(limit=1, offset=1), org.id, cursor=None
+        )
+        keyset_page = repository.fetch_filtered_benchmark_rows(
+            FetchBenchmarksRequest(limit=1, cursor=""), org.id, cursor=None
+        )
+        next_page = repository.fetch_filtered_benchmark_rows(
+            FetchBenchmarksRequest(limit=1, cursor="ignored"),
+            org.id,
+            cursor=(keyset_page.rows[0].started_at, keyset_page.rows[0].id),
+        )
+        empty_page = repository.fetch_filtered_benchmark_rows(FetchBenchmarksRequest(limit=1), uuid4(), cursor=None)
+
+        assert ascending_page.rows[0].id == benchmarks[0].id
+        assert ascending_page.rows[0].final_evaluation is None
+        assert offset_page.total_count == 3
+        assert offset_page.rows[0].id == benchmarks[1].id
+        assert keyset_page.has_next_page is True
+        assert next_page.rows[0].id != keyset_page.rows[0].id
+        assert empty_page.rows == []
+        assert empty_page.total_count == 0
+
+    def test_task_counts_and_resource_adapters_preserve_scope(self, empty_database_session: Session) -> None:
+        """Reporting counts and resource adapters reject missing or cross-organization rows."""
+        org = Org(id=uuid4(), name="owner")
+        other_org = Org(id=uuid4(), name="other")
+        empty_database_session.add_all([org, other_org])
+        empty_database_session.commit()
+        benchmark = make_benchmark(org_id=org.id, session=empty_database_session)
+        finished = make_task(benchmark, "finished", status=TaskStatus.FINISHED)
+        finished.finished_at = datetime(2026, 1, 1, tzinfo=ZoneInfo("UTC"))
+        stopped = make_task(benchmark, "stopped", status=TaskStatus.STOPPED)
+        empty_database_session.add_all([finished, stopped])
+        empty_database_session.commit()
+        repository = ReportingRepository(empty_database_session)
+        benchmark_repository = BenchmarkRepository(empty_database_session)
+        task_repository = TaskRepository(empty_database_session)
+
+        assert repository.get_stopped_task_count(benchmark.id, org.id) == 1
+        assert fetch_benchmark_row(benchmark.id, benchmark_repository, org).id == benchmark.id
+        assert fetch_task_row(finished.id, task_repository, org).id == finished.id
+
+        with pytest.raises(ValueError, match="does not belong"):
+            fetch_benchmark_row(benchmark.id, benchmark_repository, other_org)
+        with pytest.raises(TrackerServiceError, match="does not belong"):
+            fetch_task_row(finished.id, task_repository, other_org)
+        with pytest.raises(TrackerServiceError, match="not found"):
+            fetch_task_row(uuid4(), task_repository, org)

--- a/services/tracker/tests/unit/database/test_run_control_repository.py
+++ b/services/tracker/tests/unit/database/test_run_control_repository.py
@@ -1,0 +1,176 @@
+"""Focused tests for database-only run-control persistence."""
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+import pytest
+from sqlmodel import Session, select
+
+from tests.factories import make_benchmark, make_task
+from tracker.database.models import Benchmark, BenchmarkStatus, FinalEvaluation, Org, RetryMode, Task, TaskStatus
+from tracker.database.repositories import RetrySelection, RunControlRepository
+from tracker.exceptions import TrackerServiceError
+
+
+def test_lock_and_task_mutations_are_organization_scoped(empty_database_session: Session) -> None:
+    owner = Org(id=uuid4(), name="owner")
+    other = Org(id=uuid4(), name="other")
+    empty_database_session.add_all([owner, other])
+    empty_database_session.commit()
+    benchmark = make_benchmark(org_id=owner.id, session=empty_database_session)
+    task = make_task(benchmark, "task", status=TaskStatus.PENDING)
+    task.org_id = other.id
+    empty_database_session.add(task)
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+
+    assert repository.lock_benchmark(benchmark.id, other.id) is None
+    assert repository.stop_active_tasks(benchmark.id, owner.id, task_ids=None) == 0
+    empty_database_session.expire_all()
+    assert empty_database_session.get(Task, task.id).status == TaskStatus.PENDING  # type: ignore[union-attr]
+
+
+def test_explicit_empty_task_ids_never_means_whole_run(empty_database_session: Session) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    task = make_task(benchmark, "task", status=TaskStatus.PENDING)
+    empty_database_session.add(task)
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+
+    assert repository.apply_stop(benchmark, benchmark.org_id, force=True, task_ids=[]) == 0
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+    assert repository.stop_active_tasks(benchmark.id, benchmark.org_id, task_ids=[]) == 0
+    empty_database_session.expire_all()
+    assert empty_database_session.get(Task, task.id).status == TaskStatus.PENDING  # type: ignore[union-attr]
+
+
+def test_stop_writes_remain_uncommitted_until_caller_decides(empty_database_session: Session) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    task = make_task(benchmark, "task", status=TaskStatus.PENDING)
+    empty_database_session.add(task)
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+
+    assert repository.apply_stop(benchmark, benchmark.org_id, force=False, task_ids=None) == 1
+    assert task.status == TaskStatus.STOPPED
+    empty_database_session.rollback()
+    empty_database_session.expire_all()
+    persisted = empty_database_session.get(Task, task.id)
+    assert persisted is not None
+    assert persisted.status == TaskStatus.PENDING
+    assert empty_database_session.get(Benchmark, benchmark.id).status == BenchmarkStatus.IN_PROGRESS  # type: ignore[union-attr]
+
+
+def test_retry_selection_is_deterministic_and_preserves_status_matrix(empty_database_session: Session) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    now = datetime(2026, 1, 1, tzinfo=ZoneInfo("UTC"))
+    first = make_task(benchmark, "first", status=TaskStatus.ERROR, started_at=now + timedelta(minutes=2))
+    second = make_task(benchmark, "second", status=TaskStatus.ERROR, started_at=now)
+    stopped = make_task(benchmark, "stopped", status=TaskStatus.STOPPED, started_at=now + timedelta(minutes=1))
+    finished = make_task(benchmark, "finished", status=TaskStatus.FINISHED, finished_at=now)
+    empty_database_session.add_all([first, second, stopped, finished])
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+
+    active = repository.select_retryable(benchmark, benchmark.org_id, retry=True, rerun_task_ids=["first", "second"])
+    assert [task.task_id for task in active.existing_tasks] == ["second", "first"]
+    assert active.new_task_ids == []
+
+    benchmark.status = BenchmarkStatus.STOPPED
+    empty_database_session.commit()
+    terminal = repository.select_retryable(benchmark, benchmark.org_id, retry=False, rerun_task_ids=[])
+    assert [task.task_id for task in terminal.existing_tasks] == ["stopped"]
+    assert terminal.new_task_ids == []
+
+
+def test_active_retry_rejects_non_error_ids_without_mutating_rows(empty_database_session: Session) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    task = make_task(benchmark, "stopped", status=TaskStatus.STOPPED)
+    empty_database_session.add(task)
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+
+    with pytest.raises(TrackerServiceError, match="cannot be retried"):
+        repository.select_retryable(benchmark, benchmark.org_id, retry=True, rerun_task_ids=["stopped"])
+    empty_database_session.rollback()
+    empty_database_session.expire_all()
+    assert empty_database_session.get(Task, task.id).status == TaskStatus.STOPPED  # type: ignore[union-attr]
+
+
+def test_failed_retry_precondition_leaves_database_state_unchanged(empty_database_session: Session) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    task = make_task(benchmark, "task", status=TaskStatus.STOPPED)
+    evaluation = FinalEvaluation(org_id=benchmark.org_id, benchmark=benchmark.id, final_score=1, properties={})
+    other_org = Org(id=uuid4(), name="other")
+    empty_database_session.add_all([task, evaluation, other_org])
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+    selection = RetrySelection(benchmark, [task], [])
+
+    with pytest.raises(TrackerServiceError, match="does not belong"):
+        repository.apply_retry(
+            selection,
+            other_org.id,
+            retry_mode=RetryMode.AUTO,
+        )
+    empty_database_session.rollback()
+    empty_database_session.expire_all()
+    assert empty_database_session.get(Task, task.id).status == TaskStatus.STOPPED  # type: ignore[union-attr]
+    assert empty_database_session.get(FinalEvaluation, evaluation.id) is not None
+    assert empty_database_session.get(Benchmark, benchmark.id).status == BenchmarkStatus.IN_PROGRESS  # type: ignore[union-attr]
+
+
+def test_apply_retry_deletes_only_owned_final_evaluation_and_creates_missing_rows(
+    empty_database_session: Session,
+) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    other = Org(id=uuid4(), name="other")
+    empty_database_session.add(other)
+    existing = make_task(benchmark, "existing", status=TaskStatus.STOPPED)
+    empty_database_session.add(existing)
+    owner_evaluation = FinalEvaluation(org_id=benchmark.org_id, benchmark=benchmark.id, final_score=1, properties={})
+    foreign_evaluation = FinalEvaluation(org_id=other.id, benchmark=benchmark.id, final_score=2, properties={})
+    empty_database_session.add_all([owner_evaluation, foreign_evaluation])
+    empty_database_session.commit()
+    repository = RunControlRepository(empty_database_session)
+    selection = RetrySelection(benchmark, [existing], ["missing"])
+
+    repository.apply_retry(
+        selection,
+        benchmark.org_id,
+        retry_mode=RetryMode.FROM_SCRATCH,
+    )
+    assert (
+        empty_database_session.exec(select(FinalEvaluation).where(FinalEvaluation.org_id == benchmark.org_id)).all()
+        == []
+    )
+    assert empty_database_session.get(FinalEvaluation, foreign_evaluation.id) is not None
+    created = empty_database_session.exec(
+        select(Task).where(Task.benchmark == benchmark.id).where(Task.task_id == "missing")
+    ).one()
+    assert created.org_id == benchmark.org_id
+    assert created.status == TaskStatus.PENDING
+    assert existing.status == TaskStatus.PENDING
+    assert benchmark.status == BenchmarkStatus.IN_PROGRESS
+
+    empty_database_session.rollback()
+    assert empty_database_session.get(FinalEvaluation, owner_evaluation.id) is not None
+    assert empty_database_session.exec(select(Task).where(Task.task_id == "missing")).all() == []
+
+
+def test_apply_retry_clears_loaded_owned_final_evaluation(empty_database_session: Session) -> None:
+    benchmark = make_benchmark(session=empty_database_session)
+    task = make_task(benchmark, "task", status=TaskStatus.STOPPED)
+    evaluation = FinalEvaluation(org_id=benchmark.org_id, benchmark=benchmark.id, final_score=1, properties={})
+    empty_database_session.add_all([task, evaluation])
+    empty_database_session.commit()
+    assert benchmark.final_evaluation is not None
+
+    RunControlRepository(empty_database_session).apply_retry(
+        RetrySelection(benchmark, [task], []),
+        benchmark.org_id,
+        retry_mode=RetryMode.FROM_SCRATCH,
+    )
+
+    assert benchmark.final_evaluation is None

--- a/services/tracker/tests/unit/database/test_task_execution_repository.py
+++ b/services/tracker/tests/unit/database/test_task_execution_repository.py
@@ -1,0 +1,230 @@
+"""Focused transaction and authority tests for task execution persistence."""
+
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from sqlmodel import Session, select
+
+from tests.factories import make_benchmark, make_task
+from tracker.database.models import (
+    ErrorResult,
+    EvaluationResult,
+    ExecutorDispatch,
+    ExecutorDispatchStatus,
+    Org,
+    Task,
+    TaskBreakdown,
+    TaskStatus,
+)
+from tracker.database.repositories import TaskExecutionRepository
+from tracker.executor.execution_authority import ExecutionAuthority
+
+
+def _task_with_authority(
+    session: Session,
+    executor_authority: Callable[..., ExecutionAuthority],
+    *,
+    status: TaskStatus = TaskStatus.IN_PROGRESS,
+) -> tuple[Task, ExecutionAuthority]:
+    benchmark = make_benchmark(session=session)
+    task = make_task(benchmark, "task", status=status)
+    session.add(task)
+    session.commit()
+    authority = executor_authority(benchmark)
+    return task, authority
+
+
+def test_revoked_authority_rolls_back_error_row(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """Authority revocation rejects and removes the staged terminal error."""
+    task, authority = _task_with_authority(database_session, executor_authority)
+    dispatch = database_session.get(ExecutorDispatch, authority.dispatch_id)
+    assert dispatch is not None
+    dispatch.status = ExecutorDispatchStatus.FAILED
+    database_session.commit()
+
+    assert TaskExecutionRepository(database_session).record_error(task.id, task.org_id, "revoked", authority) is False
+    assert database_session.exec(select(ErrorResult).where(ErrorResult.task == task.id)).all() == []
+    database_session.expire_all()
+    assert database_session.get(Task, task.id).status == TaskStatus.IN_PROGRESS  # type: ignore[union-attr]
+
+
+def test_stale_attempt_rolls_back_error_row(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """A stale attempt cannot leave an error row behind."""
+    started_at = datetime.now(UTC)
+    task, authority = _task_with_authority(database_session, executor_authority)
+    assert (
+        TaskExecutionRepository(database_session).record_error(
+            task.id,
+            task.org_id,
+            "stale",
+            authority,
+            expected_started_at=started_at - timedelta(seconds=1),
+        )
+        is False
+    )
+    assert database_session.exec(select(ErrorResult).where(ErrorResult.task == task.id)).all() == []
+
+
+def test_stopped_task_rejects_non_stop_writes(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """Stopped tasks reject transitions and resume-state writes."""
+    task, authority = _task_with_authority(database_session, executor_authority, status=TaskStatus.STOPPED)
+    repository = TaskExecutionRepository(database_session)
+
+    assert repository.transition_status(task.id, task.org_id, TaskStatus.BUILDING, authority) is False
+    assert repository.save_eval_resume_state(task.id, task.org_id, {"cursor": 1}, authority) is False
+    database_session.expire_all()
+    persisted = database_session.get(Task, task.id)
+    assert persisted is not None
+    assert persisted.status == TaskStatus.STOPPED
+    assert persisted.eval_resume_state is None
+
+
+def test_error_write_is_atomic_and_caller_owns_commit(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """Successful error persistence stays uncommitted until the caller commits."""
+    task, authority = _task_with_authority(database_session, executor_authority)
+    repository = TaskExecutionRepository(database_session)
+
+    assert repository.record_error(task.id, task.org_id, "failure", authority) is True
+    assert database_session.in_transaction()
+    database_session.rollback()
+    assert database_session.exec(select(ErrorResult).where(ErrorResult.task == task.id)).all() == []
+
+    assert repository.record_error(task.id, task.org_id, "failure", authority) is True
+    database_session.commit()
+    database_session.expire_all()
+    assert database_session.get(Task, task.id).status == TaskStatus.ERROR  # type: ignore[union-attr]
+    assert len(database_session.exec(select(ErrorResult).where(ErrorResult.task == task.id)).all()) == 1
+
+
+def test_dangling_evaluation_breakdown_rolls_back_all_writes(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """A dangling evaluation breakdown rejects the result without partial writes."""
+    task, authority = _task_with_authority(database_session, executor_authority, status=TaskStatus.EVALUATING)
+    dangling_breakdown_id = uuid4()
+    task.task_breakdown = dangling_breakdown_id
+    database_session.commit()
+    result = EvaluationResult(org_id=task.org_id, task=task.id, result={"score": 1})
+    repository = TaskExecutionRepository(database_session)
+
+    assert (
+        repository.record_evaluation_and_finish(
+            task.id,
+            task.org_id,
+            result,
+            authority,
+            expected_started_at=task.started_at,
+            evaluation_run_duration=2.0,
+            sandbox_run_duration=3.0,
+        )
+        is False
+    )
+    assert not database_session.in_transaction()
+
+    database_session.expire_all()
+    persisted = database_session.get(Task, task.id)
+    assert persisted is not None
+    assert persisted.status == TaskStatus.EVALUATING
+    assert persisted.finished_at is None
+    assert persisted.task_breakdown == dangling_breakdown_id
+    assert database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task.id)).all() == []
+    assert database_session.get(TaskBreakdown, dangling_breakdown_id) is None
+
+
+def test_evaluation_breakdown_and_status_are_atomic(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """Evaluation, duration updates, and finishing status share one transaction."""
+    task, authority = _task_with_authority(database_session, executor_authority, status=TaskStatus.EVALUATING)
+    breakdown = TaskBreakdown(agent_run_duration=1.0)
+    task.task_breakdown = breakdown.id
+    database_session.add(breakdown)
+    database_session.commit()
+    result = EvaluationResult(org_id=task.org_id, task=task.id, result={"score": 1})
+    repository = TaskExecutionRepository(database_session)
+
+    assert (
+        repository.record_evaluation_and_finish(
+            task.id,
+            task.org_id,
+            result,
+            authority,
+            expected_started_at=task.started_at,
+            evaluation_run_duration=2.0,
+            sandbox_run_duration=3.0,
+        )
+        is True
+    )
+    database_session.rollback()
+    database_session.expire_all()
+    persisted = database_session.get(Task, task.id)
+    assert persisted is not None
+    assert persisted.status == TaskStatus.EVALUATING
+    assert database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task.id)).all() == []
+    persisted_breakdown = database_session.get(TaskBreakdown, breakdown.id)
+    assert persisted_breakdown is not None
+    assert persisted_breakdown.evaluation_run_duration is None
+
+    result = EvaluationResult(org_id=task.org_id, task=task.id, result={"score": 1})
+    assert (
+        repository.record_evaluation_and_finish(
+            task.id,
+            task.org_id,
+            result,
+            authority,
+            expected_started_at=task.started_at,
+            evaluation_run_duration=2.0,
+            sandbox_run_duration=3.0,
+        )
+        is True
+    )
+    database_session.commit()
+    database_session.expire_all()
+    assert database_session.get(Task, task.id).status == TaskStatus.FINISHED  # type: ignore[union-attr]
+    persisted_breakdown = database_session.get(TaskBreakdown, breakdown.id)
+    assert persisted_breakdown is not None
+    assert persisted_breakdown.evaluation_run_duration == 2.0
+    assert persisted_breakdown.sandbox_run_duration == 3.0
+
+
+def test_task_lookup_and_writes_are_organization_scoped(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """Foreign organizations cannot read or mutate an execution task."""
+    task, authority = _task_with_authority(database_session, executor_authority)
+    other_org = Org(id=uuid4(), name="other")
+    database_session.add(other_org)
+    database_session.commit()
+    repository = TaskExecutionRepository(database_session)
+
+    assert repository.get_for_execution(task.id, other_org.id) is None
+    assert repository.get_for_benchmark(task.benchmark, task.task_id, other_org.id) is None
+    assert repository.transition_status(task.id, other_org.id, TaskStatus.BUILDING, authority) is False
+    database_session.expire_all()
+    assert database_session.get(Task, task.id).status == TaskStatus.IN_PROGRESS  # type: ignore[union-attr]
+
+
+def test_is_current_checks_attempt_and_authority(
+    database_session: Session, executor_authority: Callable[..., ExecutionAuthority]
+) -> None:
+    """Current-attempt checks reject stale started-at values and revoked dispatches."""
+    task, authority = _task_with_authority(database_session, executor_authority)
+    repository = TaskExecutionRepository(database_session)
+
+    assert repository.is_current(task.id, task.org_id, authority, task.started_at) is True
+    assert repository.is_current(task.id, task.org_id, authority, datetime.now(UTC)) is False
+
+    dispatch = database_session.get(ExecutorDispatch, authority.dispatch_id)
+    assert dispatch is not None
+    dispatch.status = ExecutorDispatchStatus.FAILED
+    database_session.commit()
+    assert repository.is_current(task.id, task.org_id, authority, task.started_at) is False

--- a/services/tracker/tests/unit/test_auth.py
+++ b/services/tracker/tests/unit/test_auth.py
@@ -10,6 +10,7 @@ from sqlmodel import Session
 from tests.utils import TEST_ORG_ID
 from tracker.auth import forward_tracker_api_key
 from tracker.database.models import DEFAULT_ORG_NAME, Org
+from tracker.database.repositories import OrgRepository
 
 
 class TestGetDefaultOrg:
@@ -22,7 +23,7 @@ class TestGetDefaultOrg:
         empty_database_session.add(vals_org)
         empty_database_session.commit()
 
-        result = get_default_org(empty_database_session)
+        result = get_default_org(OrgRepository(empty_database_session))
         assert result.id == TEST_ORG_ID
         assert result.name == DEFAULT_ORG_NAME
 
@@ -32,7 +33,7 @@ class TestGetDefaultOrg:
         setattr(auth_module, "_cached_default_org", None)
 
         with pytest.raises(RuntimeError, match="Default org not found"):
-            auth_module.get_default_org(empty_database_session)
+            auth_module.get_default_org(OrgRepository(empty_database_session))
 
 
 class TestForwardTrackerApiKey:

--- a/services/tracker/tests/unit/test_auth_descope.py
+++ b/services/tracker/tests/unit/test_auth_descope.py
@@ -24,6 +24,7 @@ from tracker.auth import (
     resolve_descope_identity,
 )
 from tracker.database.models import DEFAULT_ORG_NAME, Org
+from tracker.database.repositories import OrgRepository
 
 
 @pytest.fixture
@@ -89,7 +90,7 @@ class TestDescopeIdentityResolution:
         mock_descope.exchange_access_key.return_value = descope_access_key_response()
 
         identity = resolve_descope_identity("valid-key")
-        org = find_org_by_tenant(identity.tenant_name, empty_database_session)
+        org = find_org_by_tenant(identity.tenant_name, OrgRepository(empty_database_session))
         assert org is not None
         assert org.id == test_org.id
 
@@ -111,14 +112,14 @@ class TestDescopeIdentityResolution:
         )
 
         with pytest.raises(HTTPException) as exc_info:
-            resolve_bearer_session("bad-session", empty_database_session)
+            resolve_bearer_session("bad-session", OrgRepository(empty_database_session))
 
         assert exc_info.value.status_code == 401
         assert exc_info.value.detail == "Invalid session"
         assert "Sensitive provider detail" not in str(exc_info.value.detail)
 
     def test_org_not_in_db_returns_none(self, empty_database_session: Session) -> None:
-        org = find_org_by_tenant("nonexistent-org", empty_database_session)
+        org = find_org_by_tenant("nonexistent-org", OrgRepository(empty_database_session))
         assert org is None
 
     def test_resolve_descope_identity_full_claims(self, mock_descope: MagicMock) -> None:
@@ -251,7 +252,7 @@ class TestCurrentStarterResolution:
         monkeypatch.setattr("tracker.auth._cached_default_org", None)
 
         mock_request = MagicMock()
-        identity = get_current_starter(mock_request, empty_database_session)
+        identity = get_current_starter(mock_request, OrgRepository(empty_database_session))
 
         assert isinstance(identity, RequestIdentity)
         assert identity.org.name == DEFAULT_ORG_NAME
@@ -272,7 +273,7 @@ class TestCurrentStarterResolution:
         mock_request = MagicMock()
         mock_request.headers = {"x-api-key": "valid-key"}
 
-        identity = get_current_starter(mock_request, empty_database_session)
+        identity = get_current_starter(mock_request, OrgRepository(empty_database_session))
 
         assert isinstance(identity, RequestIdentity)
         assert identity.org.id == test_org.id
@@ -299,7 +300,7 @@ class TestCurrentStarterResolution:
         mock_request = MagicMock()
         mock_request.headers = {"x-api-key": "valid-key"}
 
-        identity = get_current_starter(mock_request, empty_database_session)
+        identity = get_current_starter(mock_request, OrgRepository(empty_database_session))
 
         assert identity.org.id == test_org.id
         assert identity.access_key_id == "K2abc"
@@ -319,7 +320,7 @@ class TestCurrentStarterResolution:
         mock_request = MagicMock()
         mock_request.headers = {"x-api-key": "valid-key"}
 
-        org = get_current_org(mock_request, empty_database_session)
+        org = get_current_org(mock_request, OrgRepository(empty_database_session))
 
         assert org.id == test_org.id
         mock_descope.mgmt.user.load_by_user_id.assert_not_called()

--- a/services/tracker/tests/unit/test_docent_analysis.py
+++ b/services/tracker/tests/unit/test_docent_analysis.py
@@ -11,6 +11,7 @@ import pytest
 from sqlmodel import Session
 
 from tracker.database.models import Benchmark, BenchmarkStatus, DocentReadingStatus
+from tracker.database.repositories import BenchmarkRepository
 from tracker.docent_analysis import invoke_analyzer
 from tracker.types import AWSCredentials
 from tracker.utils import catch_errors_during_cleanup
@@ -134,6 +135,7 @@ def test_cleanup_sweeps_running_docent_status_to_error(
         database_session,
         org,
         authority=authority,
+        benchmark_repository=BenchmarkRepository(database_session),
     )
 
     database_session.refresh(example_benchmark_object)

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -53,6 +53,7 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.config import STABLE_QUEUE_NAME
+from tracker.database.repositories import BenchmarkRepository
 from tracker.exceptions import TrackerServiceError
 from tracker.types import (
     BenchmarkTableRow,
@@ -233,8 +234,10 @@ class TestTrackerAPI:
             example_benchmark_object.id,
             9,
             database_session,
+            BenchmarkRepository(database_session),
             Org(id=TEST_ORG_ID, name="default"),
         )
+        database_session.commit()
 
         assert result.status == BenchmarkStatus.STOPPED
         database_session.expire_all()
@@ -245,31 +248,27 @@ class TestTrackerAPI:
 
     def test_update_benchmark_concurrency_returns_snapshot_from_locked_transaction(
         self,
-        monkeypatch: MonkeyPatch,
         database_session: Session,
         example_benchmark_object: Benchmark,
     ) -> None:
         database_session.add(example_benchmark_object)
         database_session.commit()
-        commit_update = database_session.commit
-
-        def commit_then_stop() -> None:
-            commit_update()
-            with Session(bind=database_session.get_bind()) as concurrent_session:
-                concurrent_benchmark = concurrent_session.get(Benchmark, example_benchmark_object.id)
-                assert concurrent_benchmark is not None
-                concurrent_benchmark.status = BenchmarkStatus.STOPPED
-                concurrent_session.add(concurrent_benchmark)
-                concurrent_session.commit()
-
-        monkeypatch.setattr(database_session, "commit", commit_then_stop)
 
         result = update_benchmark_concurrency(
             example_benchmark_object.id,
             9,
             database_session,
+            BenchmarkRepository(database_session),
             Org(id=TEST_ORG_ID, name="default"),
         )
+        database_session.commit()
+
+        with Session(bind=database_session.get_bind()) as concurrent_session:
+            concurrent_benchmark = concurrent_session.get(Benchmark, example_benchmark_object.id)
+            assert concurrent_benchmark is not None
+            concurrent_benchmark.status = BenchmarkStatus.STOPPED
+            concurrent_session.add(concurrent_benchmark)
+            concurrent_session.commit()
 
         assert result.status == BenchmarkStatus.IN_PROGRESS
         database_session.expire_all()
@@ -1545,6 +1544,11 @@ class TestTrackerAPI:
         body = response.json()
         assert not body["email_claim_missing"]
         assert body["org_name"] == "test-tenant"
+        assert body["created"] is True
+
+        repeat_response = client.post("/init", headers={"X-Api-Key": "valid-key"})
+        assert repeat_response.status_code == 200
+        assert repeat_response.json()["created"] is False
 
     async def test_init_org_returns_email_claim_missing(
         self,

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -310,7 +310,7 @@ class TestBenchmarkServiceFailures:
             raise BenchmarkServiceError(html_error)
 
         monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
-        benchmark_row = fetch_benchmark_row(benchmark_id, database_session, TEST_ORG)
+        benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(database_session), TEST_ORG)
         authority_kwargs = executor_authority_kwargs(benchmark_row)
 
         await process_benchmark(
@@ -321,7 +321,7 @@ class TestBenchmarkServiceFailures:
         )
 
         with Session(bind=database_session.bind) as session:
-            benchmark_row = fetch_benchmark_row(benchmark_id, session, TEST_ORG)
+            benchmark_row = fetch_benchmark_row(benchmark_id, BenchmarkRepository(session), TEST_ORG)
             assert benchmark_row.status == BenchmarkStatus.ERROR
             assert benchmark_row.error_message is not None
             assert "Final score failed with status code 404" in benchmark_row.error_message

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -571,7 +571,6 @@ class TestRunRecovery:
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
-            session=database_session,
             benchmark_service=start_benchmark_request.benchmark_service,
             retry=False,
             retry_mode=RetryMode.AUTO,
@@ -642,7 +641,6 @@ class TestRunRecovery:
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
-            session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
             retry=False,
             retry_mode=retry_mode,
@@ -705,7 +703,6 @@ class TestRunRecovery:
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
-            session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
             retry=True,
             retry_mode=RetryMode.AUTO,
@@ -756,7 +753,6 @@ class TestRunRecovery:
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
-            session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
             retry=False,
             retry_mode=RetryMode.AUTO,
@@ -803,7 +799,6 @@ class TestRunRecovery:
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
-            session=database_session,
             benchmark_service=benchmark_row.benchmark_service(),
             retry=True,
             retry_mode=RetryMode.AUTO,
@@ -887,7 +882,6 @@ class TestRunRecovery:
         # Resume with a new task id — should be lazily created as PENDING
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
-            session=database_session,
             benchmark_service=start_benchmark_request.benchmark_service,
             retry=False,
             retry_mode=RetryMode.AUTO,

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -29,6 +29,7 @@ from tests.factories import make_benchmark, make_error_result, make_evaluation_r
 from tests.unit.utils.task_execution_support import MockKicker, make_retrieve_task_response
 from tests.utils import TEST_ORG_ID, async_iterator
 from tracker.auth import RequestIdentity
+from tracker.database.repositories import BenchmarkRepository, RunControlRepository
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -395,7 +396,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", get_sandbox_provider)
         monkeypatch.setattr(
-            "tracker.utils.run_control.datetime",
+            "tracker.database.repositories.run_control.datetime",
             SimpleNamespace(now=resumed_attempt_time),
         )
 
@@ -541,7 +542,13 @@ class TestRunRecovery:
         database_session.commit()
 
         # Stop benchmark - only tasks that are pending become stopped
-        await initiate_stop_benchmark(benchmark_row, database_session, force=False, org=self._test_org)
+        await initiate_stop_benchmark(
+            benchmark_row,
+            database_session,
+            force=False,
+            org=self._test_org,
+            repository=RunControlRepository(database_session),
+        )
 
         # Verify: 2 tasks are finished, 3 tasks are stopped
         finished_count = len(
@@ -570,6 +577,8 @@ class TestRunRecovery:
             retry_mode=RetryMode.AUTO,
             rerun_task_ids=[],
             org=self._test_org,
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
         database_session.commit()
         # Only 3 tasks should be verified for resume (the 3 tasks that are stopped)
@@ -639,6 +648,8 @@ class TestRunRecovery:
             retry_mode=retry_mode,
             rerun_task_ids=[],
             org=self._test_org,
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
         database_session.commit()
 
@@ -700,6 +711,8 @@ class TestRunRecovery:
             retry_mode=RetryMode.AUTO,
             rerun_task_ids=["task_error", "task_result"],
             org=self._test_org,
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
 
         assert verified_task_ids == ["task_error", "task_result"]
@@ -749,6 +762,8 @@ class TestRunRecovery:
             retry_mode=RetryMode.AUTO,
             rerun_task_ids=["task_1", "task_2"],
             org=self._test_org,
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
 
         task_statuses = {
@@ -794,6 +809,8 @@ class TestRunRecovery:
             retry_mode=RetryMode.AUTO,
             rerun_task_ids=["task_requested"],
             org=self._test_org,
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
 
         task_statuses = {
@@ -876,6 +893,8 @@ class TestRunRecovery:
             retry_mode=RetryMode.AUTO,
             rerun_task_ids=[new_task_id],
             org=self._test_org,
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
         database_session.commit()
         assert verified_task_ids == [new_task_id]
@@ -1143,6 +1162,7 @@ class TestRunRecovery:
             *,
             sandbox_provider: str,
             task_ids: list[str] | None = None,
+            **_kwargs: Any,
         ) -> None:
             captured["sandbox_provider_secret_name"] = sandbox_provider_secret_name
             captured["sandbox_provider"] = sandbox_provider
@@ -1346,7 +1366,14 @@ class TestRunRecovery:
                 persisted.status = BenchmarkStatus.IN_PROGRESS
                 control_session.add(persisted)
                 control_session.commit()
-                update_benchmark_concurrency(benchmark_row.id, 9, control_session, self._test_org)
+                update_benchmark_concurrency(
+                    benchmark_row.id,
+                    9,
+                    control_session,
+                    BenchmarkRepository(control_session),
+                    self._test_org,
+                )
+                control_session.commit()
             return ["task_0"]
 
         monkeypatch.setattr("main.reset_to_in_progress_status", _concurrent_reset)
@@ -2120,7 +2147,13 @@ class TestRunRecovery:
         database_session.commit()
         authority = executor_authority(benchmark_row, session=database_session)
 
-        await initiate_stop_benchmark(benchmark_row, database_session, force=False, org=self._test_org)
+        await initiate_stop_benchmark(
+            benchmark_row,
+            database_session,
+            force=False,
+            org=self._test_org,
+            repository=RunControlRepository(database_session),
+        )
 
         database_session.refresh(benchmark_row)
         database_session.refresh(pending_task)
@@ -2162,7 +2195,13 @@ class TestRunRecovery:
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
 
-        await initiate_stop_benchmark(benchmark_row, database_session, force=True, org=self._test_org)
+        await initiate_stop_benchmark(
+            benchmark_row,
+            database_session,
+            force=True,
+            org=self._test_org,
+            repository=RunControlRepository(database_session),
+        )
         assert benchmark_row.status == BenchmarkStatus.STOPPING
 
         def _empty_list_sandboxes(*_args: Any, **_kwargs: Any) -> AsyncIterator[None]:
@@ -2195,6 +2234,8 @@ class TestRunRecovery:
             harness_config.aws,
             self._test_org,
             sandbox_provider="daytona",
+            repository=RunControlRepository(database_session),
+            benchmark_repository=BenchmarkRepository(database_session),
         )
 
         database_session.refresh(benchmark_row)

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -22,6 +22,7 @@ from main import app
 from tests.factories import make_benchmark
 from tests.utils import TEST_ORG_ID
 from tracker.auth import RequestIdentity
+from tracker.database.repositories import BenchmarkRepository, ReportingRepository, TaskRepository
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -152,13 +153,13 @@ class TestRunState:
 
         def capture_locked_fetch(
             benchmark_id: UUID,
-            session: Session,
+            benchmark_repository: BenchmarkRepository,
             org: Org,
             *,
             for_update: bool = False,
         ) -> Benchmark:
             locked_fetches.append(for_update)
-            return fetch_benchmark_row(benchmark_id, session, org, for_update=for_update)
+            return fetch_benchmark_row(benchmark_id, benchmark_repository, org, for_update=for_update)
 
         monkeypatch.setattr("main.fetch_benchmark_row", capture_locked_fetch)
 
@@ -168,7 +169,11 @@ class TestRunState:
         assert response.json() == {"status": "success"}
         assert locked_fetches == [True]
 
-        benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session, self._test_org)
+        benchmark_row = fetch_benchmark_row(
+            benchmark_row.id,
+            BenchmarkRepository(database_session),
+            self._test_org,
+        )
         assert benchmark_row.status == BenchmarkStatus.STOPPING
 
         # Task status in pending state should be set to "stopped" / otherwise known as no pending tasks left
@@ -263,7 +268,11 @@ class TestRunState:
         assert len(task_ids) == 5
 
         # Validate the benchmark is now in progress state
-        benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session, self._test_org)
+        benchmark_row = fetch_benchmark_row(
+            benchmark_row.id,
+            BenchmarkRepository(database_session),
+            self._test_org,
+        )
         assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
 
         # Reset benchmark row to stopped state
@@ -433,13 +442,19 @@ class TestRunState:
         database_session.add(benchmark_row)
         database_session.commit()
         authority = executor_authority(benchmark_row, session=database_session)
+        task_repository = TaskRepository(database_session)
 
         # Verified tasks to create
         verified_task_ids = [f"task_{i}" for i in range(5)]
 
         # Creates all tasks in pending state
         task_rows = create_task_rows(
-            verified_task_ids, benchmark_row, database_session, self._test_org, authority=authority
+            verified_task_ids,
+            benchmark_row,
+            database_session,
+            self._test_org,
+            authority=authority,
+            task_repository=task_repository,
         )
         assert len(task_rows) == len(verified_task_ids)
         assert all(task_row[1].status == TaskStatus.PENDING for task_row in task_rows)
@@ -450,7 +465,12 @@ class TestRunState:
 
         # Try calling the same method again when the tasks already exist
         task_rows = create_task_rows(
-            verified_task_ids, benchmark_row, database_session, self._test_org, authority=authority
+            verified_task_ids,
+            benchmark_row,
+            database_session,
+            self._test_org,
+            authority=authority,
+            task_repository=task_repository,
         )
         assert len(task_rows) == len(verified_task_ids)
         assert all(task_row[1].status == TaskStatus.PENDING for task_row in task_rows)
@@ -460,7 +480,14 @@ class TestRunState:
         assert len(all_tasks) == len(verified_task_ids)
         assert all(task.status == TaskStatus.PENDING for task in all_tasks)
 
-        task_rows = create_task_rows(["task_1"], benchmark_row, database_session, self._test_org, authority=authority)
+        task_rows = create_task_rows(
+            ["task_1"],
+            benchmark_row,
+            database_session,
+            self._test_org,
+            authority=authority,
+            task_repository=task_repository,
+        )
         assert [task_id for task_id, _ in task_rows] == ["task_1"]
 
     def test_fetch_final_score_inputs_waits_for_runnable_tasks(
@@ -507,7 +534,7 @@ class TestRunState:
         database_session.commit()
 
         assert not has_runnable_tasks(database_session, benchmark_row, self._test_org)
-        assert fetch_final_score_inputs(database_session, benchmark_row, self._test_org) == {
+        assert fetch_final_score_inputs(ReportingRepository(database_session), benchmark_row, self._test_org) == {
             "task_finished": {"score": 1.0},
             "task_error": None,
             "task_stopped": None,
@@ -600,7 +627,14 @@ class TestRunState:
 
         # Create some pending tasks
         task_ids = [f"task_{i}" for i in range(5)]
-        task_rows = create_task_rows(task_ids, benchmark_row, database_session, self._test_org, authority=authority)
+        task_rows = create_task_rows(
+            task_ids,
+            benchmark_row,
+            database_session,
+            self._test_org,
+            authority=authority,
+            task_repository=TaskRepository(database_session),
+        )
         assert len(task_rows) == len(task_ids)
         assert all(task_row[1].status == TaskStatus.PENDING for task_row in task_rows)
 
@@ -654,7 +688,7 @@ class TestFetchStartedByFilter:
 
         rows, total, _ = fetch_filtered_benchmark_rows(
             FetchBenchmarksRequest(started_by=["alice@vals.ai"], limit=10),
-            database_session,
+            ReportingRepository(database_session),
             org,
         )
         assert total == 1
@@ -669,7 +703,7 @@ class TestFetchStartedByFilter:
 
         rows, total, _ = fetch_filtered_benchmark_rows(
             FetchBenchmarksRequest(started_by=["alice@vals.ai", "bob@vals.ai"], limit=10),
-            database_session,
+            ReportingRepository(database_session),
             org,
         )
         assert total == 2
@@ -686,7 +720,7 @@ class TestFetchStartedByFilter:
 
         rows, total, _ = fetch_filtered_benchmark_rows(
             FetchBenchmarksRequest(started_by=["ALICE@VALS.AI"], limit=10),
-            database_session,
+            ReportingRepository(database_session),
             org,
         )
         assert total == 1
@@ -700,7 +734,7 @@ class TestFetchStartedByFilter:
 
         _, total, _ = fetch_filtered_benchmark_rows(
             FetchBenchmarksRequest(started_by=None, limit=10),
-            database_session,
+            ReportingRepository(database_session),
             org,
         )
         assert total == 2
@@ -713,7 +747,7 @@ class TestFetchStartedByFilter:
 
         rows, total, _ = fetch_filtered_benchmark_rows(
             FetchBenchmarksRequest(started_by=["  alice@vals.ai  "], limit=10),
-            database_session,
+            ReportingRepository(database_session),
             org,
         )
         assert total == 1
@@ -739,7 +773,7 @@ class TestFetchStartedByFilter:
 
         rows, total, _ = fetch_filtered_benchmark_rows(
             FetchBenchmarksRequest(started_by=["alice@vals.ai"], limit=10),
-            database_session,
+            ReportingRepository(database_session),
             default_org,
         )
         assert total == 1
@@ -761,7 +795,7 @@ def test_fetch_filtered_by_label(database_session: Session) -> None:
 
     rows, total, _ = fetch_filtered_benchmark_rows(
         FetchBenchmarksRequest(label="nightLY", limit=10),
-        database_session,
+        ReportingRepository(database_session),
         org,
     )
 


### PR DESCRIPTION
## Summary
Consolidate tracker persistence behind explicit, request-scoped domain repositories. Document when to use the repository pattern and keep repository tests organized under one subpackage.

## Changes
- Add benchmark, reporting, organization, task, task-execution, and run-control repositories.
- Inject repositories through FastAPI dependencies and session-bound helpers.
- Remove unused raw `Session` dependencies while preserving commit, lock, dispatch, and fresh-session SSE boundaries.
- Add `.agents/repository-design-pattern/SKILL.md` with repository selection, transaction, tenant-isolation, concurrency, and testing guidance.
- Move repository unit tests into `services/tracker/tests/unit/database/repositories/`.
- Preserve force-stop ordering, execution authority fences, CAS predicates, worker boundaries, and fresh-session SSE polling.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Tracker unit and API tests pass. Repository subpackage tests pass. Ruff, formatting, targeted basedpyright, and `git diff --check` pass. PostgreSQL/Testcontainers coverage remains blocked by the local Docker socket timing out.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed; repository guidance was added
