### PR TITLE
feat(tracker): emit structured sandbox.delete audit events #patch

### DIFF
--- a/services/tracker/src/tracker/logging/context.py
+++ b/services/tracker/src/tracker/logging/context.py
@@ -18,9 +18,11 @@ def get_context_tags() -> dict[str, str]:
 
 
 class ContextFilter(logging.Filter):
-    """Injects context variables into every log record for structured logging."""
+    """Injects context variables into log records without overriding fields set explicitly via `extra`."""
 
     def filter(self, record: logging.LogRecord) -> bool:
         for key, value in get_context_tags().items():
+            if getattr(record, key, None):
+                continue
             setattr(record, key, value)
         return True

--- a/services/tracker/src/tracker/logging/context.py
+++ b/services/tracker/src/tracker/logging/context.py
@@ -22,7 +22,6 @@ class ContextFilter(logging.Filter):
 
     def filter(self, record: logging.LogRecord) -> bool:
         for key, value in get_context_tags().items():
-            if getattr(record, key, None):
-                continue
-            setattr(record, key, value)
+            if not getattr(record, key, None):
+                setattr(record, key, value)
         return True

--- a/services/tracker/src/tracker/logging/context.py
+++ b/services/tracker/src/tracker/logging/context.py
@@ -18,7 +18,11 @@ def get_context_tags() -> dict[str, str]:
 
 
 class ContextFilter(logging.Filter):
-    """Injects context variables into log records without overriding fields set explicitly via `extra`."""
+    """Backfills context variables onto log records.
+
+    A truthy value already on the record (e.g. set via `extra`) takes precedence;
+    missing or falsy fields are filled from ambient context, which may be empty.
+    """
 
     def filter(self, record: logging.LogRecord) -> bool:
         for key, value in get_context_tags().items():

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -92,10 +92,7 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
 
 
 SandboxDeleteInitiator = Literal["create_cancelled", "force_stop", "task_teardown"]
-"""Known sources of sandbox deletions, recorded as `initiated_by` in the sandbox.delete audit event."""
-
 SandboxDeleteOutcome = Literal["deleted", "already_gone", "cancelled", "failed"]
-"""What became of a sandbox delete attempt; `cancelled` means the provider may or may not have acted."""
 
 
 def _audit_sandbox_delete(
@@ -105,7 +102,6 @@ def _audit_sandbox_delete(
     outcome: SandboxDeleteOutcome,
     error: str | None = None,
 ) -> None:
-    """Record who deleted which sandbox, on whose behalf, and what came of it."""
     # Labels attached at sandbox creation (utils/task_execution.py):
     # {"Benchmark": name, "Id": benchmark id, "Task": task id}.
     labels = sandbox.labels or {}
@@ -132,7 +128,7 @@ async def delete_sandbox(
     initiated_by: SandboxDeleteInitiator,
     org_id: str | None = None,
 ) -> None:
-    """Delete sandbox through its provider. `initiated_by` names the caller in the audit trail."""
+    """Delete sandbox through its provider."""
     try:
         await provider.delete_sandbox(sandbox.id)
     except SandboxNotFoundError:
@@ -142,8 +138,7 @@ async def delete_sandbox(
         _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
         raise
     except asyncio.CancelledError:
-        # Cancelled mid-flight: the delete request may still have reached the provider.
-        # Record the attempt before propagating so the deletion is never unattributed.
+        # Caught only to audit: a cancelled delete may still have reached the provider.
         _audit_sandbox_delete(sandbox, initiated_by, org_id, "cancelled")
         raise
     except Exception as e:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -91,15 +91,15 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
     return bundle_path / contract_name
 
 
-def _log_sandbox_delete(
+def _audit_sandbox_delete(
     sandbox: Sandbox,
     initiated_by: str,
     org_id: str | None,
-    *,
     outcome: str,
     error: str | None = None,
 ) -> None:
-    """Structured audit record for every sandbox deletion attempt (vtl#170)."""
+    """Record who deleted which sandbox, on whose behalf, and what came of it."""
+    # Provider labels set at creation: {"Benchmark": name, "Id": benchmark id, "Task": task id}.
     labels = sandbox.labels or {}
     logger.info(
         "sandbox.delete",
@@ -124,20 +124,20 @@ async def delete_sandbox(
     initiated_by: str,
     org_id: str | None = None,
 ) -> None:
-    """Delete sandbox through its provider."""
+    """Delete sandbox through its provider. `initiated_by` names the caller in the audit trail."""
     try:
         await provider.delete_sandbox(sandbox.id)
     except SandboxNotFoundError:
-        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="already_gone")
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "already_gone")
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
     except ProviderSandboxError as e:
-        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="failed", error=str(e))
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", str(e))
         raise
     except Exception as e:
-        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="failed", error=str(e))
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", str(e))
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
     else:
-        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="deleted")
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "deleted")
 
 
 def _source_name(source: SandboxSource) -> str:

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -10,7 +10,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import Any, AsyncGenerator, assert_never
+from typing import Any, AsyncGenerator, Literal, assert_never
 
 import logfire
 import sentry_sdk
@@ -91,15 +91,23 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
     return bundle_path / contract_name
 
 
