### PR TITLE
Fix production live-test CloudWatch access #patch

### DIFF
--- a/infra/shared.py
+++ b/infra/shared.py
@@ -226,7 +226,7 @@ class SharedStack(Stack):
         role.add_to_principal_policy(
             aws_iam.PolicyStatement(
                 actions=["logs:CreateLogStream"],
-                resources=[child_log_group_arn],
+                resources=[child_log_stream_arn],
             )
         )
         role.add_to_principal_policy(

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -12,6 +12,7 @@ from aws_cdk import (
     aws_elasticache,
     aws_events,
     aws_events_targets,
+    aws_iam,
     aws_route53,
     aws_s3,
     aws_servicediscovery,
@@ -53,6 +54,8 @@ DEPLOYMENT_FAILURE_STATUSES = (
     "ROLLBACK_COMPLETE",
     "DELETE_FAILED",
 )
+LIVE_INTEGRATION_TEST_ROLE_NAME = "github-actions-valkyrie-tests"
+LIVE_INTEGRATION_LOG_GROUP_PREFIX = "valkyrie-test-log-group"
 
 
 class SharedStack(Stack):
@@ -61,6 +64,9 @@ class SharedStack(Stack):
     def __init__(self, scope: Construct, id: str, stage: Stage, **kwargs: Any):
         super().__init__(scope, id, **kwargs)
         self.stage = stage
+
+        if self.stage.is_prod:
+            self._grant_live_integration_test_log_access()
 
         # shared VPC - public subnets only, no NAT gateway (cost savings)
         self.vpc = aws_ec2.Vpc(
@@ -190,6 +196,39 @@ class SharedStack(Stack):
 
         if not self.stage.is_prod:
             self._publish_shared_contract()
+
+    def _grant_live_integration_test_log_access(self) -> None:
+        """Allow production integration tests to write only their per-run logs."""
+        role = aws_iam.Role.from_role_name(
+            self,
+            "LiveIntegrationTestRole",
+            LIVE_INTEGRATION_TEST_ROLE_NAME,
+            mutable=True,
+        )
+        child_log_group_arn = self.format_arn(
+            service="logs",
+            resource="log-group",
+            resource_name=f"{LIVE_INTEGRATION_LOG_GROUP_PREFIX}/*",
+            arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
+        )
+        child_log_stream_arn = self.format_arn(
+            service="logs",
+            resource="log-group",
+            resource_name=f"{LIVE_INTEGRATION_LOG_GROUP_PREFIX}/*:log-stream:*",
+            arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
+        )
+        role.add_to_principal_policy(
+            aws_iam.PolicyStatement(
+                actions=["logs:CreateLogGroup", "logs:PutRetentionPolicy"],
+                resources=[child_log_group_arn],
+            )
+        )
+        role.add_to_principal_policy(
+            aws_iam.PolicyStatement(
+                actions=["logs:CreateLogStream", "logs:PutLogEvents"],
+                resources=[child_log_stream_arn],
+            )
+        )
 
     def _publish_shared_contract(self) -> None:
         """Publish the account-local resource contract consumed by benchmark-service stacks."""

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -225,7 +225,13 @@ class SharedStack(Stack):
         )
         role.add_to_principal_policy(
             aws_iam.PolicyStatement(
-                actions=["logs:CreateLogStream", "logs:PutLogEvents"],
+                actions=["logs:CreateLogStream"],
+                resources=[child_log_group_arn],
+            )
+        )
+        role.add_to_principal_policy(
+            aws_iam.PolicyStatement(
+                actions=["logs:PutLogEvents"],
                 resources=[child_log_stream_arn],
             )
         )

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -410,7 +410,26 @@ class DevAccountInfrastructureTest(unittest.TestCase):
                             ),
                             assertions.Match.object_like(
                                 {
-                                    "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                                    "Action": "logs:CreateLogStream",
+                                    "Effect": "Allow",
+                                    "Resource": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:",
+                                                {"Ref": "AWS::Partition"},
+                                                (
+                                                    f":logs:{TEST_REGION}:{TEST_ACCOUNT}:log-group:"
+                                                    "valkyrie-test-log-group/*"
+                                                ),
+                                            ],
+                                        ]
+                                    },
+                                }
+                            ),
+                            assertions.Match.object_like(
+                                {
+                                    "Action": "logs:PutLogEvents",
                                     "Effect": "Allow",
                                     "Resource": {
                                         "Fn::Join": [

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -420,7 +420,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
                                                 {"Ref": "AWS::Partition"},
                                                 (
                                                     f":logs:{TEST_REGION}:{TEST_ACCOUNT}:log-group:"
-                                                    "valkyrie-test-log-group/*"
+                                                    "valkyrie-test-log-group/*:log-stream:*"
                                                 ),
                                             ],
                                         ]

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -376,6 +376,68 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         template = assertions.Template.from_stack(shared)
         self.assertFalse(template.find_resources("AWS::SSM::Parameter"))
 
+    def test_prod_shared_stack_grants_live_tests_scoped_child_log_access(self) -> None:
+        app = cdk.App(context=PROD_CONTEXT)
+        stage = Stage(PROD)
+        shared = SharedStack(app, stage.stack_id("SharedStack"), stage=stage, env=TEST_ENV)
+        template = assertions.Template.from_stack(shared)
+
+        template.has_resource_properties(
+            "AWS::IAM::Policy",
+            {
+                "Roles": ["github-actions-valkyrie-tests"],
+                "PolicyDocument": {
+                    "Statement": assertions.Match.array_with(
+                        [
+                            assertions.Match.object_like(
+                                {
+                                    "Action": ["logs:CreateLogGroup", "logs:PutRetentionPolicy"],
+                                    "Effect": "Allow",
+                                    "Resource": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:",
+                                                {"Ref": "AWS::Partition"},
+                                                (
+                                                    f":logs:{TEST_REGION}:{TEST_ACCOUNT}:log-group:"
+                                                    "valkyrie-test-log-group/*"
+                                                ),
+                                            ],
+                                        ]
+                                    },
+                                }
+                            ),
+                            assertions.Match.object_like(
+                                {
+                                    "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+                                    "Effect": "Allow",
+                                    "Resource": {
+                                        "Fn::Join": [
+                                            "",
+                                            [
+                                                "arn:",
+                                                {"Ref": "AWS::Partition"},
+                                                (
+                                                    f":logs:{TEST_REGION}:{TEST_ACCOUNT}:log-group:"
+                                                    "valkyrie-test-log-group/*:log-stream:*"
+                                                ),
+                                            ],
+                                        ]
+                                    },
+                                }
+                            ),
+                        ]
+                    )
+                },
+            },
+        )
+
+    def test_dev_shared_stack_does_not_attach_prod_live_test_role(self) -> None:
+        _, shared = dev_shared_stack()
+        policies = assertions.Template.from_stack(shared).find_resources("AWS::IAM::Policy")
+        self.assertNotIn("github-actions-valkyrie-tests", json.dumps(policies))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.29.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.6" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.29.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.30.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.6" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.29.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.29.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
+version = "0.27.6"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.27.6"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
+version = "0.29.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.29.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
+version = "0.30.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.30.0#831da520999041bbc1fc33340c4f3e0e292e2cf6" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.30.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.29.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.30.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.6" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.29.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.29.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.27.6" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.29.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
+version = "0.30.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.30.0#831da520999041bbc1fc33340c4f3e0e292e2cf6" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.30.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.27.6"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
+version = "0.29.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.29.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
+version = "0.27.6"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.27.6"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
+version = "0.29.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.29.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
+version = "0.27.6"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6#e4aa7f2cd6eaff13da7c41759f9f2d74460508c4" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.27.6" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.29.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0#bbf1b44b8c7f98eef05108fe71a6ff7bc5a788b3" }
+version = "0.30.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.30.0#831da520999041bbc1fc33340c4f3e0e292e2cf6" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.29.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.30.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

