### PR TITLE
Add least-privilege coordinated agent publisher roles

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -49,6 +49,22 @@ the `sts.amazonaws.com` audience. The stacks import that provider and create
 separate environment-bound executor release roles; they do not create a fallback
 provider.
 
+The production and development Shared stacks also create separate coordinated
+agent-publisher roles for `agent-registry`. Each role can write only
+`agents/opencode_thinking.zip` in its own artifact bucket, including the abort
+permission required by the CLI's multipart uploader. Its OIDC trust requires the
+immutable `agent-registry` repository and organization IDs, `main`, the matching
+`coordinated-agent-release-prod` or `coordinated-agent-release-dev` GitHub
+Environment, and the reusable publisher workflow from `main`. Configure that
+Environment to allow only `main`, retain required reviewers, and set its
+stage-specific role variable from the `CoordinatedAgentPublisherRoleArn` stack
+output.
+
+This change intentionally does not deny the existing publisher roles. Roll out
+and prove the new roles and workflow first, republish the immutable aliases, and
+only then add the separately reviewed bucket-policy deny that prevents every
+other principal from writing the coordinated alias key.
+
 The application imports these account-local values:
 
 - `/valkyrie/dev/dns/tracker/hosted-zone-id`

--- a/infra/README.md
+++ b/infra/README.md
@@ -68,7 +68,8 @@ put the new role ARN in the legacy repository variables
 This change intentionally does not deny the existing publisher roles. Roll out
 and prove the new roles and workflow first, republish the immutable aliases, and
 only then add the separately reviewed bucket-policy deny that prevents every
-other principal from writing the coordinated alias key.
+other principal from mutating the coordinated alias key, including multipart
+writes/aborts and object/version deletion.
 
 The application imports these account-local values:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -57,8 +57,10 @@ immutable `agent-registry` repository and organization IDs, `main`, the matching
 `coordinated-agent-release-prod` or `coordinated-agent-release-dev` GitHub
 Environment, and the reusable publisher workflow from `main`. Configure that
 Environment to allow only `main`, retain required reviewers, and set its
-stage-specific role variable from the `CoordinatedAgentPublisherRoleArn` stack
-output.
+environment-scoped `COORDINATED_AGENT_PUBLISH_ROLE_ARN` variable from the
+`CoordinatedAgentPublisherRoleArn` stack output. Do not put the new role ARN in
+the legacy repository variables `AGENT_PUBLISH_ROLE_ARN` or
+`DEV_AGENT_PUBLISH_ROLE_ARN`.
 
 This change intentionally does not deny the existing publisher roles. Roll out
 and prove the new roles and workflow first, republish the immutable aliases, and

--- a/infra/README.md
+++ b/infra/README.md
@@ -65,6 +65,14 @@ the matching account's `CoordinatedAgentPublisherRoleArn` stack output. Do not
 put the new role ARN in the legacy repository variables
 `AGENT_PUBLISH_ROLE_ARN` or `DEV_AGENT_PUBLISH_ROLE_ARN`.
 
+This repository deploys `SCOPE=core` automatically after a push to `dev`, and
+`core` includes `ValkDevSharedStack`. Merging the role change into `dev` will
+therefore normally create the development role immediately through that
+reviewed workflow. It does not create the production role: production requires
+a separate reviewed promotion to `prod`, whose core deployment updates the
+production Shared stack. Configure and prove each stage only after its matching
+stack deployment succeeds.
+
 This change intentionally does not deny the existing publisher roles. Roll out
 and prove the new roles and workflow first, republish the immutable aliases, and
 only then add the separately reviewed bucket-policy deny that prevents every

--- a/infra/README.md
+++ b/infra/README.md
@@ -55,12 +55,15 @@ agent-publisher roles for `agent-registry`. Each role can write only
 permission required by the CLI's multipart uploader. Its OIDC trust requires the
 immutable `agent-registry` repository and organization IDs, `main`, the matching
 `coordinated-agent-release-prod` or `coordinated-agent-release-dev` GitHub
