### PR TITLE
ci: pass placeholder secret names to offline synth

### DIFF
--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -84,6 +84,8 @@ jobs:
             CDK_DEFAULT_REGION=us-east-1 \
             AWS_REGION=us-east-1 \
             STAGE="$stage" \
+            SENTRY_DSN_SECRET_NAME=offline-synth \
+            DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
             DESCOPE_PROJECT_ID=offline-synth \
               uv run --frozen cdk synth "$stack_id" -c stage="$stage" --output "$assembly"
           )
@@ -183,6 +185,8 @@ jobs:
             CDK_DEFAULT_REGION=us-east-1 \
             AWS_REGION=us-east-1 \
             STAGE="$stage" \
+            SENTRY_DSN_SECRET_NAME=offline-synth \
+            DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
             DESCOPE_PROJECT_ID=offline-synth \
               uv run --frozen cdk synth "$stack_id" -c stage="$stage" --output "$assembly"
           )


### PR DESCRIPTION
## Summary

Offline synth in `maintenance-classification.yaml` now passes placeholder values for `SENTRY_DSN_SECRET_NAME` and `DESCOPE_MANAGEMENT_KEY_SECRET_NAME` alongside the existing `DESCOPE_PROJECT_ID=offline-synth`.

The workflow runs on `pull_request_target`, so its definition is read from `dev` — this has to land on `dev` before the synth jobs on #670 can pass.

## Changes
- `SENTRY_DSN_SECRET_NAME=offline-synth` and `DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth` in both the base and head synth steps

## Type of Change
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/43a9c6c0c5f746cdb5d0c978323296cf
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/672" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->