### PR TITLE
fix: contain Redis access and retention

### DIFF
--- a/infra/app.py
+++ b/infra/app.py
@@ -50,6 +50,7 @@ tracker = TrackerStack(
     hosted_zone=shared.hosted_zone,
     bucket_name=shared.bucket_name,
     redis_url=shared.redis_url,
+    redis_security_group=shared.redis_security_group,
     tracker_repository=tracker_repository,
     image_tag=release_test_image_tag,
     env=env,
@@ -91,6 +92,7 @@ if stage.is_release_test:
         db_port=tracker.database.db_instance_endpoint_port,
         db_credentials=cast(aws_secretsmanager.ISecret, tracker.db_credentials),
         redis_url=shared.redis_url,
+        redis_security_group=shared.redis_security_group,
         env=env,
     )
     driver.add_dependency(tracker)

--- a/infra/driver_stack.py
+++ b/infra/driver_stack.py
@@ -63,6 +63,7 @@ class DriverStack(Stack):
         db_port: str,
         db_credentials: aws_secretsmanager.ISecret,
         redis_url: str,
+        redis_security_group: aws_ec2.ISecurityGroup,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, id, **kwargs)
@@ -103,6 +104,16 @@ class DriverStack(Stack):
             security_group_name=stage.phys("PackageRDriver"),
             description="No-ingress security group for the release-test Package R driver",
             allow_all_outbound=False,
+        )
+        aws_ec2.CfnSecurityGroupIngress(
+            self,
+            "DriverToRedisIngress",
+            group_id=redis_security_group.security_group_id,
+            source_security_group_id=self.security_group.security_group_id,
+            ip_protocol="tcp",
+            from_port=REDIS_PORT,
+            to_port=REDIS_PORT,
+            description="Allow release-test Driver to connect to Redis",
         )
         self.security_group.add_egress_rule(
             aws_ec2.Peer.ipv4(VPC_CIDR),

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -31,6 +31,7 @@ from constants import (
     EXECUTOR_RELEASE_PREFIX,
     EXECUTOR_RELEASE_ROLE_NAME,
     POSTGRES_DB,
+    POSTGRES_PORT,
     SANDBOX_CLEANUP_DLQ_NAME,
     SANDBOX_CLEANUP_FUNCTION_NAME,
     SANDBOX_CLEANUP_LOG_GROUP_NAME,
@@ -39,6 +40,7 @@ from constants import (
     WORKER_LOG_GROUP_NAME,
     WORKER_SCALING_CPU_PERCENT,
     WORKER_STOP_TIMEOUT_SECONDS,
+    VPC_CIDR,
     executor_release_launch_parameter,
 )
 from constructs import Construct
@@ -319,6 +321,34 @@ class ExecutorStack(Stack):
         database: aws_rds.DatabaseInstance,
         db_secret: aws_secretsmanager.ISecret,
     ) -> None:
+        control_security_group = aws_ec2.SecurityGroup(
+            self,
+            "ExecutorReleaseSecurityGroup",
+            vpc=vpc,
+            description="No-ingress security group for executor-release control tasks",
+            allow_all_outbound=False,
+        )
+        control_security_group.add_egress_rule(
+            aws_ec2.Peer.ipv4(VPC_CIDR),
+            aws_ec2.Port.tcp(POSTGRES_PORT),
+            "Tracker PostgreSQL",
+        )
+        control_security_group.add_egress_rule(
+            aws_ec2.Peer.ipv4(VPC_CIDR),
+            aws_ec2.Port.udp(53),
+            "VPC DNS UDP",
+        )
+        control_security_group.add_egress_rule(
+            aws_ec2.Peer.ipv4(VPC_CIDR),
+            aws_ec2.Port.tcp(53),
+            "VPC DNS TCP",
+        )
+        control_security_group.add_egress_rule(
+            aws_ec2.Peer.any_ipv4(),
+            aws_ec2.Port.tcp(443),
+            "AWS API endpoints",
+        )
+
         task_role = aws_iam.Role(
             self,
             "ExecutorReleaseTaskRole",
@@ -415,7 +445,6 @@ class ExecutorStack(Stack):
             ),
         )
 
