### PR TITLE
feat(tracker): expose selected inference settings to benchmark setup

### DIFF
--- a/services/tracker/src/tracker/agent/contract.py
+++ b/services/tracker/src/tracker/agent/contract.py
@@ -74,6 +74,11 @@ def _parse_yaml_contract(contract_path: Path, agent_config: AgentConfig) -> Agen
         return AgentContractRequest(
             name=agent_contract.name,
             model=agent_config.model,
+            # Preserve the validated values independently of the rendered
+            # command. Trusted benchmark setup may need selected non-secret
+            # settings (for example a reasoning-effort variant) before the
+            # agent command is launched.
+            kwargs={key: str(value) for key, value in validated_kwargs.items()},
             run_cmd=agent_contract.format_run_cmd(validated_kwargs),
             install_cmd=agent_contract.install_cmd,
             final_output=str(agent_contract.final_output) if agent_contract.final_output is not None else None,

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -667,6 +667,11 @@ async def _process_task_attempt(
             **resolve_secrets(start_benchmark_request.contract.secrets, harness_config.aws),
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
+            # Benchmark setup runs before the agent command and may need the
+            # selected model to provision a run-scoped provider capability.
+            # This is non-secret contract metadata; keeping it separate from
+            # the rendered command avoids asking services to parse shell text.
+            "VALKYRIE_AGENT_MODEL": start_benchmark_request.contract.model or "",
             "IDENTITY": json.dumps(identity),
             # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
             # are filterable per benchmark run and separable from other environments sharing the

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -672,6 +672,10 @@ async def _process_task_attempt(
             # This is non-secret contract metadata; keeping it separate from
             # the rendered command avoids asking services to parse shell text.
             "VALKYRIE_AGENT_MODEL": start_benchmark_request.contract.model or "",
+            # The validated variant is also needed before the untrusted agent
+            # starts so a benchmark can authorize an immutable inference
+            # configuration instead of trusting a player-owned adapter.
+            "VALKYRIE_AGENT_VARIANT": start_benchmark_request.contract.kwargs.get("variant", ""),
             "IDENTITY": json.dumps(identity),
             # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
             # are filterable per benchmark run and separable from other environments sharing the

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -54,7 +54,12 @@ class TestProcessTaskEnvironment:
         monkeypatch: pytest.MonkeyPatch,
         harness_config: HarnessConfig,
     ) -> None:
-        contract = contract.model_copy(update={"secrets": {"UNRELATED_SECRET": "secret-name"}})
+        contract = contract.model_copy(
+            update={
+                "model": "provider/model",
+                "secrets": {"UNRELATED_SECRET": "secret-name"},
+            }
+        )
         run_starter = RequestIdentity(
             org=TEST_ORG,
             access_key_id="access-key-id",
@@ -79,6 +84,7 @@ class TestProcessTaskEnvironment:
             return {
                 "RUN_ID": "secret-run-id",
                 "TASK_ID": "secret-task-id",
+                "VALKYRIE_AGENT_MODEL": "secret-model",
                 "IDENTITY": '{"source":"secret"}',
                 "UNRELATED_SECRET": "secret-value",
                 "MODEL_GATEWAY_URL": "https://gateway.example.test",
@@ -100,6 +106,7 @@ class TestProcessTaskEnvironment:
         assert env_vars["RUN_ID"] == str(benchmark_id)
         assert "QUESTION_ID" not in env_vars
         assert env_vars["TASK_ID"] == "task_0"
+        assert env_vars["VALKYRIE_AGENT_MODEL"] == "provider/model"
         assert json.loads(env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,
@@ -139,6 +146,7 @@ class TestProcessTaskEnvironment:
         assert result == {"task_0": {"status": "success", "score": 1.0}}
         assert len(captured_env_vars) == 1
         env_vars = captured_env_vars[0]
+        assert env_vars["VALKYRIE_AGENT_MODEL"] == ""
         assert json.loads(env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -57,6 +57,7 @@ class TestProcessTaskEnvironment:
         contract = contract.model_copy(
             update={
                 "model": "provider/model",
+                "kwargs": {"variant": "xhigh"},
                 "secrets": {"UNRELATED_SECRET": "secret-name"},
             }
         )
@@ -85,6 +86,7 @@ class TestProcessTaskEnvironment:
                 "RUN_ID": "secret-run-id",
                 "TASK_ID": "secret-task-id",
                 "VALKYRIE_AGENT_MODEL": "secret-model",
+                "VALKYRIE_AGENT_VARIANT": "secret-variant",
                 "IDENTITY": '{"source":"secret"}',
                 "UNRELATED_SECRET": "secret-value",
                 "MODEL_GATEWAY_URL": "https://gateway.example.test",
@@ -107,6 +109,7 @@ class TestProcessTaskEnvironment:
         assert "QUESTION_ID" not in env_vars
         assert env_vars["TASK_ID"] == "task_0"
         assert env_vars["VALKYRIE_AGENT_MODEL"] == "provider/model"
+        assert env_vars["VALKYRIE_AGENT_VARIANT"] == "xhigh"
         assert json.loads(env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,
@@ -147,6 +150,7 @@ class TestProcessTaskEnvironment:
         assert len(captured_env_vars) == 1
         env_vars = captured_env_vars[0]
         assert env_vars["VALKYRIE_AGENT_MODEL"] == ""
+        assert env_vars["VALKYRIE_AGENT_VARIANT"] == ""
         assert json.loads(env_vars["IDENTITY"]) == {
             "benchmark_name": "swebench",
             "agent_name": contract.name,

--- a/tests/unit/cli/agent/test_contract.py
+++ b/tests/unit/cli/agent/test_contract.py
@@ -357,6 +357,7 @@ class TestParseYamlContract:
         assert isinstance(result, AgentContractRequest)
         assert "--temp 0.7" in result.run_cmd
         assert "{problem_statement_path}" in result.run_cmd
+        assert result.kwargs == {"temperature": "0.7"}
 
     def test_cli_kwargs_override_defaults(self, tmp_path: Path) -> None:
         """
@@ -382,6 +383,7 @@ class TestParseYamlContract:
         result = _parse_yaml_contract(path, AgentConfig(kwargs={"temperature": 1.0}))
 
         assert "--temp 1.0" in result.run_cmd
+        assert result.kwargs == {"temperature": "1.0"}
 
     def test_required_kwarg_missing_raises(self, tmp_path: Path) -> None:
         """


### PR DESCRIPTION
## Summary
- preserve validated agent kwargs separately from the rendered command
- pass the selected model and reasoning-effort variant to trusted benchmark setup as non-secret `VALKYRIE_AGENT_MODEL` / `VALKYRIE_AGENT_VARIANT` metadata
- keep both tracker-owned values authoritative over any same-named resolved secret
- preserve empty strings for model-less or variant-less agents

## Why
KSPBench must authorize a run-scoped Model Gateway query token before the agent command starts. The benchmark service receives the sandbox during setup but not the rendered agent command; parsing shell text would be fragile and would risk mixing the trusted finalizer credential with the evaluated agent.

The Gateway authorization must bind both the exact model and the selected max-effort variant. Otherwise a player-owned adapter could silently use a different setting while the run is labeled `xhigh`. This handoff supplies only validated, non-secret contract metadata; it does not expose the privileged Gateway finalizer credential.

This PR is stacked on #683 because replacement sandboxes must receive the same stable run ID and inference metadata. It does not authorize, query, deploy, or change credentials by itself.

## Validation
- tracker unit suite: 557 passed
- CLI agent-contract suite: 44 passed
- focused handoff/contract tests: 39 passed
- Ruff check/format: passed
- configured repository basedpyright: 0 errors
- `git diff --check`: passed

## Rollout gate
Keep draft until the Gateway authorize/finalize API and KSPBench consumer are reviewed together. Merge #683 first, then this PR, before deploying the run-scoped KSPBench service. Fresh run-scoped starts must use the versioned/current-only KSP agent release; legacy agent bundles cannot be allowed to ignore this binding.