-Environment, and the reusable publisher workflow from `main`. Configure that
-Environment to allow only `main`, retain required reviewers, and set its
-environment-scoped `COORDINATED_AGENT_PUBLISH_ROLE_ARN` variable from the
-`CoordinatedAgentPublisherRoleArn` stack output. Do not put the new role ARN in
-the legacy repository variables `AGENT_PUBLISH_ROLE_ARN` or
-`DEV_AGENT_PUBLISH_ROLE_ARN`.
+Environment, and
+`vals-ai/agent-registry/.github/workflows/publish-coordinated-agent.yaml@refs/heads/main`.
+Operators start the separate manual `release-coordinated-agent.yaml` caller,
+which selects exactly one environment and invokes that reusable publisher.
+Configure each Environment to allow only `main`, retain required reviewers, and
+set its environment-scoped `COORDINATED_AGENT_PUBLISH_ROLE_ARN` variable from
+the matching account's `CoordinatedAgentPublisherRoleArn` stack output. Do not
+put the new role ARN in the legacy repository variables
+`AGENT_PUBLISH_ROLE_ARN` or `DEV_AGENT_PUBLISH_ROLE_ARN`.
 
 This change intentionally does not deny the existing publisher roles. Roll out
 and prove the new roles and workflow first, republish the immutable aliases, and

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -65,6 +65,14 @@ ALB_IDLE_TIMEOUT_SECONDS = 60
 
 # S3
 S3_BUCKET_NAME = "agentic-harness"
+COORDINATED_AGENT_ALIAS_KEY = "agents/opencode_thinking.zip"
+COORDINATED_AGENT_PUBLISHER_ROLE_PREFIX = "github-actions-agent-registry-coordinated"
+COORDINATED_AGENT_PUBLISH_WORKFLOW_REF = (
+    "vals-ai/agent-registry/.github/workflows/publish-coordinated-agent.yaml@refs/heads/main"
+)
+AGENT_REGISTRY_REPOSITORY = "vals-ai/agent-registry"
+AGENT_REGISTRY_REPOSITORY_ID = "1181332178"
+VALS_AI_ORGANIZATION_ID = "129814943"
 EXECUTOR_RELEASE_BUCKET_NAME = "valkyrie-executor-releases"
 EXECUTOR_RELEASE_PREFIX = "releases"
 EXECUTOR_RELEASE_ROLE_NAME = "ValkyrieExecutorRelease"
