### PR TITLE
fix(tracker): restrict custom service destinations

### DIFF
--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -31,6 +31,7 @@ from monitoring_stack import MonitoringStack
 from shared import SharedStack
 from executor_stack import ExecutorStack
 from stage import DEV, DEV_STACK_PREFIX, PROD, RELEASE_TEST, Stage
+from stage_config import DEV_CONFIG
 from tracker_stack import TrackerStack
 
 TEST_ALERTS_SLACK_ENV = {
@@ -496,15 +497,15 @@ class MonitoringStackTest(unittest.TestCase):
         )
         tracker_template.has_resource_properties(
             "AWS::ApplicationAutoScaling::ScalableTarget",
-            {"MinCapacity": 1, "MaxCapacity": 1},
+            {"MinCapacity": DEV_CONFIG.tracker.min_tasks, "MaxCapacity": DEV_CONFIG.tracker.max_tasks},
         )
         worker_template.has_resource_properties(
             "AWS::ECS::Service",
-            {"DesiredCount": 1},
+            {"DesiredCount": DEV_CONFIG.worker.min_tasks},
         )
         worker_template.has_resource_properties(
             "AWS::ApplicationAutoScaling::ScalableTarget",
-            {"MinCapacity": 1, "MaxCapacity": 2},
+            {"MinCapacity": DEV_CONFIG.worker.min_tasks, "MaxCapacity": DEV_CONFIG.worker.max_tasks},
         )
         worker_template.has_resource_properties(
             "AWS::Logs::LogGroup",

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -91,7 +91,7 @@ from tracker.executor.release_control import MaintenanceModeError, ReleaseContro
 from tracker.executor.release_retirement import AutomaticReleaseRetirement
 from tracker.middleware import RequestContextMiddleware
 from tracker.observability import configure_observability
-from tracker.outbound_security import validate_service_url_syntax
+from tracker.outbound_security import validate_custom_service_destination, validate_service_url_syntax
 from tracker.types import (
     AnalyzeBenchmarkRequest,
     FetchBenchmarkMetadataResponse,
@@ -353,6 +353,17 @@ async def _resolve_contract_from_s3(request: StartBenchmarkRequest) -> AgentCont
     return resolved
 
 
+def _authorize_custom_benchmark_destination(url: str, org: Org) -> None:
+    try:
+        validate_custom_service_destination(
+            url,
+            org_name=org.name,
+            auth_required=AUTH_REQUIRED,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+
+
 @app.post("/start-benchmark")
 async def start_benchmark(
     http_request: Request,
@@ -376,6 +387,9 @@ async def start_benchmark(
     - 400 Bad Request if parameters are invalid
     - 500 Internal Server Error if benchmark fails to start
     """
+    if request.custom_benchmark_service is not None:
+        _authorize_custom_benchmark_destination(request.custom_benchmark_service, run_starter.org)
+
     # Prefer harness_config from X-Harness-* headers (web FE); fall back to request body (CLI).
     header_harness_config = try_fetch_harness_config(http_request)
     effective_harness_config = header_harness_config or request.harness_config
@@ -519,11 +533,14 @@ async def fetch_benchmark_tasks(
     http_request: Request,
     request: FetchBenchmarkTasksRequest,
     harness_config: HarnessConfig = Depends(fetch_harness_config),
-    _org: Org = Depends(get_current_org),
+    org: Org = Depends(get_current_org),
 ) -> VerifyTaskIdsResponse:
     """
     Fetch all task ids for a benchmark dataset.
     """
+    if request.custom_benchmark_service is not None:
+        _authorize_custom_benchmark_destination(request.custom_benchmark_service, org)
+
     try:
         benchmark_service = create_benchmark_service_client(
             url=request.custom_benchmark_service or create_benchmark_service_url(request.benchmark_name),
@@ -717,6 +734,9 @@ async def retrieve_results(
             for task_id, result in fetch_final_score_inputs(session, benchmark_row, org).items()
             if task_id in task_ids_set
         }
+
+        if benchmark_row.custom_benchmark_service is not None:
+            _authorize_custom_benchmark_destination(benchmark_row.custom_benchmark_service, org)
 
         effective_service_headers = forward_tracker_api_key(
             None,
@@ -955,6 +975,10 @@ async def retry_or_resume_benchmark(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    effective_benchmark_url = benchmark_url if benchmark_url is not None else benchmark_row.custom_benchmark_service
+    if effective_benchmark_url is not None:
+        _authorize_custom_benchmark_destination(effective_benchmark_url, org)
+
     if concurrency is not None and concurrency < 1:
         raise HTTPException(status_code=400, detail="Concurrency must be greater than 0.")
 
@@ -980,6 +1004,8 @@ async def retry_or_resume_benchmark(
             lock_executor_admission(session)
         benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
         effective_benchmark_url = benchmark_url if benchmark_url is not None else benchmark_row.custom_benchmark_service
+        if effective_benchmark_url is not None:
+            _authorize_custom_benchmark_destination(effective_benchmark_url, org)
         effective_service_headers = forward_tracker_api_key(
             service_headers,
             http_request.headers.get("x-api-key"),

--- a/services/tracker/src/tracker/api/benchmark_services.py
+++ b/services/tracker/src/tracker/api/benchmark_services.py
@@ -10,8 +10,9 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 import httpx
 
 from tracker.auth import get_current_org
-from tracker.config import BENCHMARK_CATALOG_URL
+from tracker.config import AUTH_REQUIRED, BENCHMARK_CATALOG_URL
 from tracker.database.models import Org
+from tracker.outbound_security import validate_custom_service_destination
 from tracker.types import (
     BenchmarkServiceCatalogResponse,
     BenchmarkServiceHealth,
@@ -90,11 +91,22 @@ async def catalog_benchmark_services(
 @router.post("", response_model=BenchmarkServicesResponse)
 async def list_benchmark_services(
     request: BenchmarkServicesRequest,
-    _org: Org = Depends(get_current_org),
+    org: Org = Depends(get_current_org),
 ) -> BenchmarkServicesResponse:
     """Health-check the caller-provided benchmark services with concurrent pings."""
     if not request.services:
         return BenchmarkServicesResponse(services=[])
+
+    try:
+        for service in request.services:
+            validate_custom_service_destination(
+                service.url,
+                org_name=org.name,
+                auth_required=AUTH_REQUIRED,
+                restrict_vals_hosts=False,
+            )
+    except ValueError as exc:
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
 
     async with httpx.AsyncClient(timeout=HEALTH_CHECK_TIMEOUT_SECONDS) as client:
         health_entries = await asyncio.gather(

--- a/services/tracker/src/tracker/outbound_security.py
+++ b/services/tracker/src/tracker/outbound_security.py
@@ -34,6 +34,7 @@ _FORBIDDEN_HEADER_PREFIXES = ("forwarded", "proxy-", "sec-websocket-", "x-forwar
 _VALS_TENANT_ID = "vals.ai"
 _RESTRICTED_HOSTNAMES = {"internal", "local", "localhost"}
 _RESTRICTED_HOSTNAME_SUFFIXES = (".localhost", ".local", ".internal")
+_IDNA_SEPARATOR_TRANSLATION = str.maketrans({"。": ".", "．": ".", "｡": "."})
 _CUSTOM_DESTINATION_DENIED = "Custom benchmark destination is not allowed"
 
 
@@ -70,7 +71,7 @@ def validate_custom_service_destination(
 
     hostname = urlsplit(value).hostname
     assert hostname is not None
-    normalized_host = hostname.lower().rstrip(".")
+    normalized_host = hostname.translate(_IDNA_SEPARATOR_TRANSLATION).lower().rstrip(".")
     if (
         (restrict_vals_hosts and normalized_host == _VALS_TENANT_ID)
         or (restrict_vals_hosts and normalized_host.endswith(f".{_VALS_TENANT_ID}"))

--- a/services/tracker/src/tracker/outbound_security.py
+++ b/services/tracker/src/tracker/outbound_security.py
@@ -8,7 +8,9 @@ here, which would change persisted/API values or defer failures until request ti
 from __future__ import annotations
 
 from collections.abc import Mapping
+from ipaddress import ip_address
 import re
+from socket import inet_aton
 from urllib.parse import urlsplit
 
 _BENCHMARK_NAME_RE = re.compile(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?")
@@ -29,6 +31,10 @@ _FORBIDDEN_HEADER_NAMES = {
     "x-real-ip",
 }
 _FORBIDDEN_HEADER_PREFIXES = ("forwarded", "proxy-", "sec-websocket-", "x-forwarded-")
+_VALS_TENANT_ID = "vals.ai"
+_RESTRICTED_HOSTNAMES = {"internal", "local", "localhost"}
+_RESTRICTED_HOSTNAME_SUFFIXES = (".localhost", ".local", ".internal")
+_CUSTOM_DESTINATION_DENIED = "Custom benchmark destination is not allowed"
 
 
 def validate_benchmark_name(value: str) -> str:
@@ -49,6 +55,39 @@ def validate_service_headers(headers: Mapping[str, str]) -> None:
             or normalized.startswith(_FORBIDDEN_HEADER_PREFIXES)
         ):
             raise ValueError("Unsupported benchmark service header")
+
+
+def validate_custom_service_destination(
+    value: str,
+    *,
+    org_name: str,
+    auth_required: bool,
+    restrict_vals_hosts: bool = True,
+) -> None:
+    """Keep private and optionally Vals-owned custom destinations limited to trusted callers."""
+    if not auth_required or org_name == _VALS_TENANT_ID:
+        return
+
+    hostname = urlsplit(value).hostname
+    assert hostname is not None
+    normalized_host = hostname.lower().rstrip(".")
+    if (
+        (restrict_vals_hosts and normalized_host == _VALS_TENANT_ID)
+        or (restrict_vals_hosts and normalized_host.endswith(f".{_VALS_TENANT_ID}"))
+        or normalized_host in _RESTRICTED_HOSTNAMES
+        or normalized_host.endswith(_RESTRICTED_HOSTNAME_SUFFIXES)
+    ):
+        raise ValueError(_CUSTOM_DESTINATION_DENIED)
+
+    try:
+        parsed_ip = ip_address(normalized_host)
+    except ValueError:
+        try:
+            parsed_ip = ip_address(inet_aton(normalized_host))
+        except OSError:
+            return
+    if not parsed_ip.is_global or parsed_ip.is_multicast:
+        raise ValueError(_CUSTOM_DESTINATION_DENIED)
 
 
 def validate_service_url_syntax(value: str) -> str:

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -289,11 +289,6 @@ async def process_benchmark(
     start_benchmark_request: StartBenchmarkRequest = StartBenchmarkRequest(**start_benchmark_request_json)
     benchmark_id = authority.benchmark_id
     harness_config: HarnessConfig = start_benchmark_request.harness_config
-    sandbox_provider_config = fetch_sandbox_provider_config(
-        harness_config.sandbox_provider_secret_name,
-        harness_config.aws,
-        start_benchmark_request.sandbox_provider,
-    )
 
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
@@ -323,16 +318,23 @@ async def process_benchmark(
             raise TrackerServiceError(f"Run with id {benchmark_id} not found")
         org = session.exec(select(Org).where(Org.id == benchmark_row.org_id)).one()
 
-    if start_benchmark_request.custom_benchmark_service is not None:
-        validate_custom_service_destination(
-            start_benchmark_request.custom_benchmark_service,
-            org_name=org.name,
-            auth_required=AUTH_REQUIRED,
-        )
     benchmark_service = create_benchmark_service_client_from_request(start_benchmark_request)
 
     finalization_deferred = False
     try:
+        if start_benchmark_request.custom_benchmark_service is not None:
+            validate_custom_service_destination(
+                start_benchmark_request.custom_benchmark_service,
+                org_name=org.name,
+                auth_required=AUTH_REQUIRED,
+            )
+
+        sandbox_provider_config = fetch_sandbox_provider_config(
+            harness_config.sandbox_provider_secret_name,
+            harness_config.aws,
+            start_benchmark_request.sandbox_provider,
+        )
+
         # Create benchmark cloudwatch log group
         create_benchmark_log_group(
             str(benchmark_id), harness_config.aws, harness_config.log_group, harness_config.log_retention_policy

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -14,7 +14,7 @@ from sqlmodel import Session, col, desc, func, select
 
 from tracker._lambda import invoke_lambda, lambda_client
 from tracker.aws.cloudwatch_logs import create_benchmark_log_group
-from tracker.config import broker
+from tracker.config import AUTH_REQUIRED, broker
 from tracker.database.models import (
     Benchmark,
     BenchmarkStatus,
@@ -32,6 +32,7 @@ from tracker.executor.execution_authority import ExecutionAuthority, lock_execut
 from executor_protocol import EXECUTOR_TASK_NAME
 from tracker.logging import get_logger
 from tracker.notifications import NotificationContext, SlackNotifier
+from tracker.outbound_security import validate_custom_service_destination
 from tracker.types import (
     FinalViewResponse,
     HarnessConfig,
@@ -293,7 +294,6 @@ async def process_benchmark(
         harness_config.aws,
         start_benchmark_request.sandbox_provider,
     )
-    benchmark_service = create_benchmark_service_client_from_request(start_benchmark_request)
 
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
@@ -322,6 +322,14 @@ async def process_benchmark(
         if not benchmark_row:
             raise TrackerServiceError(f"Run with id {benchmark_id} not found")
         org = session.exec(select(Org).where(Org.id == benchmark_row.org_id)).one()
+
+    if start_benchmark_request.custom_benchmark_service is not None:
+        validate_custom_service_destination(
+            start_benchmark_request.custom_benchmark_service,
+            org_name=org.name,
+            auth_required=AUTH_REQUIRED,
+        )
+    benchmark_service = create_benchmark_service_client_from_request(start_benchmark_request)
 
     finalization_deferred = False
     try:

--- a/services/tracker/tests/unit/api/test_benchmark_services.py
+++ b/services/tracker/tests/unit/api/test_benchmark_services.py
@@ -271,6 +271,38 @@ class TestBenchmarkServicesHealth:
         }
         assert sensitive_detail not in response.text
 
+    def test_benchmark_services_endpoint_blocks_external_internal_destination(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(benchmark_services_api, "AUTH_REQUIRED", True)
+
+        response = _client.post(
+            "/benchmark-services",
+            json={"services": [{"name": "swebench", "url": "http://localhost:8001"}]},
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Custom benchmark destination is not allowed"}
+
+    def test_benchmark_services_endpoint_allows_vals_catalog_destination(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def handle_request(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, request=request)
+
+        monkeypatch.setattr(benchmark_services_api, "AUTH_REQUIRED", True)
+        _install_http_transport(monkeypatch, handle_request)
+
+        response = _client.post(
+            "/benchmark-services",
+            json={"services": [{"name": "swebench", "url": "https://swebench.benchmarks.vals.ai"}]},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["services"][0]["healthy"]
+
     def test_benchmark_services_endpoint_returns_empty_services(self) -> None:
         """An empty health-check request must preserve the successful empty contract.
 

--- a/services/tracker/tests/unit/api/test_benchmark_services.py
+++ b/services/tracker/tests/unit/api/test_benchmark_services.py
@@ -275,15 +275,23 @@ class TestBenchmarkServicesHealth:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        requests: list[httpx.Request] = []
+
+        async def handle_request(request: httpx.Request) -> httpx.Response:
+            requests.append(request)
+            return httpx.Response(200, request=request)
+
         monkeypatch.setattr(benchmark_services_api, "AUTH_REQUIRED", True)
+        _install_http_transport(monkeypatch, handle_request)
 
         response = _client.post(
             "/benchmark-services",
-            json={"services": [{"name": "swebench", "url": "http://localhost:8001"}]},
+            json={"services": [{"name": "swebench", "url": "http://127。0。0。1:8001"}]},
         )
 
         assert response.status_code == 403
         assert response.json() == {"detail": "Custom benchmark destination is not allowed"}
+        assert requests == []
 
     def test_benchmark_services_endpoint_allows_vals_catalog_destination(
         self,

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -443,6 +443,28 @@ class TestTrackerAPI:
         assert observed_headers[0]["X-Descope-Api-Key"] == "tracker-api-key"
         assert "X-Descope-Api-Key" not in observed_headers[1]
 
+    async def test_fetch_benchmark_tasks_blocks_external_internal_custom_destination(
+        self,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(main_module, "AUTH_REQUIRED", True)
+
+        blocked = client.post(
+            "/fetch-benchmark-tasks",
+            json={
+                "benchmark_name": "swebench",
+                "custom_benchmark_service": "https://benchmarks-dev.vals.ai",
+            },
+        )
+        canonical = client.post(
+            "/fetch-benchmark-tasks",
+            json={"benchmark_name": "swebench"},
+        )
+
+        assert blocked.status_code == 403
+        assert blocked.json() == {"detail": "Custom benchmark destination is not allowed"}
+        assert canonical.status_code == 200
+
     async def test_start_benchmark(
         self,
         contract: AgentContractRequest,
@@ -1302,6 +1324,28 @@ class TestTrackerAPI:
         assert observed_results["task_11"] is None
         assert response.json()["final_evaluation"]["final_score"] == 2.0
 
+    async def test_retrieve_results_blocks_external_persisted_internal_destination(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        example_benchmark_object.custom_benchmark_service = "http://service.internal:8001"
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+        monkeypatch.setattr(main_module, "AUTH_REQUIRED", True)
+
+        response = client.get(
+            "/retrieve-results",
+            params=[
+                ("benchmark_id", str(example_benchmark_object.id)),
+                ("task_ids", "task_0"),
+            ],
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Custom benchmark destination is not allowed"}
+
     async def test_retrieve_results_does_not_forward_tracker_key_to_legacy_named_custom_service(
         self,
         monkeypatch: MonkeyPatch,
@@ -1531,6 +1575,27 @@ class TestTrackerAPI:
         response_json = response.json()
         assert response_json.get("total_count") == 1
         assert response_json["benchmarks"][0]["error_message"] == "Dominant task error"
+
+    async def test_start_benchmark_blocks_external_internal_custom_destination(
+        self,
+        contract: AgentContractRequest,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(main_module, "AUTH_REQUIRED", True)
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=5,
+            task_ids=None,
+            harness_config=harness_config,
+            custom_benchmark_service="http://10.0.0.1:8001",
+        )
+
+        response = client.post("/start-benchmark", json=request.model_dump())
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Custom benchmark destination is not allowed"}
 
     async def test_start_benchmark_accepts_custom_service_from_request(
         self,

--- a/services/tracker/tests/unit/test_outbound_security.py
+++ b/services/tracker/tests/unit/test_outbound_security.py
@@ -134,6 +134,10 @@ class TestCustomServiceDestinationPolicy:
             "http://service.local:8001",
             "http://service.internal:8001",
             "http://127.0.0.1:8001",
+            "http://127。0。0。1:8001",
+            "http://127．0．0．1:8001",
+            "http://127｡0｡0｡1:8001",
+            "http://localhost。:8001",
             "http://127.1:8001",
             "http://2130706433:8001",
             "http://0x7f000001:8001",
@@ -158,6 +162,7 @@ class TestCustomServiceDestinationPolicy:
         "service_url",
         [
             "http://team.example",
+            "http://team。example",
             "https://evilvals.ai",
             "https://vals.ai.evil.com",
         ],

--- a/services/tracker/tests/unit/test_outbound_security.py
+++ b/services/tracker/tests/unit/test_outbound_security.py
@@ -12,6 +12,7 @@ from tracker.config import (
     create_benchmark_service_url,
 )
 from tracker.database.models import AgentContractRequest
+from tracker.outbound_security import validate_custom_service_destination
 from tracker.types import (
     BenchmarkServiceEntry,
     FetchBenchmarkTasksRequest,
@@ -116,6 +117,71 @@ class TestBenchmarkServiceDestination:
         assert (
             classify_benchmark_service_destination("swebench", "http://swebench.local")
             is BenchmarkServiceDestination.HOSTED
+        )
+
+
+class TestCustomServiceDestinationPolicy:
+    """Tenant-aware authorization for caller-supplied benchmark destinations."""
+
+    @pytest.mark.parametrize(
+        "service_url",
+        [
+            "https://vals.ai",
+            "https://benchmarks-dev.vals.ai",
+            "http://localhost:8001",
+            "http://local:8001",
+            "http://internal:8001",
+            "http://service.local:8001",
+            "http://service.internal:8001",
+            "http://127.0.0.1:8001",
+            "http://127.1:8001",
+            "http://2130706433:8001",
+            "http://0x7f000001:8001",
+            "http://0177.0.0.1:8001",
+            "http://10.0.0.1:8001",
+            "http://100.64.0.1:8001",
+            "http://169.254.1.1:8001",
+            "http://224.0.0.1:8001",
+            "http://0.0.0.0:8001",
+            "http://[::1]:8001",
+        ],
+    )
+    def test_external_tenant_rejects_internal_destination(self, service_url: str) -> None:
+        with pytest.raises(ValueError, match="Custom benchmark destination is not allowed"):
+            validate_custom_service_destination(
+                service_url,
+                org_name="external-tenant",
+                auth_required=True,
+            )
+
+    @pytest.mark.parametrize(
+        "service_url",
+        [
+            "http://team.example",
+            "https://evilvals.ai",
+            "https://vals.ai.evil.com",
+        ],
+    )
+    def test_external_tenant_allows_public_destination(self, service_url: str) -> None:
+        validate_custom_service_destination(
+            service_url,
+            org_name="external-tenant",
+            auth_required=True,
+        )
+
+    @pytest.mark.parametrize(
+        ("org_name", "auth_required"),
+        [("vals.ai", True), ("default", False)],
+    )
+    def test_trusted_caller_keeps_internal_destination_access(
+        self,
+        org_name: str,
+        auth_required: bool,
+    ) -> None:
+        validate_custom_service_destination(
+            "http://service.internal:8001",
+            org_name=org_name,
+            auth_required=auth_required,
         )
 
 

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -19,6 +19,7 @@ from websockets.frames import Close
 from websockets.http11 import Response
 
 import tracker.sandbox as sandbox_module
+import tracker.utils.run_orchestration as run_orchestration_module
 import tracker.utils.task_execution as utils_module
 from tests.unit.utils.task_execution_support import TEST_ORG, create_task_environment, run_process_task
 from tracker.database.models import AgentContractRequest, BenchmarkStatus, ErrorResult, Task, TaskStatus
@@ -291,6 +292,33 @@ class TestBenchmarkServiceFailures:
         assert task_row.status == TaskStatus.ERROR
         assert self._latest_task_error(database_session, task_row) == "ConnectTimeout"
         assert any("[ERROR] ConnectTimeout" in message for message in logged_messages)
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_process_benchmark_blocks_external_internal_custom_destination(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        executor_authority_kwargs: Any,
+    ) -> None:
+        start_benchmark_request, _task_row, benchmark_id, _authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        start_benchmark_request = start_benchmark_request.model_copy(
+            update={"custom_benchmark_service": "http://service.internal:8001"}
+        )
+        benchmark_row = fetch_benchmark_row(benchmark_id, database_session, TEST_ORG)
+        authority_kwargs = executor_authority_kwargs(benchmark_row)
+        monkeypatch.setattr(run_orchestration_module, "AUTH_REQUIRED", True)
+
+        with pytest.raises(ValueError, match="Custom benchmark destination is not allowed"):
+            await process_benchmark(
+                start_benchmark_request_json=start_benchmark_request.model_dump(),
+                benchmark_id_str=str(benchmark_id),
+                verified_task_ids=["task_0"],
+                **authority_kwargs,
+            )
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_benchmark_service_error_in_process_benchmark(

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -300,25 +300,32 @@ class TestBenchmarkServiceFailures:
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
         harness_config: HarnessConfig,
-        executor_authority_kwargs: Any,
     ) -> None:
-        start_benchmark_request, _task_row, benchmark_id, _authority = create_task_environment(
+        start_benchmark_request, _task_row, benchmark_id, authority = create_task_environment(
             contract, database_session, harness_config
         )
         start_benchmark_request = start_benchmark_request.model_copy(
             update={"custom_benchmark_service": "http://service.internal:8001"}
         )
-        benchmark_row = fetch_benchmark_row(benchmark_id, database_session, TEST_ORG)
-        authority_kwargs = executor_authority_kwargs(benchmark_row)
         monkeypatch.setattr(run_orchestration_module, "AUTH_REQUIRED", True)
+        monkeypatch.setattr(
+            run_orchestration_module,
+            "fetch_sandbox_provider_config",
+            lambda *_args, **_kwargs: pytest.fail("sandbox config resolved before destination validation"),
+        )
 
-        with pytest.raises(ValueError, match="Custom benchmark destination is not allowed"):
-            await process_benchmark(
-                start_benchmark_request_json=start_benchmark_request.model_dump(),
-                benchmark_id_str=str(benchmark_id),
-                verified_task_ids=["task_0"],
-                **authority_kwargs,
-            )
+        await process_benchmark(
+            start_benchmark_request_json=start_benchmark_request.model_dump(),
+            benchmark_id_str=str(benchmark_id),
+            verified_task_ids=["task_0"],
+            executor_dispatch_id=str(authority.dispatch_id),
+        )
+
+        with Session(bind=database_session.bind) as session:
+            benchmark_row = fetch_benchmark_row(benchmark_id, session, TEST_ORG)
+            assert benchmark_row.status == BenchmarkStatus.ERROR
+            assert benchmark_row.error_message is not None
+            assert "Custom benchmark destination is not allowed" in benchmark_row.error_message
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_benchmark_service_error_in_process_benchmark(

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -24,7 +24,9 @@ from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 from sqlmodel import Session, select
 
+import main as main_module
 from main import app
+import tracker.utils as tracker_utils
 from tests.factories import make_benchmark, make_error_result, make_evaluation_result
 from tests.unit.utils.task_execution_support import MockKicker, make_retrieve_task_response
 from tests.utils import TEST_ORG_ID, async_iterator
@@ -1098,6 +1100,27 @@ class TestRunRecovery:
         assert task_row.status == TaskStatus.STOPPED
         assert evaluations == []
 
+    async def test_retry_or_resume_blocks_external_persisted_internal_destination(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        benchmark_row.custom_benchmark_service = "https://benchmarks-dev.vals.ai"
+        database_session.add(benchmark_row)
+        database_session.commit()
+        monkeypatch.setattr(main_module, "AUTH_REQUIRED", True)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            json={"task_ids": [], "service_headers": {}},
+        )
+
+        assert response.status_code == 403
+        assert response.json() == {"detail": "Custom benchmark destination is not allowed"}
+
     async def test_retry_or_resume_forwards_tracker_api_key_to_benchmark_service(
         self,
         example_benchmark_object: Benchmark,
@@ -1303,6 +1326,14 @@ class TestRunRecovery:
         database_session.commit()
         verified_urls: list[str] = []
         verified_headers: list[dict[str, str]] = []
+        create_benchmark_service_client = tracker_utils.create_benchmark_service_client
+
+        def _create_benchmark_service_client(
+            url: str,
+            service_headers: dict[str, str] | None = None,
+        ) -> BenchmarkServiceClient:
+            verified_urls.append(url)
+            return create_benchmark_service_client(url, service_headers)
 
         async def _verify_task_ids(
             benchmark_service: BenchmarkServiceClient,
@@ -1311,11 +1342,11 @@ class TestRunRecovery:
             slice_str: str | None,
             dataset: str | None,
         ) -> VerifyTaskIdsResponse:
-            verified_urls.append(benchmark_service._url)
             verified_headers.append(dict(getattr(benchmark_service, "_headers")))
 
             return VerifyTaskIdsResponse(task_ids=task_ids)
 
+        monkeypatch.setattr(tracker_utils, "create_benchmark_service_client", _create_benchmark_service_client)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_task_ids)
 
         invalid_response = client.post(


### PR DESCRIPTION
## What changed

Tracker now checks caller-provided benchmark service destinations before it makes an outbound request.

For external hosted tenants, Tracker rejects custom destinations that point to:

- `vals.ai` or a real `vals.ai` subdomain
- local or internal hostnames
- non-public literal IP addresses, including alternate forms such as `127.1`

Public custom services still work. Canonical benchmark services, the `vals.ai` tenant, and self-hosted Tracker behavior are unchanged.

## Why

### Before

An external tenant could provide a custom benchmark service URL and Tracker would reuse it across the run lifecycle. A URL such as `http://10.0.0.1:8001` or `https://benchmarks-dev.vals.ai` could reach destinations that should only be available to trusted Vals workflows.

### After

Tracker rejects restricted custom destinations before creating or using the benchmark service client. The same policy applies when the URL comes directly from a request or from a previously persisted run.

## Affected flows

| Flow | Outcome after this change |
| --- | --- |
| Start benchmark | Rejects a restricted custom destination before the run starts |
| Fetch benchmark tasks | Rejects a restricted custom destination before task discovery |
| Retry or resume | Checks both a replacement URL and the URL already stored on the run |
| Retrieve and rescore results | Checks the persisted custom destination before contacting it |
| Executor processing | Rechecks the queued request before the worker creates the client |
| Service health checks | Rejects local and non-public destinations before probing them |

The health-check endpoint intentionally allows public Vals catalog URLs. Its request contains both official catalog entries and custom entries, so it cannot distinguish their provenance. Actual benchmark-use flows still reject custom `vals.ai` destinations for external tenants.

## Concrete examples

For an external hosted tenant:

| Destination | Outcome |
| --- | --- |
| `https://benchmarks-dev.vals.ai` | Rejected on benchmark-use flows |
| `http://10.0.0.1:8001` | Rejected |
| `http://127.1:8001` | Rejected as loopback |
| `https://team.example` | Allowed |
| No custom URL | Canonical service resolution remains unchanged |

For the `vals.ai` tenant or self-hosted Tracker, existing internal-service workflows remain unchanged.

## Implementation

Start with `services/tracker/src/tracker/outbound_security.py`. It owns the shared destination policy.

The remaining source changes apply that policy at the HTTP routes and executor boundary:

- `services/tracker/main.py`
- `services/tracker/src/tracker/api/benchmark_services.py`
- `services/tracker/src/tracker/utils/run_orchestration.py`

This policy is separate from benchmark-service credential forwarding.

## How tested

- `236 passed` across the focused Tracker policy, route, recovery, and executor tests
- Ruff formatting and lint passed
- LSP diagnostics: 9/9 changed files clean
- `git diff --check` passed
- Independent correctness, security, and code-quality reviews passed

No live production request was made. The outbound calls are covered with route-level tests and mocked HTTP transports.

## Known exclusions

This change does not add DNS pinning or redirect destination validation. DNS rebinding and redirects remain outside this PR's scope.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->