### PR TITLE
feat(infra): add prod-external production deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -147,6 +147,271 @@ jobs:
               print(f"{key}={str(result[key]).lower()}")
           PY
 
+  deploy-prod-external-core:
+    if: >-
+      github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
+      needs.classify-deployment.outputs.core_maintenance_required != 'true' &&
+      needs.classify-deployment.outputs.database_maintenance_required != 'true'
+    needs: classify-deployment
+    concurrency:
+      group: valkyrie-prod-external-deploy
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: us-east-1
+      PRODUCTION_ACCOUNT_ID: "613431292675"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: "infra/uv.lock"
+
+      - name: Install CDK and infrastructure dependencies
+        run: |
+          npm install -g aws-cdk@2.1132.0
+          uv sync --frozen --python 3.12 --project infra
+
+      - name: Deploy prod-external core stacks
+        env:
+          SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
+          VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
+          DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID: ${{ secrets.DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID }}
+          BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}
+        working-directory: infra
+        run: >-
+          make deploy
+          STAGE=prod-external
+          SCOPE=core
+          AWS_REGION="$AWS_REGION"
+
+  executor-prod-external:
+    if: >-
+      always() && github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
+      needs.classify-deployment.result == 'success' &&
+      (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+       needs.classify-deployment.outputs.executor_release_required == 'true' ||
+       needs.classify-deployment.outputs.database_maintenance_required == 'true') &&
+      (needs.classify-deployment.outputs.core_maintenance_required == 'true' ||
+       needs.classify-deployment.outputs.database_maintenance_required == 'true' ||
+       needs.deploy-prod-external-core.result == 'success')
+    needs: [classify-deployment, deploy-prod-external-core]
+    concurrency:
+      group: valkyrie-prod-external-deploy
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04-arm
+    environment: prod-external
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: us-east-1
+      EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod-external/executor-release/launch-config
+      PRODUCTION_ACCOUNT_ID: "613431292675"
+
+    steps:
+      - name: Verify current prod-external executor revision
+        id: freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_REF_NAME" --jq .sha)"
+          if [[ "$current_sha" == "$GITHUB_SHA" ]]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping stale executor revision $GITHUB_SHA; current $GITHUB_REF_NAME is $current_sha."
+          fi
+
+      - name: Checkout code
+        if: steps.freshness.outputs.current == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        if: steps.freshness.outputs.current == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        if: steps.freshness.outputs.current == 'true'
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            infra/executor_release/uv.lock
+            infra/uv.lock
+            services/executor_artifact/uv.lock
+
+      - name: Build immutable executor artifact
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_release_required == 'true'
+        run: |
+          PYTHONPATH=services/tracker/src python services/executor_artifact/build.py \
+            --output-directory "$GITHUB_WORKSPACE/executor-release" \
+            --source-revision "$GITHUB_SHA"
+
+      - name: Configure prod-external release preflight credentials
+        if: steps.freshness.outputs.current == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::613431292675:role/ValkyrieExecutorRelease-prod-external
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+          role-session-name: valkyrie-prod-external-release-preflight-${{ github.run_id }}
+          unset-current-credentials: true
+
+      - name: Require deployed prod-external release control
+        if: steps.freshness.outputs.current == 'true'
+        run: |
+          set -euo pipefail
+          error_file="$(mktemp)"
+          if aws ssm get-parameter --name "$EXECUTOR_RELEASE_LAUNCH_PARAMETER" >/dev/null 2>"$error_file"; then
+            exit 0
+          fi
+          if grep -q "ParameterNotFound" "$error_file"; then
+            echo "::error::prod-external executor release control is not deployed. Complete the documented prod-external bootstrap (MonitoringStack, then the separately authorized ValkProdExternalWorkerStack deploy), then rerun this workflow."
+          else
+            cat "$error_file" >&2
+          fi
+          exit 1
+
+      - name: Begin prod-external maintenance
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        working-directory: infra
+        run: >-
+          PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
+          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --maintenance-operation begin
+          --region "$AWS_REGION"
+          --stage prod-external
+          --target-sha "$GITHUB_SHA"
+
+      - name: Restore prod-external deployment credentials
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+          role-session-name: valkyrie-prod-external-executor-deploy-${{ github.run_id }}
+          unset-current-credentials: true
+
+      - name: Setup Node.js
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Install CDK and infrastructure dependencies
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        run: |
+          npm install -g aws-cdk@2.1132.0
+          uv sync --frozen --python 3.12 --project infra
+
+      - name: Deploy prod-external core stacks under maintenance
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.core_maintenance_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        env:
+          SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
+          VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
+          DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID: ${{ secrets.DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID }}
+          BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}
+        working-directory: infra
+        run: make deploy STAGE=prod-external SCOPE=core AWS_REGION="$AWS_REGION"
+
+      - name: Deploy prod-external executor stack
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_stack_deploy_required == 'true'
+        working-directory: infra
+        run: make deploy STAGE=prod-external SCOPE=executor AWS_REGION="$AWS_REGION"
+
+      - name: Configure prod-external release credentials
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_release_required == 'true' ||
+           needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::613431292675:role/ValkyrieExecutorRelease-prod-external
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+          role-session-name: valkyrie-prod-external-executor-release-${{ github.run_id }}
+          unset-current-credentials: true
+
+      - name: Publish and activate prod-external executor release
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_release_required == 'true'
+        working-directory: infra
+        run: >-
+          PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
+          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --artifact "$GITHUB_WORKSPACE/executor-release/executor.pex"
+          --manifest "$GITHUB_WORKSPACE/executor-release/manifest.json"
+          --region "$AWS_REGION"
+          --stage prod-external
+
+      - name: Finish prod-external maintenance
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        working-directory: infra
+        run: >-
+          PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
+          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --maintenance-operation finish
+          --region "$AWS_REGION"
+          --stage prod-external
+          --target-sha "$GITHUB_SHA"
+
   deploy-production-core:
     if: >-
       github.event_name == 'push' && github.ref == 'refs/heads/prod' &&

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -9,8 +9,8 @@ DEV_ACCOUNT_ID ?=
 PROFILE ?=
 SCOPE ?= all
 
