### PR TITLE
fix: make terminal run results artifact-durable

### DIFF
--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -80,7 +80,7 @@ def handle_s3_error(message: str) -> Callable[[Callable[_P, Awaitable[_R]]], Cal
 
 @logfire.instrument("upload_to_s3", extract_args=("s3_key", "s3_bucket"))
 @handle_s3_error(message="Failed to upload to S3")
-async def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> None:
+async def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", s3_bucket: str) -> str:
     """
     Upload file content to S3.
 
@@ -94,7 +94,33 @@ async def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", 
         S3Error: If upload fails due to AWS errors or network issues
     """
     async with s3_client(aws) as client:
-        await client.put_object(Bucket=s3_bucket, Key=s3_key, Body=file_content)
+        response = await client.put_object(Bucket=s3_bucket, Key=s3_key, Body=file_content)
+
+    etag = response.get("ETag")
+    if not isinstance(etag, str) or not etag:
+        raise S3Error("S3 upload response did not include an ETag")
+
+    return etag
+
+
+@logfire.instrument("verify_s3_object", extract_args=("s3_key", "s3_bucket"))
+@handle_s3_error(message="Failed to verify S3 object")
+async def verify_s3_object(
+    s3_key: str,
+    aws: "AWSCredentials",
+    s3_bucket: str,
+    *,
+    expected_size: int,
+    expected_etag: str,
+) -> None:
+    """Verify that an uploaded object is durably readable with the expected identity."""
+    async with s3_client(aws) as client:
+        response = await client.head_object(Bucket=s3_bucket, Key=s3_key)
+
+    content_length = response.get("ContentLength")
+    etag = response.get("ETag")
+    if content_length != expected_size or etag != expected_etag:
+        raise S3Error(f"S3 object verification failed for {s3_key}: expected size and ETag did not match")
 
 
 @logfire.instrument("upload_stream_to_s3", extract_args=("s3_key", "s3_bucket"))

--- a/services/tracker/src/tracker/utils/reporting.py
+++ b/services/tracker/src/tracker/utils/reporting.py
@@ -20,6 +20,7 @@ from tracker.aws.s3 import (
     S3_BENCHMARKS_PREFIX,
     create_benchmark_url,
     upload_to_s3,
+    verify_s3_object,
 )
 from tracker.database.models import (
     Benchmark,
@@ -559,11 +560,19 @@ async def upload_final_view(
 ) -> str:
     """Uploads the final view to the root of the benchmark folder and returns the s3 key"""
     s3_key = f"{S3_BENCHMARKS_PREFIX}/{benchmark_row.id}/{benchmark_row.name}.json"
-    await upload_to_s3(
-        final_view.model_dump_json(indent=4, exclude_none=True).encode(),
+    content = final_view.model_dump_json(indent=4, exclude_none=True).encode()
+    etag = await upload_to_s3(
+        content,
         s3_key,
         harness_config.aws,
         harness_config.s3_bucket,
+    )
+    await verify_s3_object(
+        s3_key,
+        harness_config.aws,
+        harness_config.s3_bucket,
+        expected_size=len(content),
+        expected_etag=etag,
     )
 
     return s3_key

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -3,6 +3,7 @@
 import asyncio
 import traceback
 from asyncio import Semaphore, gather
+from datetime import UTC, datetime
 from typing import Any, Sequence, cast
 from uuid import UUID
 
@@ -449,15 +450,14 @@ async def process_benchmark(
                 session.flush()
 
             session.add(final_evaluation_row)
-            # Commit the final score and terminal status together while retry/resume is blocked.
-            set_benchmark_final_status(benchmark_row, session, org, authority=authority)
-
-            # Recheck dispatch authority after the status commit without holding the
-            # Retry admission lock across external operations.
-            lock_execution_authority(session, authority, require_in_progress=False)
-            session.commit()
-
-            final_view: FinalViewResponse = create_final_view(benchmark_row, session, org)
+            session.flush()
+            benchmark_row.final_evaluation = final_evaluation_row
+            final_view: FinalViewResponse = create_final_view(benchmark_row, session, org).model_copy(
+                update={
+                    "status": BenchmarkStatus.FINISHED,
+                    "finished_at": datetime.now(UTC),
+                }
+            )
             final_view_benchmark = benchmark_row
             lambda_function = benchmark_row.arguments.lambda_function
             lambda_payload: dict[str, Any] | None = None
@@ -465,6 +465,10 @@ async def process_benchmark(
                 lambda_payload = benchmark_row.arguments.model_dump()
                 lambda_payload["benchmark_id"] = str(benchmark_id)
                 lambda_payload["benchmark_name"] = benchmark_row.name
+
+            # Persist the score before the external upload, but keep the run non-terminal
+            # until its canonical result is durable.
+            session.commit()
 
         await upload_final_view_if_current(
             final_view_benchmark,
@@ -476,12 +480,11 @@ async def process_benchmark(
         # A Retry may win while the upload is in flight. Do not emit follow-on
         # callbacks for an execution that no longer owns the run.
         with Session(bind=engine) as authority_session:
-            lock_execution_authority(
-                authority_session,
-                authority,
-                require_in_progress=False,
-            )
-            authority_session.commit()
+            benchmark_row = fetch_benchmark_row(benchmark_id, authority_session, org, for_update=True)
+            if has_runnable_tasks(authority_session, benchmark_row, org):
+                finalization_deferred = True
+                return
+            set_benchmark_final_status(benchmark_row, authority_session, org, authority=authority)
 
         if lambda_function and lambda_payload is not None:
             invoke_lambda(lambda_client(harness_config.aws), lambda_function, lambda_payload)

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -52,6 +52,95 @@ from tracker.utils.task_execution import TaskMonitor
 class TestRunFinalization:
     """Run finalization and concurrent retry behavior."""
 
+    async def test_run_is_only_finished_after_canonical_result_upload(
+        self,
+        postgres_engine: Engine,
+        postgres_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        executor_authority_kwargs: Any,
+    ) -> None:
+        org = Org(id=uuid4(), name=f"durable-finalization-{uuid4()}")
+        contract = AgentContractRequest(name="durable-agent", install_cmd="true", run_cmd="true")
+        benchmark = make_benchmark(
+            name="durable-finalization",
+            org_id=org.id,
+            contract=contract,
+            status=BenchmarkStatus.IN_PROGRESS,
+        )
+        task = make_task(benchmark, "finished-task", status=TaskStatus.FINISHED)
+        postgres_session.add(org)
+        postgres_session.flush()
+        postgres_session.add(benchmark)
+        postgres_session.flush()
+        postgres_session.add(task)
+        postgres_session.flush()
+        postgres_session.add(
+            EvaluationResult(
+                org_id=org.id,
+                task=task.id,
+                instance_id=f"durable-{task.id}",
+                result={"score": 1.0},
+            )
+        )
+        postgres_session.commit()
+
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name=benchmark.name,
+            concurrency=1,
+            harness_config=harness_config,
+        )
+        statuses_during_upload: list[BenchmarkStatus] = []
+
+        async def record_upload(
+            _benchmark: Benchmark,
+            final_view: Any,
+            _harness_config: HarnessConfig,
+        ) -> None:
+            with Session(postgres_engine) as upload_session:
+                persisted_benchmark = upload_session.get_one(Benchmark, benchmark.id)
+                statuses_during_upload.append(persisted_benchmark.status)
+
+            assert final_view.status is BenchmarkStatus.FINISHED
+
+        async def final_score(*_args: Any, **_kwargs: Any) -> FinalScoreResponse:
+            return FinalScoreResponse(tasks_evaluated=[task.task_id], final_score=1.0, metadata={})
+
+        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
+            return "test-log-group"
+
+        def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
+            return DaytonaProviderConfig(
+                DAYTONA_API_KEY="test-key",
+                DAYTONA_API_URL="https://example.com",
+                DAYTONA_TARGET="test-target",
+            )
+
+        monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
+        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
+        monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
+        monkeypatch.setattr(run_orchestration_module, "upload_final_view", record_upload)
+        monkeypatch.setattr(BenchmarkServiceClient, "final_score", final_score)
+
+        authority_kwargs = executor_authority_kwargs(benchmark, session=postgres_session)
+        assert benchmark.current_execution_release_id is not None
+        promote_release(postgres_session, benchmark.current_execution_release_id)
+        postgres_session.commit()
+
+        await process_benchmark(
+            start_benchmark_request_json=request.model_dump(),
+            benchmark_id_str=str(benchmark.id),
+            verified_task_ids=[],
+            **authority_kwargs,
+        )
+
+        with Session(postgres_engine) as assertion_session:
+            persisted_benchmark = assertion_session.get_one(Benchmark, benchmark.id)
+
+        assert statuses_during_upload == [BenchmarkStatus.IN_PROGRESS]
+        assert persisted_benchmark.status is BenchmarkStatus.FINISHED
+
     async def test_all_error_finalization_honors_concurrent_status_changes(
         self,
         postgres_engine: Engine,

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -69,7 +69,10 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     def _mock_get_contract_s3_key(contract_name: str) -> str:
         return f"contracts/{contract_name}.zip"
 
-    async def _mock_upload_to_s3(*_args: Any, **_kwargs: Any) -> None:
+    async def _mock_upload_to_s3(*_args: Any, **_kwargs: Any) -> str:
+        return '"mock-etag"'
+
+    async def _mock_verify_s3_object(*_args: Any, **_kwargs: Any) -> None:
         return None
 
     async def _mock_copy_agent_to_benchmark(*_args: Any, **_kwargs: Any) -> bool:
@@ -78,6 +81,7 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("tracker.aws.s3.download_from_s3", _mock_download_from_s3)
     monkeypatch.setattr("tracker.aws.s3.get_contract_s3_key", _mock_get_contract_s3_key)
     monkeypatch.setattr("tracker.utils.reporting.upload_to_s3", _mock_upload_to_s3)
+    monkeypatch.setattr("tracker.utils.reporting.verify_s3_object", _mock_verify_s3_object)
     monkeypatch.setattr("main.copy_agent_to_benchmark", _mock_copy_agent_to_benchmark)
 
 

--- a/services/tracker/tests/unit/utils/test_reporting_uploads.py
+++ b/services/tracker/tests/unit/utils/test_reporting_uploads.py
@@ -1,0 +1,48 @@
+from typing import Any, cast
+from uuid import uuid4
+
+import pytest
+
+import tracker.utils.reporting as reporting_module
+from tracker.database.models import Benchmark
+from tracker.types import FinalViewResponse, HarnessConfig
+
+
+class _SerializableFinalView:
+    def model_dump_json(self, **_kwargs: object) -> str:
+        return '{"status":"FINISHED"}'
+
+
+@pytest.mark.asyncio
+async def test_final_view_upload_is_verified_before_returning(
+    harness_config: HarnessConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    benchmark_id = uuid4()
+    benchmark = cast(Benchmark, type("BenchmarkStub", (), {"id": benchmark_id, "name": "valsmith"})())
+    final_view = cast(FinalViewResponse, _SerializableFinalView())
+    uploaded: list[tuple[bytes, str]] = []
+    verified: list[tuple[str, str, int, str]] = []
+
+    async def upload(content: bytes, key: str, *_args: Any) -> str:
+        uploaded.append((content, key))
+        return '"uploaded-etag"'
+
+    async def verify(
+        key: str,
+        _aws: object,
+        bucket: str,
+        *,
+        expected_size: int,
+        expected_etag: str,
+    ) -> None:
+        verified.append((bucket, key, expected_size, expected_etag))
+
+    monkeypatch.setattr(reporting_module, "upload_to_s3", upload)
+    monkeypatch.setattr(reporting_module, "verify_s3_object", verify, raising=False)
+
+    key = await reporting_module.upload_final_view(benchmark, final_view, harness_config)
+
+    expected_content = b'{"status":"FINISHED"}'
+    assert uploaded == [(expected_content, key)]
+    assert verified == [(harness_config.s3_bucket, key, len(expected_content), '"uploaded-etag"')]


### PR DESCRIPTION
## Summary
Make run finalization durable: a canonical final result is uploaded and verified in S3 before the benchmark run is marked FINISHED or the downstream Lambda is invoked. This closes the ordering hole that left completed Valkyrie work unavailable to ValSmith.

## Changes
- Serialize the terminal result once and upload that exact canonical view
- Verify object length and ETag with S3 HEAD before committing terminal state
- Keep the benchmark IN_PROGRESS until artifact durability is confirmed
- Invoke the completion Lambda only after the terminal database commit
- Add unit and database integration coverage for the ordering invariant

## Related Issues
No linked issue.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Tracker: 616 passed, 1 warning. Root format check and strict type checking pass.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/680" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->