### PR TITLE
fix(tracker): restrict benchmark service key forwarding

### DIFF
--- a/services/tracker/README.md
+++ b/services/tracker/README.md
@@ -8,6 +8,10 @@ Tracker is the FastAPI control plane. It records release-bound dispatches in Pos
 
 Local Docker Compose starts only Tracker, PostgreSQL, and Redis. It does not run ExecutorHost, create an active executor release, or execute benchmarks. Use a deployed release environment for benchmark execution.
 
+### Benchmark-service authentication
+
+Tracker automatically forwards its inbound Descope API key only when the effective benchmark-service origin exactly matches the hosted origin derived from the benchmark name and Tracker configuration. Custom benchmark-service origins do not receive the Tracker key. They can still use explicit service-owned headers or secret-backed service authentication.
+
 ## Running
 
 ```bash

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -54,7 +54,13 @@ from tracker.aws.s3 import (
     s3_object_exists,
 )
 from tracker.agent.schemas import AgentConfig
-from tracker.config import AUTH_REQUIRED, ENVIRONMENT, broker, create_benchmark_service_url
+from tracker.config import (
+    AUTH_REQUIRED,
+    ENVIRONMENT,
+    broker,
+    classify_benchmark_service_destination,
+    create_benchmark_service_url,
+)
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -394,6 +400,10 @@ async def start_benchmark(
             "service_headers": forward_tracker_api_key(
                 service_headers,
                 http_request.headers.get("x-api-key"),
+                destination=classify_benchmark_service_destination(
+                    request.benchmark_name,
+                    request.custom_benchmark_service,
+                ),
             ),
         }
     )
@@ -511,7 +521,14 @@ async def fetch_benchmark_tasks(
     try:
         benchmark_service = create_benchmark_service_client(
             url=request.custom_benchmark_service or create_benchmark_service_url(request.benchmark_name),
-            service_headers=forward_tracker_api_key(request.service_headers, http_request.headers.get("x-api-key")),
+            service_headers=forward_tracker_api_key(
+                request.service_headers,
+                http_request.headers.get("x-api-key"),
+                destination=classify_benchmark_service_destination(
+                    request.benchmark_name,
+                    request.custom_benchmark_service,
+                ),
+            ),
         )
         try:
             return await benchmark_service.verify_task_ids(
@@ -695,7 +712,14 @@ async def retrieve_results(
             if task_id in task_ids_set
         }
 
-        effective_service_headers = forward_tracker_api_key(None, http_request.headers.get("x-api-key"))
+        effective_service_headers = forward_tracker_api_key(
+            None,
+            http_request.headers.get("x-api-key"),
+            destination=classify_benchmark_service_destination(
+                benchmark_row.name,
+                benchmark_row.custom_benchmark_service,
+            ),
+        )
         benchmark_service = benchmark_row.benchmark_service(service_headers=effective_service_headers)
         try:
             resp = await benchmark_service.final_score(
@@ -943,17 +967,21 @@ async def retry_or_resume_benchmark(
             session.commit()
         return RetryOrResumeBenchmarkResponse(status="success")
 
-    effective_service_headers = forward_tracker_api_key(
-        service_headers,
-        http_request.headers.get("x-api-key"),
-    )
-
     dispatch_id = uuid4()
     pre_action_status: BenchmarkStatus | None = None
     try:
         with session.no_autoflush:
             lock_executor_admission(session)
         benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
+        effective_benchmark_url = benchmark_url if benchmark_url is not None else benchmark_row.custom_benchmark_service
+        effective_service_headers = forward_tracker_api_key(
+            service_headers,
+            http_request.headers.get("x-api-key"),
+            destination=classify_benchmark_service_destination(
+                benchmark_row.name,
+                effective_benchmark_url,
+            ),
+        )
         if benchmark_row.status == BenchmarkStatus.STOPPING:
             raise HTTPException(
                 status_code=400,

--- a/services/tracker/src/tracker/auth.py
+++ b/services/tracker/src/tracker/auth.py
@@ -13,7 +13,12 @@ from requests.exceptions import ReadTimeout
 from sqlmodel import Session, select
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
-from tracker.config import AUTH_REQUIRED, DESCOPE_MANAGEMENT_KEY, DESCOPE_PROJECT_ID
+from tracker.config import (
+    AUTH_REQUIRED,
+    DESCOPE_MANAGEMENT_KEY,
+    DESCOPE_PROJECT_ID,
+    BenchmarkServiceDestination,
+)
 from tracker.database.models import DEFAULT_ORG_NAME, Org
 from tracker.database.session import get_session
 from tracker.logging import get_logger
@@ -227,8 +232,10 @@ def find_org_by_tenant(tenant_name: str, session: Session) -> Org | None:
 def forward_tracker_api_key(
     service_headers: Mapping[str, str] | None,
     tracker_api_key: str | None,
+    *,
+    destination: BenchmarkServiceDestination,
 ) -> dict[str, str]:
-    """Copy service headers and inject the tracker API key for benchmark-service auth.
+    """Copy service headers and inject the tracker API key only for hosted services.
 
     The downstream benchmark-service auth header must not reuse ``X-Api-Key`` because that
     header is already reserved for Daytona sandbox credentials.
@@ -238,7 +245,7 @@ def forward_tracker_api_key(
         validate_service_headers(forwarded_headers)
     except ValueError as exc:
         raise HTTPException(status_code=422, detail="Unsupported benchmark service header") from exc
-    if not tracker_api_key:
+    if not tracker_api_key or destination is not BenchmarkServiceDestination.HOSTED:
         return forwarded_headers
 
     has_explicit_override = any(key.lower() == BENCHMARK_SERVICE_API_KEY_HEADER.lower() for key in forwarded_headers)

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -1,7 +1,9 @@
 """Configuration for the tracker service."""
 
+from enum import Enum
 import os
 from typing import Any
+from urllib.parse import urlsplit
 
 from dotenv import load_dotenv
 from executor_protocol import DEFAULT_STABLE_QUEUE_NAME
@@ -24,6 +26,13 @@ _BENCHMARK_SERVICE_BASE_URL: str | None = os.environ.get("BENCHMARK_SERVICE_BASE
 BENCHMARK_CATALOG_URL = os.environ.get("BENCHMARK_CATALOG_URL", "").rstrip("/")
 
 
+class BenchmarkServiceDestination(Enum):
+    """Trust classification for benchmark-service credential forwarding."""
+
+    HOSTED = "hosted"
+    CUSTOM = "custom"
+
+
 def create_benchmark_service_url(benchmark_name: str) -> str:
     """
     Derive the benchmark service URL from the benchmark name.
@@ -37,6 +46,26 @@ def create_benchmark_service_url(benchmark_name: str) -> str:
         return f"https://{benchmark_name}.{_BENCHMARK_SERVICE_BASE_URL}"
 
     return f"http://{benchmark_name}.{_BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE}:{_CLOUDMAP_PORT}"
+
+
+def _normalized_origin(url: str) -> tuple[str, str, int]:
+    parsed = urlsplit(url)
+    assert parsed.hostname is not None
+    default_port = 443 if parsed.scheme == "https" else 80
+    port = parsed.port if parsed.port is not None else default_port
+    return parsed.scheme, parsed.hostname.lower(), port
+
+
+def classify_benchmark_service_destination(
+    benchmark_name: str,
+    service_url: str | None,
+) -> BenchmarkServiceDestination:
+    """Trust only the exact origin derived for a hosted benchmark service."""
+    hosted_url = create_benchmark_service_url(benchmark_name)
+    effective_url = service_url or hosted_url
+    if _normalized_origin(effective_url) == _normalized_origin(hosted_url):
+        return BenchmarkServiceDestination.HOSTED
+    return BenchmarkServiceDestination.CUSTOM
 
 
 AWS_S3_BUCKET = os.environ.get("AWS_S3_BUCKET", "agentic-harness")

--- a/services/tracker/src/tracker/config.py
+++ b/services/tracker/src/tracker/config.py
@@ -61,7 +61,13 @@ def classify_benchmark_service_destination(
     service_url: str | None,
 ) -> BenchmarkServiceDestination:
     """Trust only the exact origin derived for a hosted benchmark service."""
-    hosted_url = create_benchmark_service_url(benchmark_name)
+    try:
+        hosted_url = create_benchmark_service_url(benchmark_name)
+    except ValueError:
+        # Persisted custom-service runs can predate benchmark-name validation.
+        if service_url is not None:
+            return BenchmarkServiceDestination.CUSTOM
+        raise
     effective_url = service_url or hosted_url
     if _normalized_origin(effective_url) == _normalized_origin(hosted_url):
         return BenchmarkServiceDestination.HOSTED

--- a/services/tracker/tests/unit/test_auth.py
+++ b/services/tracker/tests/unit/test_auth.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 
 from tests.utils import TEST_ORG_ID
 from tracker.auth import forward_tracker_api_key
+from tracker.config import BenchmarkServiceDestination
 from tracker.database.models import DEFAULT_ORG_NAME, Org
 
 
@@ -38,13 +39,42 @@ class TestGetDefaultOrg:
 class TestForwardTrackerApiKey:
     """Tracker API key forwarding and header validation."""
 
-    def test_forward_tracker_api_key_preserves_explicit_override_case_insensitive(self) -> None:
+    def test_forward_tracker_api_key_injects_key_for_hosted_service(self) -> None:
+        headers = forward_tracker_api_key(
+            {},
+            "tracker-api-key",
+            destination=BenchmarkServiceDestination.HOSTED,
+        )
+
+        assert headers == {"X-Descope-Api-Key": "tracker-api-key"}
+
+    @pytest.mark.parametrize(
+        "destination",
+        [BenchmarkServiceDestination.HOSTED, BenchmarkServiceDestination.CUSTOM],
+    )
+    def test_forward_tracker_api_key_preserves_explicit_override_case_insensitive(
+        self,
+        destination: BenchmarkServiceDestination,
+    ) -> None:
         original_headers = {"x-descope-api-key": "override-key"}
 
-        headers = forward_tracker_api_key(original_headers, "tracker-api-key")
+        headers = forward_tracker_api_key(
+            original_headers,
+            "tracker-api-key",
+            destination=destination,
+        )
 
         assert headers == original_headers
         assert headers is not original_headers
+
+    def test_forward_tracker_api_key_does_not_inject_key_for_custom_service(self) -> None:
+        headers = forward_tracker_api_key(
+            {"Authorization": "Bearer service-key"},
+            "tracker-api-key",
+            destination=BenchmarkServiceDestination.CUSTOM,
+        )
+
+        assert headers == {"Authorization": "Bearer service-key"}
 
     @pytest.mark.parametrize(
         "header_name",
@@ -62,7 +92,11 @@ class TestForwardTrackerApiKey:
     def test_forward_tracker_api_key_rejects_protocol_and_routing_headers(self, header_name: str) -> None:
         """Reject caller headers that can alter HTTP routing or protocol handling."""
         with pytest.raises(HTTPException) as exc_info:
-            forward_tracker_api_key({header_name: "attacker-controlled"}, "tracker-api-key")
+            forward_tracker_api_key(
+                {header_name: "attacker-controlled"},
+                "tracker-api-key",
+                destination=BenchmarkServiceDestination.HOSTED,
+            )
 
         assert exc_info.value.status_code == 422
         assert exc_info.value.detail == "Unsupported benchmark service header"
@@ -80,7 +114,11 @@ class TestForwardTrackerApiKey:
     def test_forward_tracker_api_key_rejects_malformed_headers(self, header_name: str, header_value: str) -> None:
         """Reject headers that the outbound HTTP transport cannot encode or send."""
         with pytest.raises(HTTPException) as exc_info:
-            forward_tracker_api_key({header_name: header_value}, "tracker-api-key")
+            forward_tracker_api_key(
+                {header_name: header_value},
+                "tracker-api-key",
+                destination=BenchmarkServiceDestination.HOSTED,
+            )
 
         assert exc_info.value.status_code == 422
         assert exc_info.value.detail == "Unsupported benchmark service header"

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -1299,13 +1299,14 @@ class TestTrackerAPI:
         assert observed_results["task_11"] is None
         assert response.json()["final_evaluation"]["final_score"] == 2.0
 
-    async def test_retrieve_results_does_not_forward_tracker_key_to_custom_service(
+    async def test_retrieve_results_does_not_forward_tracker_key_to_legacy_named_custom_service(
         self,
         monkeypatch: MonkeyPatch,
         database_session: Session,
         example_benchmark_object: Benchmark,
     ) -> None:
         benchmark_row = example_benchmark_object
+        benchmark_row.name = "terminal_bench"
         benchmark_row.custom_benchmark_service = "https://team.example"
         task_row = Task(
             org_id=TEST_ORG_ID,

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -409,6 +409,40 @@ class TestTrackerAPI:
         assert response.status_code == 200
         assert response.json() == {"task_ids": ["task_1", "task_2"]}
 
+    async def test_fetch_benchmark_tasks_forwards_tracker_key_only_to_hosted_origin(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        observed_headers: list[dict[str, str]] = []
+
+        async def _mock_verify_task_ids(
+            service_client: BenchmarkServiceClient,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> VerifyTaskIdsResponse:
+            observed_headers.append(dict(getattr(service_client, "_headers")))
+            return VerifyTaskIdsResponse(task_ids=["task_1"])
+
+        monkeypatch.setattr("tracker.config._BENCHMARK_SERVICE_BASE_URL", "benchmarks.vals.ai")
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        for service_url in (
+            "https://swebench.benchmarks.vals.ai:443/path",
+            "https://team.example",
+        ):
+            response = client.post(
+                "/fetch-benchmark-tasks",
+                json={
+                    "benchmark_name": "swebench",
+                    "custom_benchmark_service": service_url,
+                },
+                headers={"X-Api-Key": "tracker-api-key"},
+            )
+            assert response.status_code == 200
+
+        assert observed_headers[0]["X-Descope-Api-Key"] == "tracker-api-key"
+        assert "X-Descope-Api-Key" not in observed_headers[1]
+
     async def test_start_benchmark(
         self,
         contract: AgentContractRequest,
@@ -763,8 +797,13 @@ class TestTrackerAPI:
         expected_detail = "Benchmark service 'swebench' is not reachable"
         assert response.json().get("detail") == expected_detail
 
+    @pytest.mark.parametrize(
+        "custom_benchmark_service",
+        [None, "https://swebench.benchmarks.vals.ai:443/path"],
+    )
     async def test_start_benchmark_forwards_tracker_api_key_to_benchmark_service(
         self,
+        custom_benchmark_service: str | None,
         contract: AgentContractRequest,
         monkeypatch: MonkeyPatch,
         harness_config: HarnessConfig,
@@ -772,12 +811,14 @@ class TestTrackerAPI:
     ) -> None:
         observed_headers: dict[str, str] = {}
 
+        monkeypatch.setattr("tracker.config._BENCHMARK_SERVICE_BASE_URL", "benchmarks.vals.ai")
         request = StartBenchmarkRequest(
             contract=contract,
             benchmark_name="swebench",
             concurrency=10,
             task_ids=None,
             harness_config=harness_config,
+            custom_benchmark_service=custom_benchmark_service,
         )
 
         async def _mock_health_check(
@@ -806,6 +847,84 @@ class TestTrackerAPI:
 
         queued_request = mock_kicker.queued_calls[0]["start_benchmark_request_json"]
         assert queued_request["service_headers"]["X-Descope-Api-Key"] == "tracker-api-key"
+
+    async def test_start_benchmark_does_not_forward_tracker_key_to_custom_service(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+        mock_kicker: Any,
+    ) -> None:
+        observed_headers: dict[str, str] = {}
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            harness_config=harness_config,
+            custom_benchmark_service="https://team.example",
+        )
+
+        async def _mock_verify_task_ids(
+            service_client: BenchmarkServiceClient,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> VerifyTaskIdsResponse:
+            observed_headers.update(getattr(service_client, "_headers"))
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        response = client.post(
+            "/start-benchmark",
+            json=request.model_dump(),
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+
+        assert response.status_code == 200
+        assert "X-Descope-Api-Key" not in observed_headers
+        queued_request = mock_kicker.queued_calls[0]["start_benchmark_request_json"]
+        assert "X-Descope-Api-Key" not in queued_request["service_headers"]
+
+    async def test_start_benchmark_preserves_custom_service_descope_key(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+        mock_kicker: Any,
+    ) -> None:
+        observed_headers: dict[str, str] = {}
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            harness_config=harness_config,
+            custom_benchmark_service="https://team.example",
+            service_auth_header_name="X-Descope-Api-Key",
+            service_auth_secret_name="TeamBenchmarkKey",
+        )
+
+        async def _mock_verify_task_ids(
+            service_client: BenchmarkServiceClient,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> VerifyTaskIdsResponse:
+            observed_headers.update(getattr(service_client, "_headers"))
+            return VerifyTaskIdsResponse(task_ids=["task_0"])
+
+        def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+            return {"X-Descope-Api-Key": "custom-service-key"}
+
+        monkeypatch.setattr(main_module, "resolve_secrets", _mock_resolve_secrets)
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _mock_verify_task_ids)
+
+        response = client.post(
+            "/start-benchmark",
+            json=request.model_dump(),
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+
+        assert response.status_code == 200
+        assert observed_headers["X-Descope-Api-Key"] == "custom-service-key"
+        queued_request = mock_kicker.queued_calls[0]["start_benchmark_request_json"]
+        assert queued_request["service_headers"]["X-Descope-Api-Key"] == "custom-service-key"
 
     async def test_start_benchmark_keeps_selected_provider_secret_with_harness_headers(
         self,
@@ -1179,6 +1298,52 @@ class TestTrackerAPI:
         assert observed_results.keys() == {"task_1", "task_11"}
         assert observed_results["task_11"] is None
         assert response.json()["final_evaluation"]["final_score"] == 2.0
+
+    async def test_retrieve_results_does_not_forward_tracker_key_to_custom_service(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.custom_benchmark_service = "https://team.example"
+        task_row = Task(
+            org_id=TEST_ORG_ID,
+            task_id="task_1",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.FINISHED,
+        )
+        database_session.add_all(
+            [
+                benchmark_row,
+                task_row,
+                EvaluationResult(
+                    org_id=TEST_ORG_ID,
+                    task=task_row.id,
+                    instance_id=str(uuid4()),
+                    result={"finished": True},
+                ),
+            ]
+        )
+        database_session.commit()
+
+        observed_headers: dict[str, str] = {}
+
+        async def _mock_final_score(service_client: BenchmarkServiceClient, **kwargs: Any) -> FinalScoreResponse:
+            observed_headers.update(getattr(service_client, "_headers"))
+            task_ids = list(kwargs["evaluation_results"])
+            return FinalScoreResponse(tasks_evaluated=task_ids, final_score=len(task_ids), metadata={})
+
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
+        response = client.get(
+            "/retrieve-results",
+            params=[("benchmark_id", str(benchmark_row.id)), ("task_ids", "task_1")],
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["final_evaluation"]["final_score"] == 1.0
+        assert "X-Descope-Api-Key" not in observed_headers
 
     async def test_benchmark_error_handling(
         self,

--- a/services/tracker/tests/unit/test_outbound_security.py
+++ b/services/tracker/tests/unit/test_outbound_security.py
@@ -6,7 +6,11 @@ Run: uv run pytest tests/unit/test_outbound_security.py
 import pytest
 from pydantic import ValidationError
 
-from tracker.config import create_benchmark_service_url
+from tracker.config import (
+    BenchmarkServiceDestination,
+    classify_benchmark_service_destination,
+    create_benchmark_service_url,
+)
 from tracker.database.models import AgentContractRequest
 from tracker.types import (
     BenchmarkServiceEntry,
@@ -77,6 +81,42 @@ class TestBenchmarkServiceNameValidation:
         assert create_benchmark_service_url("swebench") == "http://swebench.local:8001"
         assert FetchBenchmarkTasksRequest(benchmark_name="swebench").benchmark_name == "swebench"
         assert _start_benchmark_request(harness_config).benchmark_name == "swebench"
+
+
+class TestBenchmarkServiceDestination:
+    """Credential forwarding trust derives from the exact hosted-service origin."""
+
+    @pytest.mark.parametrize(
+        ("service_url", "expected"),
+        [
+            (None, BenchmarkServiceDestination.HOSTED),
+            ("https://swebench.benchmarks.vals.ai", BenchmarkServiceDestination.HOSTED),
+            ("https://swebench.benchmarks.vals.ai:443/path", BenchmarkServiceDestination.HOSTED),
+            ("http://swebench.benchmarks.vals.ai", BenchmarkServiceDestination.CUSTOM),
+            ("https://other.benchmarks.vals.ai", BenchmarkServiceDestination.CUSTOM),
+            ("https://swebench.benchmarks.vals.ai:8443", BenchmarkServiceDestination.CUSTOM),
+            ("https://swebench.benchmarks.vals.ai:0", BenchmarkServiceDestination.CUSTOM),
+        ],
+    )
+    def test_classifies_only_exact_hosted_origin(
+        self,
+        service_url: str | None,
+        expected: BenchmarkServiceDestination,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("tracker.config._BENCHMARK_SERVICE_BASE_URL", "benchmarks.vals.ai")
+
+        assert classify_benchmark_service_destination("swebench", service_url) is expected
+
+    def test_normalizes_default_http_port(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("tracker.config._BENCHMARK_SERVICE_BASE_URL", None)
+        monkeypatch.setattr("tracker.config._BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE", "local")
+        monkeypatch.setattr("tracker.config._CLOUDMAP_PORT", 80)
+
+        assert (
+            classify_benchmark_service_destination("swebench", "http://swebench.local")
+            is BenchmarkServiceDestination.HOSTED
+        )
 
 
 class TestCustomServiceUrlValidation:

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1112,6 +1112,42 @@ class TestRunRecovery:
         database_session.refresh(benchmark_row)
         assert benchmark_row.arguments.concurrency == 20
 
+    async def test_retry_or_resume_does_not_forward_tracker_key_to_custom_service(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: Any,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        benchmark_row.custom_benchmark_service = "https://team.example"
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        observed_headers: dict[str, str] = {}
+
+        async def _mock_reset_to_in_progress_status(
+            *_args: Any,
+            benchmark_service: BenchmarkServiceClient,
+            **_kwargs: Any,
+        ) -> list[str]:
+            observed_headers.update(getattr(benchmark_service, "_headers"))
+            return ["task_0"]
+
+        monkeypatch.setattr("main.reset_to_in_progress_status", _mock_reset_to_in_progress_status)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            json={"task_ids": [], "service_headers": {}},
+            headers={"X-Api-Key": "tracker-api-key"},
+        )
+
+        assert response.status_code == 200
+        assert "X-Descope-Api-Key" not in observed_headers
+        admitted_request = mock_kicker.queued_calls[0]["start_benchmark_request_json"]
+        assert "X-Descope-Api-Key" not in admitted_request["service_headers"]
+
     async def test_force_stop_uses_stored_provider_secret(
         self,
         example_benchmark_object: Benchmark,
@@ -1238,6 +1274,7 @@ class TestRunRecovery:
         database_session.add_all([benchmark_row, task_row])
         database_session.commit()
         verified_urls: list[str] = []
+        verified_headers: list[dict[str, str]] = []
 
         async def _verify_task_ids(
             benchmark_service: BenchmarkServiceClient,
@@ -1247,6 +1284,7 @@ class TestRunRecovery:
             dataset: str | None,
         ) -> VerifyTaskIdsResponse:
             verified_urls.append(benchmark_service._url)
+            verified_headers.append(dict(getattr(benchmark_service, "_headers")))
 
             return VerifyTaskIdsResponse(task_ids=task_ids)
 
@@ -1276,13 +1314,16 @@ class TestRunRecovery:
                 "service_headers": {},
                 "benchmark_url": "https://new.example/",
             },
+            headers={"X-Api-Key": "tracker-api-key"},
         )
 
         assert response.status_code == 200
         assert verified_urls == ["https://new.example"]
+        assert "X-Descope-Api-Key" not in verified_headers[0]
 
         queued_request = mock_kicker.queued_calls[0]["start_benchmark_request_json"]
         assert queued_request["custom_benchmark_service"] == "https://new.example"
+        assert "X-Descope-Api-Key" not in queued_request["service_headers"]
 
         database_session.refresh(benchmark_row)
         assert benchmark_row.custom_benchmark_service == "https://new.example"


### PR DESCRIPTION
## Summary

Tracker now automatically forwards its inbound Descope API key only when the effective benchmark-service origin matches the Vals-hosted origin. Custom benchmark services receive only explicitly configured service-owned headers. Redirect behavior is unchanged.

## Human Description

Send Descope keys only to vals hosted benchmark services

## Changes

- Classify benchmark-service destinations by normalized scheme, hostname, and effective port
- Apply hosted-only key forwarding to task fetch, benchmark start, subset scoring, retry/resume, and queued requests
- Preserve explicit custom-service credentials, including case-insensitive Descope header overrides
- Document the authentication boundary and add regression coverage for direct and queued paths

## Related Issues

None

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Manually tested
- Local Tracker → dev SWE-bench: no inbound key returned 502; the configured inbound key was forwarded successfully and returned 102 `vals_index` tasks
- Local Tracker → recording local custom benchmark service: the explicit Bearer credential and marker arrived, the Tracker Descope key did not, and the request returned the expected task

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->