-EXPECTED_ACCOUNT_ID = $(if $(filter dev release-test,$(STAGE)),$(DEV_ACCOUNT_ID),$(if $(filter prod,$(STAGE)),$(PRODUCTION_ACCOUNT_ID),))
-STACK_PREFIX = $(if $(filter dev,$(STAGE)),ValkDev,$(if $(filter release-test,$(STAGE)),ValkReleaseTest,))
+EXPECTED_ACCOUNT_ID = $(if $(filter dev release-test,$(STAGE)),$(DEV_ACCOUNT_ID),$(if $(filter prod prod-external,$(STAGE)),$(PRODUCTION_ACCOUNT_ID),))
+STACK_PREFIX = $(if $(filter dev,$(STAGE)),ValkDev,$(if $(filter release-test,$(STAGE)),ValkReleaseTest,$(if $(filter prod-external,$(STAGE)),ValkProdExternal,)))
 STACKS_shared = $(STACK_PREFIX)SharedStack
 STACKS_tracker = $(STACK_PREFIX)TrackerStack
 STACKS_driver = $(STACK_PREFIX)DriverStack
@@ -36,7 +36,7 @@ help:
 	@echo "Makefile for Valkyrie infrastructure"
 	@echo ""
 	@echo "  make install                                  - Install CDK dependencies"
-	@echo "  make plan STAGE=dev|release-test|prod AWS_REGION=us-east-1 - Show a CDK diff"
+	@echo "  make plan STAGE=dev|release-test|prod|prod-external AWS_REGION=us-east-1 - Show a CDK diff"
 	@echo "  make deploy STAGE=<stage> AWS_REGION=us-east-1 - Deploy a component"
 	@echo "  make test                                     - Run infrastructure tests"
 	@echo "  make lint                                     - Check infrastructure formatting and lint"

--- a/infra/README.md
+++ b/infra/README.md
@@ -17,6 +17,16 @@ Production imports the existing `vals.ai` hosted zone. Development imports only
 the account-local `benchmark-tracker-dev.vals.ai` child zone. Each production
 and development Tracker stack creates and owns its ACM certificate.
 
+The `prod` and `prod-external` stages are both production: same sizing, log
+retention, public ALB, TLS, and `vals.ai` hosted zone. `prod` owns the
+unsuffixed physical names and `benchmark-tracker.vals.ai`; `prod-external`
+prefixes its stack ids with `ValkProdExternal`, suffixes every physical name
+with `-prod-external`, serves `benchmark-tracker-external.vals.ai`, and always
+requires authentication against its own Descope project
+(`PROD_EXTERNAL_DESCOPE_PROJECT_ID` in `infra/constants.py`). The hourly sandbox
+cleanup schedule stays on `prod` only, because both stages share one sandbox
+provider account.
+
 ## Prerequisites
 
 - AWS CLI configured with appropriate credentials
@@ -58,8 +68,13 @@ make install
 ## Deployment
 
 Production and development deploy automatically when changes reach `prod` and
-`dev`. The manual **Deploy to AWS** workflow on `dev` supports only
-`credentials-only` and `plan`; deployments come from branch pushes.
+`dev`. A `prod` push deploys both production stages: `deploy-production-core` /
+`executor-production` for internal prod and `deploy-prod-external-core` /
+`executor-prod-external` for `prod-external`. The two lanes take separate
+deployment mutexes (`valkyrie-prod-deploy`, `valkyrie-prod-external-deploy`) and
+run concurrently; both act on the same classification of the pushed commit. The
+manual **Deploy to AWS** workflow on `dev` supports only `credentials-only` and
+`plan`; deployments come from branch pushes.
 
 Core and executor changes use separate jobs but one deployment mutex per stage.
 A core-only change never builds an executor artifact, enters executor maintenance,
