### PR TITLE
fix(tracker): reopen run on finalization-only resume

### DIFF
--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -251,6 +251,8 @@ async def reset_to_in_progress_status(
 
         # Allow re-running the end of the benchmark without running any tasks
         if not existing_rows and not new_task_ids:
+            _open_new_execution(benchmark_row, session)
+
             return []
 
         # Verify the task ids are still valid before priming to resume
@@ -260,16 +262,7 @@ async def reset_to_in_progress_status(
             task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
         )
 
-        old_evaluation = benchmark_row.final_evaluation
-        if old_evaluation is not None:
-            benchmark_row.final_evaluation = None
-            session.delete(old_evaluation)
-
-        # Retry/resume always starts a new active execution.
-        if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
-            benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        benchmark_row.finished_at = None
-        session.add(benchmark_row)
+        _open_new_execution(benchmark_row, session)
 
         for task in existing_rows:
             task.status = (
@@ -291,6 +284,18 @@ async def reset_to_in_progress_status(
         raise
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error resuming run {benchmark_row.id}: {str(e)}") from e
+
+
+def _open_new_execution(benchmark_row: Benchmark, session: Session) -> None:
+    """Drop the previous execution's terminal state so retry/resume runs as a new execution."""
+    old_evaluation = benchmark_row.final_evaluation
+    if old_evaluation is not None:
+        benchmark_row.final_evaluation = None
+        session.delete(old_evaluation)
+
+    benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+    benchmark_row.finished_at = None
+    session.add(benchmark_row)
 
 
 def _retry_task_filters(benchmark_row: Benchmark, retry: bool, rerun_task_ids: list[str], org: Org) -> list[Any]:

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1471,6 +1471,39 @@ class TestRunRecovery:
         assert persisted.arguments.concurrency == 9
         assert persisted.arguments.contract.secrets == {"ANTHROPIC_API_KEY": "new-secret"}
 
+    async def test_no_task_resume_reopens_errored_run(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        mock_kicker: Any,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.ERROR
+        benchmark_row.finished_at = _ORIGINAL_ATTEMPT_AT
+        database_session.add(benchmark_row)
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED)
+        )
+        database_session.commit()
+        database_session.add(FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark_row.id, final_score=0.0))
+        database_session.commit()
+
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}",
+            json={"task_ids": [], "service_headers": {}},
+        )
+
+        assert response.status_code == 200
+        assert mock_kicker.queued_calls[0]["verified_task_ids"] == []
+
+        database_session.expire_all()
+        persisted = database_session.get(Benchmark, benchmark_row.id)
+
+        assert persisted is not None
+        assert persisted.status == BenchmarkStatus.IN_PROGRESS
+        assert persisted.finished_at is None
+        assert persisted.final_evaluation is None
+
     async def test_running_retry_noops_without_error_tasks(
         self,
         example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -339,6 +339,15 @@ class TestRunState:
         response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=false")
         assert response.status_code == 200
 
+        # That resume reopened the run, so put it back in a terminal state for the cases below
+        database_session.expire_all()
+        benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session, self._test_org)
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
         # Ensure that we can recreate the environment the benchmark was started in
         original_start_benchmark_request = StartBenchmarkRequest(
             contract=contract,


### PR DESCRIPTION
## Summary

`valk run resume <id>` on a run with no rerunnable tasks (every task FINISHED, run terminalized as ERROR because only the final-score step failed) 500s in the tracker before anything is dispatched:

```
IntegrityError: CHECK constraint failed: benchmark_finished_requires_timestamp
```

`reset_to_in_progress_status()` has an early return for the "re-run the end of the benchmark without running any tasks" path, and it returned *before* the block that clears the previous execution's terminal state. The benchmark therefore stayed `ERROR` while `admit_recovery_dispatch()` set `finished_at = None` and then issued a query (`terminalize_active_dispatches`) that autoflushes — flushing `status = ERROR, finished_at = NULL`, which the constraint rejects.

Both recovery paths need the same lifecycle transition, so it moves into one helper called on both:

```python
if not existing_rows and not new_task_ids:
    _open_new_execution(benchmark_row, session)   # IN_PROGRESS, finished_at=None, drop stale final_evaluation
    return []
```

Found on real runs: SNAP `a3caba26-4e69-4ba2-81cd-e7b13e256552` and `ec98aa93-1a04-4874-a5bc-476bad03c7be`, both 230/230 tasks with 0 task errors, unrecoverable by resume until this lands. (Their final-score failure itself is a separate platform SDK bug — vals-ai/platform PR to follow.)

## Changes
- `run_control.py`: extract `_open_new_execution()`; call it on the no-task recovery path as well as the normal one, so a finalization-only resume reopens the run before dispatch touches `finished_at`.
- `test_run_recovery.py`: regression test resuming an ERROR run whose only task is FINISHED — asserts 200, nothing enqueued, and `IN_PROGRESS` / `finished_at is None` / stale `final_evaluation` dropped. Reverting only `run_control.py` makes it fail with the production `IntegrityError` above.
- `test_run_state.py`: `test_resume_benchmark_edge_cases` walks one benchmark through several states in sequence and assumed the no-task resume left it terminal; it now asserts the run reopened and puts it back to `STOPPED` for the later sub-cases. Behavior change is intentional — a run re-executing finalization is no longer left marked terminal.

Reviewer entry point: the diff in `run_control.py` is the whole fix; the ordering hazard it protects against lives in `executor/dispatch_control.py::admit_recovery_dispatch`.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Not verified against the hosted tracker: reproducing it live requires resuming a real terminalized run, and the two runs above are blocked on this deploy. The failing-before/passing-after regression test is the only evidence for the fix so far; a live `valk run resume` on those run IDs is the intended post-deploy check.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

## Human Description

### Why

<!-- author -->

### How

<!-- author -->


Link to Devin session: https://app.devin.ai/sessions/ad47b5d08913480fb603e30a03467118
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/692" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->