@@ -85,6 +93,14 @@ DOCKER_ASSET_EXCLUDES = (
 
 def executor_release_launch_parameter(stage_name: str) -> str:
     return f"/valkyrie/{stage_name}/executor-release/launch-config"
+
+
+def coordinated_agent_publisher_role_name(stage_name: str) -> str:
+    return f"{COORDINATED_AGENT_PUBLISHER_ROLE_PREFIX}-{stage_name}-publish"
+
+
+def coordinated_agent_release_environment(stage_name: str) -> str:
+    return f"coordinated-agent-release-{stage_name}"
 
 
 # Release-test service images. Dedicated repositories keep deployment writes

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -1,6 +1,6 @@
 """Shared infrastructure: VPC, ECS Cluster, Service Discovery namespace, S3, ElastiCache."""
 
-from typing import Any
+from typing import Any, cast
 
 import aws_cdk as cdk
 from aws_cdk import (
@@ -12,6 +12,7 @@ from aws_cdk import (
     aws_elasticache,
     aws_events,
     aws_events_targets,
+    aws_iam,
     aws_route53,
     aws_s3,
     aws_servicediscovery,
@@ -19,7 +20,11 @@ from aws_cdk import (
     aws_ssm,
 )
 from constants import (
+    AGENT_REGISTRY_REPOSITORY,
+    AGENT_REGISTRY_REPOSITORY_ID,
     CLUSTER_NAME,
+    COORDINATED_AGENT_ALIAS_KEY,
+    COORDINATED_AGENT_PUBLISH_WORKFLOW_REF,
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV,
     DEV_SHARED_ARTIFACT_BUCKET_PARAMETER,
     DEV_SHARED_AVAILABILITY_ZONES_PARAMETER,
@@ -36,6 +41,9 @@ from constants import (
     RELEASE_TEST_EXECUTOR_HOST_REPOSITORY_NAME,
     RELEASE_TEST_TRACKER_REPOSITORY_NAME,
     S3_BUCKET_NAME,
+    VALS_AI_ORGANIZATION_ID,
+    coordinated_agent_publisher_role_name,
+    coordinated_agent_release_environment,
     stage_parameter_name,
     VPC_MAX_AZS,
     VPC_NAT_GATEWAYS,
@@ -124,6 +132,10 @@ class SharedStack(Stack):
             versioned=None if self.stage.is_prod else True,
         )
 
+        self.coordinated_agent_publisher_role: aws_iam.Role | None = None
+        if not self.stage.is_release_test:
+            self.coordinated_agent_publisher_role = self._create_coordinated_agent_publisher_role()
+
         self.tracker_repository: aws_ecr.Repository | None = None
         self.executor_host_repository: aws_ecr.Repository | None = None
         if self.stage.is_release_test:
@@ -190,6 +202,57 @@ class SharedStack(Stack):
 
         if not self.stage.is_prod:
             self._publish_shared_contract()
+
+    def _create_coordinated_agent_publisher_role(self) -> aws_iam.Role:
+        """Create the only role intended to write the coordinated KSP agent alias."""
+        github_environment = coordinated_agent_release_environment(self.stage.name)
+        oidc_provider = aws_iam.OpenIdConnectProvider.from_open_id_connect_provider_arn(
+            self,
+            "AgentPublisherGitHubOidcProvider",
+            f"arn:{self.partition}:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com",
+        )
+        role = aws_iam.Role(
+            self,
+            "CoordinatedAgentPublisherRole",
+            role_name=coordinated_agent_publisher_role_name(self.stage.name),
+            assumed_by=cast(
+                aws_iam.IPrincipal,
+                aws_iam.WebIdentityPrincipal(
+                    oidc_provider.open_id_connect_provider_arn,
+                    conditions={
+                        "StringEquals": {
+                            "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                            "token.actions.githubusercontent.com:environment": github_environment,
+                            "token.actions.githubusercontent.com:job_workflow_ref": (
+                                COORDINATED_AGENT_PUBLISH_WORKFLOW_REF
+                            ),
+                            "token.actions.githubusercontent.com:ref": "refs/heads/main",
+                            "token.actions.githubusercontent.com:repository": AGENT_REGISTRY_REPOSITORY,
+                            "token.actions.githubusercontent.com:repository_id": AGENT_REGISTRY_REPOSITORY_ID,
+                            "token.actions.githubusercontent.com:repository_owner_id": VALS_AI_ORGANIZATION_ID,
+                            "token.actions.githubusercontent.com:sub": (
+                                f"repo:{AGENT_REGISTRY_REPOSITORY}:environment:{github_environment}"
+                            ),
+                        }
+                    },
+                ),
+            ),
+        )
+        role.add_to_policy(
+            aws_iam.PolicyStatement(
+                actions=["s3:AbortMultipartUpload", "s3:PutObject"],
+                resources=[self.bucket.arn_for_objects(COORDINATED_AGENT_ALIAS_KEY)],
+            )
+        )
+        cdk.CfnOutput(
+            self,
+            "CoordinatedAgentPublisherRoleArn",
+            value=role.role_arn,
+            description=(
+                "Role ARN for the agent-registry coordinated publisher; configure it only on the matching GitHub Environment"
+            ),
+        )
+        return role
 
     def _publish_shared_contract(self) -> None:
         """Publish the account-local resource contract consumed by benchmark-service stacks."""

--- a/infra/tests/test_agent_publisher_roles.py
+++ b/infra/tests/test_agent_publisher_roles.py
@@ -1,0 +1,126 @@
+"""Tests for the environment-bound coordinated agent publisher roles."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from collections.abc import Mapping
+from typing import cast
+
+import aws_cdk as cdk
+from aws_cdk import assertions
+
+from constants import (
+    AGENT_REGISTRY_REPOSITORY,
+    AGENT_REGISTRY_REPOSITORY_ID,
+    COORDINATED_AGENT_ALIAS_KEY,
+    COORDINATED_AGENT_PUBLISH_WORKFLOW_REF,
+    VALS_AI_ORGANIZATION_ID,
+    coordinated_agent_publisher_role_name,
+    coordinated_agent_release_environment,
+)
+from shared import SharedStack
+from stage import DEV, PROD, RELEASE_TEST, Stage
+
+TEST_ACCOUNT = "123456789012"
+TEST_REGION = "us-east-1"
+TEST_ENV = cdk.Environment(account=TEST_ACCOUNT, region=TEST_REGION)
+TEST_CONTEXT = {
+    f"availability-zones:account={TEST_ACCOUNT}:region={TEST_REGION}": [
+        f"{TEST_REGION}a",
+        f"{TEST_REGION}b",
+    ],
+    f"hosted-zone:account={TEST_ACCOUNT}:domainName=vals.ai:region={TEST_REGION}": {
+        "Id": "/hostedzone/Z0000000000000000000",
+        "Name": "vals.ai.",
+    },
+}
+
+
+def shared_template(stage_name: str) -> assertions.Template:
+    app = cdk.App(context=TEST_CONTEXT)
+    stage = Stage(stage_name)
+    stack = SharedStack(
+        app,
+        stage.stack_id("SharedStack"),
+        stage=stage,
+        env=TEST_ENV,
+    )
+    return assertions.Template.from_stack(stack)
+
+
+class CoordinatedAgentPublisherRoleTest(unittest.TestCase):
+    def test_prod_and_dev_roles_are_exactly_bound_and_least_privileged(self) -> None:
+        for stage_name in (PROD, DEV):
+            with self.subTest(stage=stage_name):
+                template = shared_template(stage_name)
+                roles = template.find_resources("AWS::IAM::Role")
+                role_id, role = next(
+                    (logical_id, resource)
+                    for logical_id, resource in roles.items()
+                    if resource["Properties"].get("RoleName") == coordinated_agent_publisher_role_name(stage_name)
+                )
+
+                environment = coordinated_agent_release_environment(stage_name)
+                expected_conditions = {
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+                    "token.actions.githubusercontent.com:environment": environment,
+                    "token.actions.githubusercontent.com:job_workflow_ref": (COORDINATED_AGENT_PUBLISH_WORKFLOW_REF),
+                    "token.actions.githubusercontent.com:ref": "refs/heads/main",
+                    "token.actions.githubusercontent.com:repository": AGENT_REGISTRY_REPOSITORY,
+                    "token.actions.githubusercontent.com:repository_id": (AGENT_REGISTRY_REPOSITORY_ID),
+                    "token.actions.githubusercontent.com:repository_owner_id": (VALS_AI_ORGANIZATION_ID),
+                    "token.actions.githubusercontent.com:sub": (
+                        f"repo:{AGENT_REGISTRY_REPOSITORY}:environment:{environment}"
+                    ),
+                }
+                statements = role["Properties"]["AssumeRolePolicyDocument"]["Statement"]
+                self.assertEqual(len(statements), 1)
+                self.assertEqual(
+                    statements[0]["Condition"],
+                    {"StringEquals": expected_conditions},
+                )
+
+                policies = template.find_resources("AWS::IAM::Policy")
+                policy = next(
+                    resource for resource in policies.values() if {"Ref": role_id} in resource["Properties"]["Roles"]
+                )
+                policy_statements = policy["Properties"]["PolicyDocument"]["Statement"]
+                self.assertEqual(len(policy_statements), 1)
+                statement = policy_statements[0]
+                actions = cast(str | list[str], statement["Action"])
+                self.assertEqual(
+                    set(actions if isinstance(actions, list) else [actions]),
+                    {"s3:AbortMultipartUpload", "s3:PutObject"},
+                )
+                resource = json.dumps(statement["Resource"])
+                self.assertIn(f"/{COORDINATED_AGENT_ALIAS_KEY}", resource)
+                self.assertNotIn("*", resource)
+
+                outputs = cast(
+                    Mapping[str, Mapping[str, object]],
+                    template.to_json()["Outputs"],
+                )
+                self.assertEqual(
+                    outputs["CoordinatedAgentPublisherRoleArn"]["Value"],
+                    {"Fn::GetAtt": [role_id, "Arn"]},
+                )
+
+    def test_release_test_has_no_coordinated_publisher_role(self) -> None:
+        template = shared_template(RELEASE_TEST)
+        rendered = json.dumps(template.to_json())
+
+        self.assertNotIn("CoordinatedAgentPublisherRole", rendered)
+        self.assertNotIn("CoordinatedAgentPublisherRoleArn", rendered)
+        self.assertNotIn(COORDINATED_AGENT_ALIAS_KEY, rendered)
+
+    def test_alias_deny_is_deliberately_deferred(self) -> None:
+        for stage_name in (PROD, DEV):
+            with self.subTest(stage=stage_name):
+                rendered = json.dumps(shared_template(stage_name).to_json())
+                self.assertNotIn("DenyUncoordinatedAgentAliasWrites", rendered)
+                self.assertNotIn("aws:PrincipalArn", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create separate production and development GitHub OIDC publisher roles in the Shared stacks
- bind trust to the immutable agent-registry repository and organization IDs, exact main ref, exact per-stage GitHub Environment, and exact reusable workflow on main
- allow only multipart writes to `agents/opencode_thinking.zip` in the stage artifact bucket
- expose each role ARN for the matching GitHub Environment variable `COORDINATED_AGENT_PUBLISH_ROLE_ARN`

## Deployment effect and safety boundary
- this PR targets `dev`; merging it triggers Valkyrie's push-to-`dev` core deployment, and `core` includes `ValkDevSharedStack`, so a successful merge workflow will create the **dev** role
- it does not create the prod role; that requires a separate reviewed promotion to `prod`, whose core deployment updates the production Shared stack
- no bucket-policy Deny is added in this PR and no existing role is revoked or modified
- keep this PR draft until the dev role deployment/configuration/smoke window is explicitly authorized; configure the production Environment only after the separate prod stack deployment succeeds
- the deny/revocation phase remains blocked until both new roles and the protected workflow are deployed, configured, and used to republish and verify both immutable aliases
- the later policy must cover all alias mutation paths, including multipart write/abort and object/version deletion

## Validation
- full infra unit suite: 100 passed
- production and development Shared stack synthesis passed
- Ruff format/check passed
- basedpyright passed with 0 errors
- git diff check passed
