### PR TITLE
fix(tracker): preserve task outcome when teardown fails #patch

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.4" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.6" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.27.4"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.4#1f8d68acbad6a8820311a428df9d79206a1d1d29" }
+version = "0.27.6"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.4" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.4" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.6" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -321,7 +321,11 @@ async def create_sandbox(
         logger.error(f"Error during sandbox execution {sandbox.name}: {e}")
         raise
     finally:
-        await delete_sandbox(sandbox, provider, initiated_by="task_teardown")
+        try:
+            await delete_sandbox(sandbox, provider, initiated_by="task_teardown")
+        except ProviderSandboxError:
+            # The failed delete is audited by delete_sandbox and must not replace the task outcome.
+            pass
 
 
 @retry(

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1281,6 +1281,162 @@ class TestSandboxLifecycle:
 
         delete_mock.assert_awaited_once_with(mock_sandbox, provider, initiated_by="task_teardown")
 
+    async def test_create_sandbox_preserves_success_when_task_teardown_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = {"Benchmark": "swebench", "Id": "bench-1", "Task": "task_0"}
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> Mock:
+            return mock_sandbox
+
+        provider = Mock()
+        provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("cleanup failed"))
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock())
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock())
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        async with create_sandbox(
+            provider=provider,
+            sandbox_name="task-alias",
+            source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+            resources=Resources(vcpu=2, memory=4, disk=5),
+            creation_semaphore=asyncio.Semaphore(1),
+        ):
+            pass
+
+        audit_call = logger_mock.info.call_args_list[-1]
+        assert audit_call.args == ("sandbox.delete",)
+        assert audit_call.kwargs["extra"] == {
+            "sandbox_id": "sandbox-123",
+            "sandbox_name": "task-alias",
+            "benchmark_id": "bench-1",
+            "benchmark_name": "swebench",
+            "task_id": "task_0",
+            "org_id": None,
+            "initiated_by": "task_teardown",
+            "outcome": "failed",
+            "error": "SandboxError: cleanup failed",
+        }
+
+    async def test_create_sandbox_preserves_body_failure_when_task_teardown_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = None
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> Mock:
+            return mock_sandbox
+
+        provider = Mock()
+        provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("cleanup failed"))
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock())
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock())
+
+        primary_error = RuntimeError("primary failure")
+        with pytest.raises(RuntimeError) as exc_info:
+            async with create_sandbox(
+                provider=provider,
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                raise primary_error
+
+        assert exc_info.value is primary_error
+
+    async def test_create_sandbox_propagates_provider_error_during_cancelled_creation_cleanup(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = None
+        creation_started = asyncio.Event()
+        release_creation = asyncio.Event()
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> Mock:
+            creation_started.set()
+            await release_creation.wait()
+            return mock_sandbox
+
+        provider = Mock()
+        provider.delete_sandbox = AsyncMock(side_effect=ProviderSandboxError("cleanup failed"))
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+
+        async def use_sandbox() -> None:
+            async with create_sandbox(
+                provider=provider,
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                pass
+
+        context_task = asyncio.create_task(use_sandbox())
+        await creation_started.wait()
+        context_task.cancel()
+        release_creation.set()
+
+        with pytest.raises(ProviderSandboxError, match="cleanup failed"):
+            await context_task
+
+    async def test_create_sandbox_propagates_cancelled_task_teardown_and_audits(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = {"Benchmark": "swebench", "Id": "bench-1", "Task": "task_0"}
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> Mock:
+            return mock_sandbox
+
+        provider = Mock()
+        provider.delete_sandbox = AsyncMock(side_effect=asyncio.CancelledError())
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "distribution", Mock())
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock())
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        with pytest.raises(asyncio.CancelledError):
+            async with create_sandbox(
+                provider=provider,
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                pass
+
+        audit_call = logger_mock.info.call_args_list[-1]
+        assert audit_call.args == ("sandbox.delete",)
+        assert audit_call.kwargs["extra"] == {
+            "sandbox_id": "sandbox-123",
+            "sandbox_name": "task-alias",
+            "benchmark_id": "bench-1",
+            "benchmark_name": "swebench",
+            "task_id": "task_0",
+            "org_id": None,
+            "initiated_by": "task_teardown",
+            "outcome": "cancelled",
+            "error": None,
+        }
+
 
 class TestDeleteSandboxAudit:
     """Structured `sandbox.delete` audit records."""

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.27.4"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.4#1f8d68acbad6a8820311a428df9d79206a1d1d29" }
+version = "0.27.6"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.4" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.27.4"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.4#1f8d68acbad6a8820311a428df9d79206a1d1d29" }
+version = "0.27.6"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.4" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Human Description

[Written by the author]

Prevent deletion failure from replacing task success & bump CBS

## Summary

Adopt create-benchmark-service `v0.27.6` and keep the task body outcome authoritative when Daytona sandbox deletion fails during `task_teardown`.

CBS `v0.27.6` contains the lifecycle fixes from [CBS #136](https://github.com/vals-ai/create-benchmark-service/pull/136): durable PTY completion wins over later health failures, status publication is atomic, and cleanup reaches DELETE without start/refresh/autostop preparation. Tracker still needs to stop an audited teardown deletion failure from replacing task success or the task's original exception.

## Changes

- Pin Tracker and executor-artifact to CBS `v0.27.6`
- Regenerate root, Tracker, and executor-artifact locks at CBS commit `e4aa7f2cd6eaff13da7c41759f9f2d74460508c4`
- Suppress only `ProviderSandboxError` raised by task-teardown deletion after its existing failed-delete audit
- Preserve cancellation, creation-cancellation cleanup, force-stop, and direct-delete propagation
- Add focused task-outcome, audit, cancellation, and initiator regressions

## Related Issues

Related to vals-ai/valkyrie-ticket-library#112

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] Manually tested

- Focused Tracker teardown contract: 4 passed
- Tracker unit suite: 514 passed
- Changed-file Ruff and format: passed
- Changed-file Basedpyright: 0 errors, warnings, or notes
- Root, Tracker, and executor-artifact lock checks: passed
- Compile, LSP, and diff checks: passed
- [CBS live provider integration](https://github.com/vals-ai/create-benchmark-service/actions/runs/31446948960) on the exact released commit: Daytona 3 passed; Modal 1 passed

No live Tracker failure injection was run: safely forcing a real provider teardown failure while independently proving the task-body outcome is not deterministic. The live CBS contract verified real command execution, PTY health behavior, deletion during an active stream, stale handles, and cleanup.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->