- attach a production-only inline policy to the existing `github-actions-valkyrie-tests` role
- allow log-group creation and retention only under `valkyrie-test-log-group/*`
- authorize `CreateLogStream` and `PutLogEvents` on child log-stream ARNs
- keep development and release-test stacks unchanged
- align all production create-benchmark-service locks on v0.30.0

## Why

The production integration suite creates one child CloudWatch log group per benchmark. The deployed role cannot create those groups or write their streams, so the production recovery suite cannot run.

AWS authorizes `CreateLogStream` and `PutLogEvents` on the log-stream resource type. The current head therefore uses `...:log-group:valkyrie-test-log-group/*:log-stream:*` for both actions and retains the bare child log-group ARN only for `CreateLogGroup` and `PutRetentionPolicy`.

Reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-identity-based-access-control-cwl.html

## Validation

- infrastructure suite: 99 tests passed
- infrastructure Ruff and format checks passed
- infrastructure basedpyright: 0 errors
- all three create-benchmark-service locks resolve v0.30.0 and pass lock validation
- GitHub checks must pass again at final head

## Expected pre-deploy live-test state

The live integration check tests the currently deployed production role. It can remain red until this PR is merged and the production SharedStack is deployed; that expected pre-deploy failure is not evidence that the synthesized policy is wrong.

## Rollout

1. Review and merge this scoped infrastructure prerequisite.
2. Deploy the production SharedStack.
3. Rerun the production live integration suite and require it to pass.
4. Refresh #684 from final #683 and the current production base, then rerun it.
5. Do not deploy KSP production until the dev forced-preemption gate and production live suite pass.