-        tracker_security_group = tracker_service.connections.security_groups[0]
         launch_parameter = aws_ssm.StringParameter(
             self,
             "ExecutorReleaseLaunchConfig",
@@ -426,7 +455,7 @@ class ExecutorStack(Stack):
                     "cluster": cluster.cluster_arn,
                     "container": container_name,
                     "prefix": EXECUTOR_RELEASE_PREFIX,
-                    "security_group": tracker_security_group.security_group_id,
+                    "security_group": control_security_group.security_group_id,
                     "subnets": vpc.select_subnets(subnet_type=aws_ec2.SubnetType.PUBLIC).subnet_ids,
                     "task_definition": task_definition.task_definition_arn,
                 }

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -33,11 +33,9 @@ from constants import (
     DEV_SHARED_VPC_ID_PARAMETER,
     ELASTICACHE_NODE_TYPE,
     NAMESPACE,
-    REDIS_PORT,
     RELEASE_TEST_EXECUTOR_HOST_REPOSITORY_NAME,
     RELEASE_TEST_TRACKER_REPOSITORY_NAME,
     S3_BUCKET_NAME,
-    VPC_CIDR,
     stage_parameter_name,
     VPC_MAX_AZS,
     VPC_NAT_GATEWAYS,
@@ -154,18 +152,12 @@ class SharedStack(Stack):
         # Single-node Redis used as the Taskiq message broker, shared by
         # Tracker (producer) and ExecutorHost (consumer).
 
-        redis_sg = aws_ec2.SecurityGroup(
+        self.redis_security_group = aws_ec2.SecurityGroup(
             self,
             "RedisSG",
             vpc=self.vpc,
             description="Security group for ElastiCache Redis",
             allow_all_outbound=False,
-        )
-
-        redis_sg.add_ingress_rule(
-            peer=aws_ec2.Peer.ipv4(VPC_CIDR),
-            connection=aws_ec2.Port.tcp(REDIS_PORT),
-            description="Allow VPC services to connect to Redis",
         )
 
         redis_subnet_group = aws_elasticache.CfnSubnetGroup(
@@ -182,7 +174,7 @@ class SharedStack(Stack):
             engine="redis",
             engine_version="7.1",
             num_cache_nodes=1,
-            vpc_security_group_ids=[redis_sg.security_group_id],
+            vpc_security_group_ids=[self.redis_security_group.security_group_id],
             cache_subnet_group_name=redis_subnet_group.ref,
         )
 

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -97,6 +97,7 @@ def dev_service_templates() -> tuple[assertions.Template, assertions.Template]:
         hosted_zone=shared.hosted_zone,
         bucket_name=shared.bucket_name,
         redis_url=shared.redis_url,
+        redis_security_group=shared.redis_security_group,
         env=TEST_ENV,
     )
     executor = ExecutorStack(

--- a/infra/tests/test_driver_stack.py
+++ b/infra/tests/test_driver_stack.py
@@ -41,6 +41,7 @@ def driver_template() -> Iterator[assertions.Template]:
         bucket = aws_s3.Bucket(dependencies, "Bucket")
         tracker_repository = aws_ecr.Repository(dependencies, "TrackerRepository")
         db_credentials = aws_secretsmanager.Secret(dependencies, "DbCredentials")
+        redis_security_group = aws_ec2.SecurityGroup(dependencies, "RedisSecurityGroup", vpc=vpc)
         stage = Stage(RELEASE_TEST)
         stack = DriverStack(
             app,
@@ -55,6 +56,7 @@ def driver_template() -> Iterator[assertions.Template]:
             db_port="5432",
             db_credentials=cast(aws_secretsmanager.ISecret, db_credentials),
             redis_url="redis://redis.internal:6379",
+            redis_security_group=redis_security_group,
             env=TEST_ENV,
         )
         yield assertions.Template.from_stack(stack)
@@ -79,6 +81,7 @@ class DriverStackTest(unittest.TestCase):
             bucket = aws_s3.Bucket(dependencies, "Bucket")
             tracker_repository = aws_ecr.Repository(dependencies, "TrackerRepository")
             db_credentials = aws_secretsmanager.Secret(dependencies, "DbCredentials")
+            redis_security_group = aws_ec2.SecurityGroup(dependencies, "RedisSecurityGroup", vpc=vpc)
 
             with self.assertRaisesRegex(ValueError, "release-test"):
                 DriverStack(
@@ -94,15 +97,43 @@ class DriverStackTest(unittest.TestCase):
                     db_port="5432",
                     db_credentials=cast(aws_secretsmanager.ISecret, db_credentials),
                     redis_url="redis://redis.internal:6379",
+                    redis_security_group=redis_security_group,
                     env=TEST_ENV,
                 )
 
-    def test_driver_is_one_task_definition_with_no_service_or_ingress(self) -> None:
+    def test_driver_is_one_task_definition_with_source_sg_redis_ingress(self) -> None:
         with driver_template() as template:
             template.resource_count_is("AWS::ECS::TaskDefinition", 1)
             template.resource_count_is("AWS::ECS::Service", 0)
             template.resource_count_is("AWS::EC2::SecurityGroup", 1)
-            template.resource_count_is("AWS::EC2::SecurityGroupIngress", 0)
+            driver_security_group_id = next(
+                logical_id
+                for logical_id, resource in template.find_resources("AWS::EC2::SecurityGroup").items()
+                if resource["Properties"]["GroupDescription"]
+                == "No-ingress security group for the release-test Package R driver"
+            )
+            redis_ingress = [
+                resource["Properties"]
+                for resource in template.find_resources("AWS::EC2::SecurityGroupIngress").values()
+                if resource["Properties"].get("FromPort") == 6379 or resource["Properties"].get("ToPort") == 6379
+            ]
+            self.assertEqual(len(redis_ingress), 1)
+            ingress = redis_ingress[0]
+            self.assertEqual(
+                {key: ingress[key] for key in ("Description", "FromPort", "IpProtocol", "ToPort")},
+                {
+                    "Description": "Allow release-test Driver to connect to Redis",
+                    "FromPort": 6379,
+                    "IpProtocol": "tcp",
+                    "ToPort": 6379,
+                },
+            )
+            self.assertNotIn("CidrIp", ingress)
+            self.assertIn("RedisSecurityGroup", ingress["GroupId"]["Fn::ImportValue"])
+            self.assertEqual(
+                ingress["SourceSecurityGroupId"],
+                {"Fn::GetAtt": [driver_security_group_id, "GroupId"]},
+            )
             template.has_resource_properties(
                 "AWS::ECS::TaskDefinition",
                 {

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -174,6 +174,7 @@ def _service_templates(
         hosted_zone=shared.hosted_zone,
         bucket_name=shared.bucket_name,
         redis_url=shared.redis_url,
+        redis_security_group=shared.redis_security_group,
         tracker_repository=tracker_repository,
         image_tag=image_tag,
         env=env,
@@ -269,6 +270,113 @@ class MonitoringStackTest(unittest.TestCase):
             len(release_test_template.find_resources("AWS::ElasticLoadBalancingV2::Listener")),
             1,
         )
+
+    def test_redis_ingress_is_limited_to_tracker_and_executor_host(self) -> None:
+        for stage_name, environment in (
+            (PROD, {}),
+            (DEV, TEST_DEV_ENV),
+            (RELEASE_TEST, {"DESCOPE_PROJECT_ID": "release-test"}),
+        ):
+            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
+                shared_template = _shared_template(stage_name)
+                shared_security_groups = shared_template.find_resources("AWS::EC2::SecurityGroup")
+                redis_security_group = next(
+                    resource
+                    for resource in shared_security_groups.values()
+                    if resource["Properties"]["GroupDescription"] == "Security group for ElastiCache Redis"
+                )
+                self.assertNotIn("SecurityGroupIngress", redis_security_group["Properties"])
+                self.assertFalse(shared_template.find_resources("AWS::EC2::SecurityGroupIngress"))
+
+                tracker_template, executor_template, _ = _service_templates(stage_name)
+                tracker_security_groups = tracker_template.find_resources("AWS::EC2::SecurityGroup")
+                tracker_security_group_id = next(
+                    logical_id
+                    for logical_id, resource in tracker_security_groups.items()
+                    if resource["Properties"]["GroupDescription"].endswith("TrackerService/Service/SecurityGroup")
+                )
+                redis_ingress = [
+                    resource["Properties"]
+                    for resource in tracker_template.find_resources("AWS::EC2::SecurityGroupIngress").values()
+                    if resource["Properties"].get("FromPort") == 6379 or resource["Properties"].get("ToPort") == 6379
+                ]
+                self.assertEqual(len(redis_ingress), 1)
+                ingress = redis_ingress[0]
+                self.assertEqual(
+                    {key: ingress[key] for key in ("Description", "FromPort", "IpProtocol", "ToPort")},
+                    {
+                        "Description": "Allow Tracker and ExecutorHost to connect to Redis",
+                        "FromPort": 6379,
+                        "IpProtocol": "tcp",
+                        "ToPort": 6379,
+                    },
+                )
+                self.assertNotIn("CidrIp", ingress)
+                self.assertIn("RedisSG", ingress["GroupId"]["Fn::ImportValue"])
+                self.assertEqual(
+                    ingress["SourceSecurityGroupId"],
+                    {"Fn::GetAtt": [tracker_security_group_id, "GroupId"]},
+                )
+
+                executor_service = next(iter(executor_template.find_resources("AWS::ECS::Service").values()))
+                executor_security_groups = executor_service["Properties"]["NetworkConfiguration"][
+                    "AwsvpcConfiguration"
+                ]["SecurityGroups"]
+                self.assertEqual(len(executor_security_groups), 1)
+                self.assertIn(tracker_security_group_id, json.dumps(executor_security_groups))
+
+                executor_security_groups_by_id = executor_template.find_resources("AWS::EC2::SecurityGroup")
+                control_security_group_id, control_security_group = next(
+                    (logical_id, resource)
+                    for logical_id, resource in executor_security_groups_by_id.items()
+                    if resource["Properties"]["GroupDescription"]
+                    == "No-ingress security group for executor-release control tasks"
+                )
+                self.assertNotEqual(control_security_group_id, tracker_security_group_id)
+                self.assertNotIn("SecurityGroupIngress", control_security_group["Properties"])
+                self.assertEqual(
+                    control_security_group["Properties"]["SecurityGroupEgress"],
+                    [
+                        {
+                            "CidrIp": "10.0.0.0/16",
+                            "Description": "Tracker PostgreSQL",
+                            "FromPort": 5432,
+                            "IpProtocol": "tcp",
+                            "ToPort": 5432,
+                        },
+                        {
+                            "CidrIp": "10.0.0.0/16",
+                            "Description": "VPC DNS UDP",
+                            "FromPort": 53,
+                            "IpProtocol": "udp",
+                            "ToPort": 53,
+                        },
+                        {
+                            "CidrIp": "10.0.0.0/16",
+                            "Description": "VPC DNS TCP",
+                            "FromPort": 53,
+                            "IpProtocol": "tcp",
+                            "ToPort": 53,
+                        },
+                        {
+                            "CidrIp": "0.0.0.0/0",
+                            "Description": "AWS API endpoints",
+                            "FromPort": 443,
+                            "IpProtocol": "tcp",
+                            "ToPort": 443,
+                        },
+                    ],
+                )
+                self.assertNotIn("6379", json.dumps(control_security_group["Properties"]))
+
+                launch_parameter = next(
+                    resource
+                    for resource in executor_template.find_resources("AWS::SSM::Parameter").values()
+                    if resource["Properties"]["Name"].endswith("/executor-release/launch-config")
+                )
+                launch_config = json.dumps(launch_parameter["Properties"]["Value"])
+                self.assertIn(control_security_group_id, launch_config)
+                self.assertNotIn(tracker_security_group_id, launch_config)
 
     def test_release_test_owns_immutable_service_image_repositories(self) -> None:
         release_template = _shared_template(RELEASE_TEST)

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -273,9 +273,9 @@ class MonitoringStackTest(unittest.TestCase):
 
     def test_redis_ingress_is_limited_to_tracker_and_executor_host(self) -> None:
         for stage_name, environment in (
-            (PROD, {}),
+            (PROD, TEST_PROD_ENV),
             (DEV, TEST_DEV_ENV),
-            (RELEASE_TEST, {"DESCOPE_PROJECT_ID": "release-test"}),
+            (RELEASE_TEST, TEST_RELEASE_TEST_ENV),
         ):
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
                 shared_template = _shared_template(stage_name)

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -36,6 +36,7 @@ from constants import (
     POSTGRES_DB,
     POSTGRES_PORT,
     POSTGRES_USER,
+    REDIS_PORT,
     TRACKER_DOMAIN,
     TRACKER_LOG_GROUP_NAME,
     TRACKER_PORT,
@@ -71,6 +72,7 @@ class TrackerStack(Stack):
         hosted_zone: aws_route53.IHostedZone | None,
         bucket_name: str,
         redis_url: str,
+        redis_security_group: aws_ec2.ISecurityGroup,
         tracker_repository: aws_ecr.IRepository | None = None,
         image_tag: str | None = None,
         **kwargs: Any,
@@ -330,6 +332,18 @@ class TrackerStack(Stack):
 
         # ── Network access ───────────────────────────────────────────────
 
+        tracker_security_group = self.tracker_fargate_service.connections.security_groups[0]
+        aws_ec2.CfnSecurityGroupIngress(
+            self,
+            "TrackerToRedisIngress",
+            group_id=redis_security_group.security_group_id,
+            source_security_group_id=tracker_security_group.security_group_id,
+            ip_protocol="tcp",
+            from_port=REDIS_PORT,
+            to_port=REDIS_PORT,
+            description="Allow Tracker and ExecutorHost to connect to Redis",
+        )
+
         # Allow VPC services (tracker + worker) to reach RDS.
         db_security_group.add_ingress_rule(
             peer=aws_ec2.Peer.ipv4(VPC_CIDR),
@@ -342,7 +356,7 @@ class TrackerStack(Stack):
                 self,
                 "TrackerSecurityGroupParameter",
                 parameter_name=stage_parameter_name(DEV_TRACKER_SECURITY_GROUP_PARAMETER, stage.name),
-                string_value=self.service.service.connections.security_groups[0].security_group_id,
+                string_value=tracker_security_group.security_group_id,
             )
             aws_ssm.StringParameter(
                 self,

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -19,6 +19,7 @@ from typing import Mapping, Protocol, Unpack, cast
 import boto3
 import psycopg2  # pyright: ignore[reportMissingModuleSource]
 from psycopg2.extensions import connection as PostgresConnection  # pyright: ignore[reportMissingModuleSource]
+from redis.asyncio import Redis
 from taskiq_redis import RedisStreamBroker
 from executor_protocol import (
     DEFAULT_EXECUTOR_RELEASE_PREFIX,
@@ -598,11 +599,24 @@ async def _terminate_process_group(process: asyncio.subprocess.Process) -> None:
         await process.wait()
 
 
+class DeleteAfterAckRedisStreamBroker(RedisStreamBroker):
+    """Delete stream entries after Taskiq acknowledges their processing."""
+
+    def _ack_generator(self, id: str, queue_name: str) -> Callable[[], Awaitable[None]]:
+        async def _ack() -> None:
+            async with Redis(connection_pool=self.connection_pool) as redis_conn:
+                acknowledged = await redis_conn.xack(queue_name, self.consumer_group_name, id)
+                if acknowledged == 1:
+                    await redis_conn.xdel(queue_name, id)
+
+        return _ack
+
+
 REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
 QUEUE_NAME = os.environ.get("STABLE_QUEUE_NAME", DEFAULT_STABLE_QUEUE_NAME)
 CACHE_DIR = Path(os.environ.get("EXECUTOR_CACHE_DIR", DEFAULT_CACHE_DIR))
 
-broker = RedisStreamBroker(
+broker = DeleteAfterAckRedisStreamBroker(
     url=REDIS_URL,
     queue_name=QUEUE_NAME,
     consumer_group_name=QUEUE_NAME,

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -39,6 +39,13 @@ _PROTECTION_EXPIRY_MINUTES = 120
 _PROTECTION_REFRESH_SECONDS = 30 * 60
 _PROTECTION_RETRY_SECONDS = 30
 _AUTHORITY_LOSS_GRACE_SECONDS = 10
+_ACK_AND_DELETE_SCRIPT = """
+local acknowledged = redis.call("XACK", KEYS[1], ARGV[1], ARGV[2])
+if acknowledged == 1 then
+    redis.call("XDEL", KEYS[1], ARGV[2])
+end
+return acknowledged
+"""
 _active_execution_count = 0
 _protection_refresh_task: asyncio.Task[None] | None = None
 _execution_lock = asyncio.Lock()
@@ -605,9 +612,13 @@ class DeleteAfterAckRedisStreamBroker(RedisStreamBroker):
     def _ack_generator(self, id: str, queue_name: str) -> Callable[[], Awaitable[None]]:
         async def _ack() -> None:
             async with Redis(connection_pool=self.connection_pool) as redis_conn:
-                acknowledged = await redis_conn.xack(queue_name, self.consumer_group_name, id)
-                if acknowledged == 1:
-                    await redis_conn.xdel(queue_name, id)
+                await redis_conn.eval(
+                    _ACK_AND_DELETE_SCRIPT,
+                    1,
+                    queue_name,
+                    self.consumer_group_name,
+                    id,
+                )
 
         return _ack
 

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -7,6 +7,7 @@ from json import JSONDecodeError
 import logging
 import sys
 from collections.abc import Awaitable, Callable
+from functools import partial
 from pathlib import Path
 from typing import cast
 
@@ -116,6 +117,32 @@ class RecordingConnection:
 
     def cursor(self) -> RecordingCursor:
         return self.recording_cursor
+
+
+class MockRedis:
+    def __init__(
+        self,
+        *,
+        connection_pool: object,
+        commands: list[tuple[object, ...]],
+        eval_result: int | Exception,
+    ) -> None:
+        self.connection_pool = connection_pool
+        self.commands = commands
+        self.eval_result = eval_result
+
+    async def __aenter__(self) -> MockRedis:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def eval(self, script: str, numkeys: int, *keys_and_args: str) -> int:
+        self.commands.append(("eval", script, numkeys, *keys_and_args))
+        if isinstance(self.eval_result, Exception):
+            raise self.eval_result
+
+        return self.eval_result
 
 
 def _dispatch(*, digest: str) -> ArtifactDispatch:
@@ -561,29 +588,13 @@ async def test_broker_payload_dispatch_id_reaches_dispatch_owner(
     assert captured["executor_dispatch_id"] == "dispatch-1"
 
 
-@pytest.mark.asyncio
 async def test_stream_message_is_deleted_only_after_successful_ack(monkeypatch: pytest.MonkeyPatch) -> None:
     commands: list[tuple[object, ...]] = []
-
-    class FakeRedis:
-        def __init__(self, *, connection_pool: object) -> None:
-            assert connection_pool is broker.connection_pool
-
-        async def __aenter__(self) -> FakeRedis:
-            return self
-
-        async def __aexit__(self, *_args: object) -> None:
-            return None
-
-        async def xack(self, stream: str, group: str, message_id: str) -> int:
-            commands.append(("xack", stream, group, message_id))
-            return 1
-
-        async def xdel(self, stream: str, message_id: str) -> int:
-            commands.append(("xdel", stream, message_id))
-            return 1
-
-    monkeypatch.setattr(supervisor_module, "Redis", FakeRedis)
+    monkeypatch.setattr(
+        supervisor_module,
+        "Redis",
+        partial(MockRedis, commands=commands, eval_result=1),
+    )
     broker = DeleteAfterAckRedisStreamBroker(
         url="redis://localhost:6379",
         queue_name="default-stream",
@@ -597,42 +608,33 @@ async def test_stream_message_is_deleted_only_after_successful_ack(monkeypatch: 
 
     await acknowledge()
 
-    assert commands == [
-        ("xack", "selected-stream", "executor-group", "1700000000000-0"),
-        ("xdel", "selected-stream", "1700000000000-0"),
-    ]
+    assert len(commands) == 1
+
+    command = commands[0]
+    assert command[0] == "eval"
+    assert command[2:] == (1, "selected-stream", "executor-group", "1700000000000-0")
+
+    script = cast(str, command[1])
+    assert " ".join(script.split()) == (
+        'local acknowledged = redis.call("XACK", KEYS[1], ARGV[1], ARGV[2]) '
+        "if acknowledged == 1 then "
+        'redis.call("XDEL", KEYS[1], ARGV[2]) '
+        "end return acknowledged"
+    )
     await broker.shutdown()
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("ack_result", [0, RuntimeError("redis unavailable")], ids=["not-acked", "ack-error"])
 async def test_stream_message_is_not_deleted_when_ack_fails(
     monkeypatch: pytest.MonkeyPatch,
     ack_result: int | Exception,
 ) -> None:
     commands: list[tuple[object, ...]] = []
-
-    class FakeRedis:
-        def __init__(self, *, connection_pool: object) -> None:
-            assert connection_pool is broker.connection_pool
-
-        async def __aenter__(self) -> FakeRedis:
-            return self
-
-        async def __aexit__(self, *_args: object) -> None:
-            return None
-
-        async def xack(self, stream: str, group: str, message_id: str) -> int:
-            commands.append(("xack", stream, group, message_id))
-            if isinstance(ack_result, Exception):
-                raise ack_result
-            return ack_result
-
-        async def xdel(self, stream: str, message_id: str) -> int:
-            commands.append(("xdel", stream, message_id))
-            return 1
-
-    monkeypatch.setattr(supervisor_module, "Redis", FakeRedis)
+    monkeypatch.setattr(
+        supervisor_module,
+        "Redis",
+        partial(MockRedis, commands=commands, eval_result=ack_result),
+    )
     broker = DeleteAfterAckRedisStreamBroker(
         url="redis://localhost:6379",
         queue_name="default-stream",
@@ -646,9 +648,10 @@ async def test_stream_message_is_not_deleted_when_ack_fails(
         with pytest.raises(RuntimeError, match="redis unavailable"):
             await acknowledge()
     else:
-        await acknowledge()
+        assert await acknowledge() is None
 
-    assert commands == [("xack", "selected-stream", "executor-group", "1700000000000-0")]
+    assert len(commands) == 1
+    assert commands[0][0] == "eval"
     await broker.shutdown()
 
 

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -17,6 +17,7 @@ from services.executor_host.supervisor import (  # pyright: ignore[reportMissing
     ArtifactDispatch,
     DispatchAuthority,
     DispatchAuthorityLostError,
+    DeleteAfterAckRedisStreamBroker,
     ExecutorSupervisor,
     PostgresExecutorDispatchStore,
     run_executor_dispatch,
@@ -558,6 +559,97 @@ async def test_broker_payload_dispatch_id_reaches_dispatch_owner(
     )
 
     assert captured["executor_dispatch_id"] == "dispatch-1"
+
+
+@pytest.mark.asyncio
+async def test_stream_message_is_deleted_only_after_successful_ack(monkeypatch: pytest.MonkeyPatch) -> None:
+    commands: list[tuple[object, ...]] = []
+
+    class FakeRedis:
+        def __init__(self, *, connection_pool: object) -> None:
+            assert connection_pool is broker.connection_pool
+
+        async def __aenter__(self) -> FakeRedis:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def xack(self, stream: str, group: str, message_id: str) -> int:
+            commands.append(("xack", stream, group, message_id))
+            return 1
+
+        async def xdel(self, stream: str, message_id: str) -> int:
+            commands.append(("xdel", stream, message_id))
+            return 1
+
+    monkeypatch.setattr(supervisor_module, "Redis", FakeRedis)
+    broker = DeleteAfterAckRedisStreamBroker(
+        url="redis://localhost:6379",
+        queue_name="default-stream",
+        consumer_group_name="executor-group",
+    )
+
+    acknowledge = broker._ack_generator(  # pyright: ignore[reportPrivateUsage]
+        id="1700000000000-0", queue_name="selected-stream"
+    )
+    assert commands == []
+
+    await acknowledge()
+
+    assert commands == [
+        ("xack", "selected-stream", "executor-group", "1700000000000-0"),
+        ("xdel", "selected-stream", "1700000000000-0"),
+    ]
+    await broker.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ack_result", [0, RuntimeError("redis unavailable")], ids=["not-acked", "ack-error"])
+async def test_stream_message_is_not_deleted_when_ack_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    ack_result: int | Exception,
+) -> None:
+    commands: list[tuple[object, ...]] = []
+
+    class FakeRedis:
+        def __init__(self, *, connection_pool: object) -> None:
+            assert connection_pool is broker.connection_pool
+
+        async def __aenter__(self) -> FakeRedis:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        async def xack(self, stream: str, group: str, message_id: str) -> int:
+            commands.append(("xack", stream, group, message_id))
+            if isinstance(ack_result, Exception):
+                raise ack_result
+            return ack_result
+
+        async def xdel(self, stream: str, message_id: str) -> int:
+            commands.append(("xdel", stream, message_id))
+            return 1
+
+    monkeypatch.setattr(supervisor_module, "Redis", FakeRedis)
+    broker = DeleteAfterAckRedisStreamBroker(
+        url="redis://localhost:6379",
+        queue_name="default-stream",
+        consumer_group_name="executor-group",
+    )
+    acknowledge = broker._ack_generator(  # pyright: ignore[reportPrivateUsage]
+        id="1700000000000-0", queue_name="selected-stream"
+    )
+
+    if isinstance(ack_result, Exception):
+        with pytest.raises(RuntimeError, match="redis unavailable"):
+            await acknowledge()
+    else:
+        await acknowledge()
+
+    assert commands == [("xack", "selected-stream", "executor-group", "1700000000000-0")]
+    await broker.shutdown()
 
 
 def test_executor_host_uses_one_taskiq_process() -> None:


### PR DESCRIPTION
## Summary

Restrict Valkyrie's Redis access to explicit workload security groups and atomically remove successfully acknowledged ExecutorHost stream entries.

This keeps Redis access for Tracker, ExecutorHost, and the release-test Driver. The separate executor-release control task now uses a dedicated security group without Redis access because it does not receive `REDIS_URL`.

## Changes

- Replace VPC-wide Redis ingress with source-security-group rules for Tracker/ExecutorHost and the release-test Driver.
- Give executor-release control tasks a dedicated no-ingress security group with only PostgreSQL, DNS, and HTTPS egress.
- Use one Redis 7.1-compatible Lua `EVAL` to run `XACK` and conditionally `XDEL` atomically.
- Add focused infrastructure and ExecutorHost regression coverage.

Historical acknowledged stream entries are not migrated or removed by this change; cleanup is prospective.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

Final-head local verification:

- [x] Added/updated unit tests
- [ ] Manually tested
- ExecutorHost tests: 33 passed
- Infrastructure tests: 97 passed
- Ruff format and lint: clean for changed root files and full infra package
- basedpyright: 0 errors in root changed files and full infra package
- `git diff --check`: clean

No deployment or live Redis validation was performed. GitHub CI provides the final remote suite.

## Rollout

This changes `ExecutorStack`, so `maintenance-classification` intentionally requires the repository's authorized force-merge maintenance path. The established maintenance flow stops Tracker and ExecutorHost before stack updates; a normal merge is not expected to pass that sentinel.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed
