### PR TITLE
Refresh hosted benchmark S3 credentials

### DIFF
--- a/infra/benchmark_storage.py
+++ b/infra/benchmark_storage.py
@@ -1,0 +1,44 @@
+"""Least-privilege workload access to Valkyrie's hosted benchmark results."""
+
+from __future__ import annotations
+
+from aws_cdk import aws_ecs, aws_iam
+
+
+RUNTIME_S3_CREDENTIALS_ENV = "VALKYRIE_USE_RUNTIME_S3_CREDENTIALS"
+
+
+def runtime_s3_environment() -> dict[str, str]:
+    """Enable refreshable workload credentials in the hosted runtime."""
+    return {RUNTIME_S3_CREDENTIALS_ENV: "true"}
+
+
+def grant_benchmark_result_access(
+    task_definition: aws_ecs.FargateTaskDefinition,
+    *,
+    bucket_name: str,
+) -> None:
+    """Grant only the result-prefix operations used by Tracker and ExecutorHost.
+
+    Agent bundles remain caller-owned. Delete is intentionally excluded so this
+    role cannot erase completed result objects.
+    """
+    object_arn = f"arn:aws:s3:::{bucket_name}/benchmarks/*"
+    task_definition.add_to_task_role_policy(
+        aws_iam.PolicyStatement(
+            actions=[
+                "s3:AbortMultipartUpload",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:PutObject",
+            ],
+            resources=[object_arn],
+        )
+    )
+    task_definition.add_to_task_role_policy(
+        aws_iam.PolicyStatement(
+            actions=["s3:ListBucket"],
+            resources=[f"arn:aws:s3:::{bucket_name}"],
+            conditions={"StringLike": {"s3:prefix": ["benchmarks/*"]}},
+        )
+    )

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -24,6 +24,7 @@ from aws_cdk import (
     aws_ssm,
 )
 from aws_cdk.aws_ecr_assets import Platform
+from benchmark_storage import grant_benchmark_result_access, runtime_s3_environment
 from constants import (
     DOCKER_ASSET_EXCLUDES,
     EXECUTOR_HOST_LOG_GROUP_NAME,
@@ -120,6 +121,7 @@ class ExecutorStack(Stack):
         shared_env = {
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket_name,
+            **runtime_s3_environment(),
             "ENVIRONMENT": stage_config.runtime_environment,
             "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
@@ -153,6 +155,7 @@ class ExecutorStack(Stack):
             memory_limit_mib=stage_config.worker.memory_mib,
             runtime_platform=_ARM64_PLATFORM,
         )
+        grant_benchmark_result_access(executor_task_def, bucket_name=bucket_name)
         executor_task_def.add_container(
             "ExecutorHostContainer",
             image=executor_host_image,

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -143,6 +143,64 @@ def ssm_parameter_id(template: Mapping[str, object], parameter_name: str) -> str
 
 
 class DevAccountInfrastructureTest(unittest.TestCase):
+    def test_hosted_runtimes_use_scoped_refreshable_benchmark_storage(self) -> None:
+        with mock.patch.dict(os.environ, DEV_AUTH_ENV, clear=True):
+            templates = dev_service_templates()
+
+        for template in templates:
+            template.has_resource_properties(
+                "AWS::ECS::TaskDefinition",
+                {
+                    "ContainerDefinitions": assertions.Match.array_with(
+                        [
+                            assertions.Match.object_like(
+                                {
+                                    "Environment": assertions.Match.array_with(
+                                        [
+                                            {
+                                                "Name": "VALKYRIE_USE_RUNTIME_S3_CREDENTIALS",
+                                                "Value": "true",
+                                            }
+                                        ]
+                                    )
+                                }
+                            )
+                        ]
+                    )
+                },
+            )
+
+            statements = [
+                statement
+                for policy in template.find_resources("AWS::IAM::Policy").values()
+                for statement in policy["Properties"]["PolicyDocument"]["Statement"]
+            ]
+            object_statement = next(
+                statement
+                for statement in statements
+                if "benchmarks/*" in json.dumps(statement.get("Resource"))
+                and "s3:PutObject"
+                in ([statement["Action"]] if isinstance(statement["Action"], str) else statement["Action"])
+            )
+            self.assertEqual(
+                set(object_statement["Action"]),
+                {
+                    "s3:AbortMultipartUpload",
+                    "s3:GetObject",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                },
+            )
+            self.assertNotIn("s3:DeleteObject", object_statement["Action"])
+
+            list_statement = next(
+                statement
+                for statement in statements
+                if statement.get("Action") == "s3:ListBucket"
+                and statement.get("Condition") == {"StringLike": {"s3:prefix": ["benchmarks/*"]}}
+            )
+            self.assertNotEqual(list_statement["Resource"], "*")
+
     def test_dev_buckets_are_owned_and_hardened_by_their_domains(self) -> None:
         _, shared = dev_shared_stack()
         shared_template = assertions.Template.from_stack(shared)

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -21,6 +21,7 @@ from aws_cdk import (
     aws_ssm,
 )
 from aws_cdk.aws_ecr_assets import Platform
+from benchmark_storage import grant_benchmark_result_access, runtime_s3_environment
 from constants import (
     ALB_HEALTH_INTERVAL_SECONDS,
     ALB_IDLE_TIMEOUT_SECONDS,
@@ -101,6 +102,7 @@ class TrackerStack(Stack):
         shared_env = {
             "BROKER_ENVIRONMENT": stage_config.runtime_environment,
             "AWS_S3_BUCKET": bucket_name,
+            **runtime_s3_environment(),
             "ENVIRONMENT": stage_config.runtime_environment,
             "BENCHMARK_SERVICE_CLOUDMAP_NAMESPACE": namespace.namespace_name,
             "DAYTONA_HAPPY_EYEBALLS_DELAY": "none",
@@ -197,6 +199,7 @@ class TrackerStack(Stack):
             memory_limit_mib=stage_config.tracker.memory_mib,
             runtime_platform=_ARM64_PLATFORM,
         )
+        grant_benchmark_result_access(tracker_task_def, bucket_name=bucket_name)
 
         tracker_task_def.add_container(
             "TrackerContainer",

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -1,5 +1,6 @@
 """S3 upload utilities for the tracker service."""
 
+import os
 from collections.abc import AsyncIterable, AsyncIterator, Awaitable, Callable, Coroutine, Iterable
 from contextlib import suppress
 from datetime import datetime
@@ -30,6 +31,9 @@ _CLIENT_CONFIG = Config(max_pool_connections=200, retries={"mode": "standard"})
 # S3 multipart uploads require every part except the last to be at least 5 MiB.
 _MULTIPART_PART_BYTES = 8 * 1024 * 1024
 
+_RUNTIME_S3_CREDENTIALS_ENV = "VALKYRIE_USE_RUNTIME_S3_CREDENTIALS"
+_RUNTIME_S3_BUCKET_ENV = "AWS_S3_BUCKET"
+
 
 @lru_cache(maxsize=32)
 def _s3_session(aws: "AWSCredentials") -> aioboto3.Session:
@@ -40,6 +44,38 @@ def _s3_session(aws: "AWSCredentials") -> aioboto3.Session:
         aws_session_token=aws.aws_session_token,
         region_name=aws.aws_default_region,
     )
+
+
+@lru_cache(maxsize=8)
+def _runtime_s3_session(region: str) -> aioboto3.Session:
+    """Session backed by the AWS default chain, including refreshable ECS credentials."""
+    return aioboto3.Session(region_name=region)
+
+
+def _uses_runtime_credentials(s3_bucket: str, s3_key: str) -> bool:
+    """Select the workload role only for this deployment's benchmark-result namespace.
+
+    Hosted Valkyrie can finish a task after the operator's temporary credentials
+    expire. The workload role is intentionally confined to the configured runtime
+    bucket and ``benchmarks/`` prefix; agents and external buckets retain the
+    caller-credential behavior.
+    """
+    return (
+        os.getenv(_RUNTIME_S3_CREDENTIALS_ENV, "").lower() == "true"
+        and bool(runtime_bucket := os.getenv(_RUNTIME_S3_BUCKET_ENV, ""))
+        and s3_bucket == runtime_bucket
+        and (s3_key == S3_BENCHMARKS_PREFIX or s3_key.startswith(f"{S3_BENCHMARKS_PREFIX}/"))
+    )
+
+
+def _s3_client_for_object(aws: "AWSCredentials", s3_bucket: str, s3_key: str) -> Any:
+    """Open an S3 client using the safe credential source for one object/prefix."""
+    session = (
+        _runtime_s3_session(aws.aws_default_region)
+        if _uses_runtime_credentials(s3_bucket, s3_key)
+        else _s3_session(aws)
+    )
+    return session.client("s3", config=_CLIENT_CONFIG)  # pyright: ignore[reportUnknownMemberType]
 
 
 def s3_client(aws: "AWSCredentials") -> Any:
@@ -93,7 +129,7 @@ async def upload_to_s3(file_content: bytes, s3_key: str, aws: "AWSCredentials", 
     Raises:
         S3Error: If upload fails due to AWS errors or network issues
     """
-    async with s3_client(aws) as client:
+    async with _s3_client_for_object(aws, s3_bucket, s3_key) as client:
         await client.put_object(Bucket=s3_bucket, Key=s3_key, Body=file_content)
 
 
@@ -123,7 +159,7 @@ async def upload_stream_to_s3(
         S3Error: If upload fails due to AWS errors or network issues
     """
     total_bytes = 0
-    async with s3_client(aws) as client:
+    async with _s3_client_for_object(aws, s3_bucket, s3_key) as client:
         multipart = await client.create_multipart_upload(Bucket=s3_bucket, Key=s3_key)
         upload_id = multipart["UploadId"]
         try:
@@ -178,7 +214,7 @@ async def download_from_s3(s3_key: str, aws: "AWSCredentials", s3_bucket: str) -
     Raises:
         S3Error: If download fails due to AWS errors, network issues, or file not found
     """
-    async with s3_client(aws) as client:
+    async with _s3_client_for_object(aws, s3_bucket, s3_key) as client:
         response = await client.get_object(Bucket=s3_bucket, Key=s3_key)
         async with response["Body"] as stream:
             return await stream.read()
@@ -194,6 +230,13 @@ async def _as_async_iter(keys: AsyncIterable[str] | Iterable[str]) -> AsyncItera
             yield key
 
 
+async def _prepend_async(first: str, remaining: AsyncIterator[str]) -> AsyncIterator[str]:
+    """Yield one consumed value before the rest of an async iterator."""
+    yield first
+    async for key in remaining:
+        yield key
+
+
 async def download_many_from_s3(
     s3_keys: AsyncIterable[str] | Iterable[str], aws: "AWSCredentials", s3_bucket: str
 ) -> AsyncIterator[tuple[str, bytes]]:
@@ -205,8 +248,14 @@ async def download_many_from_s3(
     each object is read fully into memory one at a time, so peak memory is
     bounded by the largest single object rather than the whole set.
     """
-    async with s3_client(aws) as client:
-        async for s3_key in _as_async_iter(s3_keys):
+    key_iterator = _as_async_iter(s3_keys)
+    try:
+        first_key = await anext(key_iterator)
+    except StopAsyncIteration:
+        return
+
+    async with _s3_client_for_object(aws, s3_bucket, first_key) as client:
+        async for s3_key in _prepend_async(first_key, key_iterator):
             try:
                 response = await client.get_object(Bucket=s3_bucket, Key=s3_key)
                 async with response["Body"] as stream:
@@ -283,7 +332,7 @@ async def s3_object_exists(s3_key: str, aws: "AWSCredentials", s3_bucket: str) -
     Returns:
         True if the object exists, False otherwise
     """
-    async with s3_client(aws) as client:
+    async with _s3_client_for_object(aws, s3_bucket, s3_key) as client:
         try:
             await client.head_object(Bucket=s3_bucket, Key=s3_key)
             return True
@@ -310,7 +359,7 @@ async def list_s3_objects(prefix: str, aws: "AWSCredentials", s3_bucket: str) ->
         S3Error: If listing fails due to AWS errors or network issues
     """
     try:
-        async with s3_client(aws) as client:
+        async with _s3_client_for_object(aws, s3_bucket, prefix) as client:
             paginator = client.get_paginator("list_objects_v2")
             async for page in paginator.paginate(Bucket=s3_bucket, Prefix=prefix):
                 for s3_object in page.get("Contents", []):
@@ -337,7 +386,7 @@ async def create_presigned_url(s3_key: str, aws: "AWSCredentials", s3_bucket: st
     Raises:
         S3Error: If presigned URL creation fails
     """
-    async with s3_client(aws) as client:
+    async with _s3_client_for_object(aws, s3_bucket, s3_key) as client:
         presigned_url: str = await client.generate_presigned_url(
             "get_object",
             Params={"Bucket": s3_bucket, "Key": s3_key},

--- a/services/tracker/tests/unit/aws/test_s3.py
+++ b/services/tracker/tests/unit/aws/test_s3.py
@@ -1,3 +1,5 @@
+# pyright: reportPrivateImportUsage=false, reportPrivateUsage=false
+
 """Unit tests for tracker S3 streaming uploads.
 
 Run: uv run pytest tests/unit/aws/test_s3.py
@@ -50,10 +52,10 @@ class FakeS3Client:
 def fake_client(monkeypatch: pytest.MonkeyPatch) -> FakeS3Client:
     client = FakeS3Client()
 
-    def fake_s3_client(_aws: AWSCredentials) -> FakeS3Client:
+    def fake_s3_client(_aws: AWSCredentials, _bucket: str, _key: str) -> FakeS3Client:
         return client
 
-    monkeypatch.setattr(s3_module, "s3_client", fake_s3_client)
+    monkeypatch.setattr(s3_module, "_s3_client_for_object", fake_s3_client)
     monkeypatch.setattr(s3_module, "_MULTIPART_PART_BYTES", 8)
     return client
 
@@ -107,10 +109,10 @@ class TestUploadStreamToS3:
         """
         client = FakeS3Client(fail_on_part=1)
 
-        def fake_s3_client(_aws: AWSCredentials) -> FakeS3Client:
+        def fake_s3_client(_aws: AWSCredentials, _bucket: str, _key: str) -> FakeS3Client:
             return client
 
-        monkeypatch.setattr(s3_module, "s3_client", fake_s3_client)
+        monkeypatch.setattr(s3_module, "_s3_client_for_object", fake_s3_client)
         monkeypatch.setattr(s3_module, "_MULTIPART_PART_BYTES", 8)
 
         async def chunks() -> AsyncIterator[bytes]:
@@ -144,3 +146,51 @@ class TestUploadStreamToS3:
         assert fake_client.parts == [(1, b"final")]
         assert fake_client.completed_parts is None
         assert fake_client.aborted
+
+
+class TestRuntimeCredentialSelection:
+    """Hosted result objects use refreshable workload credentials within a tight boundary."""
+
+    def test_uses_runtime_credentials_for_configured_benchmark_prefix(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VALKYRIE_USE_RUNTIME_S3_CREDENTIALS", "true")
+        monkeypatch.setenv("AWS_S3_BUCKET", "agentic-harness-dev")
+
+        assert s3_module._uses_runtime_credentials("agentic-harness-dev", "benchmarks/run-id/task-id/output.tar.gz")
+        assert s3_module._uses_runtime_credentials("agentic-harness-dev", "benchmarks")
+
+    @pytest.mark.parametrize(
+        ("bucket", "key"),
+        [
+            ("another-bucket", "benchmarks/run-id/output.json"),
+            ("agentic-harness-dev", "agents/terminus.zip"),
+            ("agentic-harness-dev", "benchmark-lookalike/run-id/output.json"),
+        ],
+    )
+    def test_keeps_caller_credentials_outside_runtime_boundary(
+        self, monkeypatch: pytest.MonkeyPatch, bucket: str, key: str
+    ) -> None:
+        monkeypatch.setenv("VALKYRIE_USE_RUNTIME_S3_CREDENTIALS", "true")
+        monkeypatch.setenv("AWS_S3_BUCKET", "agentic-harness-dev")
+
+        assert not s3_module._uses_runtime_credentials(bucket, key)
+
+    def test_runtime_mode_is_opt_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("VALKYRIE_USE_RUNTIME_S3_CREDENTIALS", raising=False)
+        monkeypatch.setenv("AWS_S3_BUCKET", "agentic-harness-dev")
+
+        assert not s3_module._uses_runtime_credentials("agentic-harness-dev", "benchmarks/run-id/output.json")
+
+    def test_runtime_session_does_not_receive_static_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[dict[str, str]] = []
+
+        class Session:
+            def __init__(self, **kwargs: str) -> None:
+                calls.append(kwargs)
+
+        monkeypatch.setattr(s3_module.aioboto3, "Session", Session)
+        s3_module._runtime_s3_session.cache_clear()
+
+        s3_module._runtime_s3_session("us-east-1")
+
+        assert calls == [{"region_name": "us-east-1"}]
+        s3_module._runtime_s3_session.cache_clear()


### PR DESCRIPTION
## What changed

- lets hosted Tracker and ExecutorHost use refreshable ECS task credentials for the configured `benchmarks/*` result namespace
- scopes workload-role access to the runtime bucket and benchmark prefix
- grants only get, put, list, version-read, and multipart-abort operations; delete remains excluded
- retains caller credentials for agent artifacts and external buckets

## Why

Long-running benchmark tasks could finish after the initiating user's temporary AWS credentials expired. Their final multipart result upload then failed despite successful model work. Runtime task credentials now refresh automatically for hosted result storage.

## Operator impact

No CLI workflow changes are required. Long BioMysteryBench runs and other hosted benchmarks no longer depend on the initiating SSO session remaining valid through result upload.

## Validation

- Tracker S3 tests: 24 passed
- Infrastructure tests: 98 passed, including 62 subtests
- Ruff and strict basedpyright passed for the changed service and infrastructure files

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/687" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->