### PR TITLE
fix: prevent shell injection via pr title in title check workflow

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -5,13 +5,16 @@ on:
     types: [opened, edited, synchronize, reopened]
     branches: [prod]
 
+permissions: {}
+
 jobs:
   check-pr-title:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title for version tag
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
           if [[ ! "$TITLE" =~ \#(minor|major|patch) ]]; then
             echo "❌ PR title must contain #minor, #major or #patch. Visit https://github.com/vals-ai/Valkyrie/blob/dev/docs/DEVELOPMENT.md#versioning to learn more."
             exit 1


### PR DESCRIPTION
## Why

The semantic-versioning check expanded the PR title directly into its `run:` script via `${{ github.event.pull_request.title }}`. GitHub Actions substitutes that expression before the shell ever runs, so anyone who could open or edit a PR against `prod` could put shell metacharacters in the title and execute arbitrary commands on the CI runner. The title is now passed through the step's `env:` block instead, so it reaches the script as an environment variable — data the shell never parses as code. The workflow also now declares `permissions: {}`: the job only inspects the title, so it gets no GitHub token access at all.

## Testing

Not yet live-tested - need to make a prod PR to test

Design: not architectural (two-line CI hardening; no components or contracts change)
