### PR TITLE
Bind benchmark contracts to immutable agent archives

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,6 +41,7 @@ jobs:
       executor_host_redeploy_required: ${{ steps.result.outputs.executor_host_redeploy_required }}
       executor_release_required: ${{ steps.result.outputs.executor_release_required }}
       core_maintenance_required: ${{ steps.result.outputs.core_maintenance_required }}
+      atomic_protocol_transition_required: ${{ steps.result.outputs.atomic_protocol_transition_required }}
       database_maintenance_required: ${{ steps.result.outputs.database_maintenance_required }}
 
     steps:
@@ -144,6 +145,7 @@ jobs:
               "executor_host_redeploy_required",
               "executor_release_required",
               "core_maintenance_required",
+              "atomic_protocol_transition_required",
               "database_maintenance_required",
           ):
               print(f"{key}={str(result[key]).lower()}")
@@ -443,6 +445,7 @@ jobs:
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.atomic_protocol_transition_required == 'true' ||
            needs.classify-deployment.outputs.database_maintenance_required == 'true')
         working-directory: infra
         run: >-
@@ -530,6 +533,7 @@ jobs:
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.atomic_protocol_transition_required == 'true' ||
            needs.classify-deployment.outputs.database_maintenance_required == 'true')
         working-directory: infra
         run: >-
@@ -639,6 +643,7 @@ jobs:
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.atomic_protocol_transition_required == 'true' ||
            needs.classify-deployment.outputs.database_maintenance_required == 'true')
         working-directory: infra
         run: >-
@@ -743,6 +748,7 @@ jobs:
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.atomic_protocol_transition_required == 'true' ||
            needs.classify-deployment.outputs.database_maintenance_required == 'true')
         working-directory: infra
         run: >-

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ valkyrie benchmark tasks swebench --dataset default --output tasks.txt
 | `-s` / `--secret` | Secret pair as `ENV_VAR aws_secret_name`. Repeatable. Merged into the stored run contract before resumed/retried tasks are enqueued (CLI wins on conflict) |
 | `--task-ids` | Comma-separated task IDs to resume/retry. Any id without an existing row is created as fresh `PENDING` if valid in the current dataset — lets you grow scope without starting a new run. |
 | `--task-ids-file` | Local path or http(s) URL to a text file with one task ID per line |
-| `--update-agent, -u` | Refresh the frozen agent copy from the current `agents/<name>.zip` in S3 before resuming |
+| `--update-agent, -u` | Freeze the current agent alias as a new immutable run revision, derive its contract from that exact archive, and resume atomically |
 | `--from-scratch` | Clear stored eval resume state and rerun generation for retried tasks |
 | `--benchmark-url` | Replace the benchmark service URL stored on the run |
 | `--connect` | Stream run updates after resume/retry |

--- a/infra/classify_repository_change.py
+++ b/infra/classify_repository_change.py
@@ -73,6 +73,10 @@ _EXECUTOR_RELEASE_DIRECTORIES = (
     "services/tracker/src/tracker/observability/",
     "services/tracker/src/tracker/utils/",
 )
+# Wire-protocol transitions change both the tracker producer and immutable
+# executor consumer. They must deploy as one maintenance-fenced sequence:
+# begin fence -> core -> stable host -> artifact activation -> finish fence.
+_ATOMIC_EXECUTOR_PROTOCOL_FILES = {"services/tracker/src/executor_protocol.py"}
 
 
 @dataclass(frozen=True)
@@ -91,6 +95,7 @@ class Classification:
     executor_host_redeploy_required: bool
     executor_release_required: bool
     core_maintenance_required: bool
+    atomic_protocol_transition_required: bool
     database_maintenance_required: bool
     changed_migrations: list[str]
     reasons: list[str]