+SandboxDeleteInitiator = Literal["create_cancelled", "force_stop", "task_teardown"]
+"""Known sources of sandbox deletions, recorded as `initiated_by` in the sandbox.delete audit event."""
+
+SandboxDeleteOutcome = Literal["deleted", "already_gone", "cancelled", "failed"]
+"""What became of a sandbox delete attempt; `cancelled` means the provider may or may not have acted."""
+
+
 def _audit_sandbox_delete(
     sandbox: Sandbox,
-    initiated_by: str,
+    initiated_by: SandboxDeleteInitiator,
     org_id: str | None,
-    outcome: str,
+    outcome: SandboxDeleteOutcome,
     error: str | None = None,
 ) -> None:
     """Record who deleted which sandbox, on whose behalf, and what came of it."""
-    # Provider labels set at creation: {"Benchmark": name, "Id": benchmark id, "Task": task id}.
+    # Labels attached at sandbox creation (utils/task_execution.py):
+    # {"Benchmark": name, "Id": benchmark id, "Task": task id}.
     labels = sandbox.labels or {}
     logger.info(
         "sandbox.delete",
@@ -121,7 +129,7 @@ async def delete_sandbox(
     sandbox: Sandbox,
     provider: SandboxProvider,
     *,
-    initiated_by: str,
+    initiated_by: SandboxDeleteInitiator,
     org_id: str | None = None,
 ) -> None:
     """Delete sandbox through its provider. `initiated_by` names the caller in the audit trail."""
@@ -131,10 +139,15 @@ async def delete_sandbox(
         _audit_sandbox_delete(sandbox, initiated_by, org_id, "already_gone")
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
     except ProviderSandboxError as e:
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", str(e))
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
+        raise
+    except asyncio.CancelledError:
+        # Cancelled mid-flight: the delete request may still have reached the provider.
+        # Record the attempt before propagating so the deletion is never unattributed.
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "cancelled")
         raise
     except Exception as e:
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", str(e))
+        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
     else:
         _audit_sandbox_delete(sandbox, initiated_by, org_id, "deleted")

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -91,16 +91,53 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
     return bundle_path / contract_name
 
 
-async def delete_sandbox(sandbox: Sandbox, provider: SandboxProvider) -> None:
+def _log_sandbox_delete(
+    sandbox: Sandbox,
+    initiated_by: str,
+    org_id: str | None,
+    *,
+    outcome: str,
+    error: str | None = None,
+) -> None:
+    """Structured audit record for every sandbox deletion attempt (vtl#170)."""
+    labels = sandbox.labels or {}
+    logger.info(
+        "sandbox.delete",
+        extra={
+            "sandbox_id": sandbox.id,
+            "sandbox_name": sandbox.name,
+            "benchmark_id": labels.get("Id"),
+            "benchmark_name": labels.get("Benchmark"),
+            "task_id": labels.get("Task"),
+            "org_id": org_id,
+            "initiated_by": initiated_by,
+            "outcome": outcome,
+            "error": error,
+        },
+    )
+
+
+async def delete_sandbox(
+    sandbox: Sandbox,
+    provider: SandboxProvider,
+    *,
+    initiated_by: str,
+    org_id: str | None = None,
+) -> None:
     """Delete sandbox through its provider."""
     try:
         await provider.delete_sandbox(sandbox.id)
     except SandboxNotFoundError:
+        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="already_gone")
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
-    except ProviderSandboxError:
+    except ProviderSandboxError as e:
+        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="failed", error=str(e))
         raise
     except Exception as e:
+        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="failed", error=str(e))
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
+    else:
+        _log_sandbox_delete(sandbox, initiated_by, org_id, outcome="deleted")
 
 
 def _source_name(source: SandboxSource) -> str:
@@ -257,7 +294,7 @@ async def create_sandbox(
                 sandbox = await asyncio.shield(creation_task)
             except asyncio.CancelledError:
                 sandbox = await creation_task
-                await delete_sandbox(sandbox, provider)
+                await delete_sandbox(sandbox, provider, initiated_by="create_cancelled")
                 raise
     except Exception as e:
         incr("valkyrie.sandbox.create.errors", tags={"error_class": type(e).__name__})
@@ -276,7 +313,7 @@ async def create_sandbox(
         logger.error(f"Error during sandbox execution {sandbox.name}: {e}")
         raise
     finally:
-        await delete_sandbox(sandbox, provider)
+        await delete_sandbox(sandbox, provider, initiated_by="task_teardown")
 
 
 @retry(

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -75,9 +75,9 @@ async def initiate_stop_benchmark(
         raise TrackerServiceError(f"Unexpected error stopping run {benchmark_row.id}: {str(e)}") from e
 
 
-async def stop_sandbox(sandbox: Sandbox, provider: SandboxProvider) -> str | None:
+async def stop_sandbox(sandbox: Sandbox, provider: SandboxProvider, org: Org) -> str | None:
     try:
-        await delete_sandbox(sandbox, provider)
+        await delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id=str(org.id))
         return None
     except SandboxNotFoundError:
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
@@ -148,7 +148,7 @@ async def force_stop_sandboxes(
     results: dict[str, str | None] = {}
     try:
         async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids):
-            result = await stop_sandbox(sandbox, provider)
+            result = await stop_sandbox(sandbox, provider, org)
             results[sandbox.name] = result
     finally:
         await benchmark_service.close()

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -607,7 +607,9 @@ async def _process_task_attempt(
         task_data = await benchmark_service.retrieve_task(task_id=task_id, dataset=start_benchmark_request.dataset)
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
 
-        # Labels that show up in the UI we can use to filter sandboxes
+        # Labels that show up in the UI we can use to filter sandboxes.
+        # The Benchmark/Id/Task keys are also read back by sandbox._audit_sandbox_delete
+        # to attribute sandbox deletions in the sandbox.delete audit event.
         labels = {
             "Benchmark": start_benchmark_request.benchmark_name,
             "Id": str(benchmark_id),

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -608,8 +608,7 @@ async def _process_task_attempt(
         sandbox_provider = benchmark_service.get_sandbox_provider(sandbox_provider_config)
 
         # Labels that show up in the UI we can use to filter sandboxes.
-        # The Benchmark/Id/Task keys are also read back by sandbox._audit_sandbox_delete
-        # to attribute sandbox deletions in the sandbox.delete audit event.
+        # Benchmark/Id/Task are read back by sandbox._audit_sandbox_delete.
         labels = {
             "Benchmark": start_benchmark_request.benchmark_name,
             "Id": str(benchmark_id),

--- a/services/tracker/tests/unit/logging/test_logging.py
+++ b/services/tracker/tests/unit/logging/test_logging.py
@@ -87,48 +87,25 @@ class TestContextFilter:
             task_id_var.reset(task_token)
 
     def test_context_filter_preserves_explicit_record_fields(self) -> None:
-        """Explicit extra fields win over ambient context so deletion audit records keep their identity.
-
-        Test cases:
-        - Record fields set from audit extra are not overwritten by ambient context.
-        - Empty record fields are still filled from context variables.
-        """
+        """Fields passed via `extra` survive ambient context, so audit records keep their own identity."""
         context_filter = ContextFilter()
-
-        # First test: explicit values win over ambient context
         record = _log_record()
         record.benchmark_id = "bench-from-extra"
         record.task_id = "task-from-extra"
 
-        request_token = request_id_var.set("req-1")
+        request_token = request_id_var.set("req-123")
         benchmark_token = benchmark_id_var.set("bench-ambient")
         task_token = task_id_var.set("task-ambient")
         try:
             context_filter.filter(record)
 
-            assert record.request_id == "req-1"
+            assert record.request_id == "req-123"
             assert record.benchmark_id == "bench-from-extra"
             assert record.task_id == "task-from-extra"
         finally:
             request_id_var.reset(request_token)
             benchmark_id_var.reset(benchmark_token)
             task_id_var.reset(task_token)
-
-        # Second test: empty values are filled from context
-        record2 = _log_record()
-        record2.benchmark_id = ""
-
-        request_token2 = request_id_var.set("req-2")
-        benchmark_token2 = benchmark_id_var.set("bench-filled")
-        task_token2 = task_id_var.set("task-2")
-        try:
-            context_filter.filter(record2)
-
-            assert record2.benchmark_id == "bench-filled"
-        finally:
-            request_id_var.reset(request_token2)
-            benchmark_id_var.reset(benchmark_token2)
-            task_id_var.reset(task_token2)
 
 
 class TestConfigureLogging:

--- a/services/tracker/tests/unit/logging/test_logging.py
+++ b/services/tracker/tests/unit/logging/test_logging.py
@@ -86,6 +86,50 @@ class TestContextFilter:
             benchmark_id_var.reset(benchmark_token)
             task_id_var.reset(task_token)
 
+    def test_context_filter_preserves_explicit_record_fields(self) -> None:
+        """Explicit extra fields win over ambient context so deletion audit records keep their identity.
+
+        Test cases:
+        - Record fields set from audit extra are not overwritten by ambient context.
+        - Empty record fields are still filled from context variables.
+        """
+        context_filter = ContextFilter()
+
+        # First test: explicit values win over ambient context
+        record = _log_record()
+        record.benchmark_id = "bench-from-extra"
+        record.task_id = "task-from-extra"
+
+        request_token = request_id_var.set("req-1")
+        benchmark_token = benchmark_id_var.set("bench-ambient")
+        task_token = task_id_var.set("task-ambient")
+        try:
+            context_filter.filter(record)
+
+            assert record.request_id == "req-1"
+            assert record.benchmark_id == "bench-from-extra"
+            assert record.task_id == "task-from-extra"
+        finally:
+            request_id_var.reset(request_token)
+            benchmark_id_var.reset(benchmark_token)
+            task_id_var.reset(task_token)
+
+        # Second test: empty values are filled from context
+        record2 = _log_record()
+        record2.benchmark_id = ""
+
+        request_token2 = request_id_var.set("req-2")
+        benchmark_token2 = benchmark_id_var.set("bench-filled")
+        task_token2 = task_id_var.set("task-2")
+        try:
+            context_filter.filter(record2)
+
+            assert record2.benchmark_id == "bench-filled"
+        finally:
+            request_id_var.reset(request_token2)
+            benchmark_id_var.reset(benchmark_token2)
+            task_id_var.reset(task_token2)
+
 
 class TestConfigureLogging:
     """Logging configuration across deployment environments."""

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -7,6 +7,7 @@ import asyncio
 import shlex
 from collections import deque
 from collections.abc import AsyncIterator, Callable, Mapping
+from contextlib import suppress
 from typing import Any, Never, cast
 from unittest.mock import AsyncMock, Mock, call
 
@@ -17,6 +18,7 @@ from benchmark_service import (
     ExecResult,
     ImageSource,
     Resources,
+    SandboxNotFoundError,
     SandboxSource,
     SnapshotSource,
     TargetedSnapshotSource,
@@ -24,7 +26,6 @@ from benchmark_service import (
 )
 from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxCommandError
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
-from benchmark_service.sandbox import SandboxNotFoundError
 
 from tracker import sandbox as sandbox_module
 from tracker.database.models import (
@@ -1252,37 +1253,43 @@ class TestSandboxLifecycle:
         assert active_sandbox_ids == set()
 
 
-_UNSET = object()
-
-
 class TestDeleteSandboxAudit:
-    """Structured audit records for sandbox deletions."""
+    """Structured `sandbox.delete` audit records."""
 
     @staticmethod
-    def _make_sandbox(
-        sandbox_id: str = "sandbox-123",
-        sandbox_name: str = "task-alias",
-        labels: dict[str, str] | None | object = _UNSET,
-    ) -> AsyncMock:
-        """Build a mock sandbox with id, name, and optional labels."""
+    def _sandbox() -> AsyncMock:
         sandbox = AsyncMock()
-        sandbox.id = sandbox_id
-        sandbox.name = sandbox_name
-        # Default labels if not explicitly provided; explicit None means no labels
-        if labels is _UNSET:
-            labels = {"Benchmark": "swebench", "Id": "bench-1", "Task": "task_0"}
-        sandbox.labels = labels  # type: ignore[attr-defined]
+        sandbox.id = "sandbox-123"
+        sandbox.name = "task-alias"
+        sandbox.labels = {"Benchmark": "swebench", "Id": "bench-1", "Task": "task_0"}
         return sandbox
 
-    async def test_delete_sandbox_audit_success_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Successful deletion emits audit with outcome=deleted."""
+    @pytest.mark.parametrize(
+        ("provider_error", "outcome", "error"),
+        [
+            (None, "deleted", None),
+            (SandboxNotFoundError("gone"), "already_gone", None),
+            (ProviderSandboxError("state change"), "failed", "state change"),
+            (RuntimeError("boom"), "failed", "boom"),
+        ],
+        ids=["deleted", "already-gone", "provider-error", "unexpected-error"],
+    )
+    async def test_delete_sandbox_audits_every_outcome(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        provider_error: Exception | None,
+        outcome: str,
+        error: str | None,
+    ) -> None:
+        """Every attempt emits one record naming the initiator, the sandbox, and what happened to it."""
         logger_mock = Mock()
         monkeypatch.setattr(sandbox_module, "logger", logger_mock)
-
-        sandbox = self._make_sandbox()
         provider = AsyncMock()
+        provider.delete_sandbox = AsyncMock(side_effect=provider_error)
 
-        await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
+        # Only ProviderSandboxError propagates; test_delete_sandbox_raises_provider_errors pins that.
+        with suppress(ProviderSandboxError):
+            await _delete_sandbox(self._sandbox(), provider, initiated_by="force_stop", org_id="org-1")
 
         logger_mock.info.assert_called_once_with(
             "sandbox.delete",
@@ -1294,75 +1301,19 @@ class TestDeleteSandboxAudit:
                 "task_id": "task_0",
                 "org_id": "org-1",
                 "initiated_by": "force_stop",
-                "outcome": "deleted",
-                "error": None,
+                "outcome": outcome,
+                "error": error,
             },
         )
-        provider.delete_sandbox.assert_awaited_once_with("sandbox-123")
 
-    async def test_delete_sandbox_audit_already_gone(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Sandbox already deleted: audit outcome=already_gone, warning logged, no raise."""
+    async def test_delete_sandbox_audits_unlabelled_sandbox(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A sandbox the provider reports without labels still identifies its deleter."""
         logger_mock = Mock()
         monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+        sandbox = self._sandbox()
+        sandbox.labels = None
 
-        sandbox = self._make_sandbox()
-        provider = AsyncMock()
-        provider.delete_sandbox = AsyncMock(side_effect=SandboxNotFoundError("gone"))
-
-        await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
-
-        logger_mock.info.assert_called_once()
-        call_args = logger_mock.info.call_args
-        assert call_args[0][0] == "sandbox.delete"
-        assert call_args[1]["extra"]["outcome"] == "already_gone"
-        assert call_args[1]["extra"]["error"] is None
-        logger_mock.warning.assert_called_once()
-
-    async def test_delete_sandbox_audit_provider_failure_reraises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Provider error re-raised: audit outcome=failed with error string, exception raised."""
-        logger_mock = Mock()
-        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
-
-        sandbox = self._make_sandbox()
-        provider = AsyncMock()
-        provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("state change"))
-
-        with pytest.raises(ProviderSandboxError, match="state change"):
-            await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
-
-        logger_mock.info.assert_called_once()
-        call_args = logger_mock.info.call_args
-        assert call_args[0][0] == "sandbox.delete"
-        assert call_args[1]["extra"]["outcome"] == "failed"
-        assert call_args[1]["extra"]["error"] == "state change"
-
-    async def test_delete_sandbox_audit_unexpected_failure_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Unexpected exception swallowed: audit outcome=failed with error string, no raise."""
-        logger_mock = Mock()
-        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
-
-        sandbox = self._make_sandbox()
-        provider = AsyncMock()
-        provider.delete_sandbox = AsyncMock(side_effect=RuntimeError("boom"))
-
-        await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
-
-        logger_mock.info.assert_called_once()
-        call_args = logger_mock.info.call_args
-        assert call_args[0][0] == "sandbox.delete"
-        assert call_args[1]["extra"]["outcome"] == "failed"
-        assert call_args[1]["extra"]["error"] == "boom"
-        logger_mock.error.assert_called_once()
-
-    async def test_delete_sandbox_audit_labels_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """No labels: benchmark/task identity fields are None."""
-        logger_mock = Mock()
-        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
-
-        sandbox = self._make_sandbox(labels=None)
-        provider = AsyncMock()
-
-        await _delete_sandbox(sandbox, provider, initiated_by="task_teardown")
+        await _delete_sandbox(sandbox, AsyncMock(), initiated_by="task_teardown")
 
         logger_mock.info.assert_called_once_with(
             "sandbox.delete",

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -24,6 +24,7 @@ from benchmark_service import (
 )
 from benchmark_service.sandbox import SandboxCommandError as ProviderSandboxCommandError
 from benchmark_service.sandbox import SandboxError as ProviderSandboxError
+from benchmark_service.sandbox import SandboxNotFoundError
 
 from tracker import sandbox as sandbox_module
 from tracker.database.models import (
@@ -1073,7 +1074,7 @@ class TestSandboxLifecycle:
         provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("state change"))
 
         with pytest.raises(ProviderSandboxError, match="state change"):
-            await _delete_sandbox(mock_sandbox, provider)
+            await _delete_sandbox(mock_sandbox, provider, initiated_by="force_stop")
 
         provider.delete_sandbox.assert_awaited_once_with("sandbox-123")
 
@@ -1219,7 +1220,7 @@ class TestSandboxLifecycle:
 
             return await asyncio.shield(remote_creation_task)
 
-        async def mock_delete_sandbox(sandbox: AsyncMock, _provider: Any) -> None:
+        async def mock_delete_sandbox(sandbox: AsyncMock, _provider: Any, **_kwargs: Any) -> None:
             active_sandbox_ids.remove(sandbox.id)
 
         monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
@@ -1247,6 +1248,136 @@ class TestSandboxLifecycle:
         assert remote_creation_task is not None
         await remote_creation_task
         assert active_sandbox_ids == set()
+
+
+_UNSET = object()
+
+
+class TestDeleteSandboxAudit:
+    """Structured audit records for sandbox deletions."""
+
+    @staticmethod
+    def _make_sandbox(
+        sandbox_id: str = "sandbox-123",
+        sandbox_name: str = "task-alias",
+        labels: dict[str, str] | None | object = _UNSET,
+    ) -> AsyncMock:
+        """Build a mock sandbox with id, name, and optional labels."""
+        sandbox = AsyncMock()
+        sandbox.id = sandbox_id
+        sandbox.name = sandbox_name
+        # Default labels if not explicitly provided; explicit None means no labels
+        if labels is _UNSET:
+            labels = {"Benchmark": "swebench", "Id": "bench-1", "Task": "task_0"}
+        sandbox.labels = labels  # type: ignore[attr-defined]
+        return sandbox
+
+    async def test_delete_sandbox_audit_success_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful deletion emits audit with outcome=deleted."""
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        sandbox = self._make_sandbox()
+        provider = AsyncMock()
+
+        await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
+
+        logger_mock.info.assert_called_once_with(
+            "sandbox.delete",
+            extra={
+                "sandbox_id": "sandbox-123",
+                "sandbox_name": "task-alias",
+                "benchmark_id": "bench-1",
+                "benchmark_name": "swebench",
+                "task_id": "task_0",
+                "org_id": "org-1",
+                "initiated_by": "force_stop",
+                "outcome": "deleted",
+                "error": None,
+            },
+        )
+        provider.delete_sandbox.assert_awaited_once_with("sandbox-123")
+
+    async def test_delete_sandbox_audit_already_gone(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sandbox already deleted: audit outcome=already_gone, warning logged, no raise."""
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        sandbox = self._make_sandbox()
+        provider = AsyncMock()
+        provider.delete_sandbox = AsyncMock(side_effect=SandboxNotFoundError("gone"))
+
+        await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
+
+        logger_mock.info.assert_called_once()
+        call_args = logger_mock.info.call_args
+        assert call_args[0][0] == "sandbox.delete"
+        assert call_args[1]["extra"]["outcome"] == "already_gone"
+        assert call_args[1]["extra"]["error"] is None
+        logger_mock.warning.assert_called_once()
+
+    async def test_delete_sandbox_audit_provider_failure_reraises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Provider error re-raised: audit outcome=failed with error string, exception raised."""
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        sandbox = self._make_sandbox()
+        provider = AsyncMock()
+        provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("state change"))
+
+        with pytest.raises(ProviderSandboxError, match="state change"):
+            await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
+
+        logger_mock.info.assert_called_once()
+        call_args = logger_mock.info.call_args
+        assert call_args[0][0] == "sandbox.delete"
+        assert call_args[1]["extra"]["outcome"] == "failed"
+        assert call_args[1]["extra"]["error"] == "state change"
+
+    async def test_delete_sandbox_audit_unexpected_failure_swallowed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unexpected exception swallowed: audit outcome=failed with error string, no raise."""
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        sandbox = self._make_sandbox()
+        provider = AsyncMock()
+        provider.delete_sandbox = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await _delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id="org-1")
+
+        logger_mock.info.assert_called_once()
+        call_args = logger_mock.info.call_args
+        assert call_args[0][0] == "sandbox.delete"
+        assert call_args[1]["extra"]["outcome"] == "failed"
+        assert call_args[1]["extra"]["error"] == "boom"
+        logger_mock.error.assert_called_once()
+
+    async def test_delete_sandbox_audit_labels_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No labels: benchmark/task identity fields are None."""
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        sandbox = self._make_sandbox(labels=None)
+        provider = AsyncMock()
+
+        await _delete_sandbox(sandbox, provider, initiated_by="task_teardown")
+
+        logger_mock.info.assert_called_once_with(
+            "sandbox.delete",
+            extra={
+                "sandbox_id": "sandbox-123",
+                "sandbox_name": "task-alias",
+                "benchmark_id": None,
+                "benchmark_name": None,
+                "task_id": None,
+                "org_id": None,
+                "initiated_by": "task_teardown",
+                "outcome": "deleted",
+                "error": None,
+            },
+        )
 
 
 class TestUploadAgentArtifacts:

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1258,20 +1258,18 @@ class TestSandboxLifecycle:
 
     async def test_create_sandbox_teardown_names_initiator(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Normal context-manager exit attributes the deletion to task_teardown in the audit trail."""
-        mock_sandbox = AsyncMock()
-        mock_sandbox.id = "sandbox-123"
-        mock_sandbox.name = "task-alias"
+        mock_sandbox = Mock()
 
-        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncMock:
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> Mock:
             return mock_sandbox
 
         delete_mock = AsyncMock()
         monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
         monkeypatch.setattr(sandbox_module, "delete_sandbox", delete_mock)
-        monkeypatch.setattr(sandbox_module, "distribution", Mock(), raising=False)
-        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock())
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock())
 
-        provider = AsyncMock()
+        provider = Mock()
         async with create_sandbox(
             provider=provider,
             sandbox_name="task-alias",
@@ -1318,8 +1316,7 @@ class TestDeleteSandboxAudit:
         provider = AsyncMock()
         provider.delete_sandbox = AsyncMock(side_effect=provider_error)
 
-        # Of these, only ProviderSandboxError propagates; test_delete_sandbox_raises_provider_errors
-        # pins that. Cancellation propagates too — test_delete_sandbox_audits_cancelled_delete.
+        # Of these outcomes only ProviderSandboxError propagates; test_delete_sandbox_raises_provider_errors pins that.
         with suppress(ProviderSandboxError):
             await _delete_sandbox(self._sandbox(), provider, initiated_by="force_stop", org_id="org-1")
 
@@ -1339,7 +1336,7 @@ class TestDeleteSandboxAudit:
         )
 
     async def test_delete_sandbox_audits_unlabelled_sandbox(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A sandbox the provider reports without labels still identifies its deleter."""
+        """Unlabelled sandboxes still audit; the other fields are pinned by the `deleted` case above."""
         logger_mock = Mock()
         monkeypatch.setattr(sandbox_module, "logger", logger_mock)
         sandbox = self._sandbox()
@@ -1347,20 +1344,9 @@ class TestDeleteSandboxAudit:
 
         await _delete_sandbox(sandbox, AsyncMock(), initiated_by="task_teardown")
 
-        logger_mock.info.assert_called_once_with(
-            "sandbox.delete",
-            extra={
-                "sandbox_id": "sandbox-123",
-                "sandbox_name": "task-alias",
-                "benchmark_id": None,
-                "benchmark_name": None,
-                "task_id": None,
-                "org_id": None,
-                "initiated_by": "task_teardown",
-                "outcome": "deleted",
-                "error": None,
-            },
-        )
+        logger_mock.info.assert_called_once()
+        extra = logger_mock.info.call_args.kwargs["extra"]
+        assert (extra["benchmark_id"], extra["benchmark_name"], extra["task_id"]) == (None, None, None)
 
     async def test_delete_sandbox_audits_cancelled_delete(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A delete cancelled mid-flight still leaves a record: the provider may have acted on it."""

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1069,6 +1069,7 @@ class TestSandboxLifecycle:
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = None
 
         provider = AsyncMock()
         provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("state change"))
@@ -1140,6 +1141,7 @@ class TestSandboxLifecycle:
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = None
         provider = AsyncMock()
         provider.create_sandbox.return_value = mock_sandbox
         distribution = Mock()
@@ -1334,9 +1336,7 @@ class TestDeleteSandboxAudit:
         assert call_args[1]["extra"]["outcome"] == "failed"
         assert call_args[1]["extra"]["error"] == "state change"
 
-    async def test_delete_sandbox_audit_unexpected_failure_swallowed(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_delete_sandbox_audit_unexpected_failure_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Unexpected exception swallowed: audit outcome=failed with error string, no raise."""
         logger_mock = Mock()
         monkeypatch.setattr(sandbox_module, "logger", logger_mock)

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1223,8 +1223,11 @@ class TestSandboxLifecycle:
 
             return await asyncio.shield(remote_creation_task)
 
-        async def mock_delete_sandbox(sandbox: AsyncMock, _provider: Any, **_kwargs: Any) -> None:
+        deletion_initiators: list[Any] = []
+
+        async def mock_delete_sandbox(sandbox: AsyncMock, _provider: Any, **kwargs: Any) -> None:
             active_sandbox_ids.remove(sandbox.id)
+            deletion_initiators.append(kwargs.get("initiated_by"))
 
         monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
         monkeypatch.setattr(sandbox_module, "delete_sandbox", mock_delete_sandbox)
@@ -1251,6 +1254,34 @@ class TestSandboxLifecycle:
         assert remote_creation_task is not None
         await remote_creation_task
         assert active_sandbox_ids == set()
+        assert deletion_initiators == ["create_cancelled"]
+
+    async def test_create_sandbox_teardown_names_initiator(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Normal context-manager exit attributes the deletion to task_teardown in the audit trail."""
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncMock:
+            return mock_sandbox
+
+        delete_mock = AsyncMock()
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", delete_mock)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock(), raising=False)
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock(), raising=False)
+
+        provider = AsyncMock()
+        async with create_sandbox(
+            provider=provider,
+            sandbox_name="task-alias",
+            source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+            resources=Resources(vcpu=2, memory=4, disk=5),
+            creation_semaphore=asyncio.Semaphore(1),
+        ):
+            pass
+
+        delete_mock.assert_awaited_once_with(mock_sandbox, provider, initiated_by="task_teardown")
 
 
 class TestDeleteSandboxAudit:
@@ -1269,8 +1300,8 @@ class TestDeleteSandboxAudit:
         [
             (None, "deleted", None),
             (SandboxNotFoundError("gone"), "already_gone", None),
-            (ProviderSandboxError("state change"), "failed", "state change"),
-            (RuntimeError("boom"), "failed", "boom"),
+            (ProviderSandboxError("state change"), "failed", "SandboxError: state change"),
+            (RuntimeError("boom"), "failed", "RuntimeError: boom"),
         ],
         ids=["deleted", "already-gone", "provider-error", "unexpected-error"],
     )
@@ -1287,7 +1318,8 @@ class TestDeleteSandboxAudit:
         provider = AsyncMock()
         provider.delete_sandbox = AsyncMock(side_effect=provider_error)
 
-        # Only ProviderSandboxError propagates; test_delete_sandbox_raises_provider_errors pins that.
+        # Of these, only ProviderSandboxError propagates; test_delete_sandbox_raises_provider_errors
+        # pins that. Cancellation propagates too — test_delete_sandbox_audits_cancelled_delete.
         with suppress(ProviderSandboxError):
             await _delete_sandbox(self._sandbox(), provider, initiated_by="force_stop", org_id="org-1")
 
@@ -1326,6 +1358,31 @@ class TestDeleteSandboxAudit:
                 "org_id": None,
                 "initiated_by": "task_teardown",
                 "outcome": "deleted",
+                "error": None,
+            },
+        )
+
+    async def test_delete_sandbox_audits_cancelled_delete(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A delete cancelled mid-flight still leaves a record: the provider may have acted on it."""
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+        provider = AsyncMock()
+        provider.delete_sandbox = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await _delete_sandbox(self._sandbox(), provider, initiated_by="task_teardown")
+
+        logger_mock.info.assert_called_once_with(
+            "sandbox.delete",
+            extra={
+                "sandbox_id": "sandbox-123",
+                "sandbox_name": "task-alias",
+                "benchmark_id": "bench-1",
+                "benchmark_name": "swebench",
+                "task_id": "task_0",
+                "org_id": None,
+                "initiated_by": "task_teardown",
+                "outcome": "cancelled",
                 "error": None,
             },
         )

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -2204,9 +2204,7 @@ class TestRunRecovery:
         assert dispatch is not None
         assert dispatch.status == ExecutorDispatchStatus.FAILED
 
-    async def test_stop_sandbox_audits_forced_stop_deletion(
-        self, monkeypatch: MonkeyPatch
-    ) -> None:
+    async def test_stop_sandbox_audits_forced_stop_deletion(self, monkeypatch: MonkeyPatch) -> None:
         """Forced stop identifies itself and its org on every sandbox deletion."""
         delete_mock = AsyncMock()
         monkeypatch.setattr("tracker.utils.run_control.delete_sandbox", delete_mock)
@@ -2217,6 +2215,4 @@ class TestRunRecovery:
         result = await stop_sandbox(sandbox, provider, self._test_org)
 
         assert result is None
-        delete_mock.assert_awaited_once_with(
-            sandbox, provider, initiated_by="force_stop", org_id=str(TEST_ORG_ID)
-        )
+        delete_mock.assert_awaited_once_with(sandbox, provider, initiated_by="force_stop", org_id=str(TEST_ORG_ID))

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -59,6 +59,7 @@ from tracker.utils import (
     process_task,
     reset_to_in_progress_status,
     start_benchmark_request_to_benchmark,
+    stop_sandbox,
     update_benchmark_concurrency,
 )
 from tracker.utils.task_execution import handle_early_exit
@@ -2202,3 +2203,20 @@ class TestRunRecovery:
         assert benchmark_row.status == BenchmarkStatus.STOPPED
         assert dispatch is not None
         assert dispatch.status == ExecutorDispatchStatus.FAILED
+
+    async def test_stop_sandbox_audits_forced_stop_deletion(
+        self, monkeypatch: MonkeyPatch
+    ) -> None:
+        """Forced stop identifies itself and its org on every sandbox deletion."""
+        delete_mock = AsyncMock()
+        monkeypatch.setattr("tracker.utils.run_control.delete_sandbox", delete_mock)
+
+        sandbox = Mock()
+        provider = Mock()
+
+        result = await stop_sandbox(sandbox, provider, self._test_org)
+
+        assert result is None
+        delete_mock.assert_awaited_once_with(
+            sandbox, provider, initiated_by="force_stop", org_id=str(TEST_ORG_ID)
+        )


### PR DESCRIPTION
Adds a structured audit trail at the sandbox-deletion boundary. This is the traceability half of the forced-stop deletion work; the race fix needs generation-safe teardown and is not attempted here.

## Problem

Six active sandbox command operations failed within 199ms across six distinct sandbox IDs. The provider reported a delete immediately prior, with no stop event recorded. The retained evidence could not identify which sandbox was deleted or which caller issued it, because nothing recorded who initiated a deletion or which run/task it belonged to.

## Change

- `_audit_sandbox_delete()` emits one `logger.info("sandbox.delete", extra={...})` per attempt: `sandbox_id`, `sandbox_name`, `benchmark_id`, `benchmark_name`, `task_id`, `org_id`, `initiated_by`, `outcome`, `error` — identity read from the labels set at creation.
- `delete_sandbox()` gains required `initiated_by` and optional `org_id`, emitting from all paths (`deleted`, `already_gone`, `cancelled`, both `failed`). `Literal` types constrain the vocabulary.
- `run_control.py` is a 3-line diff threading the in-scope `org` so forced stop reports `initiated_by="force_stop"`.
- `ContextFilter.filter` fills a field only when unset, so audit identity isn't clobbered by ambient contextvars.

## Zero behavior change, one exception

Deletion semantics, ordering, error aggregation and the raised `TrackerServiceError` are untouched. Verified no `extra` key collides with a reserved `LogRecord` attribute (that raises `KeyError` in `makeRecord`), `labels or {}` handles `None`, and the filter cannot raise.

**Exception:** a delete cancelled mid-flight previously emitted nothing; it now emits `cancelled` and propagates unchanged. The request may already have reached the provider — deleting server-side with no local record, plausibly what happened in the incident above. Happy to drop that hunk for the strict letter of no-behavior-change.

## Two reviewer calls

1. **`ContextFilter` is repo-wide.** It changes emitted `request_id`/`benchmark_id`/`task_id` on any record setting those via `extra`, fixing the same latent clobber in existing `agent_output.*`/`output_artifact.*` events. Load-bearing here: `force_stop_sandboxes` runs inline in the HTTP handler where those contextvars are empty. Root cause confirmed — the `bind_benchmark_id` dependency at `main.py:178` is a `sync def`, so its contextvar set is lost by the time the route runs. Distinct key names (`audit_benchmark_id`) were rejected: they'd bifurcate the query vocabulary so every `benchmark_id` dashboard silently misses audit records.
2. **`sandbox_cleanup.py` is un-audited.** It deletes via `provider.delete_sandbox` directly, so the orphan reaper emits nothing — an archetypal source of an unexplained delete. Fast-follow: it already holds the `Sandbox`, so it can use this path with a new `initiated_by="orphan_cleanup"`.

## Verified end-to-end

Driven through the real FastAPI app, real middleware, the real force-stop route and the real production logging configuration, capturing emitted stdout — on in-memory sqlite and again against a real postgres:16 container: the `sandbox.delete` record carries correct `benchmark_id`, `task_id`, `sandbox_id`, `org_id` and `initiated_by=force_stop`, and `uvicorn.access` records on the same request confirm the ambient contextvars really are empty there. With `ContextFilter` reverted to its pre-change form, the identical flow blanks `benchmark_id` and `task_id` to `""` — so the change is demonstrably load-bearing, not defensive.

Blast radius measured rather than argued: 21 emitted records in both the changed and reverted flows, per-record key sets identical, nothing added or dropped; the only semantic differences are the two identity fields. The worker path was exercised separately with real contextvars set, covering `task_teardown` and `create_cancelled` including a real cancellation.

Root `make lint`, `make typecheck`, `make test-unit` (482) and `make test-integration-local` (36 + 26) green. 24 mutations against the audit boundary, zero survivors.

`run_control.py` is also touched by #588 and #579; 3 lines here, no restructuring, should rebase cleanly.
