### PR TITLE
fix(tracker): unbreak the live provider-error assertion after the CBS bump #patch

### DIFF
--- a/services/tracker/tests/integration/live/sandbox/test_provider.py
+++ b/services/tracker/tests/integration/live/sandbox/test_provider.py
@@ -189,7 +189,10 @@ class TestProvider:
             create_timeout=360,
         )
 
-        with pytest.raises(SandboxError, match="failed to start"):
+        # Match the provider wrapper rather than the SDK's prose for the failure, which is
+        # reworded across Daytona releases; this still separates a hard error from the
+        # connection and not-found classifications, which have their own prefixes.
+        with pytest.raises(SandboxError, match="Daytona sandbox provider error"):
             await sandbox_provider.create_sandbox(request)
 
         sandbox = await sandbox_provider.get_sandbox(random_sandbox_name)

--- a/services/tracker/tests/integration/live/sandbox/test_provider.py
+++ b/services/tracker/tests/integration/live/sandbox/test_provider.py
@@ -189,9 +189,6 @@ class TestProvider:
             create_timeout=360,
         )
 
-        # Match the provider wrapper rather than the SDK's prose for the failure, which is
-        # reworded across Daytona releases; this still separates a hard error from the
-        # connection and not-found classifications, which have their own prefixes.
         with pytest.raises(SandboxError, match="Daytona sandbox provider error"):
             await sandbox_provider.create_sandbox(request)
 


### PR DESCRIPTION
## What

- `test_error_state_sandbox_can_be_deleted` matches the provider-error wrapper instead of the Daytona SDK's prose for a failed start.

## Why

- The CBS bump to v0.27.4 reworded the failure: `sandbox failed to start` became `... entered error state: SandboxState.BUILD_FAILED ...`, so the `match="failed to start"` assertion fails and takes the whole live suite red on `dev`.
- Nothing caught it because the live job is gated to manual re-runs on non-prod PRs — it reports success without running. Opening that gate on another branch is how this surfaced.
- `Daytona sandbox provider error` is the wrapper this service owns (`daytona.py`, `_sandbox_error`), so the assertion no longer tracks SDK wording while still separating a hard error from the connection and not-found classifications, which carry their own prefixes.

## How tested

- Regex checked against the exact message from the failing run and against the pre-bump wording (both match), and against the connection-error and not-found messages (neither matches), so the classification the test asserts is unchanged.
- `ruff` clean; the live file collects.
- Live gate re-run on this PR — the run is the real verification, since this test only executes there.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->