@@ -248,6 +253,7 @@ def classify_repository_change(
     executor_release_required = False
     core_maintenance_required = False
     database_maintenance_required = False
+    atomic_protocol_transition_required = False
 
     for status, paths in _changed_entries(repository, base_sha, head_sha):
         if any(_is_executor_stack_path(path) for path in paths):
@@ -255,6 +261,10 @@ def classify_repository_change(
             reasons.add("executor-core-change")
         if any(path in _EXECUTOR_SHARED_FILES for path in paths):
             core_maintenance_required = True
+        if any(path in _ATOMIC_EXECUTOR_PROTOCOL_FILES for path in paths):
+            atomic_protocol_transition_required = True
+            core_maintenance_required = True
+            reasons.add("executor-protocol-transition")
         if any(_is_executor_release_path(path) for path in paths):
             executor_release_required = True
             reasons.add("executor-release-change")
@@ -275,7 +285,9 @@ def classify_repository_change(
     if executor_effect.redeploy_required:
         executor_stack_deploy_required = True
         reasons.update(executor_effect.reasons)
-    maintenance_required = executor_effect.redeploy_required or database_maintenance_required
+    maintenance_required = (
+        executor_effect.redeploy_required or database_maintenance_required or atomic_protocol_transition_required
+    )
     classification = "maintenance-required" if maintenance_required else "safe"
     return Classification(
         classification=classification,
@@ -285,6 +297,7 @@ def classify_repository_change(
         executor_host_redeploy_required=executor_effect.redeploy_required,
         executor_release_required=executor_release_required,
         core_maintenance_required=core_maintenance_required,
+        atomic_protocol_transition_required=atomic_protocol_transition_required,
         database_maintenance_required=database_maintenance_required,
         changed_migrations=sorted(changed_migrations),
         reasons=sorted(reasons),

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -69,6 +69,7 @@ class DeployWorkflowTest(unittest.TestCase):
                 self.assertIn("executor_host_redeploy_required", executor_job)
                 self.assertIn("executor_release_required", executor_job)
                 self.assertIn("core_maintenance_required", executor_job)
+                self.assertIn("atomic_protocol_transition_required", executor_job)
                 self.assertIn("database_maintenance_required", executor_job)
                 self.assertIn(
                     "PYTHONPATH=services/tracker/src python services/executor_artifact/build.py",
@@ -86,8 +87,12 @@ class DeployWorkflowTest(unittest.TestCase):
                 )[0]
                 finish = executor_job.split(f"      - name: Finish {stage} maintenance", maxsplit=1)[1]
                 self.assertIn("executor_host_redeploy_required == 'true'", begin)
+                self.assertIn("atomic_protocol_transition_required == 'true'", begin)
+                self.assertNotIn("core_maintenance_required == 'true'", begin)
                 self.assertNotIn("executor_stack_deploy_required == 'true'", begin)
                 self.assertIn("executor_host_redeploy_required == 'true'", finish)
+                self.assertIn("atomic_protocol_transition_required == 'true'", finish)
+                self.assertNotIn("core_maintenance_required == 'true'", finish)
                 self.assertNotIn("executor_stack_deploy_required == 'true'", finish)
                 self.assertLess(executor_job.index("Begin"), executor_job.index("SCOPE=executor"))
                 self.assertLess(executor_job.index("SCOPE=executor"), executor_job.index("Publish and activate"))
@@ -107,6 +112,37 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertEqual(workflow.count("--maintenance-operation finish"), 2)
         self.assertNotIn("actions/upload-artifact", workflow)
         self.assertNotIn("actions/download-artifact", workflow)
+
+    def test_protocol_transition_fences_core_host_and_v2_activation_as_one_sequence(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        classifier = (ROOT / "infra" / "classify_repository_change.py").read_text(encoding="utf-8")
+        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
+            "  executor-production:", maxsplit=1
+        )[0]
+        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+
+        self.assertIn(
+            '_ATOMIC_EXECUTOR_PROTOCOL_FILES = {"services/tracker/src/executor_protocol.py"}',
+            classifier,
+        )
+        self.assertIn('reasons.add("executor-protocol-transition")', classifier)
+
+        for executor_job, stage in ((dev_executor, "dev"), (prod_executor, "production")):
+            with self.subTest(stage=stage):
+                begin = executor_job.index(f"Begin {stage} maintenance")
+                core = executor_job.index(f"Deploy {stage} core stacks under maintenance")
+                host = executor_job.index(f"Deploy {stage} executor stack")
+                activation = executor_job.index(f"Publish and activate {stage} executor release")
+                finish = executor_job.index(f"Finish {stage} maintenance")
+
+                self.assertLess(begin, core)
+                self.assertLess(core, host)
+                self.assertLess(host, activation)
+                self.assertLess(activation, finish)
+                begin_step = executor_job[begin:core]
+                finish_step = executor_job[finish:]
+                self.assertIn("atomic_protocol_transition_required == 'true'", begin_step)
+                self.assertIn("atomic_protocol_transition_required == 'true'", finish_step)
 
     def test_maintenance_paths_bypass_the_skipped_core_job_and_preserve_failed_fences(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
@@ -238,6 +274,7 @@ class DeployWorkflowTest(unittest.TestCase):
             "executor_host_redeploy_required",
             "executor_release_required",
             "core_maintenance_required",
+            "atomic_protocol_transition_required",
             "database_maintenance_required",
         ):
             self.assertIn(output, workflow)

--- a/infra/tests/test_maintenance_classifier.py
+++ b/infra/tests/test_maintenance_classifier.py
@@ -389,6 +389,7 @@ def upgrade() -> None:
         self.assertFalse(result.executor_host_redeploy_required)
         self.assertFalse(result.executor_release_required)
         self.assertTrue(result.core_maintenance_required)
+        self.assertFalse(result.atomic_protocol_transition_required)
         self.assertFalse(result.database_maintenance_required)
 
     def test_tracker_stack_change_does_not_require_executor_work(self) -> None:
@@ -478,6 +479,30 @@ def upgrade() -> None:
         self.assertTrue(result.executor_release_required)
         self.assertFalse(result.database_maintenance_required)
         self.assertEqual(result.reasons, ["executor-release-change"])
+
+    def test_executor_protocol_transition_requires_atomic_core_maintenance(self) -> None:
+        head_sha = self._commit_file(
+            "services/tracker/src/executor_protocol.py",
+            'SUPPORTED_PROTOCOL_VERSION = "next"\n',
+        )
+
+        result = self._classify(head_sha)
+
+        self.assertEqual(result.classification, "maintenance-required")
+        self.assertTrue(result.executor_stack_deploy_required)
+        self.assertFalse(result.executor_host_redeploy_required)
+        self.assertTrue(result.executor_release_required)
+        self.assertTrue(result.core_maintenance_required)
+        self.assertTrue(result.atomic_protocol_transition_required)
+        self.assertFalse(result.database_maintenance_required)
+        self.assertEqual(
+            result.reasons,
+            [
+                "executor-core-change",
+                "executor-protocol-transition",
+                "executor-release-change",
+            ],
+        )
 
     def test_existing_migration_history_cannot_be_changed(self) -> None:
         path = f"{_MIGRATION_DIRECTORY}/existing.py"

--- a/packages/valkyrie-sdk/pyproject.toml
+++ b/packages/valkyrie-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "valkyrie-sdk"
-version = "0.2.4"
+version = "0.2.5"
 description = "Async Python SDK for managing Valkyrie benchmark runs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/models/agents.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/models/agents.py
@@ -66,6 +66,10 @@ class AgentContractRequest(BaseModel):
     egress_allowlist: list[str] = Field(default_factory=list)
     secrets: dict[str, str] = Field(default_factory=dict)
     kwargs: dict[str, str] = Field(default_factory=dict)
+    # Tracker-owned identity for an exact run-scoped archive. These are omitted
+    # from ordinary SDK start requests and populated by the service.
+    frozen_archive_s3_key: str | None = Field(default=None, exclude_if=lambda value: value is None)
+    frozen_archive_sha256: str | None = Field(default=None, exclude_if=lambda value: value is None)
 
     @field_validator("output_artifacts")
     @classmethod

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/resources/runs.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/resources/runs.py
@@ -300,6 +300,7 @@ class RunsResource:
         service_headers: Mapping[str, str] | None = None,
         from_scratch: bool = False,
         benchmark_url: str | None = None,
+        update_agent: bool = False,
     ) -> RetryOrResumeBenchmarkResponse:
         """Resume unfinished work for a run."""
         return await self._retry_or_resume(
@@ -311,6 +312,7 @@ class RunsResource:
             service_headers=service_headers,
             from_scratch=from_scratch,
             benchmark_url=benchmark_url,
+            update_agent=update_agent,
         )
 
     async def retry(
@@ -323,6 +325,7 @@ class RunsResource:
         service_headers: Mapping[str, str] | None = None,
         from_scratch: bool = False,
         benchmark_url: str | None = None,
+        update_agent: bool = False,
     ) -> RetryOrResumeBenchmarkResponse:
         """Retry failed or selected work for a run."""
         return await self._retry_or_resume(
@@ -334,6 +337,7 @@ class RunsResource:
             service_headers=service_headers,
             from_scratch=from_scratch,
             benchmark_url=benchmark_url,
+            update_agent=update_agent,
         )
 
     async def _retry_or_resume(
@@ -347,6 +351,7 @@ class RunsResource:
         service_headers: Mapping[str, str] | None,
         from_scratch: bool,
         benchmark_url: str | None,
+        update_agent: bool,
     ) -> RetryOrResumeBenchmarkResponse:
         """Send a retry or resume request."""
         if concurrency is not None and concurrency < 1:
@@ -360,6 +365,8 @@ class RunsResource:
         }
         if concurrency is not None:
             params["concurrency"] = concurrency
+        if update_agent:
+            params["update_agent"] = True
 
         body: dict[str, Any] = {
             "task_ids": list(task_ids or []),

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -24,8 +24,8 @@ from taskiq_redis import RedisStreamBroker
 from executor_protocol import (
     DEFAULT_EXECUTOR_RELEASE_PREFIX,
     DEFAULT_STABLE_QUEUE_NAME,
+    EXECUTOR_HOST_COMPATIBLE_PROTOCOL_VERSIONS,
     EXECUTOR_TASK_NAME,
-    SUPPORTED_PROTOCOL_VERSION,
     ExecutorPayload,
     validate_executor_artifact_uri,
     validate_executor_digest,
@@ -147,7 +147,7 @@ class ArtifactDispatch:
     def from_payload(cls, payload: Mapping[str, object]) -> ArtifactDispatch:
         digest = validate_executor_digest(_required_string(payload, "executor_artifact_digest"))
         protocol_version = _required_string(payload, "executor_protocol_version")
-        if protocol_version != SUPPORTED_PROTOCOL_VERSION:
+        if protocol_version not in EXECUTOR_HOST_COMPATIBLE_PROTOCOL_VERSIONS:
             raise ValueError(f"Unsupported executor protocol version: {protocol_version}")
         return cls(
             release_id=_required_string(payload, "executor_release_id"),

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -49,7 +49,6 @@ from tracker.aws.s3 import (
     download_from_s3,
     download_many_from_s3,
     get_benchmark_contract_s3_key,
-    get_contract_s3_key,
     list_s3_objects,
     s3_object_exists,
 )
@@ -339,15 +338,30 @@ def init_org(
     return {"org_name": org.name, "created": created, "email_claim_missing": identity.email is None}
 
 
-async def _resolve_contract_from_s3(request: StartBenchmarkRequest) -> AgentContractRequest:
-    """Resolve install_cmd/run_cmd/etc by parsing the agent's contract file inside its S3 zip."""
+async def _resolve_contract_from_frozen_agent(
+    request: StartBenchmarkRequest,
+    benchmark_id: UUID,
+) -> AgentContractRequest:
+    """Resolve executable contract fields from this run's frozen agent archive.
+
+    Clients may have read ``agents/<name>.zip`` before submitting the start
+    request.  That alias can move before the tracker admits the run, so the
+    client-supplied install/run commands are not an immutable identity.  The
+    tracker first copies the alias to the run-scoped key and then parses this
+    exact copy.  Model/kwarg choices and explicit secret overrides remain
+    request inputs; every executable field comes from the frozen archive.
+    """
     zip_bytes = await download_from_s3(
-        get_contract_s3_key(request.contract.name),
+        get_benchmark_contract_s3_key(str(benchmark_id), request.contract.name),
         request.harness_config.aws,
         request.harness_config.s3_bucket,
     )
     agent_config = AgentConfig(model=request.contract.model, kwargs=dict(request.contract.kwargs))
     resolved = get_contract_from_zip_bytes(request.contract.name, zip_bytes, agent_config)
+    if resolved.name != request.contract.name:
+        raise ValueError(
+            f"Frozen agent contract name {resolved.name!r} does not match requested agent {request.contract.name!r}"
+        )
     if request.contract.secrets:
         resolved.secrets = {**resolved.secrets, **request.contract.secrets}
     return resolved
@@ -422,9 +436,6 @@ async def start_benchmark(
         }
     )
 
-    if not request.contract.install_cmd and not request.contract.run_cmd:
-        request = request.model_copy(update={"contract": await _resolve_contract_from_s3(request)})
-
     logger.info(f"Starting benchmark run - contract: {request.contract.name}, benchmark: {request.benchmark_name}")
 
     benchmark_service = request.benchmark_service
@@ -456,18 +467,23 @@ async def start_benchmark(
         except Exception:
             logger.exception("Failed to close benchmark service client for %s", request.benchmark_name)
 
-    benchmark_row = start_benchmark_request_to_benchmark(request, run_starter)
+    benchmark_id = uuid4()
     dispatch_id = uuid4()
     agent_copy_created = False
     try:
         agent_copy_created = bool(
             await copy_agent_to_benchmark(
-                str(benchmark_row.id),
+                str(benchmark_id),
                 request.contract.name,
                 request.harness_config.aws,
                 request.harness_config.s3_bucket,
             )
         )
+        request = request.model_copy(
+            update={"contract": await _resolve_contract_from_frozen_agent(request, benchmark_id)}
+        )
+        benchmark_row = start_benchmark_request_to_benchmark(request, run_starter)
+        benchmark_row.id = benchmark_id
         for task_id in verify_response.task_ids:
             session.add(Task(org_id=benchmark_row.org_id, benchmark=benchmark_row.id, task_id=task_id))
         executor_dispatch = admit_start_dispatch(
@@ -480,7 +496,7 @@ async def start_benchmark(
         session.rollback()
         await _delete_uncommitted_agent_copy(
             created=agent_copy_created,
-            benchmark_id=benchmark_row.id,
+            benchmark_id=benchmark_id,
             request=request,
         )
         raise HTTPException(status_code=503, detail=str(exc)) from exc
@@ -488,7 +504,7 @@ async def start_benchmark(
         session.rollback()
         await _delete_uncommitted_agent_copy(
             created=agent_copy_created,
-            benchmark_id=benchmark_row.id,
+            benchmark_id=benchmark_id,
             request=request,
         )
         raise TrackerServiceError("Failed to admit benchmark execution") from exc

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import io
 import logging
 import tarfile
@@ -41,6 +42,7 @@ from tracker.aws.secrets import resolve_secrets
 from tracker.agent.contract import get_contract_from_zip_bytes
 from tracker.aws.s3 import (
     S3_BENCHMARKS_PREFIX,
+    copy_s3_object,
     copy_agent_to_benchmark,
     create_benchmark_url,
     delete_from_s3,
@@ -48,7 +50,9 @@ from tracker.aws.s3 import (
     create_presigned_url,
     download_from_s3,
     download_many_from_s3,
+    get_benchmark_contract_revision_s3_key,
     get_benchmark_contract_s3_key,
+    get_contract_s3_key,
     list_s3_objects,
     s3_object_exists,
 )
@@ -338,6 +342,43 @@ def init_org(
     return {"org_name": org.name, "created": created, "email_claim_missing": identity.email is None}
 
 
+def _resolve_contract_from_agent_archive_bytes(
+    contract: AgentContractRequest,
+    zip_bytes: bytes,
+    archive_s3_key: str,
+) -> AgentContractRequest:
+    """Resolve executable fields and identity from one exact archive payload."""
+    agent_config = AgentConfig(model=contract.model, kwargs=dict(contract.kwargs))
+    resolved = get_contract_from_zip_bytes(contract.name, zip_bytes, agent_config)
+    if resolved.name != contract.name:
+        raise ValueError(
+            f"Frozen agent contract name {resolved.name!r} does not match requested agent {contract.name!r}"
+        )
+    if contract.secrets:
+        resolved.secrets = {**resolved.secrets, **contract.secrets}
+    return resolved.model_copy(
+        update={
+            "kwargs": dict(contract.kwargs),
+            "frozen_archive_s3_key": archive_s3_key,
+            "frozen_archive_sha256": hashlib.sha256(zip_bytes).hexdigest(),
+        }
+    )
+
+
+async def _resolve_contract_from_agent_archive(
+    contract: AgentContractRequest,
+    archive_s3_key: str,
+    harness_config: HarnessConfig,
+) -> AgentContractRequest:
+    """Download and resolve a contract from the exact run-scoped S3 key."""
+    zip_bytes = await download_from_s3(
+        archive_s3_key,
+        harness_config.aws,
+        harness_config.s3_bucket,
+    )
+    return _resolve_contract_from_agent_archive_bytes(contract, zip_bytes, archive_s3_key)
+
+
 async def _resolve_contract_from_frozen_agent(
     request: StartBenchmarkRequest,
     benchmark_id: UUID,
@@ -351,20 +392,64 @@ async def _resolve_contract_from_frozen_agent(
     exact copy.  Model/kwarg choices and explicit secret overrides remain
     request inputs; every executable field comes from the frozen archive.
     """
-    zip_bytes = await download_from_s3(
+    return await _resolve_contract_from_agent_archive(
+        request.contract,
         get_benchmark_contract_s3_key(str(benchmark_id), request.contract.name),
-        request.harness_config.aws,
-        request.harness_config.s3_bucket,
+        request.harness_config,
     )
-    agent_config = AgentConfig(model=request.contract.model, kwargs=dict(request.contract.kwargs))
-    resolved = get_contract_from_zip_bytes(request.contract.name, zip_bytes, agent_config)
-    if resolved.name != request.contract.name:
-        raise ValueError(
-            f"Frozen agent contract name {resolved.name!r} does not match requested agent {request.contract.name!r}"
+
+
+async def _stage_agent_revision(
+    benchmark_id: UUID,
+    contract: AgentContractRequest,
+    harness_config: HarnessConfig,
+) -> tuple[str, bytes]:
+    """Copy the moving alias to a unique key and validate that exact payload."""
+    revision_key = get_benchmark_contract_revision_s3_key(
+        str(benchmark_id),
+        contract.name,
+        str(uuid4()),
+    )
+    try:
+        await copy_s3_object(
+            get_contract_s3_key(contract.name),
+            revision_key,
+            harness_config.aws,
+            harness_config.s3_bucket,
         )
-    if request.contract.secrets:
-        resolved.secrets = {**resolved.secrets, **request.contract.secrets}
-    return resolved
+        zip_bytes = await download_from_s3(
+            revision_key,
+            harness_config.aws,
+            harness_config.s3_bucket,
+        )
+        _resolve_contract_from_agent_archive_bytes(contract, zip_bytes, revision_key)
+        return revision_key, zip_bytes
+    except Exception:
+        try:
+            await delete_from_s3(revision_key, harness_config.aws, harness_config.s3_bucket)
+        except Exception:
+            logger.exception(
+                "Failed to delete rejected agent revision",
+                extra={"benchmark_id": str(benchmark_id), "agent_revision_key": revision_key},
+            )
+        raise
+
+
+async def _delete_uncommitted_agent_revision(
+    revision_key: str | None,
+    benchmark_id: UUID,
+    harness_config: HarnessConfig,
+) -> None:
+    """Best-effort cleanup for an append-only revision not referenced by the DB."""
+    if revision_key is None:
+        return
+    try:
+        await delete_from_s3(revision_key, harness_config.aws, harness_config.s3_bucket)
+    except Exception:
+        logger.exception(
+            "Failed to delete uncommitted agent revision",
+            extra={"benchmark_id": str(benchmark_id), "agent_revision_key": revision_key},
+        )
 
 
 def _authorize_custom_benchmark_destination(url: str, org: Org) -> None:
@@ -951,6 +1036,7 @@ async def retry_or_resume_benchmark(
     retry: bool = Query(default=False),
     retry_mode: RetryMode = Query(default=RetryMode.AUTO),
     concurrency: int | None = Query(default=None),
+    update_agent: bool = Query(default=False),
     task_ids: list[str] = Body(default=[]),
     service_headers: dict[str, str] = Body(default={}),
     secrets: dict[str, str] = Body(default={}),
@@ -970,6 +1056,7 @@ async def retry_or_resume_benchmark(
         benchmark_id: The benchmark ID to retry/resume
         retry: If true, retry failed tasks. If false, resume from where it left off
         concurrency: Optional new concurrency level (overrides original value)
+        update_agent: Freeze and bind the current shared agent alias before dispatch
         task_ids: Optional list of specific task IDs to run. If a task id is not yet
             registered but is valid in the current dataset, a fresh PENDING row is created.
         benchmark_url: Optional replacement benchmark service URL stored on the run.
@@ -983,6 +1070,12 @@ async def retry_or_resume_benchmark(
         raise HTTPException(
             status_code=400,
             detail=f"Run {benchmark_id} is in the {benchmark_row.status} state. Cannot continue a run that is stopping.",
+        )
+
+    if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and update_agent:
+        raise HTTPException(
+            status_code=409,
+            detail="Cannot update an agent while its run is in progress. Stop the run before updating it.",
         )
 
     if benchmark_url is not None:
@@ -1015,7 +1108,17 @@ async def retry_or_resume_benchmark(
 
     dispatch_id = uuid4()
     pre_action_status: BenchmarkStatus | None = None
+    staged_agent_key: str | None = None
+    staged_agent_bytes: bytes | None = None
+    agent_revision_committed = False
     try:
+        if update_agent:
+            staged_agent_key, staged_agent_bytes = await _stage_agent_revision(
+                benchmark_id,
+                benchmark_row.arguments.contract,
+                harness_config,
+            )
+
         with session.no_autoflush:
             lock_executor_admission(session)
         benchmark_row = fetch_benchmark_row(benchmark_id, session, org, for_update=True)
@@ -1035,7 +1138,31 @@ async def retry_or_resume_benchmark(
                 status_code=400,
                 detail=f"Run {benchmark_id} is in the {benchmark_row.status} state. Cannot continue a run that is stopping.",
             )
+        if benchmark_row.status == BenchmarkStatus.IN_PROGRESS and update_agent:
+            raise HTTPException(
+                status_code=409,
+                detail="Cannot update an agent while its run is in progress. Stop the run before updating it.",
+            )
         pre_action_status = benchmark_row.status
+
+        if update_agent:
+            if staged_agent_key is None or staged_agent_bytes is None:
+                raise RuntimeError("Updated agent revision was not staged")
+            runtime_contract = benchmark_row.arguments.contract.model_copy(
+                update={
+                    "secrets": {
+                        **benchmark_row.arguments.contract.secrets,
+                        **secrets,
+                    }
+                }
+            )
+            updated_contract = _resolve_contract_from_agent_archive_bytes(
+                runtime_contract,
+                staged_agent_bytes,
+                staged_agent_key,
+            )
+            benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": updated_contract})
+            session.add(benchmark_row)
 
         verified_task_ids = await reset_to_in_progress_status(
             benchmark_row=benchmark_row,
@@ -1088,6 +1215,7 @@ async def retry_or_resume_benchmark(
             kind=dispatch_kind,
         )
         session.commit()
+        agent_revision_committed = update_agent
     except ReleaseControlError as exc:
         session.rollback()
         status_code = (
@@ -1099,6 +1227,9 @@ async def retry_or_resume_benchmark(
     except Exception:
         session.rollback()
         raise
+    finally:
+        if not agent_revision_committed:
+            await _delete_uncommitted_agent_revision(staged_agent_key, benchmark_id, harness_config)
 
     await _enqueue_executor_dispatch(
         executor_dispatch,

--- a/services/tracker/src/executor_protocol.py
+++ b/services/tracker/src/executor_protocol.py
@@ -5,7 +5,14 @@ from typing import Any, TypedDict, Unpack
 from urllib.parse import urlparse
 
 EXECUTOR_TASK_NAME = "tracker.utils:process_benchmark"
-SUPPORTED_PROTOCOL_VERSION = "1"
+# Version 2 adds a tracker-owned, digest-verified agent archive identity to the
+# nested StartBenchmarkRequest contract. Version 1 executors ignore those
+# fields and therefore cannot safely execute refreshed run revisions.
+SUPPORTED_PROTOCOL_VERSION = "2"
+# Stable hosts may drain dispatches already pinned to the preceding immutable
+# artifact. Tracker admission still requires ``SUPPORTED_PROTOCOL_VERSION`` for
+# all new work; this set is only the host-side compatibility window.
+EXECUTOR_HOST_COMPATIBLE_PROTOCOL_VERSIONS = frozenset({"1", SUPPORTED_PROTOCOL_VERSION})
 DEFAULT_STABLE_QUEUE_NAME = "valkyrie-stable"
 DEFAULT_EXECUTOR_RELEASE_PREFIX = "releases"
 

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -57,6 +57,11 @@ def get_benchmark_contract_s3_key(benchmark_id: str, contract_name: str) -> str:
     return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{contract_name}.zip"
 
 
+def get_benchmark_contract_revision_s3_key(benchmark_id: str, contract_name: str, revision_id: str) -> str:
+    """Get an append-only key for a refreshed agent revision within a run."""
+    return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/agent-revisions/{revision_id}/{contract_name}.zip"
+
+
 def get_agent_result_s3_key(benchmark_id: str, task_id: str, output_name: str) -> str:
     """Get the S3 key for a run output archive."""
     return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{task_id}/{output_name}"

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -5,7 +5,14 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, SerializerFunctionWrapHandler, field_serializer, field_validator, model_serializer
+from pydantic import (
+    BaseModel,
+    Field as PydanticField,
+    SerializerFunctionWrapHandler,
+    field_serializer,
+    field_validator,
+    model_serializer,
+)
 from sqlalchemy import Connection, Dialect, Index, event, text
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -152,6 +159,10 @@ class AgentContractRequest(BaseModel):
     egress_allowlist: list[str] = []
     secrets: dict[str, str] = {}
     kwargs: dict[str, str] = {}
+    # Tracker-owned identity for the exact run-scoped archive. Old contracts
+    # omit both fields and retain the legacy benchmarks/<run>/<agent>.zip path.
+    frozen_archive_s3_key: str | None = PydanticField(default=None, exclude_if=lambda value: value is None)
+    frozen_archive_sha256: str | None = PydanticField(default=None, exclude_if=lambda value: value is None)
 
     @field_validator("output_artifacts")
     @classmethod

--- a/services/tracker/src/tracker/executor/release_control.py
+++ b/services/tracker/src/tracker/executor/release_control.py
@@ -267,7 +267,12 @@ def select_active_release(session: Session, *, for_update: bool = False) -> Exec
         raise ReleaseControlError("No active executor release is configured")
 
     release = session.get(ExecutorRelease, admission.release_id)
-    if release is None or release.status != ExecutorReleaseStatus.ACTIVE or not release.readiness_verified:
+    if (
+        release is None
+        or release.status != ExecutorReleaseStatus.ACTIVE
+        or not release.readiness_verified
+        or release.protocol_version != SUPPORTED_PROTOCOL_VERSION
+    ):
         raise ReleaseControlError("No active executor release is configured")
     return release
 

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -1,6 +1,7 @@
 """Sandbox management utilities for the tracker service."""
 
 import asyncio
+import re
 import shlex
 import time
 import uuid
@@ -358,7 +359,16 @@ async def upload_agent_artifacts(
     """
     logger.info(f"Uploading contract {contract.name} to sandbox {sandbox.name}")
 
-    contract_s3_key = get_benchmark_contract_s3_key(benchmark_id, contract.name)
+    legacy_contract_s3_key = get_benchmark_contract_s3_key(benchmark_id, contract.name)
+    contract_s3_key = contract.frozen_archive_s3_key or legacy_contract_s3_key
+    archive_sha256 = contract.frozen_archive_sha256
+    if (contract.frozen_archive_s3_key is None) != (archive_sha256 is None):
+        raise SandboxError(f"Incomplete frozen archive identity for contract {contract.name}")
+    expected_run_prefix = legacy_contract_s3_key.rsplit("/", 1)[0] + "/"
+    if not contract_s3_key.startswith(expected_run_prefix):
+        raise SandboxError(f"Frozen archive for contract {contract.name} is outside benchmark {benchmark_id}")
+    if archive_sha256 is not None and re.fullmatch(r"[0-9a-f]{64}", archive_sha256) is None:
+        raise SandboxError(f"Invalid frozen archive digest for contract {contract.name}")
     presigned_url = await create_presigned_url(
         contract_s3_key, aws, s3_bucket, expiration=CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS
     )
@@ -388,11 +398,17 @@ async def upload_agent_artifacts(
     steps = [
         install_deps,
         f"curl -sfL -o {zip_path} {quoted_url}",
-        f"mkdir -p {bundle_dir}",
-        f"unzip -o -d {bundle_dir} {zip_path}",
-        f"rm -f {zip_path}",
-        f"mkdir -p {contract_dir}",
     ]
+    if archive_sha256 is not None:
+        steps.append(f"printf '%s  %s\\n' {shlex.quote(archive_sha256)} {zip_path} | sha256sum -c -")
+    steps.extend(
+        [
+            f"mkdir -p {bundle_dir}",
+            f"unzip -o -d {bundle_dir} {zip_path}",
+            f"rm -f {zip_path}",
+            f"mkdir -p {contract_dir}",
+        ]
+    )
 
     script = " && ".join(steps)
 

--- a/services/tracker/tests/conftest.py
+++ b/services/tracker/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy import event
 from sqlalchemy.pool import ConnectionPoolEntry
 from sqlmodel import Session, SQLModel, StaticPool, create_engine
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tests.factories import make_benchmark
 from tests.utils import TEST_ORG_ID
 from tracker.database.models import (
@@ -86,7 +87,7 @@ def executor_authority_kwargs(
                     id=release_id,
                     artifact_uri="s3://artifacts/authority-test-release.pex",
                     artifact_digest="a" * 64,
-                    protocol_version="1",
+                    protocol_version=SUPPORTED_PROTOCOL_VERSION,
                     readiness_verified=True,
                 )
                 authority_session.add(release)

--- a/services/tracker/tests/integration/local/database/test_executor_host_store.py
+++ b/services/tracker/tests/integration/local/database/test_executor_host_store.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy.engine import Engine
 from sqlmodel import Session
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from services.executor_host.supervisor import (  # pyright: ignore[reportMissingImports]
     ArtifactDispatch,
     PostgresExecutorDispatchStore,
@@ -40,7 +41,7 @@ async def test_postgres_store_fences_claim_finish_and_terminalize_with_sibling(
         id="executor-host-store-release",
         artifact_uri="s3://artifacts/executor-host-store.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
         created_at=datetime.now(UTC),
     )

--- a/services/tracker/tests/integration/local/database/test_release_control.py
+++ b/services/tracker/tests/integration/local/database/test_release_control.py
@@ -15,6 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, select
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -59,7 +60,7 @@ def _release(release_id: str) -> ExecutorRelease:
         id=release_id,
         artifact_uri=f"s3://artifacts/{release_id}.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
     )
 
@@ -69,7 +70,7 @@ def _activation_candidate() -> ExecutorRelease:
         id="concurrent-activation",
         artifact_uri="s3://artifacts/releases/concurrent-activation/executor.pex",
         artifact_digest=_EXECUTOR_ARTIFACT_DIGEST,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
 
 

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -75,10 +75,14 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     async def _mock_copy_agent_to_benchmark(*_args: Any, **_kwargs: Any) -> bool:
         return False
 
+    async def _mock_resolve_contract_from_frozen_agent(request: Any, *_args: Any, **_kwargs: Any) -> Any:
+        return request.contract
+
     monkeypatch.setattr("tracker.aws.s3.download_from_s3", _mock_download_from_s3)
     monkeypatch.setattr("tracker.aws.s3.get_contract_s3_key", _mock_get_contract_s3_key)
     monkeypatch.setattr("tracker.utils.reporting.upload_to_s3", _mock_upload_to_s3)
     monkeypatch.setattr("main.copy_agent_to_benchmark", _mock_copy_agent_to_benchmark)
+    monkeypatch.setattr("main._resolve_contract_from_frozen_agent", _mock_resolve_contract_from_frozen_agent)
 
 
 @pytest.fixture(autouse=True)

--- a/services/tracker/tests/unit/executor/test_dispatch_control.py
+++ b/services/tracker/tests/unit/executor/test_dispatch_control.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 from sqlmodel import Session
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tracker.database.models import (
     Benchmark,
     BenchmarkStatus,
@@ -38,7 +39,7 @@ def _release(release_id: str) -> ExecutorRelease:
         id=release_id,
         artifact_uri=f"s3://artifacts/{release_id}.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
         created_at=datetime.now(UTC),
     )

--- a/services/tracker/tests/unit/executor/test_maintenance_control.py
+++ b/services/tracker/tests/unit/executor/test_maintenance_control.py
@@ -5,7 +5,7 @@ from uuid import UUID, uuid4
 import pytest
 from sqlmodel import Session, select
 
-from executor_protocol import ExecutorDispatchStatus
+from executor_protocol import ExecutorDispatchStatus, SUPPORTED_PROTOCOL_VERSION
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -29,7 +29,7 @@ def _release(release_id: str = "maintenance-release") -> ExecutorRelease:
         id=release_id,
         artifact_uri=f"s3://artifacts/{release_id}.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         status=ExecutorReleaseStatus.ACTIVE,
         readiness_verified=True,
     )

--- a/services/tracker/tests/unit/executor/test_release_control.py
+++ b/services/tracker/tests/unit/executor/test_release_control.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlmodel import Session
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tracker.database.models import (
     Benchmark,
     BenchmarkStatus,
@@ -36,7 +37,7 @@ def _release(release_id: str) -> ExecutorRelease:
         id=release_id,
         artifact_uri=f"s3://artifacts/{release_id}.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
         created_at=datetime.now(UTC),
     )
@@ -72,7 +73,7 @@ def test_activate_release_registers_verifies_and_promotes_in_one_session(databas
         id="git-abc123-def456",
         artifact_uri="s3://artifacts/releases/git-abc123-def456/executor.pex",
         artifact_digest=hashlib.sha256(content).hexdigest(),
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
 
     activated = activate_release(
@@ -96,7 +97,7 @@ def test_activate_release_is_idempotent_for_exact_active_release(database_sessio
         id="git-abc123-def456",
         artifact_uri="s3://artifacts/releases/git-abc123-def456/executor.pex",
         artifact_digest=hashlib.sha256(content).hexdigest(),
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
     client = FakeS3Client(content, key="releases/git-abc123-def456/executor.pex")
     first = activate_release(
@@ -133,13 +134,13 @@ def test_activate_release_rejects_draining_release(database_session: Session) ->
         id="git-previous",
         artifact_uri="s3://artifacts/releases/git-previous/executor.pex",
         artifact_digest=hashlib.sha256(content).hexdigest(),
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
     current = ExecutorRelease(
         id="git-current",
         artifact_uri="s3://artifacts/releases/git-current/executor.pex",
         artifact_digest=hashlib.sha256(content).hexdigest(),
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
     activate_release(
         database_session,
@@ -177,7 +178,7 @@ def test_activate_release_rejects_retired_release(database_session: Session) -> 
         id="git-retired",
         artifact_uri="s3://artifacts/releases/git-retired/executor.pex",
         artifact_digest=hashlib.sha256(content).hexdigest(),
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
     register_release(database_session, release)
     release.status = ExecutorReleaseStatus.RETIRED
@@ -204,7 +205,7 @@ def test_activate_release_rejects_release_id_reuse_with_different_content(databa
         id="git-abc123-def456",
         artifact_uri="s3://artifacts/releases/git-abc123-def456/executor.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
     register_release(database_session, existing)
 
@@ -228,7 +229,7 @@ def test_activate_release_digest_failure_rolls_back_new_candidate(database_sessi
         id="git-abc123-def456",
         artifact_uri="s3://artifacts/releases/git-abc123-def456/executor.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
 
     with pytest.raises(ReleaseControlError, match="digest mismatch"):
@@ -284,7 +285,7 @@ def test_verify_release_artifact_rejects_digest_mismatch(database_session: Sessi
 
 def test_register_release_rejects_unsupported_protocol(database_session: Session) -> None:
     release = _release("unsupported")
-    release.protocol_version = "2"
+    release.protocol_version = "unsupported"
 
     with pytest.raises(ReleaseControlError, match="Unsupported executor protocol version"):
         register_release(database_session, release)
@@ -381,6 +382,21 @@ def test_promote_release_rejects_draining_release(database_session: Session) -> 
 
 
 def test_select_active_release_requires_an_admission_target(database_session: Session) -> None:
+    with pytest.raises(ReleaseControlError, match="No active executor release"):
+        select_active_release(database_session)
+
+
+def test_select_active_release_rejects_legacy_protocol_during_rollout(database_session: Session) -> None:
+    """New work waits for the matching executor instead of dispatching to a v1 artifact."""
+    legacy = _release("legacy-v1")
+    legacy.protocol_version = "1"
+    legacy.status = ExecutorReleaseStatus.ACTIVE
+    admission = database_session.get(ExecutorAdmission, 1)
+    assert admission is not None
+    admission.release_id = legacy.id
+    database_session.add_all([legacy, admission])
+    database_session.commit()
+
     with pytest.raises(ReleaseControlError, match="No active executor release"):
         select_active_release(database_session)
 

--- a/services/tracker/tests/unit/executor/test_release_entrypoint.py
+++ b/services/tracker/tests/unit/executor/test_release_entrypoint.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from pytest import MonkeyPatch
 from sqlmodel import Session
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tracker.executor import release_entrypoint
 from tracker.database import session as tracker_session
 from tracker.database.models import ExecutorAdmission, ExecutorRelease, ExecutorReleaseStatus
@@ -96,7 +97,7 @@ def _release_arguments(monkeypatch: MonkeyPatch, *, artifact_digest: str = "a" *
             "git-abc123-def456",
             "s3://releases/releases/git-abc123-def456/executor.pex",
             artifact_digest,
-            "1",
+            SUPPORTED_PROTOCOL_VERSION,
         ],
     )
 
@@ -249,7 +250,7 @@ def test_release_entrypoint_rejects_invalid_release_id_before_reading_secret(mon
     ("argument_index", "invalid_value", "error"),
     [
         (14, "s3://other/releases/git-abc123-def456/executor.pex", "configured S3 bucket"),
-        (16, "2", "Unsupported executor protocol"),
+        (16, "unsupported", "Unsupported executor protocol"),
     ],
 )
 def test_release_entrypoint_rejects_invalid_artifact_identity_before_reading_secret(

--- a/services/tracker/tests/unit/executor/test_release_retirement.py
+++ b/services/tracker/tests/unit/executor/test_release_retirement.py
@@ -8,6 +8,7 @@ from pytest import MonkeyPatch
 from sqlmodel import Session
 
 import main as main_module
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tracker.executor import release_retirement
 from tracker.database.models import ExecutorRelease, ExecutorReleaseStatus
 from tracker.executor.release_control import promote_release, register_release
@@ -23,7 +24,7 @@ def test_retirement_loop_retires_a_blocker_free_release(
             id="old",
             artifact_uri="s3://artifacts/old.pex",
             artifact_digest="a" * 64,
-            protocol_version="1",
+            protocol_version=SUPPORTED_PROTOCOL_VERSION,
             readiness_verified=True,
         ),
     )
@@ -33,7 +34,7 @@ def test_retirement_loop_retires_a_blocker_free_release(
             id="active",
             artifact_uri="s3://artifacts/active.pex",
             artifact_digest="b" * 64,
-            protocol_version="1",
+            protocol_version=SUPPORTED_PROTOCOL_VERSION,
             readiness_verified=True,
         ),
     )

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -6,6 +6,7 @@ Run: uv run pytest tests/unit/test_main.py
 import io
 import logging
 import tarfile
+import zipfile
 from collections.abc import AsyncIterator
 from datetime import timezone
 from typing import Any
@@ -63,7 +64,16 @@ from tracker.types import (
 )
 from tracker.utils import fetch_harness_config, update_benchmark_concurrency
 
+_REAL_RESOLVE_CONTRACT_FROM_FROZEN_AGENT = main_module._resolve_contract_from_frozen_agent
+
 client = TestClient(app)
+
+
+def _agent_zip(agent_name: str, contract_yaml: str) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(f"{agent_name}/contract.yaml", contract_yaml)
+    return buffer.getvalue()
 
 
 @pytest.fixture(autouse=True)
@@ -558,6 +568,132 @@ class TestTrackerAPI:
         assert json_response["executor_artifact_digest"] == "digest-test-release"
         assert json_response["executor_protocol_version"] == "1"
         assert json_response["concurrency"] == request.concurrency
+
+    async def test_start_benchmark_uses_contract_from_exact_frozen_archive(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        mock_kicker: Any,
+    ) -> None:
+        """An alias flip cannot mix the CLI's old contract with the copied zip."""
+        request_contract = AgentContractRequest(
+            name="flip-agent",
+            model="provider/model",
+            install_cmd="echo stale-install",
+            run_cmd="echo stale-run",
+            secrets={"OVERRIDE": "request-secret"},
+        )
+        request = StartBenchmarkRequest(
+            contract=request_contract,
+            benchmark_name="swebench",
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+        replacement_zip = _agent_zip(
+            "flip-agent",
+            """
+name: flip-agent
+install_cmd: echo frozen-install
+run_cmd: echo frozen-run {problem_statement_path} {task_id}
+secrets:
+  ARCHIVE_ONLY: archive-secret
+  OVERRIDE: archive-default
+""".strip(),
+        )
+        frozen_objects: dict[str, bytes] = {}
+
+        async def copy_after_alias_flip(
+            benchmark_id: str,
+            contract_name: str,
+            *_args: Any,
+            **_kwargs: Any,
+        ) -> bool:
+            # The CLI already parsed the stale request contract. Simulate the
+            # shared alias changing before the tracker freezes it for this run.
+            key = f"benchmarks/{benchmark_id}/{contract_name}.zip"
+            frozen_objects[key] = replacement_zip
+            return True
+
+        async def download_frozen(key: str, *_args: Any, **_kwargs: Any) -> bytes:
+            return frozen_objects[key]
+
+        monkeypatch.setattr(
+            main_module,
+            "_resolve_contract_from_frozen_agent",
+            _REAL_RESOLVE_CONTRACT_FROM_FROZEN_AGENT,
+        )
+        monkeypatch.setattr(main_module, "copy_agent_to_benchmark", copy_after_alias_flip)
+        monkeypatch.setattr(main_module, "download_from_s3", download_frozen)
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_single_task_id)
+
+        response = client.post("/start-benchmark", json=request.model_dump())
+
+        assert response.status_code == 200
+        benchmark_id = UUID(response.json()["benchmark_id"])
+        benchmark = database_session.get(Benchmark, benchmark_id)
+        assert benchmark is not None
+        frozen_contract = benchmark.arguments.contract
+        assert frozen_contract.name == "flip-agent"
+        assert frozen_contract.model == "provider/model"
+        assert frozen_contract.install_cmd == "echo frozen-install"
+        assert frozen_contract.run_cmd == "echo frozen-run {problem_statement_path} {task_id}"
+        assert frozen_contract.secrets == {
+            "ARCHIVE_ONLY": "archive-secret",
+            "OVERRIDE": "request-secret",
+        }
+        assert "stale" not in frozen_contract.install_cmd
+        assert "stale" not in frozen_contract.run_cmd
+
+        queued_contract = mock_kicker.queued_calls[0]["start_benchmark_request_json"]["contract"]
+        assert queued_contract == frozen_contract.model_dump()
+        assert list(frozen_objects) == [f"benchmarks/{benchmark_id}/flip-agent.zip"]
+
+    async def test_start_benchmark_fails_closed_when_frozen_archive_is_unreadable(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        harness_config: HarnessConfig,
+    ) -> None:
+        copy_agent = AsyncMock(return_value=True)
+        delete_agent_copy = AsyncMock()
+
+        async def unreadable_frozen_archive(*_args: Any, **_kwargs: Any) -> bytes:
+            return b"not-a-zip"
+
+        monkeypatch.setattr(
+            main_module,
+            "_resolve_contract_from_frozen_agent",
+            _REAL_RESOLVE_CONTRACT_FROM_FROZEN_AGENT,
+        )
+        monkeypatch.setattr(main_module, "copy_agent_to_benchmark", copy_agent)
+        monkeypatch.setattr(main_module, "download_from_s3", unreadable_frozen_archive)
+        monkeypatch.setattr(main_module, "delete_from_s3", delete_agent_copy)
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _verify_single_task_id)
+        request = StartBenchmarkRequest(
+            contract=contract,
+            benchmark_name="swebench",
+            concurrency=1,
+            task_ids=["task_0"],
+            harness_config=harness_config,
+        )
+
+        response = TestClient(app, raise_server_exceptions=False).post(
+            "/start-benchmark",
+            json=request.model_dump(),
+        )
+
+        assert response.status_code == 500
+        assert database_session.exec(select(Benchmark)).all() == []
+        copy_agent.assert_awaited_once()
+        copied_benchmark_id = copy_agent.await_args.args[0]
+        delete_agent_copy.assert_awaited_once_with(
+            f"benchmarks/{copied_benchmark_id}/{contract.name}.zip",
+            harness_config.aws,
+            harness_config.s3_bucket,
+        )
 
     async def test_start_benchmark_serializes_committed_dispatch_for_executor_host(
         self,

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -3,6 +3,7 @@
 Run: uv run pytest tests/unit/test_main.py
 """
 
+import hashlib
 import io
 import logging
 import tarfile
@@ -31,6 +32,7 @@ from taskiq.message import BrokerMessage, TaskiqMessage
 
 import main as main_module
 import services.executor_host.supervisor as executor_host  # pyright: ignore[reportMissingImports]
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from main import app, tracker_service_error_handler
 from tests.utils import TEST_ORG_ID, async_iterator
 from tracker.auth import RequestIdentity, get_current_org, get_current_starter
@@ -83,7 +85,7 @@ def active_executor_release(database_session: Session) -> None:
         id="test-release",
         artifact_uri="s3://artifacts/test-release.pex",
         artifact_digest="digest-test-release",
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         status=ExecutorReleaseStatus.ACTIVE,
         readiness_verified=True,
     )
@@ -543,7 +545,7 @@ class TestTrackerAPI:
         assert benchmark_row.current_execution_release_id == "test-release"
         assert benchmark_row.executor_artifact_uri == "s3://artifacts/test-release.pex"
         assert benchmark_row.executor_artifact_digest == "digest-test-release"
-        assert benchmark_row.executor_protocol_version == "1"
+        assert benchmark_row.executor_protocol_version == SUPPORTED_PROTOCOL_VERSION
         queued_call = mock_kicker.queued_calls[0]
         dispatch_id = UUID(queued_call["executor_dispatch_id"])
         dispatch = database_session.get(ExecutorDispatch, dispatch_id)
@@ -554,7 +556,7 @@ class TestTrackerAPI:
         assert dispatch.executor_release_id == "test-release"
         assert dispatch.executor_artifact_uri == "s3://artifacts/test-release.pex"
         assert dispatch.executor_artifact_digest == "digest-test-release"
-        assert dispatch.executor_protocol_version == "1"
+        assert dispatch.executor_protocol_version == SUPPORTED_PROTOCOL_VERSION
         assert queued_call["verified_task_ids"] == [f"task_{i}" for i in range(500)]
         task_rows = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
         assert len(task_rows) == 500
@@ -566,7 +568,7 @@ class TestTrackerAPI:
         assert json_response["executor_release_id"] == "test-release"
         assert json_response["current_execution_release_id"] == "test-release"
         assert json_response["executor_artifact_digest"] == "digest-test-release"
-        assert json_response["executor_protocol_version"] == "1"
+        assert json_response["executor_protocol_version"] == SUPPORTED_PROTOCOL_VERSION
         assert json_response["concurrency"] == request.concurrency
 
     async def test_start_benchmark_uses_contract_from_exact_frozen_archive(
@@ -643,6 +645,8 @@ secrets:
             "ARCHIVE_ONLY": "archive-secret",
             "OVERRIDE": "request-secret",
         }
+        assert frozen_contract.frozen_archive_s3_key == f"benchmarks/{benchmark_id}/flip-agent.zip"
+        assert frozen_contract.frozen_archive_sha256 == hashlib.sha256(replacement_zip).hexdigest()
         assert "stale" not in frozen_contract.install_cmd
         assert "stale" not in frozen_contract.run_cmd
 
@@ -790,7 +794,7 @@ secrets:
 
         assert taskiq_message.task_name == executor_host.launch_executor.task_name
         assert STABLE_QUEUE_NAME == executor_host.QUEUE_NAME
-        assert taskiq_message.kwargs["executor_protocol_version"] == executor_host.SUPPORTED_PROTOCOL_VERSION
+        assert taskiq_message.kwargs["executor_protocol_version"] == SUPPORTED_PROTOCOL_VERSION
         assert observed_host["executor_dispatch_id"] == str(dispatch.id)
         assert observed_host["benchmark_id_str"] == str(benchmark.id)
         assert observed_host["verified_task_ids"] == ["task_0"]

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1533,6 +1533,118 @@ class TestDeleteSandboxAudit:
 class TestUploadAgentArtifacts:
     """Agent artifact upload failure classification."""
 
+    async def test_legacy_contract_uses_fixed_run_archive_without_digest(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_credentials: AWSCredentials,
+    ) -> None:
+        """Pre-v2 persisted contracts remain runnable from their original fixed key."""
+        execute = AsyncMock(return_value=ExecResult(exit_code=0, output=""))
+        create_url = AsyncMock(return_value="https://example.com/presigned")
+        mock_sandbox = AsyncMock()
+        mock_sandbox.name = "test-sandbox"
+        monkeypatch.setattr(sandbox_module, "_exec", execute)
+        monkeypatch.setattr(sandbox_module, "create_presigned_url", create_url)
+
+        await upload_agent_artifacts(
+            mock_sandbox,
+            contract,
+            "bench-123",
+            aws_credentials,
+            "test-bucket",
+        )
+
+        create_url.assert_awaited_once_with(
+            "benchmarks/bench-123/dummy.zip",
+            aws_credentials,
+            "test-bucket",
+            expiration=sandbox_module.CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS,
+        )
+        assert "sha256sum" not in execute.await_args.args[1]
+
+    async def test_uses_bound_revision_key_and_verifies_digest(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_credentials: AWSCredentials,
+    ) -> None:
+        """The executor downloads and verifies the tracker-bound archive revision."""
+        archive_key = "benchmarks/bench-123/agent-revisions/revision-1/dummy.zip"
+        archive_sha256 = "a" * 64
+        bound_contract = contract.model_copy(
+            update={
+                "frozen_archive_s3_key": archive_key,
+                "frozen_archive_sha256": archive_sha256,
+            }
+        )
+        execute = AsyncMock(return_value=ExecResult(exit_code=0, output=""))
+        create_url = AsyncMock(return_value="https://example.com/presigned")
+        mock_sandbox = AsyncMock()
+        mock_sandbox.name = "test-sandbox"
+        monkeypatch.setattr(sandbox_module, "_exec", execute)
+        monkeypatch.setattr(sandbox_module, "create_presigned_url", create_url)
+
+        await upload_agent_artifacts(
+            mock_sandbox,
+            bound_contract,
+            "bench-123",
+            aws_credentials,
+            "test-bucket",
+        )
+
+        create_url.assert_awaited_once_with(
+            archive_key,
+            aws_credentials,
+            "test-bucket",
+            expiration=sandbox_module.CONTRACT_DOWNLOAD_URL_EXPIRES_SECONDS,
+        )
+        script = execute.await_args.args[1]
+        assert f"printf '%s  %s\\n' {archive_sha256} /tmp/dummy.zip | sha256sum -c -" in script
+
+    @pytest.mark.parametrize(
+        ("identity", "message"),
+        [
+            ({"frozen_archive_s3_key": "benchmarks/bench-123/revision.zip"}, "Incomplete"),
+            ({"frozen_archive_sha256": "a" * 64}, "Incomplete"),
+            (
+                {
+                    "frozen_archive_s3_key": "benchmarks/another-run/revision.zip",
+                    "frozen_archive_sha256": "a" * 64,
+                },
+                "outside benchmark",
+            ),
+            (
+                {
+                    "frozen_archive_s3_key": "benchmarks/bench-123/revision.zip",
+                    "frozen_archive_sha256": "not-a-digest",
+                },
+                "Invalid frozen archive digest",
+            ),
+        ],
+    )
+    async def test_malformed_bound_archive_identity_fails_closed(
+        self,
+        contract: AgentContractRequest,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_credentials: AWSCredentials,
+        identity: dict[str, str],
+        message: str,
+    ) -> None:
+        create_url = AsyncMock()
+        monkeypatch.setattr(sandbox_module, "create_presigned_url", create_url)
+
+        with pytest.raises(SandboxError, match=message):
+            await upload_agent_artifacts(
+                AsyncMock(name="test-sandbox"),
+                contract.model_copy(update=identity),
+                "bench-123",
+                aws_credentials,
+                "test-bucket",
+            )
+
+        create_url.assert_not_awaited()
+
     @pytest.mark.parametrize(
         "exit_code,retryable",
         [

--- a/services/tracker/tests/unit/utils/task_execution_support.py
+++ b/services/tracker/tests/unit/utils/task_execution_support.py
@@ -9,6 +9,7 @@ from benchmark_service import ImageSource, Resources
 from benchmark_service.schemas import RetrieveTaskResponse
 from sqlmodel import Session
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 from tests.utils import TEST_ORG_ID
 from tracker.auth import RequestIdentity
 from tracker.database.models import (
@@ -89,7 +90,7 @@ def create_task_environment(
         id="task-execution-test-release",
         artifact_uri="s3://artifacts/task-execution-test.pex",
         artifact_digest="a" * 64,
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
     )
     database_session.add(release)

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -6,6 +6,9 @@ Covers task state transitions, sandbox cleanup, and run-control API behavior.
 """
 
 import asyncio
+import hashlib
+import io
+import zipfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import datetime
@@ -24,6 +27,7 @@ from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 from sqlmodel import Session, select
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 import main as main_module
 from main import app
 import tracker.utils as tracker_utils
@@ -31,6 +35,7 @@ from tests.factories import make_benchmark, make_error_result, make_evaluation_r
 from tests.unit.utils.task_execution_support import MockKicker, make_retrieve_task_response
 from tests.utils import TEST_ORG_ID, async_iterator
 from tracker.auth import RequestIdentity
+from tracker.aws.s3 import get_benchmark_contract_s3_key
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -74,6 +79,13 @@ _RESUMED_ATTEMPT_AT = datetime(2026, 7, 9)
 client = TestClient(app)
 
 
+def _agent_zip(agent_name: str, contract_yaml: str) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr(f"{agent_name}/contract.yaml", contract_yaml)
+    return buffer.getvalue()
+
+
 @pytest.fixture
 def example_benchmark_object(contract: AgentContractRequest, database_session: Session) -> Benchmark:
     """Build recovery benchmarks with a persisted executor release identity."""
@@ -81,7 +93,7 @@ def example_benchmark_object(contract: AgentContractRequest, database_session: S
         id="test-release",
         artifact_uri="s3://artifacts/test-release.pex",
         artifact_digest="digest-test-release",
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
     )
     database_session.add(release)
@@ -387,7 +399,7 @@ class TestRunRecovery:
                 id="test-release",
                 artifact_uri="s3://artifacts/test-release.pex",
                 artifact_digest="digest-test-release",
-                protocol_version="1",
+                protocol_version=SUPPORTED_PROTOCOL_VERSION,
                 readiness_verified=True,
             )
         )
@@ -1163,6 +1175,310 @@ class TestRunRecovery:
         database_session.refresh(benchmark_row)
         assert benchmark_row.arguments.concurrency == 20
 
+    async def test_update_agent_binds_contract_to_exact_staged_revision(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        """An alias flip cannot mix a stored contract with the refreshed archive."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        old_zip = _agent_zip(
+            "dummy",
+            """
+name: dummy
+install_cmd: echo old-install
+run_cmd: echo old-run
+""".strip(),
+        )
+        old_key = get_benchmark_contract_s3_key(str(benchmark_row.id), "dummy")
+        old_contract = benchmark_row.arguments.contract.model_copy(
+            update={
+                "model": "provider/model",
+                "kwargs": {"temperature": "1"},
+                "install_cmd": "echo old-install",
+                "run_cmd": "echo old-run",
+                "final_output": "stale-output.txt",
+                "output_artifacts": ["stale-artifact.txt"],
+                "egress_allowlist": ["stale.example"],
+                "secrets": {"OVERRIDE": "stored-secret"},
+                "frozen_archive_s3_key": old_key,
+                "frozen_archive_sha256": hashlib.sha256(old_zip).hexdigest(),
+            }
+        )
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": old_contract})
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        replacement_zip = _agent_zip(
+            "dummy",
+            """
+name: dummy
+install_cmd: echo replacement-install
+run_cmd: echo replacement-run {problem_statement_path} {task_id}
+final_output: replacement-output.txt
+output_artifacts:
+  - replacement-artifact.txt
+egress_allowlist:
+  - api.replacement.example
+secrets:
+  ARCHIVE_ONLY: archive-secret
+  OVERRIDE: archive-default
+""".strip(),
+        )
+        objects = {
+            old_key: old_zip,
+            "agents/dummy.zip": replacement_zip,
+        }
+        copies: list[tuple[str, str]] = []
+
+        async def copy_object(source_key: str, dest_key: str, *_args: Any) -> None:
+            copies.append((source_key, dest_key))
+            objects[dest_key] = objects[source_key]
+
+        async def download_object(key: str, *_args: Any) -> bytes:
+            return objects[key]
+
+        async def reset_tasks(*_args: Any, **_kwargs: Any) -> list[str]:
+            return ["task_0"]
+
+        monkeypatch.setattr(main_module, "copy_s3_object", copy_object)
+        monkeypatch.setattr(main_module, "download_from_s3", download_object)
+        monkeypatch.setattr(main_module, "reset_to_in_progress_status", reset_tasks)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            params={"update_agent": "true"},
+            json={
+                "task_ids": [],
+                "service_headers": {},
+                "secrets": {"RESUME_ONLY": "resume-secret"},
+            },
+        )
+
+        assert response.status_code == 200, response.text
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted is not None
+        updated_contract = persisted.arguments.contract
+        assert updated_contract.install_cmd == "echo replacement-install"
+        assert updated_contract.run_cmd == "echo replacement-run {problem_statement_path} {task_id}"
+        assert updated_contract.final_output == "replacement-output.txt"
+        assert updated_contract.output_artifacts == ["replacement-artifact.txt"]
+        assert updated_contract.egress_allowlist == ["api.replacement.example"]
+        assert updated_contract.model == "provider/model"
+        assert updated_contract.kwargs == {"temperature": "1"}
+        assert updated_contract.secrets == {
+            "ARCHIVE_ONLY": "archive-secret",
+            "OVERRIDE": "stored-secret",
+            "RESUME_ONLY": "resume-secret",
+        }
+        revision_key = updated_contract.frozen_archive_s3_key
+        assert revision_key is not None
+        assert revision_key.startswith(f"benchmarks/{benchmark_row.id}/agent-revisions/")
+        assert revision_key.endswith("/dummy.zip")
+        assert updated_contract.frozen_archive_sha256 == hashlib.sha256(replacement_zip).hexdigest()
+        assert copies == [("agents/dummy.zip", revision_key)]
+        assert objects[old_key] == old_zip
+        assert objects[revision_key] == replacement_zip
+        queued_contract = mock_kicker.queued_calls[0]["start_benchmark_request_json"]["contract"]
+        assert queued_contract == updated_contract.model_dump()
+
+    async def test_update_agent_unreadable_revision_leaves_prior_bundle_and_contract(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        """An unreadable staged alias is deleted without changing the active run revision."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        old_zip = b"prior-valid-agent-archive"
+        old_key = get_benchmark_contract_s3_key(str(benchmark_row.id), "dummy")
+        old_contract = benchmark_row.arguments.contract.model_copy(
+            update={
+                "frozen_archive_s3_key": old_key,
+                "frozen_archive_sha256": hashlib.sha256(old_zip).hexdigest(),
+            }
+        )
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": old_contract})
+        database_session.add(benchmark_row)
+        database_session.commit()
+
+        objects = {old_key: old_zip, "agents/dummy.zip": b"not-a-zip"}
+        deleted: list[str] = []
+
+        async def copy_object(source_key: str, dest_key: str, *_args: Any) -> None:
+            objects[dest_key] = objects[source_key]
+
+        async def download_object(key: str, *_args: Any) -> bytes:
+            return objects[key]
+
+        async def delete_object(key: str, *_args: Any) -> None:
+            deleted.append(key)
+            objects.pop(key, None)
+
+        monkeypatch.setattr(main_module, "copy_s3_object", copy_object)
+        monkeypatch.setattr(main_module, "download_from_s3", download_object)
+        monkeypatch.setattr(main_module, "delete_from_s3", delete_object)
+
+        response = TestClient(app, raise_server_exceptions=False).post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            params={"update_agent": "true"},
+            json={"task_ids": [], "service_headers": {}},
+        )
+
+        assert response.status_code == 500
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted is not None
+        assert persisted.status == BenchmarkStatus.STOPPED
+        assert persisted.arguments.contract == old_contract
+        assert objects[old_key] == old_zip
+        assert len(deleted) == 1
+        assert deleted[0].startswith(f"benchmarks/{benchmark_row.id}/agent-revisions/")
+        assert deleted[0] not in objects
+        assert mock_kicker.queued_calls == []
+
+    async def test_update_agent_copy_failure_leaves_prior_bundle_and_contract(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        """A failed alias copy cannot overwrite or activate a partial agent revision."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        old_zip = b"prior-agent-archive"
+        old_key = get_benchmark_contract_s3_key(str(benchmark_row.id), "dummy")
+        old_contract = benchmark_row.arguments.contract.model_copy(
+            update={
+                "frozen_archive_s3_key": old_key,
+                "frozen_archive_sha256": hashlib.sha256(old_zip).hexdigest(),
+            }
+        )
+        benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"contract": old_contract})
+        database_session.add(benchmark_row)
+        database_session.commit()
+        objects = {old_key: old_zip}
+        deleted: list[str] = []
+
+        async def fail_copy(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("copy failed")
+
+        async def unexpected_download(*_args: Any, **_kwargs: Any) -> bytes:
+            raise AssertionError("a failed copy must not be downloaded")
+
+        async def delete_object(key: str, *_args: Any) -> None:
+            deleted.append(key)
+            objects.pop(key, None)
+
+        monkeypatch.setattr(main_module, "copy_s3_object", fail_copy)
+        monkeypatch.setattr(main_module, "download_from_s3", unexpected_download)
+        monkeypatch.setattr(main_module, "delete_from_s3", delete_object)
+
+        response = TestClient(app, raise_server_exceptions=False).post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            params={"update_agent": "true"},
+            json={"task_ids": [], "service_headers": {}},
+        )
+
+        assert response.status_code == 500
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted is not None
+        assert persisted.status == BenchmarkStatus.STOPPED
+        assert persisted.arguments.contract == old_contract
+        assert objects == {old_key: old_zip}
+        assert len(deleted) == 1
+        assert deleted[0].startswith(f"benchmarks/{benchmark_row.id}/agent-revisions/")
+        assert mock_kicker.queued_calls == []
+
+    async def test_update_agent_admission_failure_rolls_back_contract_pointer(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        harness_config: HarnessConfig,
+        monkeypatch: MonkeyPatch,
+        mock_kicker: MockKicker,
+    ) -> None:
+        """A DB admission failure keeps the prior contract and deletes the unreferenced revision."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        old_contract = benchmark_row.arguments.contract
+        database_session.add(benchmark_row)
+        database_session.commit()
+        candidate_zip = _agent_zip(
+            "dummy",
+            """
+name: dummy
+install_cmd: echo candidate-install
+run_cmd: echo candidate-run {problem_statement_path}
+""".strip(),
+        )
+        candidate_key = f"benchmarks/{benchmark_row.id}/agent-revisions/revision-1/dummy.zip"
+        delete_revision = AsyncMock()
+
+        async def reset_tasks(*_args: Any, **_kwargs: Any) -> list[str]:
+            return ["task_0"]
+
+        def fail_admission(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("admission failed")
+
+        monkeypatch.setattr(
+            main_module,
+            "_stage_agent_revision",
+            AsyncMock(return_value=(candidate_key, candidate_zip)),
+        )
+        monkeypatch.setattr(main_module, "_delete_uncommitted_agent_revision", delete_revision)
+        monkeypatch.setattr(main_module, "reset_to_in_progress_status", reset_tasks)
+        monkeypatch.setattr(main_module, "admit_recovery_dispatch", fail_admission)
+
+        response = TestClient(app, raise_server_exceptions=False).post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            params={"update_agent": "true"},
+            json={"task_ids": [], "service_headers": {}},
+        )
+
+        assert response.status_code == 500
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted is not None
+        assert persisted.status == BenchmarkStatus.STOPPED
+        assert persisted.arguments.contract == old_contract
+        delete_revision.assert_awaited_once_with(candidate_key, benchmark_row.id, harness_config)
+        assert mock_kicker.queued_calls == []
+
+    async def test_update_agent_rejects_running_run_without_staging(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+    ) -> None:
+        """A live run cannot change the agent identity underneath active tasks."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+        stage_revision = AsyncMock()
+        monkeypatch.setattr(main_module, "_stage_agent_revision", stage_revision)
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            params={"update_agent": "true"},
+            json={"task_ids": [], "service_headers": {}},
+        )
+
+        assert response.status_code == 409
+        assert "Stop the run" in response.json()["detail"]
+        stage_revision.assert_not_awaited()
+
     async def test_retry_or_resume_does_not_forward_tracker_key_to_custom_service(
         self,
         example_benchmark_object: Benchmark,
@@ -1571,14 +1887,14 @@ class TestRunRecovery:
                     id="new-release",
                     artifact_uri="s3://artifacts/new-release.pex",
                     artifact_digest="digest-new-release",
-                    protocol_version="1",
+                    protocol_version=SUPPORTED_PROTOCOL_VERSION,
                     readiness_verified=True,
                 ),
                 ExecutorRelease(
                     id="latest-release",
                     artifact_uri="s3://artifacts/latest-release.pex",
                     artifact_digest="digest-latest-release",
-                    protocol_version="1",
+                    protocol_version=SUPPORTED_PROTOCOL_VERSION,
                     readiness_verified=True,
                 ),
             ]
@@ -1813,7 +2129,7 @@ class TestRunRecovery:
             id="recovery-release",
             artifact_uri="s3://artifacts/recovery-release.pex",
             artifact_digest="digest-recovery-release",
-            protocol_version="1",
+            protocol_version=SUPPORTED_PROTOCOL_VERSION,
             readiness_verified=True,
         )
         database_session.add(release)
@@ -1842,7 +2158,7 @@ class TestRunRecovery:
             id="latest-release",
             artifact_uri="s3://artifacts/latest-release.pex",
             artifact_digest="digest-latest-release",
-            protocol_version="1",
+            protocol_version=SUPPORTED_PROTOCOL_VERSION,
             readiness_verified=True,
         )
         database_session.add(latest_release)
@@ -1908,7 +2224,7 @@ class TestRunRecovery:
                 id="new-release",
                 artifact_uri="s3://artifacts/new-release.pex",
                 artifact_digest="digest-new-release",
-                protocol_version="1",
+                protocol_version=SUPPORTED_PROTOCOL_VERSION,
                 readiness_verified=True,
             )
         )
@@ -1960,7 +2276,7 @@ class TestRunRecovery:
                 id="new-release",
                 artifact_uri="s3://artifacts/new-release.pex",
                 artifact_digest="digest-new-release",
-                protocol_version="1",
+                protocol_version=SUPPORTED_PROTOCOL_VERSION,
                 readiness_verified=True,
             )
         )

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -17,6 +17,7 @@ from httpx._models import Response
 from sqlmodel import Session, col, func, select, update
 from starlette.requests import Request
 
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION
 import tracker.utils.harness_config as harness_config_module
 from main import app
 from tests.factories import make_benchmark
@@ -61,7 +62,7 @@ def example_benchmark_object(contract: AgentContractRequest, database_session: S
         id="test-release",
         artifact_uri="s3://artifacts/test-release.pex",
         artifact_digest="digest-test-release",
-        protocol_version="1",
+        protocol_version=SUPPORTED_PROTOCOL_VERSION,
         readiness_verified=True,
     )
     database_session.add(release)

--- a/src/valkyrie/cli/agent/storage.py
+++ b/src/valkyrie/cli/agent/storage.py
@@ -11,10 +11,8 @@ import click
 import yaml
 from tracker import handle_s3_error
 from tracker.aws.s3 import (
-    copy_s3_object,
     delete_from_s3,
     download_from_s3,
-    get_benchmark_contract_s3_key,
     get_contract_s3_key,
     s3_object_exists,
 )
@@ -190,19 +188,6 @@ async def push_agent(agent_name: str, agent_path: Path):
                     UploadId=upload_id,
                 )
                 raise
-
-
-async def update_benchmark_agent_version(agent_name: str, benchmark_id: str) -> None:
-    """Overwrite the frozen benchmark agent copy from agents/<name>.zip in S3."""
-    aws = aws_credentials()
-    bucket_name = fetch_bucket_name()
-    source_key = get_contract_s3_key(agent_name)
-    dest_key = get_benchmark_contract_s3_key(benchmark_id, agent_name)
-
-    if not await s3_object_exists(source_key, aws, bucket_name):
-        raise S3Error(f"Agent '{agent_name}.zip' not found in S3.")
-
-    await copy_s3_object(source_key, dest_key, aws, bucket_name)
 
 
 async def _download_agent_zip(agent_name: str) -> bytes:

--- a/src/valkyrie/cli/run/resume.py
+++ b/src/valkyrie/cli/run/resume.py
@@ -1,14 +1,11 @@
-import asyncio
 from uuid import UUID
 
 import click
 from tracker.database.models import RetryMode
-from tracker.exceptions import S3Error
 
 from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.run.progress import stream_benchmark_status
 from valkyrie.cli.run.task_ids import resolve_task_ids
-from valkyrie.cli.agent.storage import update_benchmark_agent_version
 from valkyrie.cli.service_headers import benchmark_service_headers
 from valkyrie.cli.tracker_client import TrackerService
 
@@ -59,7 +56,7 @@ from valkyrie.cli.tracker_client import TrackerService
     "-u",
     is_flag=True,
     default=False,
-    help="Refresh the frozen agent copy from the current agents/<name>.zip in S3 before resuming.",
+    help="Atomically freeze the current agent revision and derive its executable contract before resuming.",
 )
 @click.option(
     "--from-scratch",
@@ -110,13 +107,6 @@ def resume(
             benchmark_info = tracker.fetch_benchmark(run_id)
             service_headers = benchmark_service_headers(benchmark_info.benchmark_name)
 
-            if update_agent:
-                metadata = tracker.fetch_benchmark_metadata(run_id)
-                agent_name = metadata.benchmark_arguments.contract.name
-                click.echo(f"\r\033[KUpdating agent '{agent_name}'...", nl=False)
-                asyncio.run(update_benchmark_agent_version(agent_name, str(run_id)))
-                click.echo(click.style("\r\033[K✓ Agent updated", fg="green"))
-
             _ = tracker.retry_or_resume_benchmark(
                 run_id,
                 retry,
@@ -126,6 +116,7 @@ def resume(
                 service_headers=service_headers,
                 secrets={key: value for key, value in secrets},
                 benchmark_url=benchmark_url,
+                update_agent=update_agent,
             )
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))
@@ -141,7 +132,7 @@ def resume(
             click.echo("└" + "─" * 79)
             if connect:
                 stream_benchmark_status(tracker, run_id)
-    except (TrackerServiceError, S3Error) as e:
+    except TrackerServiceError as e:
         raise click.ClickException(str(e))
 
 

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -678,6 +678,7 @@ class TrackerService:
         service_headers: dict[str, str] | None = None,
         secrets: dict[str, str] | None = None,
         benchmark_url: str | None = None,
+        update_agent: bool = False,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -691,6 +692,7 @@ class TrackerService:
             service_headers: Optional headers for benchmark service authentication
             secrets: Optional agent secret mappings to merge into the stored contract
             benchmark_url: Optional replacement benchmark service URL
+            update_agent: Freeze and bind the current agent alias before dispatch
 
         Returns:
             RetryOrResumeBenchmarkResponse with status and message
@@ -700,6 +702,8 @@ class TrackerService:
 
             if concurrency is not None:
                 params["concurrency"] = concurrency
+            if update_agent:
+                params["update_agent"] = True
 
             body: dict[str, Any] = {"task_ids": task_ids, "service_headers": service_headers or {}}
             if secrets:

--- a/tests/contract/test_sdk_tracker_contract.py
+++ b/tests/contract/test_sdk_tracker_contract.py
@@ -102,7 +102,11 @@ ROUTES = (
     ),
     ("/retrieve-results", "get", "benchmark_id s3 task_ids"),
     ("/stop-benchmark/{benchmark_id}", "post", "benchmark_id force"),
-    ("/retry-or-resume-benchmark/{benchmark_id}", "post", "benchmark_id retry retry_mode concurrency"),
+    (
+        "/retry-or-resume-benchmark/{benchmark_id}",
+        "post",
+        "benchmark_id retry retry_mode concurrency update_agent",
+    ),
     ("/benchmarks/status", "get", "ids"),
     ("/benchmarks/{benchmark_id}", "get", "benchmark_id"),
     (
@@ -320,6 +324,7 @@ def test_tracker_routes_match_the_sdk_http_contract() -> None:
     retry_parameters = {parameter["name"]: parameter for parameter in retry["parameters"]}
     assert retry_parameters["retry"]["schema"]["default"] == retry_fixture["query"]["retry"]
     assert retry_parameters["retry_mode"]["schema"]["default"] == retry_fixture["query"]["retry_mode"]
+    assert retry_parameters["update_agent"]["schema"]["default"] == retry_fixture["query"]["update_agent"]
     assert {option.get("type") for option in retry_parameters["concurrency"]["schema"]["anyOf"]} == {
         "integer",
         "null",

--- a/tests/fixtures/sdk_api/retry_resume.json
+++ b/tests/fixtures/sdk_api/retry_resume.json
@@ -9,7 +9,8 @@
   "query": {
     "retry": false,
     "retry_mode": "auto",
-    "concurrency": 2
+    "concurrency": 2,
+    "update_agent": false
   },
   "response": {
     "status": "success"

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -930,6 +930,24 @@ def test_run_resume_update_agent_reaches_tracker(
     assert mock_tracker_service.retry_or_resume_calls[0]["kwargs"]["update_agent"] is True
 
 
+def test_run_resume_update_agent_surfaces_tracker_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A failed atomic refresh is rendered as a normal CLI error."""
+
+    class FailingTrackerService(MockTrackerService):
+        def retry_or_resume_benchmark(self, *_args: object, **_kwargs: object) -> SimpleNamespace:
+            raise TrackerServiceError("agent refresh rejected")
+
+    monkeypatch.setattr(run_resume, "TrackerService", FailingTrackerService)
+
+    result = CliRunner().invoke(
+        cli_main.cli,
+        ["run", "resume", str(uuid4()), "--update-agent"],
+    )
+
+    assert result.exit_code == 1
+    assert "Error: agent refresh rejected" in result.output
+
+
 def test_run_start_provider_option_reaches_tracker(
     connect_stream_testbed: tuple[UUID, list[str], type[MockTrackerService]],
 ) -> None:

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -691,10 +691,16 @@ def test_retry_or_resume_sends_retry_mode(
         task_ids=["task-1"],
         secrets={"ANTHROPIC_API_KEY": "new-secret"},
         benchmark_url="https://new.example",
+        update_agent=True,
     )
 
     assert result.status == "success"
-    assert mock_client.params == {"retry": True, "retry_mode": "from_scratch", "concurrency": 3}
+    assert mock_client.params == {
+        "retry": True,
+        "retry_mode": "from_scratch",
+        "concurrency": 3,
+        "update_agent": True,
+    }
     assert mock_client.json == {
         "task_ids": ["task-1"],
         "service_headers": {},
@@ -901,6 +907,27 @@ def test_run_retry_benchmark_url_reaches_tracker(
 
     assert result.exit_code == 0, result.output
     assert mock_tracker_service.retry_or_resume_calls[0]["kwargs"]["benchmark_url"] == "https://new.example"
+
+
+def test_run_resume_update_agent_reaches_tracker(
+    connect_stream_testbed: tuple[UUID, list[str], type[MockTrackerService]],
+) -> None:
+    """Agent refresh is performed transactionally by the tracker.
+
+    Test cases:
+    - The CLI forwards ``--update-agent`` with the resume request.
+    - The CLI no longer mutates the run-scoped S3 archive directly.
+    """
+    _started_run_id, _streamed_run_ids, mock_tracker_service = connect_stream_testbed
+    run_id = uuid4()
+
+    result = CliRunner().invoke(
+        cli_main.cli,
+        ["run", "resume", str(run_id), "--update-agent"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert mock_tracker_service.retry_or_resume_calls[0]["kwargs"]["update_agent"] is True
 
 
 def test_run_start_provider_option_reaches_tracker(

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -24,7 +24,11 @@ from services.executor_host.supervisor import (  # pyright: ignore[reportMissing
     run_executor_dispatch,
     verify_file_digest,
 )
-from executor_protocol import validate_executor_artifact_uri
+from executor_protocol import (
+    EXECUTOR_HOST_COMPATIBLE_PROTOCOL_VERSIONS,
+    SUPPORTED_PROTOCOL_VERSION,
+    validate_executor_artifact_uri,
+)
 
 
 class FakeDispatchStore:
@@ -145,13 +149,13 @@ class MockRedis:
         return self.eval_result
 
 
-def _dispatch(*, digest: str) -> ArtifactDispatch:
+def _dispatch(*, digest: str, protocol_version: str = SUPPORTED_PROTOCOL_VERSION) -> ArtifactDispatch:
     return ArtifactDispatch.from_payload(
         {
             "executor_release_id": "release-v2",
             "executor_artifact_uri": "s3://artifacts/executors/v2.pex",
             "executor_artifact_digest": digest,
-            "executor_protocol_version": "1",
+            "executor_protocol_version": protocol_version,
         }
     )
 
@@ -184,6 +188,17 @@ def test_dispatch_rejects_missing_or_invalid_identity() -> None:
 
     with pytest.raises(ValueError, match="64-character"):
         _dispatch(digest="not-a-digest")
+
+
+def test_dispatch_accepts_drain_compatible_protocols_but_rejects_unknown() -> None:
+    digest = "0" * 64
+    assert {
+        _dispatch(digest=digest, protocol_version=version).protocol_version
+        for version in EXECUTOR_HOST_COMPATIBLE_PROTOCOL_VERSIONS
+    } == EXECUTOR_HOST_COMPATIBLE_PROTOCOL_VERSIONS
+
+    with pytest.raises(ValueError, match="Unsupported executor protocol version"):
+        _dispatch(digest=digest, protocol_version="unknown")
 
 
 def test_verify_file_digest_rejects_mismatch(tmp_path: Path) -> None:
@@ -418,7 +433,8 @@ async def test_run_forwards_dispatch_authority_to_executor(
     assert store.authority_checks
     assert store.finished == [store.authority]
     assert (
-        f"Launching benchmark benchmark-1 dispatch_id=dispatch-1 release=release-v2 digest={digest} protocol=1"
+        f"Launching benchmark benchmark-1 dispatch_id=dispatch-1 release=release-v2 "
+        f"digest={digest} protocol={SUPPORTED_PROTOCOL_VERSION}"
     ) in caplog.messages
 
 
@@ -555,7 +571,7 @@ async def test_launch_executor_rejects_invalid_dispatch_id_without_side_effects(
             executor_release_id="release-v2",
             executor_artifact_uri="s3://artifacts/executors/v2.pex",
             executor_artifact_digest=digest,
-            executor_protocol_version="1",
+            executor_protocol_version=SUPPORTED_PROTOCOL_VERSION,
         )
 
     assert store.claimed == []
@@ -582,7 +598,7 @@ async def test_broker_payload_dispatch_id_reaches_dispatch_owner(
         executor_release_id="release-v2",
         executor_artifact_uri="s3://artifacts/executors/v2.pex",
         executor_artifact_digest="0" * 64,
-        executor_protocol_version="1",
+        executor_protocol_version=SUPPORTED_PROTOCOL_VERSION,
     )
 
     assert captured["executor_dispatch_id"] == "dispatch-1"

--- a/tests/unit/sdk/test_public_api.py
+++ b/tests/unit/sdk/test_public_api.py
@@ -77,11 +77,11 @@ EXPECTED_SIGNATURES = {
     RunsResource.stop: "self, run_id, *, force=False, task_ids=None",
     RunsResource.resume: (
         "self, run_id, *, concurrency=None, task_ids=None, secrets=None, service_headers=None, from_scratch=False, "
-        "benchmark_url=None"
+        "benchmark_url=None, update_agent=False"
     ),
     RunsResource.retry: (
         "self, run_id, *, concurrency=None, task_ids=None, secrets=None, service_headers=None, from_scratch=False, "
-        "benchmark_url=None"
+        "benchmark_url=None, update_agent=False"
     ),
     BenchmarksResource.fetch: "self, run_id",
     BenchmarksResource.statuses: "self, run_ids",

--- a/tests/unit/sdk/test_sdk.py
+++ b/tests/unit/sdk/test_sdk.py
@@ -361,6 +361,7 @@ async def test_resume_and_retry_resolve_run_service_auth(
             service_headers={"Authorization": "override"},
             from_scratch=True,
             benchmark_url="https://new.example",
+            update_agent=True,
         )
 
     assert response.status == "success"
@@ -368,6 +369,7 @@ async def test_resume_and_retry_resolve_run_service_auth(
     assert request.url.params["retry"] == retry
     assert request.url.params["retry_mode"] == "from_scratch"
     assert request.url.params["concurrency"] == "4"
+    assert request.url.params["update_agent"] == "true"
     assert json.loads(request.content) == {
         "benchmark_url": "https://new.example",
         "task_ids": ["task-1"],
@@ -392,6 +394,7 @@ async def test_resume_without_optional_overrides_uses_empty_payload(make_client,
 
     request = requests[1]
     assert "concurrency" not in request.url.params
+    assert "update_agent" not in request.url.params
     assert json.loads(request.content) == {"task_ids": [], "service_headers": {}, "secrets": {}}
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2538,7 +2538,7 @@ dev = [
 
 [[package]]
 name = "valkyrie-sdk"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "packages/valkyrie-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- freeze the moving agent alias before deriving the start contract, and persist the exact run-scoped S3 key plus SHA-256
- make `resume --update-agent` a tracker-owned atomic operation using append-only run revisions; parse, copy, or admission failures leave the prior archive and database contract active
- rebuild refreshed contracts from the exact staged archive while preserving only explicit runtime model, kwargs, and secret overrides
- verify the bound archive digest in the sandbox before unzip and fail closed on incomplete, invalid, or cross-run archive identities
- move new admissions to executor protocol v2 so a v1 executor cannot silently ignore the archive identity; stable hosts retain v1 only to drain already-pinned work
- preserve old persisted contracts through the legacy fixed run archive path
- keep the public SDK model and retry/resume route in parity with the tracker

## Safety regressions

- alias A to B between client contract resolution and tracker freeze cannot create a mixed contract/archive
- alias refresh uses B executable fields while retaining only the stored model/kwargs/secrets plus explicit resume secrets
- unreadable archive, failed copy, and failed admission keep the old object and contract intact and do not enqueue work
- a live run cannot change its agent identity underneath active tasks
- malformed bound archive identities fail before a presigned URL is created
- new work rejects an active v1 executor during the rollout gap; existing pinned v1 work remains host-compatible
- CLI and SDK `update_agent` requests reach the tracker, and tracker refresh failures remain normal user-visible errors

## Verification

- tracker unit: 566 passed
- CLI unit: 201 passed with full coverage of the changed resume path
- SDK unit + tracker contract parity: 150 passed
- executor host/artifact: 37 passed
- tracker API integration: 36 passed
- infrastructure: 99 passed, including atomic protocol classification and deployment-order regressions
- Ruff check and format: clean
- root, tracker, and SDK basedpyright: 0 errors
- PostgreSQL testcontainer integration could not run locally because Docker is unavailable; the hard-coded v1 fixture was updated to the supported protocol constant, and this PR remains draft for CI and independent review

## Rollout

`services/tracker/src/executor_protocol.py` is the authoritative cross-plane compatibility marker. A change to that file now sets both `core_maintenance_required` and the distinct `atomic_protocol_transition_required` output and classifies the change as maintenance-required. The deploy workflow then enforces this order in both environments:

1. begin the launch fence
2. deploy tracker/core v2
3. deploy the compatible stable executor host/stack
4. publish and activate the v2 executor artifact
5. finish the fence

`services/tracker/main.py` and the database model file are not independently maintenance-classified because they also carry tracker-only API/model edits; requiring maintenance for every edit there would be overbroad. In this change, their cross-plane archive identity is guaranteed by the explicit protocol bump. Future cross-plane contract changes must likewise bump `executor_protocol.py`.

The maintenance-classification check is intentionally expected to remain red until the repository's authorized maintenance-rollout policy is satisfied. Do not bypass it. Existing in-progress v1 work remains drain-compatible, and old contracts retain the legacy fixed-key fallback.

There is conflict-free line-level overlap with #683 only in `tracker_client.py` and its CLI test; `git merge-tree` verified the heads auto-merge cleanly.