@@ -105,6 +120,41 @@ make plan STAGE=release-test SCOPE=all AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
 ```
 
+### Bootstrapping `prod-external`
+
+One-time, in the production account, before the automated lanes can succeed:
+
+1. Confirm the `vals.ai` hosted zone can validate
+   `benchmark-tracker-external.vals.ai`; the Tracker stack creates the record
+   and certificate itself.
+2. Create a protected `prod-external` GitHub Environment. The `prod-external`
+   executor release role trusts
+   `repo:vals-ai/Valkyrie:environment:prod-external`, so the environment must
+   exist before `executor-prod-external` runs.
+3. Deploy the core stacks, then the separately authorized executor stack:
+
+```bash
+cd infra
+make deploy STAGE=prod-external SCOPE=core AWS_REGION=us-east-1 PROFILE=vals-prod-admin
+make deploy STAGE=prod-external SCOPE=executor AWS_REGION=us-east-1 PROFILE=vals-prod-admin
+```
+
+4. Verify the sealed release control the automated executor lane requires:
+
+```bash
+aws ssm get-parameter --name /valkyrie/prod-external/executor-release/launch-config
+```
+
+The first executor release is then published by the next `prod` push, or
+manually with the same CLI the workflow uses:
+
+```bash
+cd infra
+PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py \
+  --account-id 613431292675 --region us-east-1 --stage prod-external \
+  --artifact <artifact>/executor.pex --manifest <artifact>/manifest.json
+```
+
 `SCOPE` accepts `shared`, `tracker`, `executor`, `monitoring`, `driver`
 (`release-test` only), `core`, or `all`. The `executor` scope targets the
 historical physical `WorkerStack` name. CDK follows the existing stack
@@ -123,7 +173,7 @@ export BENCHMARK_CATALOG_URL=https://<api-id>.execute-api.us-east-1.amazonaws.co
 
 ## Sandbox cleanup schedule
 
-Production includes an hourly EventBridge schedule for a singleton, 14-minute cleanup Lambda. The schedule is disabled
+Internal `prod` includes an hourly EventBridge schedule for a singleton, 14-minute cleanup Lambda. The schedule is disabled
 unless `SANDBOX_CLEANUP_ENABLED` is exactly `true`; Scheduler delivery and asynchronous Lambda failures go to an encrypted
 dead-letter queue.
 

--- a/infra/app.py
+++ b/infra/app.py
@@ -16,7 +16,7 @@ from tracker_stack import TrackerStack
 
 app = cdk.App()
 stage = resolve(app)
-if not stage.is_prod:
+if not stage.is_primary_prod:
     enforce_deployment_target(stage.name, os.environ)
 
 env = cdk.Environment(

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -21,6 +21,8 @@ NAMESPACE = "local"
 # Tracker Service
 TRACKER_LOG_GROUP_NAME = "/valkyrie/tracker"
 TRACKER_DOMAIN = "benchmark-tracker.vals.ai"
+# Public Descope project identifier for the external production deployment.
+PROD_EXTERNAL_DESCOPE_PROJECT_ID = "P2lXkZaPuDqCzGxoxGHseomQi7ac"
 TRACKER_SCALING_CPU_PERCENT = 70
 
 # Health Checks

--- a/infra/deployment_target.py
+++ b/infra/deployment_target.py
@@ -35,8 +35,8 @@ class StsClient(Protocol):
 def target_from_environment(environment: Mapping[str, str]) -> DeploymentTarget:
     """Build and validate a deployment target without calling AWS."""
     stage = _required(environment, "STAGE")
-    if stage not in ("dev", "release-test", "prod"):
-        raise DeploymentTargetError("STAGE must be 'dev', 'release-test', or 'prod'.")
+    if stage not in ("dev", "release-test", "prod", "prod-external"):
+        raise DeploymentTargetError("STAGE must be 'dev', 'release-test', 'prod', or 'prod-external'.")
 
     region = _required(environment, "AWS_REGION")
     if region != DEPLOYMENT_REGION:

--- a/infra/executor_release/main.py
+++ b/infra/executor_release/main.py
@@ -248,7 +248,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--maintenance-operation", choices=("begin", "finish"))
     parser.add_argument("--manifest", type=Path)
     parser.add_argument("--region", required=True)
-    parser.add_argument("--stage", choices=("dev", "prod", "release-test"), required=True)
+    parser.add_argument("--stage", choices=("dev", "prod", "prod-external", "release-test"), required=True)
     parser.add_argument("--target-sha")
     args = parser.parse_args(argv)
 

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -221,7 +221,9 @@ class ExecutorStack(Stack):
             db_secret=db_credentials_secret,
         )
 
-        if stage.is_prod:
+        # Both production stages share one sandbox provider account, so a single
+        # cleanup schedule covers them.
+        if stage.is_primary_prod:
             self._add_sandbox_cleanup_schedule(
                 stage=stage,
                 log_retention=stage_config.service_log_retention,

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -102,7 +102,7 @@ class SharedStack(Stack):
         )
 
         self.hosted_zone: aws_route53.IHostedZone | None = None
-        if self.stage.is_prod:
+        if self.stage.is_production:
             self.hosted_zone = aws_route53.HostedZone.from_lookup(
                 self,
                 "HostedZone",
@@ -120,10 +120,10 @@ class SharedStack(Stack):
             bucket_name=bucket_name,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             block_public_access=aws_s3.BlockPublicAccess.BLOCK_ALL,
-            encryption=None if self.stage.is_prod else aws_s3.BucketEncryption.S3_MANAGED,
-            enforce_ssl=None if self.stage.is_prod else True,
-            object_ownership=None if self.stage.is_prod else aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
-            versioned=None if self.stage.is_prod else True,
+            encryption=None if self.stage.is_primary_prod else aws_s3.BucketEncryption.S3_MANAGED,
+            enforce_ssl=None if self.stage.is_primary_prod else True,
+            object_ownership=None if self.stage.is_primary_prod else aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
+            versioned=None if self.stage.is_primary_prod else True,
         )
 
         self.tracker_repository: aws_ecr.Repository | None = None
@@ -196,7 +196,7 @@ class SharedStack(Stack):
             ],
         )
 
-        if not self.stage.is_prod:
+        if not self.stage.is_production:
             self._publish_shared_contract()
 
     def _publish_shared_contract(self) -> None:

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -2,6 +2,10 @@
 
 prod  -> every helper is the identity function, so `cdk synth -c stage=prod` is
         byte-identical to the pre-refactor `cdk synth`.
+prod-external -> production-grade deployment that lives beside prod in the same
+        AWS account: stacks get a "ValkProdExternal" construct-id prefix,
+        physical names get a "-prod-external" suffix, and the Tracker FQDN gets
+        "-external" on its first label.
 dev   -> stacks get a "ValkDev" construct-id prefix; physical names get a "-dev"
         suffix; FQDNs get "-dev" on their first label.
 release-test -> stacks get a "ValkReleaseTest" prefix and "-release-test"
@@ -14,11 +18,22 @@ from __future__ import annotations
 import aws_cdk as cdk
 
 PROD = "prod"
+PROD_EXTERNAL = "prod-external"
 DEV = "dev"
 RELEASE_TEST = "release-test"
 DEV_STACK_PREFIX = "ValkDev"
+PROD_EXTERNAL_STACK_PREFIX = "ValkProdExternal"
 RELEASE_TEST_STACK_PREFIX = "ValkReleaseTest"
-_SUPPORTED_STAGES = (PROD, DEV, RELEASE_TEST)
+_SUPPORTED_STAGES = (PROD, PROD_EXTERNAL, DEV, RELEASE_TEST)
+
+# prod owns the unsuffixed names; every other stage carries its own identity.
+_STACK_PREFIXES = {
+    PROD: "",
+    PROD_EXTERNAL: PROD_EXTERNAL_STACK_PREFIX,
+    DEV: DEV_STACK_PREFIX,
+    RELEASE_TEST: RELEASE_TEST_STACK_PREFIX,
+}
+_DOMAIN_LABELS = {PROD_EXTERNAL: "external", DEV: DEV, RELEASE_TEST: RELEASE_TEST}
 
 
 class Stage:
@@ -26,7 +41,13 @@ class Stage:
         self.name: str = name
 
     @property
-    def is_prod(self) -> bool:
+    def is_production(self) -> bool:
+        """Whether the stage serves production traffic and takes production settings."""
+        return self.name in (PROD, PROD_EXTERNAL)
+
+    @property
+    def is_primary_prod(self) -> bool:
+        """Whether the stage owns the original unsuffixed physical names."""
         return self.name == PROD
 
     @property
@@ -34,21 +55,18 @@ class Stage:
         return self.name == RELEASE_TEST
 
     def stack_id(self, base: str) -> str:
-        if self.is_prod:
-            return base
-        prefix = RELEASE_TEST_STACK_PREFIX if self.is_release_test else DEV_STACK_PREFIX
-        return f"{prefix}{base}"
+        return f"{_STACK_PREFIXES[self.name]}{base}"
 
     def phys(self, name: str) -> str:
-        return name if self.is_prod else f"{name}-{self.name}"
+        return name if self.is_primary_prod else f"{name}-{self.name}"
 
     def domain(self, fqdn: str) -> str:
         # "benchmark-tracker.vals.ai" -> "benchmark-tracker-dev.vals.ai"
         assert "." in fqdn, f"domain() requires a FQDN with a dot, got {fqdn!r}"
-        if self.is_prod:
+        if self.is_primary_prod:
             return fqdn
         first, _, rest = fqdn.partition(".")
-        return f"{first}-{self.name}.{rest}"
+        return f"{first}-{_DOMAIN_LABELS[self.name]}.{rest}"
 
 
 def resolve(app: cdk.App) -> Stage:

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from aws_cdk import aws_logs
-from stage import DEV, PROD, RELEASE_TEST, Stage
+from stage import DEV, PROD, PROD_EXTERNAL, RELEASE_TEST, Stage
 
 
 @dataclass(frozen=True)
@@ -46,6 +46,16 @@ PROD_CONFIG = StageConfig(
     service_log_retention=aws_logs.RetentionDays.ONE_YEAR,
 )
 
+# prod-external runs the production shape; only its telemetry environment tag
+# distinguishes it from internal prod.
+PROD_EXTERNAL_CONFIG = StageConfig(
+    runtime_environment=PROD_EXTERNAL,
+    tracker=PROD_CONFIG.tracker,
+    worker=PROD_CONFIG.worker,
+    database=PROD_CONFIG.database,
+    service_log_retention=PROD_CONFIG.service_log_retention,
+)
+
 DEV_CONFIG = StageConfig(
     runtime_environment="dev",
     tracker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=1, max_tasks=2),
@@ -72,6 +82,7 @@ RELEASE_TEST_BENCHMARK_SERVICE_BASE_URL = "benchmarks.vals.ai"
 
 _STAGE_CONFIGS = {
     PROD: PROD_CONFIG,
+    PROD_EXTERNAL: PROD_EXTERNAL_CONFIG,
     DEV: DEV_CONFIG,
     RELEASE_TEST: RELEASE_TEST_CONFIG,
 }
@@ -81,7 +92,7 @@ def config_for(stage: Stage) -> StageConfig:
     try:
         return _STAGE_CONFIGS[stage.name]
     except KeyError:
-        raise ValueError(f"unknown stage {stage.name!r}; expected {PROD!r}, {DEV!r}, or 'release-test'") from None
+        raise ValueError(f"unknown stage {stage.name!r}; expected one of {sorted(_STAGE_CONFIGS)}") from None
 
 
 def benchmark_service_base_url(stage: Stage) -> str | None:

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -8,13 +8,29 @@ WORKFLOW = ROOT / ".github" / "workflows" / "deploy.yaml"
 EXECUTOR_BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "executor-build.yaml"
 
 
+_JOB_MARKERS = (
+    "\n  deploy-prod-external-core:",
+    "\n  executor-prod-external:",
+    "\n  deploy-production-core:",
+    "\n  run-dev-operation:",
+    "\n  executor-development:",
+    "\n  executor-production:",
+)
+
+
+def _job(workflow: str, job_id: str) -> str:
+    """Return the workflow text of one job, up to the next top-level job id."""
+    body = workflow.split(f"  {job_id}:", maxsplit=1)[1]
+    following = [body.index(marker) for marker in _JOB_MARKERS if marker in body]
+    return body[: min(following)] if following else body
+
+
 class DeployWorkflowTest(unittest.TestCase):
     def test_core_deployments_do_not_depend_on_executor_work(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        production_core = workflow.split("  deploy-production-core:", maxsplit=1)[1].split(
-            "  run-dev-operation:", maxsplit=1
-        )[0]
-        dev_core = workflow.split("  run-dev-operation:", maxsplit=1)[1].split("  executor-development:", maxsplit=1)[0]
+        production_core = _job(workflow, "deploy-production-core")
+        external_core = _job(workflow, "deploy-prod-external-core")
+        dev_core = _job(workflow, "run-dev-operation")
 
         self.assertIn("branches: [dev, prod]", workflow)
         self.assertIn("workflow_dispatch:", workflow)
@@ -28,6 +44,14 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertNotIn("services/executor_artifact/build.py", production_core)
         self.assertNotIn("executor_release/main.py", production_core)
         self.assertNotIn("maintenance-operation", production_core)
+        self.assertIn("needs: classify-deployment", external_core)
+        self.assertIn("group: valkyrie-prod-external-deploy", external_core)
+        self.assertIn("github.ref == 'refs/heads/prod'", external_core)
+        self.assertIn("STAGE=prod-external", external_core)
+        self.assertIn("SCOPE=core", external_core)
+        self.assertNotIn("services/executor_artifact/build.py", external_core)
+        self.assertNotIn("executor_release/main.py", external_core)
+        self.assertNotIn("DESCOPE_PROJECT_ID", external_core)
         self.assertIn("needs: classify-deployment", dev_core)
         self.assertIn("group: valkyrie-dev-${{ github.event_name == 'push' && 'deploy' || github.run_id }}", dev_core)
         self.assertIn("core_maintenance_required != 'true'", dev_core)
@@ -58,12 +82,15 @@ class DeployWorkflowTest(unittest.TestCase):
 
     def test_executor_jobs_own_build_deploy_activation_and_maintenance(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        prod_executor = _job(workflow, "executor-production")
+        external_executor = _job(workflow, "executor-prod-external")
 
-        for executor_job, stage in ((dev_executor, "dev"), (prod_executor, "production")):
+        for executor_job, stage in (
+            (dev_executor, "dev"),
+            (prod_executor, "production"),
+            (external_executor, "prod-external"),
+        ):
             with self.subTest(stage=stage):
                 self.assertIn("executor_stack_deploy_required", executor_job)
                 self.assertIn("executor_host_redeploy_required", executor_job)
@@ -96,26 +123,29 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("needs: [classify-deployment, run-dev-operation]", dev_executor)
         self.assertIn("environment: dev", dev_executor)
         self.assertIn("needs: [classify-deployment, deploy-production-core]", prod_executor)
-        self.assertIn("environment: prod", prod_executor)
+        self.assertIn("environment: prod\n", prod_executor)
+        self.assertIn("needs: [classify-deployment, deploy-prod-external-core]", external_executor)
+        self.assertIn("environment: prod-external", external_executor)
+        self.assertEqual(external_executor.count("--stage prod-external"), 3)
+        self.assertNotIn("--stage prod\n", external_executor)
         self.assertNotIn("production-executor-approval", workflow)
         self.assertNotIn("production-release", workflow)
         self.assertEqual(
             workflow.count("PYTHONPATH=services/tracker/src python services/executor_artifact/build.py"),
-            2,
+            3,
         )
-        self.assertEqual(workflow.count("--maintenance-operation begin"), 2)
-        self.assertEqual(workflow.count("--maintenance-operation finish"), 2)
+        self.assertEqual(workflow.count("--maintenance-operation begin"), 3)
+        self.assertEqual(workflow.count("--maintenance-operation finish"), 3)
         self.assertNotIn("actions/upload-artifact", workflow)
         self.assertNotIn("actions/download-artifact", workflow)
 
     def test_maintenance_paths_bypass_the_skipped_core_job_and_preserve_failed_fences(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        prod_executor = _job(workflow, "executor-production")
+        external_executor = _job(workflow, "executor-prod-external")
 
-        for executor_job in (dev_executor, prod_executor):
+        for executor_job in (dev_executor, prod_executor, external_executor):
             job_condition = executor_job.split("    needs:", maxsplit=1)[0]
             self.assertIn("always()", job_condition)
             self.assertIn("core_maintenance_required == 'true'", job_condition)
@@ -134,10 +164,9 @@ class DeployWorkflowTest(unittest.TestCase):
 
     def test_executor_bootstrap_fails_closed_until_release_control_exists(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        prod_executor = _job(workflow, "executor-production")
+        external_executor = _job(workflow, "executor-prod-external")
 
         stages = (
             (
@@ -145,19 +174,28 @@ class DeployWorkflowTest(unittest.TestCase):
                 "dev",
                 "arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-dev",
                 "${{ env.AWS_DEPLOY_ROLE_ARN }}",
+                "physical WorkerStack bootstrap",
             ),
             (
                 prod_executor,
                 "production",
                 "arn:aws:iam::613431292675:role/ValkyrieExecutorRelease",
                 "arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy",
+                "physical WorkerStack bootstrap",
+            ),
+            (
+                external_executor,
+                "prod-external",
+                "arn:aws:iam::613431292675:role/ValkyrieExecutorRelease-prod-external",
+                "arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy",
+                "ValkProdExternalWorkerStack deploy",
             ),
         )
-        for executor_job, stage, release_role, deployment_role in stages:
+        for executor_job, stage, release_role, deployment_role, bootstrap_hint in stages:
             with self.subTest(stage=stage):
                 self.assertIn("aws ssm get-parameter", executor_job)
                 self.assertIn("ParameterNotFound", executor_job)
-                self.assertIn("physical WorkerStack bootstrap", executor_job)
+                self.assertIn(bootstrap_hint, executor_job)
                 self.assertNotIn("describe-stacks", executor_job)
                 self.assertNotIn("steps.executor-stack.outputs.exists", executor_job)
 
@@ -209,17 +247,21 @@ class DeployWorkflowTest(unittest.TestCase):
             "EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod/executor-release/launch-config",
             prod_executor,
         )
+        self.assertIn(
+            "EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod-external/executor-release/launch-config",
+            external_executor,
+        )
 
     def test_mutations_share_stage_mutex_and_stale_executor_jobs_do_nothing(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        prod_executor = _job(workflow, "executor-production")
+        external_executor = _job(workflow, "executor-prod-external")
 
-        self.assertEqual(workflow.count("group: valkyrie-prod-deploy"), 2)
+        self.assertEqual(workflow.count("group: valkyrie-prod-deploy\n"), 2)
+        self.assertEqual(workflow.count("group: valkyrie-prod-external-deploy\n"), 2)
         self.assertIn("group: valkyrie-dev-deploy", dev_executor)
-        for executor_job in (dev_executor, prod_executor):
+        for executor_job in (dev_executor, prod_executor, external_executor):
             self.assertIn("gh api", executor_job)
             self.assertIn("id: freshness", executor_job)
             self.assertGreaterEqual(executor_job.count("steps.freshness.outputs.current == 'true'"), 14)
@@ -324,7 +366,7 @@ class DeployWorkflowTest(unittest.TestCase):
     def test_deployment_tools_are_pinned_and_release_dependencies_are_isolated(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertEqual(workflow.count("npm install -g aws-cdk@2.1132.0"), 5)
+        self.assertEqual(workflow.count("npm install -g aws-cdk@2.1132.0"), 7)
         self.assertIn("uv sync --frozen --python 3.12 --project infra", workflow)
         self.assertIn("infra/executor_release/uv.lock", workflow)
         self.assertIn("services/executor_artifact/uv.lock", workflow)

--- a/infra/tests/test_deployment_target.py
+++ b/infra/tests/test_deployment_target.py
@@ -28,7 +28,11 @@ def environment_for(stage: str) -> dict[str, str]:
 
 class DeploymentTargetTest(unittest.TestCase):
     def test_accepts_exact_dev_and_prod_targets(self) -> None:
-        for stage, account_id in (("dev", DEV_ACCOUNT_ID), ("prod", PRODUCTION_ACCOUNT_ID)):
+        for stage, account_id in (
+            ("dev", DEV_ACCOUNT_ID),
+            ("prod", PRODUCTION_ACCOUNT_ID),
+            ("prod-external", PRODUCTION_ACCOUNT_ID),
+        ):
             with self.subTest(stage=stage):
                 self.assertEqual(
                     target_from_environment(environment_for(stage)),

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -17,11 +17,13 @@ from aws_cdk import (
 
 from constants import (
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV,
+    PROD_EXTERNAL_DESCOPE_PROJECT_ID,
     SANDBOX_CLEANUP_DLQ_NAME,
     SANDBOX_CLEANUP_FUNCTION_NAME,
     SANDBOX_CLEANUP_SCHEDULE_NAME,
     SANDBOX_CLEANUP_SECRET_NAME,
     SLACK_WORKSPACE_ID_ENV,
+    TRACKER_DOMAIN,
     TRACKER_LOG_GROUP_NAME,
     VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV,
     WORKER_LOG_GROUP_NAME,
@@ -30,7 +32,8 @@ from constants import (
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
 from executor_stack import ExecutorStack
-from stage import DEV, DEV_STACK_PREFIX, PROD, RELEASE_TEST, Stage
+from stage import DEV, DEV_STACK_PREFIX, PROD, PROD_EXTERNAL, RELEASE_TEST, Stage
+from stage_config import DEV_CONFIG
 from tracker_stack import TrackerStack
 
 TEST_ALERTS_SLACK_ENV = {
@@ -210,6 +213,88 @@ class MonitoringStackTest(unittest.TestCase):
     def test_dev_stack_ids_are_valk_scoped(self) -> None:
         self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")
         self.assertEqual(Stage(DEV).stack_id("TrackerStack"), f"{DEV_STACK_PREFIX}TrackerStack")
+
+    def test_prod_external_names_never_collide_with_internal_prod(self) -> None:
+        stage = Stage(PROD_EXTERNAL)
+        self.assertEqual(stage.stack_id("WorkerStack"), "ValkProdExternalWorkerStack")
+        self.assertEqual(stage.phys("AgenticHarnessCluster"), "AgenticHarnessCluster-prod-external")
+        self.assertEqual(stage.domain(TRACKER_DOMAIN), "benchmark-tracker-external.vals.ai")
+        self.assertTrue(stage.is_production)
+        self.assertFalse(stage.is_primary_prod)
+
+    def test_prod_external_is_production_shaped_and_physically_isolated(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            prod_tracker, prod_executor, _ = _service_templates(PROD)
+            tracker_template, executor_template, monitoring_template = _service_templates(PROD_EXTERNAL)
+
+        def sizing(template: assertions.Template, resource_type: str) -> list[dict[str, object]]:
+            return [resource["Properties"] for resource in template.find_resources(resource_type).values()]
+
+        for resource_type in ("AWS::RDS::DBInstance", "AWS::ApplicationAutoScaling::ScalableTarget"):
+            for expected, actual in (
+                (sizing(prod_tracker, resource_type), sizing(tracker_template, resource_type)),
+                (sizing(prod_executor, resource_type), sizing(executor_template, resource_type)),
+            ):
+                for expected_properties, actual_properties in zip(expected, actual, strict=True):
+                    for key in ("DBInstanceClass", "BackupRetentionPeriod", "MinCapacity", "MaxCapacity"):
+                        self.assertEqual(expected_properties.get(key), actual_properties.get(key))
+
+        tracker_template.has_resource_properties(
+            "AWS::Logs::LogGroup",
+            {"LogGroupName": f"{TRACKER_LOG_GROUP_NAME}-prod-external", "RetentionInDays": 365},
+        )
+        tracker_template.has_resource_properties("AWS::RDS::DBInstance", {"PubliclyAccessible": True})
+        self.assertEqual(len(tracker_template.find_resources("AWS::CertificateManager::Certificate")), 1)
+        self.assertIn(
+            "benchmark-tracker-external.vals.ai",
+            json.dumps(tracker_template.find_resources("AWS::Route53::RecordSet")),
+        )
+        tracker_environment = [
+            variable
+            for task_definition in tracker_template.find_resources("AWS::ECS::TaskDefinition").values()
+            for container in task_definition["Properties"]["ContainerDefinitions"]
+            for variable in container.get("Environment", [])
+        ]
+        self.assertIn({"Name": "AUTH_REQUIRED", "Value": "true"}, tracker_environment)
+        self.assertIn(
+            {"Name": "DESCOPE_PROJECT_ID", "Value": PROD_EXTERNAL_DESCOPE_PROJECT_ID},
+            tracker_environment,
+        )
+
+        parameter_names = [
+            resource["Properties"]["Name"]
+            for resource in executor_template.find_resources("AWS::SSM::Parameter").values()
+        ]
+        self.assertIn("/valkyrie/prod-external/executor-release/launch-config", parameter_names)
+        self.assertTrue(all("/valkyrie/prod-external/" in name for name in parameter_names))
+        roles = executor_template.find_resources("AWS::IAM::Role")
+        release_role = next(
+            role
+            for role in roles.values()
+            if role["Properties"].get("RoleName") == "ValkyrieExecutorRelease-prod-external"
+        )
+        self.assertIn(
+            "repo:vals-ai/Valkyrie:environment:prod-external",
+            json.dumps(release_role["Properties"]["AssumeRolePolicyDocument"]),
+        )
+        executor_template.has_resource_properties(
+            "AWS::Logs::LogGroup",
+            {"LogGroupName": f"{WORKER_LOG_GROUP_NAME}-prod-external", "RetentionInDays": 365},
+        )
+        executor_template.resource_count_is("AWS::Scheduler::Schedule", 0)
+
+        for template in (tracker_template, executor_template, monitoring_template):
+            for resource_type, name_property in (
+                ("AWS::ECS::Service", "ServiceName"),
+                ("AWS::Logs::LogGroup", "LogGroupName"),
+                ("AWS::CloudWatch::Alarm", "AlarmName"),
+                ("AWS::SNS::Topic", "TopicName"),
+                ("AWS::IAM::Role", "RoleName"),
+            ):
+                for resource in template.find_resources(resource_type).values():
+                    name = resource["Properties"].get(name_property)
+                    if isinstance(name, str):
+                        self.assertTrue(name.endswith("-prod-external"), name)
 
     def test_release_test_names_are_namespaced(self) -> None:
         stage = Stage(RELEASE_TEST)
@@ -485,15 +570,15 @@ class MonitoringStackTest(unittest.TestCase):
         )
         tracker_template.has_resource_properties(
             "AWS::ApplicationAutoScaling::ScalableTarget",
-            {"MinCapacity": 1, "MaxCapacity": 1},
+            {"MinCapacity": DEV_CONFIG.tracker.min_tasks, "MaxCapacity": DEV_CONFIG.tracker.max_tasks},
         )
         worker_template.has_resource_properties(
             "AWS::ECS::Service",
-            {"DesiredCount": 1},
+            {"DesiredCount": DEV_CONFIG.worker.min_tasks},
         )
         worker_template.has_resource_properties(
             "AWS::ApplicationAutoScaling::ScalableTarget",
-            {"MinCapacity": 1, "MaxCapacity": 2},
+            {"MinCapacity": DEV_CONFIG.worker.min_tasks, "MaxCapacity": DEV_CONFIG.worker.max_tasks},
         )
         worker_template.has_resource_properties(
             "AWS::Logs::LogGroup",
@@ -522,6 +607,7 @@ class MonitoringStackTest(unittest.TestCase):
     def test_service_environment_labels_follow_stage(self) -> None:
         for stage_name, expected_environment, expected_namespace in (
             (PROD, "production", "local"),
+            (PROD_EXTERNAL, "prod-external", "local-prod-external"),
             (DEV, "dev", "local-dev"),
         ):
             environment = TEST_DEV_ENV if stage_name == DEV else {}

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -36,6 +36,7 @@ from constants import (
     POSTGRES_DB,
     POSTGRES_PORT,
     POSTGRES_USER,
+    PROD_EXTERNAL_DESCOPE_PROJECT_ID,
     TRACKER_DOMAIN,
     TRACKER_LOG_GROUP_NAME,
     TRACKER_PORT,
@@ -44,7 +45,7 @@ from constants import (
     stage_parameter_name,
 )
 from constructs import Construct
-from stage import Stage
+from stage import PROD_EXTERNAL, Stage
 from stage_config import benchmark_service_base_url, config_for
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
@@ -135,7 +136,7 @@ class TrackerStack(Stack):
             credentials=aws_rds.Credentials.from_secret(db_credentials_secret),
             database_name=POSTGRES_DB,
             allocated_storage=stage_config.database.allocated_storage_gb,
-            publicly_accessible=stage.is_prod,
+            publicly_accessible=stage.is_production,
             deletion_protection=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             backup_retention=Duration.days(stage_config.database.backup_retention_days),
@@ -152,7 +153,9 @@ class TrackerStack(Stack):
             "DB_PASSWORD": aws_ecs.Secret.from_secrets_manager(db_credentials_secret, field="password"),
         }
 
-        sentry_secret_name = "valkyrie/sentry-dsn" if stage.is_prod else os.environ.get("SENTRY_DSN_SECRET_NAME", "")
+        sentry_secret_name = (
+            "valkyrie/sentry-dsn" if stage.is_production else os.environ.get("SENTRY_DSN_SECRET_NAME", "")
+        )
         sentry_secrets: dict[str, aws_ecs.Secret] = {}
         if sentry_secret_name:
             sentry_secret = aws_secretsmanager.Secret.from_secret_name_v2(
@@ -164,7 +167,12 @@ class TrackerStack(Stack):
 
         auth_required = os.environ.get("AUTH_REQUIRED", "false")
         descope_project_id = os.environ.get("DESCOPE_PROJECT_ID", "")
-        if not stage.is_prod:
+        if stage.name == PROD_EXTERNAL:
+            # The external deployment authenticates against its own Descope project,
+            # never the internal one configured for prod.
+            auth_required = "true"
+            descope_project_id = PROD_EXTERNAL_DESCOPE_PROJECT_ID
+        elif not stage.is_primary_prod:
             auth_required = "true"
             if not descope_project_id:
                 raise ValueError("Development deployments require DESCOPE_PROJECT_ID.")
@@ -230,10 +238,10 @@ class TrackerStack(Stack):
 
         tracker_domain: str | None = None
         tracker_hosted_zone: aws_route53.IHostedZone | None = None
-        if stage.is_prod:
+        if stage.is_production:
             if hosted_zone is None:
                 raise ValueError("Production requires the vals.ai hosted zone")
-            tracker_domain = TRACKER_DOMAIN
+            tracker_domain = stage.domain(TRACKER_DOMAIN)
             tracker_hosted_zone = hosted_zone
         elif not stage.is_release_test:
             tracker_domain = stage.domain(TRACKER_DOMAIN)
@@ -331,7 +339,7 @@ class TrackerStack(Stack):
             description="Allow VPC services to connect to RDS",
         )
 
-        if not stage.is_prod:
+        if not stage.is_production:
             aws_ssm.StringParameter(
                 self,
                 "TrackerSecurityGroupParameter",

--- a/services/tracker/src/tracker/logging/config.py
+++ b/services/tracker/src/tracker/logging/config.py
@@ -52,6 +52,7 @@ _DEVELOPMENT_FORMATTER = {
 
 _FORMATTERS = {
     "production": _JSON_FORMATTER,
+    "prod-external": _JSON_FORMATTER,
     "dev": _JSON_FORMATTER,
     "development": _DEVELOPMENT_FORMATTER,
     "release-test": _DEVELOPMENT_FORMATTER,

--- a/src/valkyrie/cli/runtime_config.py
+++ b/src/valkyrie/cli/runtime_config.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 
 PROD_ENVIRONMENT = "prod"
+EXTERNAL_ENVIRONMENT = "external"
 DEV_ENVIRONMENT = "dev"
 
 VALKYRIE_ENV_ENV_VAR = "VALKYRIE_ENV"
@@ -11,17 +12,21 @@ TRACKER_SERVICE_URL_ENV_VAR = "TRACKER_SERVICE_URL"
 VALKYRIE_CONFIG_PATH_ENV_VAR = "VALKYRIE_CONFIG_PATH"
 
 PROD_TRACKER_URL = "https://benchmark-tracker.vals.ai"
+EXTERNAL_TRACKER_URL = "https://benchmark-tracker-external.vals.ai"
 DEV_TRACKER_URL = "https://benchmark-tracker-dev.vals.ai"
 
 PROD_CONFIG_PATH = Path("~/.config/valkyrie/valkyrie.yaml")
+EXTERNAL_CONFIG_PATH = Path("~/.config/valkyrie/external.yaml")
 DEV_CONFIG_PATH = Path("~/.config/valkyrie/dev.yaml")
 
 _TRACKER_URLS = {
     PROD_ENVIRONMENT: PROD_TRACKER_URL,
+    EXTERNAL_ENVIRONMENT: EXTERNAL_TRACKER_URL,
     DEV_ENVIRONMENT: DEV_TRACKER_URL,
 }
 _CONFIG_PATHS = {
     PROD_ENVIRONMENT: PROD_CONFIG_PATH,
+    EXTERNAL_ENVIRONMENT: EXTERNAL_CONFIG_PATH,
     DEV_ENVIRONMENT: DEV_CONFIG_PATH,
 }
 

--- a/tests/unit/cli/test_runtime_config.py
+++ b/tests/unit/cli/test_runtime_config.py
@@ -10,6 +10,8 @@ import pytest
 from valkyrie.cli.runtime_config import (
     DEV_CONFIG_PATH,
     DEV_TRACKER_URL,
+    EXTERNAL_CONFIG_PATH,
+    EXTERNAL_TRACKER_URL,
     PROD_CONFIG_PATH,
     PROD_ENVIRONMENT,
     PROD_TRACKER_URL,
@@ -40,6 +42,13 @@ def test_dev_environment_uses_dev_tracker_and_config(monkeypatch: pytest.MonkeyP
 
     assert tracker_service_url() == DEV_TRACKER_URL
     assert config_location() == DEV_CONFIG_PATH.expanduser()
+
+
+def test_external_environment_uses_external_tracker_and_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(VALKYRIE_ENV_ENV_VAR, "external")
+
+    assert tracker_service_url() == EXTERNAL_TRACKER_URL
+    assert config_location() == EXTERNAL_CONFIG_PATH.expanduser()
 
 
 def test_explicit_tracker_url_overrides_selected_environment(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Adds a second production deployment, `prod-external`, living beside internal `prod` in the same AWS account (613431292675 / us-east-1) and deploying off the same `prod` branch.

## Human Description

Why / how: Allows tighter security controls for internal deployments.

## Changes

- `infra/stage.py`: split the single `is_prod` axis in two — `is_production` (production sizing/TLS/hosted zone/behavior; `prod` + `prod-external`) and `is_primary_prod` (owns the original unsuffixed physical names; `prod` only). Stack prefixes and domain labels are now table-driven, so `prod-external` gets `ValkProdExternal*` stack ids, `-prod-external` on every physical name, and `benchmark-tracker-external.vals.ai`.
- Call sites updated to the correct axis: hosted-zone lookup, publicly-accessible RDS, sentry secret, tracker domain, dev SSM contract → `is_production`; legacy S3 bucket props, deployment-target enforcement bypass, sandbox-cleanup schedule → `is_primary_prod`.
- `prod-external` tracker always requires auth against its own Descope project (`PROD_EXTERNAL_DESCOPE_PROJECT_ID` in `infra/constants.py`); the workflow does not pass `DESCOPE_PROJECT_ID`/`AUTH_REQUIRED` for it, so the internal project can never leak in.
- `PROD_EXTERNAL_CONFIG` reuses `PROD_CONFIG`'s sizing, database, and one-year log retention; only `runtime_environment` differs (`prod-external`, which `services/tracker/.../logging/config.py` now maps to the JSON formatter).
- `deployment_target.py`, `infra/Makefile`, and `executor_release/main.py` accept `prod-external` (production account, `ValkProdExternal` stack prefix).
- `.github/workflows/deploy.yaml`: `deploy-prod-external-core` + `executor-prod-external` mirror the internal production lane on the same `prod` push, with their own mutex (`valkyrie-prod-external-deploy`), GitHub Environment `prod-external`, release role `ValkyrieExecutorRelease-prod-external`, and launch parameter `/valkyrie/prod-external/executor-release/launch-config`. Stale-revision checks, maintenance fences, and the fail-closed SSM preflight are preserved.
- `valk` gains `VALKYRIE_ENV=external` (`benchmark-tracker-external.vals.ai`, `~/.config/valkyrie/external.yaml`).
- `infra/README.md`: production-stage semantics plus the manual `prod-external` bootstrap (GitHub Environment, core then executor deploy, SSM verification, first release command).
- Unrelated fix: `test_dev_stage_wires_stage_config_to_resources` asserted the pre-#669 dev sizing and fails on `dev` today; it now reads the expectations from `DEV_CONFIG`.

The hourly sandbox-cleanup schedule intentionally stays on internal `prod` only, since both stages share one sandbox provider account.

## Related Issues

n/a

## Type of Change

- [x] New feature
- [x] Docs / config

## Testing

Synthesized both production stages side by side (`CDK_OUTDIR=... python app.py` with `stage=prod` and `stage=prod-external` against account 613431292675/us-east-1) and compared the resulting CloudFormation templates:

- No physical-name collision between the two assemblies across clusters, services, buckets, log groups, IAM roles, SNS topics, SSM parameters, alarms, dashboards, and Cloud Map namespaces (the only shared name is the Cloud Map service `tracker`, which is scoped inside `local-prod-external`).
- `prod-external` synthesizes `db.t4g.small` / 7-day backups / public RDS, one ACM certificate, a Route53 record for `benchmark-tracker-external.vals.ai`, `AUTH_REQUIRED=true` with the external Descope project, `/valkyrie/prod-external/executor-release/launch-config`, `ValkyrieExecutorRelease-prod-external` trusting `repo:vals-ai/Valkyrie:environment:prod-external`, and no sandbox-cleanup resources.
- Internal `prod` templates are byte-identical to `dev`'s output except for container image asset hashes, so this does not change the existing deployment.

No AWS resources were created or mutated.

- [x] Added/updated unit tests
- [x] Manually tested

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/5cff509a141e413799bba0056017a2b4
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/671" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->