### PR TITLE
fix(tracker): stop forced sandbox teardown from racing live executor work #patch

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -91,11 +91,11 @@ def get_contract_path(contract_name: str) -> PurePosixPath:
     return bundle_path / contract_name
 
 
-SandboxDeleteInitiator = Literal["create_cancelled", "force_stop", "task_teardown"]
+SandboxDeleteInitiator = Literal["create_cancelled", "force_stop", "orphan_cleanup", "task_teardown"]
 SandboxDeleteOutcome = Literal["deleted", "already_gone", "cancelled", "failed"]
 
 
-def _audit_sandbox_delete(
+def audit_sandbox_delete(
     sandbox: Sandbox,
     initiated_by: SandboxDeleteInitiator,
     org_id: str | None,
@@ -132,20 +132,20 @@ async def delete_sandbox(
     try:
         await provider.delete_sandbox(sandbox.id)
     except SandboxNotFoundError:
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "already_gone")
+        audit_sandbox_delete(sandbox, initiated_by, org_id, "already_gone")
         logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
     except ProviderSandboxError as e:
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
+        audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
         raise
     except asyncio.CancelledError:
         # Caught only to audit: a cancelled delete may still have reached the provider.
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "cancelled")
+        audit_sandbox_delete(sandbox, initiated_by, org_id, "cancelled")
         raise
     except Exception as e:
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
+        audit_sandbox_delete(sandbox, initiated_by, org_id, "failed", f"{type(e).__name__}: {e}")
         logger.error(f"Unexpected error deleting sandbox {sandbox.name}: {e}")
     else:
-        _audit_sandbox_delete(sandbox, initiated_by, org_id, "deleted")
+        audit_sandbox_delete(sandbox, initiated_by, org_id, "deleted")
 
 
 def _source_name(source: SandboxSource) -> str:

--- a/services/tracker/src/tracker/sandbox_cleanup.py
+++ b/services/tracker/src/tracker/sandbox_cleanup.py
@@ -17,6 +17,7 @@ from benchmark_service import (
 )
 
 from tracker.logging import configure_logging, get_logger
+from tracker.sandbox import audit_sandbox_delete
 from tracker.utils.resources import fetch_sandbox_provider_config
 
 logger = get_logger(__name__)
@@ -130,14 +131,17 @@ async def cleanup_old_sandboxes(
                 timeout=_OPERATION_TIMEOUT_SECONDS,
             )
         except SandboxNotFoundError:
+            audit_sandbox_delete(current, "orphan_cleanup", org_id=None, outcome="already_gone")
             outcomes["already_absent"] += 1
         except Exception as exc:
+            audit_sandbox_delete(current, "orphan_cleanup", org_id=None, outcome="failed", error=type(exc).__name__)
             outcomes["delete_failed"] += 1
             logger.error(
                 "Failed to delete sandbox",
                 extra={"sandbox_id": current.id, "error_type": type(exc).__name__},
             )
         else:
+            audit_sandbox_delete(current, "orphan_cleanup", org_id=None, outcome="deleted")
             outcomes["deleted"] += 1
 
     return outcomes

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -1,5 +1,7 @@
 """Operations that stop, resume, or retry a run and tear down its sandboxes."""
 
+import asyncio
+import time
 import traceback
 from collections.abc import AsyncGenerator
 from datetime import datetime
@@ -23,7 +25,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
-from tracker.executor.dispatch_control import terminalize_active_dispatches
+from tracker.executor.dispatch_control import active_dispatch_exists, terminalize_active_dispatches
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import get_logger
 from tracker.sandbox import delete_sandbox
@@ -34,6 +36,10 @@ from tracker.types import (
 from tracker.utils.resources import fetch_benchmark_row, fetch_sandbox_provider_config
 
 logger = get_logger(__name__)
+
+# Bounded by the ALB idle timeout the stop request has to answer within.
+SANDBOX_DRAIN_TIMEOUT_SECONDS = 15.0
+SANDBOX_DRAIN_POLL_SECONDS = 3.0
 
 
 def apply_stop_benchmark(
@@ -109,6 +115,26 @@ async def sandbox_generator(
             yield sandbox
 
 
+async def drain_sandboxes(
+    benchmark_row: Benchmark,
+    provider: SandboxProvider,
+    task_ids: list[str] | None,
+    timeout_seconds: float,
+) -> list[Sandbox]:
+    """Wait for the executor to delete the sandboxes it owns and return the ones left behind.
+
+    The executor cancels stopped tasks within one monitor poll and then tears down each of
+    its sandboxes. Deleting underneath it instead fails whatever command is still in flight,
+    so give it a bounded window before reaping what remains.
+    """
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        remaining = [sandbox async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids)]
+        if not remaining or time.monotonic() >= deadline:
+            return remaining
+        await asyncio.sleep(SANDBOX_DRAIN_POLL_SECONDS)
+
+
 async def force_stop_sandboxes(
     benchmark_row: Benchmark,
     session: Session,
@@ -142,12 +168,16 @@ async def force_stop_sandboxes(
 
     session.exec(task_update.values(status=TaskStatus.STOPPED))
 
+    # Only a live dispatch can still be working inside these sandboxes.
+    executor_active = active_dispatch_exists(session, benchmark_row.id)
+
     session.commit()
 
     # Iterate through each running sandbox and stop it, collecting error messages
     results: dict[str, str | None] = {}
     try:
-        async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids):
+        drain_seconds = SANDBOX_DRAIN_TIMEOUT_SECONDS if executor_active else 0.0
+        for sandbox in await drain_sandboxes(benchmark_row, provider, task_ids, drain_seconds):
             result = await stop_sandbox(sandbox, provider, org)
             results[sandbox.name] = result
     finally:

--- a/services/tracker/tests/integration/live/sandbox/test_force_stop.py
+++ b/services/tracker/tests/integration/live/sandbox/test_force_stop.py
@@ -298,12 +298,16 @@ class TestForceStop:
     ) -> None:
         """Verify force stop lets a live executor tear down its own sandboxes instead of racing it.
 
+        One task, so the only sandbox in play belongs to a task that has finished building. A task
+        still inside `create_sandbox` holds a shielded creation that cannot be released until it
+        completes, which is the case the drain window deliberately does not wait for.
+
         Test cases:
         - Force stop runs while the executor is still working and deletes no sandbox itself.
         - The run still reaches STOPPED with no task errors and no sandboxes left behind.
         """
-        example_benchmark_object.arguments.slice_str = ":2"
-        example_benchmark_object.arguments.concurrency = 2
+        example_benchmark_object.arguments.slice_str = ":1"
+        example_benchmark_object.arguments.concurrency = 1
         database_session.add(example_benchmark_object)
         database_session.commit()
 

--- a/services/tracker/tests/integration/live/sandbox/test_force_stop.py
+++ b/services/tracker/tests/integration/live/sandbox/test_force_stop.py
@@ -13,6 +13,7 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, col, select
 
 import tracker.utils as tracker_utils
+import tracker.utils.run_control as run_control
 from tests.utils import TEST_ORG_ID, random_task_id
 from tracker.database.models import Benchmark, BenchmarkStatus, Org, Task, TaskStatus
 from tracker.logging import get_logger
@@ -283,6 +284,100 @@ class TestForceStop:
         _assert_no_task_errors(example_benchmark_object, database_session)
 
         await _wait_until_no_sandboxes(example_benchmark_object, provider)
+
+    async def test_force_stop_waits_for_the_executor_to_release_its_sandboxes(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        live_aws_credentials: AWSCredentials,
+        daytona_secret_name: str,
+        harness_config: HarnessConfig,
+        service_headers: dict[str, str],
+        executor_authority_kwargs: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Verify force stop lets a live executor tear down its own sandboxes instead of racing it.
+
+        Test cases:
+        - Force stop runs while the executor is still working and deletes no sandbox itself.
+        - The run still reaches STOPPED with no task errors and no sandboxes left behind.
+        """
+        example_benchmark_object.arguments.slice_str = ":2"
+        example_benchmark_object.arguments.concurrency = 2
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        benchmark_service = example_benchmark_object.benchmark_service(service_headers=service_headers)
+        benchmark_task: Optional[asyncio.Task[None]] = None
+        provider: Optional[SandboxProvider] = None
+        reaped: list[str] = []
+        release_sandbox = run_control.stop_sandbox
+
+        async def record_reaped_sandbox(sandbox: Sandbox, sandbox_provider: SandboxProvider, org: Org) -> str | None:
+            reaped.append(sandbox.name)
+            return await release_sandbox(sandbox, sandbox_provider, org)
+
+        monkeypatch.setattr(run_control, "stop_sandbox", record_reaped_sandbox)
+
+        try:
+            verify_response = await benchmark_service.verify_task_ids(
+                task_ids=example_benchmark_object.arguments.task_ids,
+                slice_str=example_benchmark_object.arguments.slice_str,
+            )
+
+            authority_kwargs = executor_authority_kwargs(example_benchmark_object)
+            benchmark_task = asyncio.create_task(
+                process_benchmark(
+                    start_benchmark_request_json=example_benchmark_object.start_benchmark_request(
+                        harness_config, service_headers=service_headers
+                    ).model_dump(),
+                    benchmark_id_str=str(example_benchmark_object.id),
+                    verified_task_ids=verify_response.task_ids,
+                    **authority_kwargs,
+                )
+            )
+
+            provider_config = fetch_sandbox_provider_config(daytona_secret_name, live_aws_credentials, "daytona")
+            provider = benchmark_service.get_sandbox_provider(provider_config)
+            await _wait_for_running_benchmark(example_benchmark_object, database_session, provider)
+
+            await force_stop_sandboxes(
+                example_benchmark_object,
+                database_session,
+                daytona_secret_name,
+                live_aws_credentials,
+                Org(id=TEST_ORG_ID, name="default"),
+                sandbox_provider="daytona",
+            )
+
+            assert reaped == [], f"Force stop deleted sandboxes the executor still owned: {', '.join(reaped)}"
+
+            await benchmark_task
+            _assert_no_task_errors(example_benchmark_object, database_session)
+
+            database_session.refresh(example_benchmark_object)
+            assert example_benchmark_object.status == BenchmarkStatus.STOPPED
+
+            await _wait_until_no_sandboxes(example_benchmark_object, provider)
+        finally:
+            monkeypatch.setattr(run_control, "stop_sandbox", release_sandbox)
+            if benchmark_task is not None and not benchmark_task.done():
+                benchmark_task.cancel()
+                await asyncio.gather(benchmark_task, return_exceptions=True)
+
+            try:
+                if provider is not None and await _sandboxes_for_benchmark(example_benchmark_object, provider):
+                    await force_stop_sandboxes(
+                        example_benchmark_object,
+                        database_session,
+                        daytona_secret_name,
+                        live_aws_credentials,
+                        Org(id=TEST_ORG_ID, name="default"),
+                        sandbox_provider="daytona",
+                    )
+                    await _wait_until_no_sandboxes(example_benchmark_object, provider)
+            finally:
+                await benchmark_service.close()
 
     async def test_force_stop_end_to_end(
         self,

--- a/services/tracker/tests/unit/test_sandbox_cleanup.py
+++ b/services/tracker/tests/unit/test_sandbox_cleanup.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator, Mapping
 from datetime import UTC, datetime, timedelta
 from types import MappingProxyType, SimpleNamespace
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 from benchmark_service import (
@@ -183,27 +184,48 @@ async def test_cleanup_reclassifies_refreshed_metadata_and_rejects_identity_chan
     )
 
 
-async def test_cleanup_treats_not_found_as_complete_and_continues_after_item_failures() -> None:
+async def test_cleanup_treats_not_found_as_complete_and_continues_after_item_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     gone = _sandbox("gone")
     refresh_failed = _sandbox("refresh-failed")
     delete_failed = _sandbox("delete-failed")
+    gone_before_delete = _sandbox("gone-before-delete")
     deleted_after_failures = _sandbox("deleted-after-failures")
     provider = FakeSandboxProvider(
-        [gone, refresh_failed, delete_failed, deleted_after_failures],
+        [gone, refresh_failed, delete_failed, gone_before_delete, deleted_after_failures],
         current={
             gone.id: SandboxNotFoundError("already absent"),
             refresh_failed.id: RuntimeError("refresh failed"),
             delete_failed.id: delete_failed,
+            gone_before_delete.id: gone_before_delete,
             deleted_after_failures.id: deleted_after_failures,
         },
-        delete_effects={delete_failed.id: RuntimeError("delete failed")},
+        delete_effects={
+            delete_failed.id: RuntimeError("delete failed"),
+            gone_before_delete.id: SandboxNotFoundError("already absent"),
+        },
     )
+    audit = Mock()
+    monkeypatch.setattr(cleanup_module, "audit_sandbox_delete", audit)
 
     outcomes = await cleanup_old_sandboxes(provider, now=NOW)
 
-    assert provider.get_calls == [gone.id, refresh_failed.id, delete_failed.id, deleted_after_failures.id]
-    assert provider.delete_calls == [delete_failed.id, deleted_after_failures.id]
-    assert outcomes == Counter({"already_absent": 1, "refresh_failed": 1, "delete_failed": 1, "deleted": 1})
+    assert provider.get_calls == [
+        gone.id,
+        refresh_failed.id,
+        delete_failed.id,
+        gone_before_delete.id,
+        deleted_after_failures.id,
+    ]
+    assert provider.delete_calls == [delete_failed.id, gone_before_delete.id, deleted_after_failures.id]
+    assert outcomes == Counter({"already_absent": 2, "refresh_failed": 1, "delete_failed": 1, "deleted": 1})
+    # Every delete the reaper attempts names itself, so an unexplained deletion can be traced back here.
+    assert [(call.args[0].id, call.args[1], call.kwargs["outcome"]) for call in audit.call_args_list] == [
+        (delete_failed.id, "orphan_cleanup", "failed"),
+        (gone_before_delete.id, "orphan_cleanup", "already_gone"),
+        (deleted_after_failures.id, "orphan_cleanup", "deleted"),
+    ]
 
 
 def test_lambda_handler_fails_for_each_unsuccessful_outcome(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -179,8 +179,10 @@ class TestBenchmarkServiceFailures:
         start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
             contract, database_session, harness_config
         )
+        expected_error = "Output artifact error: Required output artifact missing: /tmp/valkyrie/artifacts/missing.json"
+        expected_log = f"[ERROR] {expected_error}"
         logged_messages: list[str] = []
-        log_written = asyncio.Event()
+        expected_log_written = asyncio.Event()
         event_loop = asyncio.get_running_loop()
 
         async def _mock_install_agent_dependencies(*_args: Any, **_kwargs: Any) -> None:
@@ -198,7 +200,8 @@ class TestBenchmarkServiceFailures:
 
         def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
             logged_messages.append(message)
-            event_loop.call_soon_threadsafe(log_written.set)
+            if expected_log in message:
+                event_loop.call_soon_threadsafe(expected_log_written.set)
 
         monkeypatch.setattr(utils_module, "run_agent", sandbox_module.run_agent)
         monkeypatch.setattr(sandbox_module, "install_agent_dependencies", _mock_install_agent_dependencies)
@@ -211,16 +214,17 @@ class TestBenchmarkServiceFailures:
         monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
-        await asyncio.wait_for(log_written.wait(), timeout=1)
+        # Log writes are dispatched to an executor and never awaited, so the flush carrying the
+        # error can land after run_process_task returns. Wait for that flush, not just the first.
+        await asyncio.wait_for(expected_log_written.wait(), timeout=10)
 
         assert result == {"task_0": None}
 
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
-        expected_error = "Output artifact error: Required output artifact missing: /tmp/valkyrie/artifacts/missing.json"
         assert error_message == expected_error
-        assert any(f"[ERROR] {expected_error}" in message for message in logged_messages)
+        assert any(expected_log in message for message in logged_messages)
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_benchmark_service_error_produces_human_readable_message(

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -48,6 +48,7 @@ from tracker.database.models import (
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
 from tracker.executor.release_control import ReleaseControlError, promote_release
 from tracker.types import HarnessConfig, StartBenchmarkRequest
+from tracker.utils import run_control as run_control_module
 from tracker.utils import (
     ResizableLimiter,
     TaskMonitor,
@@ -65,6 +66,7 @@ from tracker.utils import (
 from tracker.utils.task_execution import handle_early_exit
 
 UTC = ZoneInfo("UTC")
+_NEVER_RELEASED = 1_000_000
 _ORIGINAL_ATTEMPT_AT = datetime(2026, 7, 8)
 _RESUMED_ATTEMPT_AT = datetime(2026, 7, 9)
 client = TestClient(app)
@@ -122,6 +124,29 @@ class MockSubsetSandboxProvider:
         task_id = query.labels.get("Task")
         if task_id is not None and task_id in self.sandboxes_by_task:
             yield self.sandboxes_by_task[task_id]
+
+    async def delete_sandbox(self, sandbox_id: str) -> None:
+        self.deleted_sandbox_ids.append(sandbox_id)
+
+
+class MockReleasingSandboxProvider:
+    """Expose one benchmark sandbox until the executor's own teardown removes it."""
+
+    sandbox_id = "sandbox-task_0"
+
+    def __init__(self, release_after_polls: int) -> None:
+        self.list_calls = 0
+        self.deleted_sandbox_ids: list[str] = []
+        self._release_after_polls = release_after_polls
+
+    async def list_sandboxes(self, _query: SandboxQuery) -> AsyncGenerator[Mock, None]:
+        self.list_calls += 1
+        if self.list_calls > self._release_after_polls:
+            return
+        sandbox = Mock()
+        sandbox.id = self.sandbox_id
+        sandbox.name = "task_0"
+        yield sandbox
 
     async def delete_sandbox(self, sandbox_id: str) -> None:
         self.deleted_sandbox_ids.append(sandbox_id)
@@ -269,6 +294,8 @@ class TestRunRecovery:
             return provider
 
         monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", get_sandbox_provider)
+        # No executor is running here, so nothing will ever release the sandboxes on its own.
+        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.0)
 
         graceful_response = client.post(
             f"/stop-benchmark/{benchmark_row.id}?force=false",
@@ -2244,6 +2271,101 @@ class TestRunRecovery:
         assert benchmark_row.status == BenchmarkStatus.STOPPED
         assert dispatch is not None
         assert dispatch.status == ExecutorDispatchStatus.FAILED
+
+    def _arrange_force_stop_race(
+        self,
+        benchmark_row: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        release_after_polls: int,
+    ) -> MockReleasingSandboxProvider:
+        """Put one in-progress task and its sandbox in front of a force stop."""
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
+        )
+        database_session.commit()
+
+        provider = MockReleasingSandboxProvider(release_after_polls)
+        monkeypatch.setattr(
+            run_control_module,
+            "fetch_sandbox_provider_config",
+            lambda *_args, **_kwargs: DaytonaProviderConfig(
+                DAYTONA_API_KEY="key", DAYTONA_API_URL="url", DAYTONA_TARGET="target"
+            ),
+        )
+        monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", lambda *_args, **_kwargs: provider)
+        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_POLL_SECONDS", 0.0)
+        return provider
+
+    @pytest.mark.parametrize(
+        ("executor_running", "expected_deletions", "expected_list_calls"),
+        [
+            pytest.param(True, [], 2, id="waits_for_executor_teardown"),
+            pytest.param(False, [MockReleasingSandboxProvider.sandbox_id], 1, id="nothing_left_to_race"),
+        ],
+    )
+    async def test_force_stop_lets_a_live_executor_release_its_own_sandboxes(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+        executor_authority: Any,
+        executor_running: bool,
+        expected_deletions: list[str],
+        expected_list_calls: int,
+    ) -> None:
+        """Force stop deletes a sandbox only once no executor can still be working inside it.
+
+        Test cases:
+        - A running dispatch gets its teardown window, so the sandbox it releases is never deleted here.
+        - With no dispatch left to race, the sandbox is deleted on the first pass.
+        """
+        benchmark_row = example_benchmark_object
+        provider = self._arrange_force_stop_race(benchmark_row, database_session, monkeypatch, release_after_polls=1)
+        if executor_running:
+            executor_authority(benchmark_row, session=database_session)
+
+        await force_stop_sandboxes(
+            benchmark_row,
+            database_session,
+            harness_config.sandbox_provider_secret_name,
+            harness_config.aws,
+            self._test_org,
+        )
+
+        assert provider.deleted_sandbox_ids == expected_deletions
+        assert provider.list_calls == expected_list_calls
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.STOPPED
+
+    async def test_force_stop_reaps_sandboxes_the_executor_never_releases(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+        executor_authority: Any,
+    ) -> None:
+        """A stalled executor cannot hold its sandboxes past the drain window."""
+        benchmark_row = example_benchmark_object
+        provider = self._arrange_force_stop_race(
+            benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
+        )
+        executor_authority(benchmark_row, session=database_session)
+        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.05)
+
+        await force_stop_sandboxes(
+            benchmark_row,
+            database_session,
+            harness_config.sandbox_provider_secret_name,
+            harness_config.aws,
+            self._test_org,
+        )
+
+        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
 
     async def test_stop_sandbox_audits_forced_stop_deletion(self, monkeypatch: MonkeyPatch) -> None:
         """Forced stop identifies itself and its org on every sandbox deletion."""


### PR DESCRIPTION
## What

- Force stop gives a live executor a bounded 15s window to tear down its own sandboxes, then deletes only the stragglers.
- No active dispatch means nothing can be running inside them, so the window is skipped and the path is unchanged.
- The orphan reaper now emits the same `sandbox.delete` record as every other caller, as `initiated_by="orphan_cleanup"`.

## Why

- Force stop deleted every labelled sandbox in the same request that stopped the tasks. The executor tears down those same sandboxes on its next poll, so deletes landed underneath commands still in flight and failed live work.
- Bounded, not open-ended: a stalled executor can't hold its sandboxes past the window, so force stop keeps its kill guarantee. 15s fits inside the 60s ALB idle timeout.
- `sandbox_cleanup.py` was the last caller deleting through the provider directly, so its deletions were the ones no log could attribute. It still calls the provider directly on purpose — the audited wrapper swallows `SandboxNotFoundError` and generic failures, which would break the Lambda's outcome counts.

## How tested

- 3 new unit cases: a released sandbox is never deleted here; with no dispatch it's deleted on the first pass; one never released is still reaped at expiry. The first fails on `dev`.
- Cleanup test pins one `orphan_cleanup` record per delete attempt, across `deleted`, `already_gone` and `failed`.
- `services/tracker && make test`: 575 passed, 88.34% coverage (85% gate). Root `make test`: 204 passed. `ruff` and `basedpyright` clean.
- Live suite is manual-only on non-prod PRs. `test_force_stop_end_to_end` still passes, exercising window expiry rather than executor release, since its blocking `TestClient` call starves the executor loop.
