### PR TITLE
fix: gate credentialed github actions jobs behind environments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -153,6 +153,7 @@ jobs:
       needs.classify-deployment.outputs.core_maintenance_required != 'true' &&
       needs.classify-deployment.outputs.database_maintenance_required != 'true'
     needs: classify-deployment
+    environment: prod
     concurrency:
       group: valkyrie-prod-deploy
       cancel-in-progress: false

--- a/.github/workflows/tracker-integration-tests.yaml
+++ b/.github/workflows/tracker-integration-tests.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   tracker-live-integration-tests:
     runs-on: ubuntu-latest
+    environment: tracker-live-tests
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Why

Two GitHub Actions jobs assume IAM roles in the prod AWS account via OIDC: the tracker live-integration-tests job (role `github-actions-valkyrie-tests`) and the prod deploy job (role `github-actions-valkyrie-deploy`). Those roles' trust policies currently accept a token minted from any ref in this repo, or from bare `dev`/`prod` branch refs — broader than the two jobs that actually use them. Pinning each trust policy to a specific GitHub environment first requires the job to declare that environment, so its OIDC token carries an `environment` claim. This PR adds those declarations; the matching IAM trust-policy changes land separately in the AWS account and depend on this merging first.

## What changed

- The `tracker-live-integration-tests` job now runs in the `tracker-live-tests` environment.
- The `deploy-production-core` job now runs in the `prod` environment (the prod executor-publish job in the same workflow already uses it).

## How to review

- No runtime behavior changes today: neither environment has protection rules, and the `prod` environment's branch policy already permits the `prod` branch (the executor-publish job deploys to it on every prod push), so `deploy-production-core` starts normally.
- This is a prerequisite, not the fix on its own. After it merges, the `-tests` and `-deploy` trust policies are pinned to these environments and the `-tests` permissions are scoped down, applied directly in the AWS account.
- Adding required reviewers to `tracker-live-tests` is a separate repo-settings step. The tracker job runs on every PR to report its required check, so a reviewer gate there would prompt on every PR — decide that before enabling it.

## Testing

Not yet live-tested.

Design: not architectural (workflow-config change; adds environment claims to existing jobs, no new component or contract, no runtime behavior change today)
