### PR TITLE
feat(tracker): persist trusted post-evaluation artifacts

### DIFF
--- a/services/tracker/src/tracker/evaluation_artifacts.py
+++ b/services/tracker/src/tracker/evaluation_artifacts.py
@@ -1,0 +1,412 @@
+"""Crash-safe, benchmark-service-owned post-evaluation artifacts.
+
+Benchmark services sometimes learn authoritative facts only while grading, after
+the evaluated agent's ordinary output artifacts have already been collected.
+They can checkpoint a small, prompt-free artifact bundle through the existing
+evaluation-resume channel.  The tracker validates that bundle, uploads the
+exact bytes under the task's normal S3 prefix, and only then commits the score.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import math
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+
+from tracker.aws.s3 import get_agent_result_s3_key, upload_to_s3
+from tracker.exceptions import OutputArtifactError
+from tracker.types import AWSCredentials
+
+TRUSTED_EVALUATION_BUNDLE_SCHEMA = "valkyrie_trusted_evaluation_bundle.v1"
+TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA = "valkyrie_trusted_evaluation_bundle_uploaded.v1"
+
+# The benchmark-service websocket is capped at 10 MiB.  Base64 expands bytes by
+# one third and the result/manifest also consume space, so decoded artifacts are
+# deliberately capped at 6 MiB total.
+MAX_TRUSTED_EVALUATION_BUNDLE_BYTES = 6 * 1024 * 1024
+
+REQUIRED_TRUSTED_EVALUATION_ARTIFACTS = {
+    "gateway-run-accounting.json": "application/json",
+    "run-report.json": "application/json",
+    "vals_format/run_config.json": "application/json",
+    "vals_format/turns.jsonl": "application/x-ndjson",
+}
+_TRUSTED_EVALUATION_ARTIFACT_COUNT = len(REQUIRED_TRUSTED_EVALUATION_ARTIFACTS)
+
+_FORBIDDEN_FIELD_NAMES = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "authorization",
+        "cookie",
+        "headers",
+        "messages",
+        "password",
+        "prompt",
+        "prompts",
+        "raw_error",
+        "refresh_token",
+        "request_body",
+        "response_body",
+        "secret",
+        "secrets",
+        "set_cookie",
+        "stack_trace",
+        "traceback",
+    }
+)
+_SAFE_ERROR_CLASSIFICATION = re.compile(r"[a-z0-9][a-z0-9_.:-]{0,127}\Z")
+_GATEWAY_ATTEMPT_STATUSES = frozenset({"success", "provider_error", "gateway_error", "unresolved"})
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON field is forbidden: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json(data: bytes, *, label: str) -> Any:
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{label} is not UTF-8") from exc
+    try:
+        return json.loads(
+            text,
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON") from exc
+
+
+def _strict_json_copy(value: Any, *, label: str) -> Any:
+    try:
+        serialized = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not strict JSON") from exc
+    return _load_json(serialized.encode(), label=label)
+
+
+def _walk_prompt_free(value: Any, *, label: str, in_turn: bool = False) -> None:
+    if isinstance(value, dict):
+        status = value.get("status")
+        this_is_turn = in_turn or ("turn_index" in value and status in {"success", "error"})
+        for raw_key, child in value.items():
+            key = str(raw_key).lower().replace("-", "_")
+            if key in _FORBIDDEN_FIELD_NAMES:
+                raise ValueError(f"{label} contains forbidden field {raw_key!r}")
+            if key == "error":
+                if not this_is_turn or not isinstance(child, str):
+                    raise ValueError(f"{label} contains a raw error field")
+                if _SAFE_ERROR_CLASSIFICATION.fullmatch(child) is None:
+                    raise ValueError(f"{label} error must be a short failure classification")
+            _walk_prompt_free(child, label=label, in_turn=this_is_turn)
+        return
+    if isinstance(value, list):
+        for child in value:
+            _walk_prompt_free(child, label=label, in_turn=in_turn)
+        return
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ValueError(f"{label} contains a non-finite number")
+
+
+def _validate_terminal_result(value: Any) -> dict[str, Any]:
+    copied = _strict_json_copy(value, label="terminal result")
+    if not isinstance(copied, dict):
+        raise ValueError("terminal result must be an object")
+    if copied.get("task") != "full_ladder":
+        raise ValueError("trusted KSP result must belong to full_ladder")
+    if not isinstance(copied.get("resolved"), bool):
+        raise ValueError("trusted KSP result must contain boolean resolved")
+    score = copied.get("score")
+    if (
+        not isinstance(score, (int, float))
+        or isinstance(score, bool)
+        or not math.isfinite(float(score))
+        or not 0.0 <= float(score) <= 1.0
+    ):
+        raise ValueError("trusted KSP result must contain a finite score in [0, 1]")
+    _walk_prompt_free(copied, label="terminal result")
+    return copied
+
+
+def _load_artifact_documents(path: str, data: bytes) -> list[Any]:
+    if path.endswith(".json"):
+        return [_load_json(data, label=path)]
+    if path != "vals_format/turns.jsonl":
+        raise ValueError(f"unsupported trusted artifact path: {path}")
+    documents: list[Any] = []
+    for line_number, line in enumerate(data.splitlines(), start=1):
+        if not line.strip():
+            raise ValueError(f"{path} contains a blank row at line {line_number}")
+        documents.append(_load_json(line, label=f"{path} line {line_number}"))
+    return documents
+
+
+def _validate_finalization_documents(documents: dict[str, list[Any]]) -> None:
+    accounting_docs = documents["gateway-run-accounting.json"]
+    if len(accounting_docs) != 1 or not isinstance(accounting_docs[0], dict):
+        raise ValueError("gateway-run-accounting.json must contain one object")
+    accounting = accounting_docs[0]
+    if accounting.get("final") is not True or accounting.get("finalized") is not True:
+        raise ValueError("Gateway accounting is not fenced and finalized")
+    attempts = accounting.get("attempts")
+    if not isinstance(attempts, list):
+        raise ValueError("Gateway accounting attempts must be a list")
+    for attempt in attempts:
+        if not isinstance(attempt, dict) or attempt.get("status") not in _GATEWAY_ATTEMPT_STATUSES:
+            raise ValueError("Gateway accounting contains an invalid attempt status")
+        if attempt["status"] == "unresolved":
+            raise ValueError("Gateway accounting still has unresolved attempts")
+
+    report_docs = documents["run-report.json"]
+    if len(report_docs) != 1 or not isinstance(report_docs[0], dict):
+        raise ValueError("run-report.json must contain one object")
+    finality = report_docs[0].get("finality")
+    if not isinstance(finality, dict) or finality.get("complete") is not True:
+        raise ValueError("run report is not final")
+
+
+def _normalized_artifact_path(value: str) -> str:
+    if not value or "\\" in value:
+        raise ValueError("trusted evaluation artifact paths must be non-empty POSIX paths")
+    path = PurePosixPath(value)
+    if path.is_absolute() or not path.parts or "." in path.parts or ".." in path.parts:
+        raise ValueError("trusted evaluation artifact paths must be normalized relative paths")
+    normalized = str(path)
+    if normalized != value:
+        raise ValueError("trusted evaluation artifact paths must already be normalized")
+    return normalized
+
+
+class _PendingArtifact(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    path: str
+    media_type: Literal["application/json", "application/x-ndjson"]
+    bytes: int = Field(ge=0)
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    content_base64: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        return _normalized_artifact_path(value)
+
+    def decode(self) -> bytes:
+        try:
+            content = base64.b64decode(self.content_base64, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise OutputArtifactError(f"Trusted evaluation artifact {self.path!r} has invalid base64") from exc
+        if base64.b64encode(content).decode("ascii") != self.content_base64:
+            raise OutputArtifactError(f"Trusted evaluation artifact {self.path!r} base64 is not canonical")
+        if len(content) != self.bytes:
+            raise OutputArtifactError(
+                f"Trusted evaluation artifact {self.path!r} size mismatch: {len(content)} != {self.bytes}"
+            )
+        observed = hashlib.sha256(content).hexdigest()
+        if observed != self.sha256:
+            raise OutputArtifactError(
+                f"Trusted evaluation artifact {self.path!r} SHA-256 mismatch: {observed} != {self.sha256}"
+            )
+        return content
+
+
+class _PendingBundle(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_version: Literal["valkyrie_trusted_evaluation_bundle.v1"]
+    result: dict[str, Any]
+    artifacts: list[_PendingArtifact] = Field(
+        min_length=_TRUSTED_EVALUATION_ARTIFACT_COUNT,
+        max_length=_TRUSTED_EVALUATION_ARTIFACT_COUNT,
+    )
+
+    @model_validator(mode="after")
+    def validate_artifacts(self) -> _PendingBundle:
+        paths = [artifact.path for artifact in self.artifacts]
+        if len(paths) != len(set(paths)):
+            raise ValueError("trusted evaluation artifact paths must be unique")
+        observed = {artifact.path: artifact.media_type for artifact in self.artifacts}
+        if observed != REQUIRED_TRUSTED_EVALUATION_ARTIFACTS:
+            raise ValueError("trusted evaluation artifact paths and media types must match the v1 manifest exactly")
+        if sum(artifact.bytes for artifact in self.artifacts) > MAX_TRUSTED_EVALUATION_BUNDLE_BYTES:
+            raise ValueError(
+                f"trusted evaluation artifact bundle exceeds {MAX_TRUSTED_EVALUATION_BUNDLE_BYTES} decoded bytes"
+            )
+        return self
+
+    @field_validator("result")
+    @classmethod
+    def validate_result(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _validate_terminal_result(value)
+
+
+class UploadedArtifact(BaseModel):
+    """Compact durable reference retained after a successful upload."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    path: str
+    media_type: Literal["application/json", "application/x-ndjson"]
+    bytes: int = Field(ge=0)
+    sha256: str = Field(pattern=r"^[0-9a-f]{64}$")
+    s3_key: str
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        return _normalized_artifact_path(value)
+
+
+class UploadedEvaluationBundle(BaseModel):
+    """Small checkpoint stored atomically with the finished task."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    schema_version: Literal["valkyrie_trusted_evaluation_bundle_uploaded.v1"]
+    result: dict[str, Any]
+    artifacts: list[UploadedArtifact] = Field(
+        min_length=_TRUSTED_EVALUATION_ARTIFACT_COUNT,
+        max_length=_TRUSTED_EVALUATION_ARTIFACT_COUNT,
+    )
+
+    @model_validator(mode="after")
+    def validate_artifacts(self) -> UploadedEvaluationBundle:
+        paths = [artifact.path for artifact in self.artifacts]
+        if len(paths) != len(set(paths)):
+            raise ValueError("uploaded trusted evaluation artifact paths must be unique")
+        observed = {artifact.path: artifact.media_type for artifact in self.artifacts}
+        if observed != REQUIRED_TRUSTED_EVALUATION_ARTIFACTS:
+            raise ValueError("uploaded trusted evaluation artifacts must match the v1 manifest exactly")
+        if sum(artifact.bytes for artifact in self.artifacts) > MAX_TRUSTED_EVALUATION_BUNDLE_BYTES:
+            raise ValueError(
+                f"uploaded trusted evaluation artifact bundle exceeds {MAX_TRUSTED_EVALUATION_BUNDLE_BYTES} bytes"
+            )
+        return self
+
+    @field_validator("result")
+    @classmethod
+    def validate_result(cls, value: dict[str, Any]) -> dict[str, Any]:
+        return _validate_terminal_result(value)
+
+
+@dataclass(frozen=True)
+class PreparedEvaluationBundle:
+    result: dict[str, Any]
+    artifacts: tuple[tuple[_PendingArtifact, bytes], ...]
+
+
+def is_pending_evaluation_bundle(value: object) -> bool:
+    return isinstance(value, dict) and value.get("schema_version") == TRUSTED_EVALUATION_BUNDLE_SCHEMA
+
+
+def is_uploaded_evaluation_bundle(value: object) -> bool:
+    return isinstance(value, dict) and value.get("schema_version") == TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA
+
+
+def uploaded_evaluation_result(value: object) -> dict[str, Any] | None:
+    """Return a previously committed result without calling a public replay API."""
+
+    if not is_uploaded_evaluation_bundle(value):
+        return None
+    try:
+        return UploadedEvaluationBundle.model_validate(value).result
+    except ValidationError as exc:
+        raise OutputArtifactError(f"Invalid uploaded trusted evaluation artifact bundle: {exc}") from exc
+
+
+def prepare_evaluation_bundle(
+    value: object,
+    *,
+    terminal_result: object,
+) -> PreparedEvaluationBundle | None:
+    """Parse and hash-check a checkpoint when it uses the reserved schema.
+
+    Other benchmark-owned evaluation checkpoints are ignored.  Once a service
+    opts into the reserved schema, malformed data fails closed instead of being
+    treated as an ordinary checkpoint.
+    """
+
+    if not is_pending_evaluation_bundle(value):
+        return None
+    try:
+        bundle = _PendingBundle.model_validate(value)
+    except ValidationError as exc:
+        raise OutputArtifactError(f"Invalid trusted evaluation artifact bundle: {exc}") from exc
+    try:
+        checked_terminal_result = _validate_terminal_result(terminal_result)
+    except ValueError as exc:
+        raise OutputArtifactError(f"Invalid trusted evaluation terminal result: {exc}") from exc
+    if bundle.result != checked_terminal_result:
+        raise OutputArtifactError("Trusted evaluation artifact bundle result does not match terminal evaluation")
+    decoded = tuple((artifact, artifact.decode()) for artifact in bundle.artifacts)
+    try:
+        documents: dict[str, list[Any]] = {}
+        for artifact, content in decoded:
+            parsed = _load_artifact_documents(artifact.path, content)
+            for document in parsed:
+                _walk_prompt_free(document, label=artifact.path)
+            documents[artifact.path] = parsed
+        _validate_finalization_documents(documents)
+    except ValueError as exc:
+        raise OutputArtifactError(f"Invalid trusted evaluation artifact content: {exc}") from exc
+    return PreparedEvaluationBundle(result=bundle.result, artifacts=decoded)
+
+
+async def upload_evaluation_bundle(
+    bundle: PreparedEvaluationBundle,
+    *,
+    benchmark_id: str,
+    task_id: str,
+    aws: AWSCredentials,
+    s3_bucket: str,
+    execution_is_current: Callable[[], bool],
+) -> UploadedEvaluationBundle:
+    """Upload exact checked bytes, preserving execution-authority fencing."""
+
+    uploaded: list[UploadedArtifact] = []
+    for artifact, content in bundle.artifacts:
+        if not execution_is_current():
+            raise OutputArtifactError("Trusted evaluation artifact upload authority was revoked")
+        s3_key = get_agent_result_s3_key(benchmark_id, task_id, artifact.path)
+        await upload_to_s3(content, s3_key, aws, s3_bucket)
+        if not execution_is_current():
+            raise OutputArtifactError("Trusted evaluation artifact upload authority was revoked")
+        uploaded.append(
+            UploadedArtifact(
+                path=artifact.path,
+                media_type=artifact.media_type,
+                bytes=artifact.bytes,
+                sha256=artifact.sha256,
+                s3_key=s3_key,
+            )
+        )
+    return UploadedEvaluationBundle(
+        schema_version=TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA,
+        result=bundle.result,
+        artifacts=uploaded,
+    )

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -5,7 +5,7 @@ import json
 import time
 import traceback
 from asyncio import Semaphore
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
@@ -52,6 +52,14 @@ from tracker.exceptions import (
     TrackerServiceError,
 )
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
+from tracker.evaluation_artifacts import (
+    UploadedEvaluationBundle,
+    is_pending_evaluation_bundle,
+    is_uploaded_evaluation_bundle,
+    prepare_evaluation_bundle,
+    upload_evaluation_bundle,
+    uploaded_evaluation_result,
+)
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms
@@ -363,6 +371,38 @@ def save_eval_resume_state(
         return result.rowcount > 0
 
 
+def _lock_current_task_attempt(
+    session: Session,
+    task_row_id: UUID,
+    org: Org,
+    *,
+    authority: ExecutionAuthority,
+    expected_started_at: datetime,
+) -> Task:
+    """Hold the run/task fence across canonical post-evaluation uploads.
+
+    The S3 keys are shared by retries. A check immediately before an upload is
+    insufficient: a superseded execution could pass the check, lose authority,
+    and then overwrite the newer attempt. Holding the same benchmark lock used
+    by stop/retry admission until the uploads and database commit finish makes
+    that transition serial.
+    """
+
+    lock_execution_authority(session, authority)
+    task = session.exec(
+        select(Task)
+        .where(col(Task.id) == task_row_id)
+        .where(col(Task.org_id) == org.id)
+        .where(col(Task.status) == TaskStatus.EVALUATING)
+        .where(col(Task.started_at) == expected_started_at)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).one_or_none()
+    if task is None:
+        raise ExecutionAuthorityRevoked("Trusted evaluation artifact task authority was revoked")
+    return task
+
+
 def _commit_task_status(
     task: Task,
     session: Session,
@@ -548,7 +588,15 @@ async def _process_task_attempt(
     flush_task = asyncio.create_task(auto_flush_logs())
 
     def on_eval_resume_state(state: dict[str, Any]) -> None:
-        save_eval_resume_state(task_row.id, org, state, expected_started_at=attempt_started_at, authority=authority)
+        saved = save_eval_resume_state(
+            task_row.id,
+            org,
+            state,
+            expected_started_at=attempt_started_at,
+            authority=authority,
+        )
+        if is_pending_evaluation_bundle(state) and not saved:
+            raise ExecutionAuthorityRevoked("Trusted evaluation artifact checkpoint authority was revoked")
 
     def execution_is_current() -> bool:
         with Session(bind=engine) as task_session:
@@ -565,37 +613,85 @@ async def _process_task_attempt(
     def task_is_stopped() -> bool:
         return not execution_is_current()
 
+    async def upload_pending_evaluation_bundle(
+        state: object,
+        terminal_result: object,
+        *,
+        execution_guard: Callable[[], bool] = execution_is_current,
+    ) -> UploadedEvaluationBundle | None:
+        prepared = prepare_evaluation_bundle(state, terminal_result=terminal_result)
+        if prepared is None:
+            return None
+        return await upload_evaluation_bundle(
+            prepared,
+            benchmark_id=str(benchmark_id),
+            task_id=task_id,
+            aws=harness_config.aws,
+            s3_bucket=harness_config.s3_bucket,
+            execution_is_current=execution_guard,
+        )
+
     try:
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
-                log_output("Resuming evaluation from durable benchmark state\n")
                 resume_eval_start_time = time.perf_counter()
-                # Reset timer to keep the last received message from the benchmarks service accurate
-                last_log_time = time.monotonic()
-                evaluation_result = await benchmark_service.resume_evaluation(
-                    task_row.task_id,
-                    eval_resume_state=task_row.eval_resume_state,
-                    on_message=log_output,
-                    on_eval_resume_state=on_eval_resume_state,
-                    dataset=start_benchmark_request.dataset,
-                    sandbox_provider=sandbox_provider_config,
-                )
-                resume_eval_duration = time.perf_counter() - resume_eval_start_time
-                evaluation_result_row = EvaluationResult(
-                    org_id=org.id,
-                    task=task_row.id,
-                    instance_id=None,
-                    result=cast(dict[str, Any], evaluation_result),
-                    agent_caused_exit_reason=None,
-                )
-
+                if is_pending_evaluation_bundle(task_row.eval_resume_state) or is_uploaded_evaluation_bundle(
+                    task_row.eval_resume_state
+                ):
+                    # This state was written only from the authenticated
+                    # benchmark-service stream after grading had completed. It
+                    # is deliberately resumed inside Tracker: exposing a
+                    # benchmark endpoint that accepts a caller-supplied score
+                    # bundle would turn the crash-recovery format into a score
+                    # forgery surface.
+                    log_output("Resuming trusted post-evaluation artifact upload\n")
+                    uploaded_result = uploaded_evaluation_result(task_row.eval_resume_state)
+                    stored_result = task_row.eval_resume_state.get("result")
+                    evaluation_result = (
+                        uploaded_result if uploaded_result is not None else cast(dict[str, Any], stored_result)
+                    )
+                else:
+                    log_output("Resuming evaluation from durable benchmark state\n")
+                    # Reset timer to keep the last received message from the benchmarks service accurate
+                    last_log_time = time.monotonic()
+                    evaluation_result = await benchmark_service.resume_evaluation(
+                        task_row.task_id,
+                        eval_resume_state=task_row.eval_resume_state,
+                        on_message=log_output,
+                        on_eval_resume_state=on_eval_resume_state,
+                        dataset=start_benchmark_request.dataset,
+                        sandbox_provider=sandbox_provider_config,
+                    )
                 with Session(bind=engine) as task_session:
+                    task_in_session = _lock_current_task_attempt(
+                        task_session,
+                        task_row.id,
+                        org,
+                        authority=authority,
+                        expected_started_at=attempt_started_at,
+                    )
+                    uploaded_bundle = await upload_pending_evaluation_bundle(
+                        task_in_session.eval_resume_state,
+                        evaluation_result,
+                        execution_guard=lambda: True,
+                    )
+                    resume_eval_duration = time.perf_counter() - resume_eval_start_time
+                    evaluation_result_row = EvaluationResult(
+                        org_id=org.id,
+                        task=task_row.id,
+                        instance_id=None,
+                        result=cast(dict[str, Any], evaluation_result),
+                        agent_caused_exit_reason=None,
+                    )
                     task_session.add(evaluation_result_row)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
                     if task_in_session.task_breakdown:
                         existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
                         assert existing_breakdown is not None
                         existing_breakdown.evaluation_run_duration = resume_eval_duration
+                    if uploaded_bundle is not None:
+                        task_in_session.eval_resume_state = uploaded_bundle.model_dump(mode="json")
+                        task_session.add(task_in_session)
+                        task_session.flush()
                     if not commit_task_status_transition(
                         task_row.id,
                         task_session,
@@ -816,31 +912,50 @@ async def _process_task_attempt(
                     dataset=start_benchmark_request.dataset,
                     sandbox_provider=sandbox_provider_config,
                 )
-                task_breakdown.evaluation_run_duration = time.perf_counter() - evaluation_start_time
-
-                task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
-
-                # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, harness_config.aws, harness_config.log_group, force_flush=True)
-
-                # Save the evaluation result to the database with the task row
-                # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
-                evaluation_result_row = EvaluationResult(
-                    org_id=org.id,
-                    task=task_row.id,
-                    instance_id=sandbox.id,
-                    result=cast(dict[str, Any], evaluation_result),
-                    agent_caused_exit_reason=exit_reason,
-                )
-
                 with Session(bind=engine) as task_session:
+                    task_in_session = _lock_current_task_attempt(
+                        task_session,
+                        task_row.id,
+                        org,
+                        authority=authority,
+                        expected_started_at=attempt_started_at,
+                    )
+                    uploaded_bundle = await upload_pending_evaluation_bundle(
+                        task_in_session.eval_resume_state,
+                        evaluation_result,
+                        execution_guard=lambda: True,
+                    )
+                    task_breakdown.evaluation_run_duration = time.perf_counter() - evaluation_start_time
+                    task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
+
+                    # Force flush the logs, maybe redundant since we have the one in finally:
+                    buffer_logs(
+                        log_queue,
+                        stream_key,
+                        harness_config.aws,
+                        harness_config.log_group,
+                        force_flush=True,
+                    )
+
+                    # Save the evaluation result to the database with the task row.
+                    # Record the termination reason if the agent did not exit cleanly (timeout / OS kill).
+                    evaluation_result_row = EvaluationResult(
+                        org_id=org.id,
+                        task=task_row.id,
+                        instance_id=sandbox.id,
+                        result=cast(dict[str, Any], evaluation_result),
+                        agent_caused_exit_reason=exit_reason,
+                    )
                     task_session.add(evaluation_result_row)
-                    task_in_session = fetch_task_row(task_row.id, task_session, org)
                     existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
                     if existing_breakdown is None:
                         raise TrackerServiceError(f"Missing task breakdown for task {task_row.id}")
                     existing_breakdown.evaluation_run_duration = task_breakdown.evaluation_run_duration
                     existing_breakdown.sandbox_run_duration = task_breakdown.sandbox_run_duration
+                    if uploaded_bundle is not None:
+                        task_in_session.eval_resume_state = uploaded_bundle.model_dump(mode="json")
+                        task_session.add(task_in_session)
+                        task_session.flush()
                     if not commit_task_status_transition(
                         task_row.id,
                         task_session,

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -46,7 +46,7 @@ from tracker.utils.reporting import create_final_view
 from tracker.utils.resources import fetch_benchmark_row
 from tracker.utils.run_orchestration import upload_final_view_if_current
 from tracker.utils.task_error_summary import summarize_task_errors
-from tracker.utils.task_execution import TaskMonitor
+from tracker.utils.task_execution import TaskMonitor, _lock_current_task_attempt
 
 
 class TestRunFinalization:
@@ -340,6 +340,99 @@ class TestRunFinalization:
         assert retry_dispatch is not None
         assert retry_dispatch.status == ExecutorDispatchStatus.QUEUED
         assert final_evaluation is None
+
+    def test_trusted_artifact_commit_fence_blocks_concurrent_retry(
+        self,
+        postgres_session: Session,
+        postgres_engine: Engine,
+        executor_authority_kwargs: Any,
+    ) -> None:
+        """Canonical artifact writes hold the same run lock as retry admission."""
+
+        org = Org(id=uuid4(), name=f"trusted-artifact-race-{uuid4()}")
+        contract = AgentContractRequest(name="artifact-race-agent", install_cmd="true", run_cmd="true")
+        benchmark = make_benchmark(
+            name="trusted-artifact-race",
+            org_id=org.id,
+            contract=contract,
+            status=BenchmarkStatus.IN_PROGRESS,
+        )
+        task = make_task(benchmark, "full_ladder", status=TaskStatus.EVALUATING)
+        # These factories populate foreign-key identifiers but do not attach ORM
+        # relationships, so flush the parent rows explicitly before their
+        # dependants. PostgreSQL correctly rejects an unordered bulk INSERT.
+        postgres_session.add(org)
+        postgres_session.flush()
+        postgres_session.add(benchmark)
+        postgres_session.flush()
+        postgres_session.add(task)
+        postgres_session.commit()
+        authority_kwargs = executor_authority_kwargs(benchmark, session=postgres_session)
+        authority = ExecutionAuthority(
+            benchmark_id=benchmark.id,
+            dispatch_id=UUID(str(authority_kwargs["executor_dispatch_id"])),
+        )
+
+        locked_task = _lock_current_task_attempt(
+            postgres_session,
+            task.id,
+            org,
+            authority=authority,
+            expected_started_at=task.started_at,
+        )
+        assert locked_task.id == task.id
+
+        retry_ready = Event()
+        retry_finished = Event()
+        retry_errors: list[BaseException] = []
+        retry_backend_pids: list[int] = []
+
+        def admit_retry() -> None:
+            try:
+                with Session(postgres_engine) as retry_session:
+                    backend_pid = retry_session.connection().exec_driver_sql("SELECT pg_backend_pid()").scalar_one()
+                    retry_backend_pids.append(int(backend_pid))
+                    retry_ready.set()
+                    retry_benchmark = fetch_benchmark_row(
+                        benchmark.id,
+                        retry_session,
+                        org,
+                        for_update=True,
+                    )
+                    retry_task = retry_session.get(Task, task.id)
+                    assert retry_task is not None
+                    retry_task.started_at = datetime.now(UTC)
+                    retry_session.add_all([retry_benchmark, retry_task])
+                    retry_session.commit()
+                    retry_finished.set()
+            except BaseException as exc:
+                retry_errors.append(exc)
+
+        retry_thread = Thread(target=admit_retry)
+        retry_thread.start()
+        assert retry_ready.wait(timeout=2)
+
+        try:
+            deadline = monotonic() + 2
+            blocking_pids: list[int] = []
+            while monotonic() < deadline:
+                blocking_pid_row = postgres_session.connection().exec_driver_sql(
+                    "SELECT pg_blocking_pids(%s)",
+                    (retry_backend_pids[0],),
+                )
+                blocking_pids = list(blocking_pid_row.scalar_one())
+                if blocking_pids:
+                    break
+                assert retry_thread.is_alive(), "retry completed while the trusted artifact fence was held"
+                sleep(0.01)
+            assert blocking_pids
+            assert not retry_finished.is_set()
+        finally:
+            postgres_session.rollback()
+            retry_thread.join(5)
+        assert not retry_thread.is_alive()
+        assert retry_errors == []
+        assert retry_finished.is_set()
 
     async def test_only_one_additive_dispatch_calls_final_score(
         self,

--- a/services/tracker/tests/unit/test_evaluation_artifacts.py
+++ b/services/tracker/tests/unit/test_evaluation_artifacts.py
@@ -1,0 +1,323 @@
+"""Tests for crash-safe post-evaluation artifact bundles."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any
+
+import pytest
+
+from tracker.evaluation_artifacts import (
+    MAX_TRUSTED_EVALUATION_BUNDLE_BYTES,
+    REQUIRED_TRUSTED_EVALUATION_ARTIFACTS,
+    TRUSTED_EVALUATION_BUNDLE_SCHEMA,
+    TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA,
+    prepare_evaluation_bundle,
+    upload_evaluation_bundle,
+    uploaded_evaluation_result,
+)
+from tracker.exceptions import OutputArtifactError
+from tracker.types import AWSCredentials
+
+
+def _artifact(path: str, content: bytes, *, media_type: str = "application/json") -> dict[str, Any]:
+    return {
+        "path": path,
+        "media_type": media_type,
+        "bytes": len(content),
+        "sha256": hashlib.sha256(content).hexdigest(),
+        "content_base64": base64.b64encode(content).decode("ascii"),
+    }
+
+
+def _bundle(*artifacts: dict[str, Any], result: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "schema_version": TRUSTED_EVALUATION_BUNDLE_SCHEMA,
+        "result": result or _result(),
+        "artifacts": list(artifacts),
+    }
+
+
+def _result(*, score: float = 1.0, resolved: bool = True) -> dict[str, Any]:
+    return {"task": "full_ladder", "resolved": resolved, "score": score}
+
+
+def _required_artifacts(*, turns: bytes | None = None) -> list[dict[str, Any]]:
+    contents = {
+        "gateway-run-accounting.json": b'{"final":true,"finalized":true,"attempts":[]}',
+        "run-report.json": b'{"finality":{"complete":true}}',
+        "vals_format/run_config.json": b'{"schema_version":"vals_run_config.v1"}',
+        "vals_format/turns.jsonl": turns or b'{"type":"assistant"}\n',
+    }
+    return [
+        _artifact(path, contents[path], media_type=media_type)
+        for path, media_type in REQUIRED_TRUSTED_EVALUATION_ARTIFACTS.items()
+    ]
+
+
+def _aws() -> AWSCredentials:
+    return AWSCredentials(
+        aws_access_key_id="test-access",
+        aws_secret_access_key="test-secret",
+        aws_default_region="us-east-1",
+    )
+
+
+def test_prepare_bundle_hash_checks_exact_bytes_and_result() -> None:
+    turns = b'{"input_tokens": 1, "cache_read_tokens": 2}\n'
+    state = _bundle(*_required_artifacts(turns=turns))
+
+    prepared = prepare_evaluation_bundle(state, terminal_result=_result())
+
+    assert prepared is not None
+    assert prepared.result == _result()
+    assert prepared.artifacts[-1][1] == turns
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda state: state["artifacts"][0].update(path="../secret"), "normalized relative paths"),
+        (lambda state: state["artifacts"][0].update(content_base64="not base64"), "invalid base64"),
+        (lambda state: state["artifacts"][0].update(bytes=99), "size mismatch"),
+        (lambda state: state["artifacts"][0].update(sha256="0" * 64), "SHA-256 mismatch"),
+        (lambda state: state.update(extra="nope"), "extra"),
+    ],
+)
+def test_prepare_bundle_rejects_malformed_reserved_state(mutate: Any, message: str) -> None:
+    state = _bundle(*_required_artifacts())
+    mutate(state)
+
+    with pytest.raises(OutputArtifactError, match=message):
+        prepare_evaluation_bundle(state, terminal_result=_result())
+
+
+def test_prepare_bundle_rejects_result_mismatch_and_duplicate_paths() -> None:
+    state = _bundle(
+        *_required_artifacts()[:-1],
+        _artifact("run-report.json", b'{"duplicate":true}'),
+    )
+
+    with pytest.raises(OutputArtifactError, match="paths must be unique"):
+        prepare_evaluation_bundle(state, terminal_result=_result())
+
+    single = _bundle(*_required_artifacts())
+    with pytest.raises(OutputArtifactError, match="does not match terminal"):
+        prepare_evaluation_bundle(single, terminal_result=_result(score=0.0, resolved=False))
+
+
+def test_prepare_bundle_rejects_total_decoded_size_limit() -> None:
+    first = b"a" * (MAX_TRUSTED_EVALUATION_BUNDLE_BYTES // 2 + 1)
+    second = b"b" * (MAX_TRUSTED_EVALUATION_BUNDLE_BYTES // 2 + 1)
+    artifacts = _required_artifacts()
+    artifacts[0] = _artifact("gateway-run-accounting.json", first)
+    artifacts[1] = _artifact("run-report.json", second)
+    state = _bundle(*artifacts)
+
+    with pytest.raises(OutputArtifactError, match="bundle exceeds"):
+        prepare_evaluation_bundle(state, terminal_result=_result())
+
+
+def test_prepare_bundle_allows_one_large_artifact_within_total_limit() -> None:
+    turns = b'{"padding":"' + b"x" * (5 * 1024 * 1024) + b'"}\n'
+    prepared = prepare_evaluation_bundle(
+        _bundle(*_required_artifacts(turns=turns)),
+        terminal_result=_result(),
+    )
+
+    assert prepared is not None
+    assert prepared.artifacts[-1][1] == turns
+
+
+def test_prepare_bundle_rejects_noncanonical_base64() -> None:
+    artifacts = _required_artifacts()
+    artifacts[0] = _artifact("gateway-run-accounting.json", b"{}")
+    canonical = artifacts[0]["content_base64"]
+    assert canonical.endswith("0=")
+    # Change only unused pad bits. Python's strict decoder accepts this and
+    # produces the same bytes, but the wire representation is not canonical.
+    artifacts[0]["content_base64"] = canonical[:-2] + "1="
+
+    with pytest.raises(OutputArtifactError, match="base64 is not canonical"):
+        prepare_evaluation_bundle(_bundle(*artifacts), terminal_result=_result())
+
+
+def test_non_reserved_checkpoint_is_ignored() -> None:
+    assert prepare_evaluation_bundle({"schema_version": "other.v1"}, terminal_result={}) is None
+
+
+async def test_upload_bundle_uses_deterministic_task_keys_and_returns_compact_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    report = b'{"finality":{"complete":true}}'
+    turns = b'{"cache_read_tokens":4}\n'
+    artifacts = _required_artifacts(turns=turns)
+    artifacts[1] = _artifact("run-report.json", report)
+    state = _bundle(*artifacts)
+    prepared = prepare_evaluation_bundle(state, terminal_result=_result())
+    assert prepared is not None
+    uploads: list[tuple[bytes, str, str]] = []
+
+    async def fake_upload(content: bytes, key: str, _aws: AWSCredentials, bucket: str) -> None:
+        uploads.append((content, key, bucket))
+
+    monkeypatch.setattr("tracker.evaluation_artifacts.upload_to_s3", fake_upload)
+
+    uploaded = await upload_evaluation_bundle(
+        prepared,
+        benchmark_id="run-1",
+        task_id="full_ladder",
+        aws=_aws(),
+        s3_bucket="artifact-bucket",
+        execution_is_current=lambda: True,
+    )
+
+    assert uploads[1] == (report, "benchmarks/run-1/full_ladder/run-report.json", "artifact-bucket")
+    assert uploads[-1] == (turns, "benchmarks/run-1/full_ladder/vals_format/turns.jsonl", "artifact-bucket")
+    assert len(uploads) == 4
+    dumped = uploaded.model_dump(mode="json")
+    assert dumped["schema_version"] == TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA
+    assert "content_base64" not in str(dumped)
+    assert dumped["artifacts"][1]["sha256"] == hashlib.sha256(report).hexdigest()
+
+
+async def test_upload_bundle_fails_when_execution_authority_is_revoked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepared = prepare_evaluation_bundle(
+        _bundle(*_required_artifacts()),
+        terminal_result=_result(),
+    )
+    assert prepared is not None
+    checks = iter([True, False])
+
+    async def fake_upload(_content: bytes, _key: str, _aws: AWSCredentials, _bucket: str) -> None:
+        return None
+
+    monkeypatch.setattr("tracker.evaluation_artifacts.upload_to_s3", fake_upload)
+
+    with pytest.raises(OutputArtifactError, match="authority was revoked"):
+        await upload_evaluation_bundle(
+            prepared,
+            benchmark_id="run-1",
+            task_id="full_ladder",
+            aws=_aws(),
+            s3_bucket="artifact-bucket",
+            execution_is_current=lambda: next(checks),
+        )
+
+
+def test_prepare_bundle_requires_exact_v1_paths_and_media_types() -> None:
+    missing = _bundle(*_required_artifacts()[:-1])
+    with pytest.raises(OutputArtifactError, match="at least 4 items"):
+        prepare_evaluation_bundle(missing, terminal_result=_result())
+
+    wrong_media = _required_artifacts()
+    wrong_media[-1]["media_type"] = "application/json"
+    with pytest.raises(OutputArtifactError, match="must match the v1 manifest exactly"):
+        prepare_evaluation_bundle(_bundle(*wrong_media), terminal_result=_result())
+
+    extra = _required_artifacts()
+    extra.append(_artifact("extra.json", b"{}"))
+    with pytest.raises(OutputArtifactError, match="at most 4 items"):
+        prepare_evaluation_bundle(_bundle(*extra), terminal_result=_result())
+
+
+@pytest.mark.parametrize(
+    ("path", "content", "message"),
+    [
+        ("run-report.json", b"\xff", "not UTF-8"),
+        ("run-report.json", b'{"finality":', "not valid JSON"),
+        ("run-report.json", b'{"finality":{"complete":true},"prompt":"private"}', "forbidden field"),
+        ("run-report.json", b'{"finality":{"complete":true},"error":"provider_error"}', "raw error field"),
+        ("run-report.json", b'{"finality":{"complete":true,"complete":true}}', "duplicate JSON field"),
+        ("run-report.json", b'{"finality":{"complete":true},"score":NaN}', "non-finite JSON"),
+        ("run-report.json", b"[]", "must contain one object"),
+        ("run-report.json", b'{"finality":{"complete":false}}', "run report is not final"),
+        ("gateway-run-accounting.json", b"[]", "must contain one object"),
+        (
+            "gateway-run-accounting.json",
+            b'{"final":true,"finalized":true,"attempts":{}}',
+            "attempts must be a list",
+        ),
+        (
+            "gateway-run-accounting.json",
+            b'{"final":true,"finalized":true,"attempts":[{"status":"unknown"}]}',
+            "invalid attempt status",
+        ),
+        (
+            "gateway-run-accounting.json",
+            b'{"final":true,"finalized":true,"attempts":[{"status":"unresolved"}]}',
+            "unresolved attempts",
+        ),
+        (
+            "gateway-run-accounting.json",
+            b'{"final":true,"finalized":false,"attempts":[]}',
+            "not fenced and finalized",
+        ),
+        (
+            "vals_format/turns.jsonl",
+            b'{"turn_index":0,"status":"error","error":"provider returned private prose"}\n',
+            "short failure classification",
+        ),
+        (
+            "vals_format/turns.jsonl",
+            b'{"turn_index":0,"status":"success"}\n\n{"turn_index":1,"status":"success"}\n',
+            "blank row",
+        ),
+    ],
+)
+def test_prepare_bundle_rejects_untrusted_artifact_content(path: str, content: bytes, message: str) -> None:
+    artifacts = _required_artifacts()
+    media_type = REQUIRED_TRUSTED_EVALUATION_ARTIFACTS[path]
+    artifacts[list(REQUIRED_TRUSTED_EVALUATION_ARTIFACTS).index(path)] = _artifact(
+        path,
+        content,
+        media_type=media_type,
+    )
+
+    with pytest.raises(OutputArtifactError, match=message):
+        prepare_evaluation_bundle(_bundle(*artifacts), terminal_result=_result())
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"task": "reach_orbit", "resolved": True, "score": 1.0},
+        {"task": "full_ladder", "resolved": "yes", "score": 1.0},
+        {"task": "full_ladder", "resolved": True, "score": 1.1},
+        {"task": "full_ladder", "resolved": True, "score": float("nan")},
+        {"task": "full_ladder", "resolved": True, "score": 1.0, "api_key": "secret"},
+    ],
+)
+def test_prepare_bundle_rejects_invalid_terminal_result(result: dict[str, Any]) -> None:
+    with pytest.raises(OutputArtifactError, match="Invalid trusted evaluation artifact bundle"):
+        prepare_evaluation_bundle(_bundle(*_required_artifacts(), result=result), terminal_result=result)
+
+
+def test_prepare_bundle_rejects_non_object_terminal_result_from_stream() -> None:
+    with pytest.raises(OutputArtifactError, match="terminal result must be an object"):
+        prepare_evaluation_bundle(_bundle(*_required_artifacts()), terminal_result=[])
+
+
+def test_uploaded_resume_state_fails_closed_if_tampered() -> None:
+    artifacts = [
+        {
+            "path": path,
+            "media_type": media_type,
+            "bytes": 0,
+            "sha256": "0" * 64,
+            "s3_key": f"benchmarks/run/full_ladder/{path}",
+        }
+        for path, media_type in REQUIRED_TRUSTED_EVALUATION_ARTIFACTS.items()
+    ]
+    artifacts[-1]["path"] = artifacts[0]["path"]
+    state = {
+        "schema_version": TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA,
+        "result": _result(),
+        "artifacts": artifacts,
+    }
+
+    with pytest.raises(OutputArtifactError, match="Invalid uploaded trusted evaluation artifact bundle"):
+        uploaded_evaluation_result(state)

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -5,6 +5,8 @@ Run: uv run pytest tests/unit/utils/test_task_execution_retry.py
 
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
+import base64
+import hashlib
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 from uuid import UUID
@@ -21,10 +23,38 @@ from tests.unit.utils.task_execution_support import (
     run_process_task,
 )
 from tracker.database.models import AgentContractRequest, ErrorResult, TaskStatus
+from tracker.evaluation_artifacts import (
+    REQUIRED_TRUSTED_EVALUATION_ARTIFACTS,
+    TRUSTED_EVALUATION_BUNDLE_SCHEMA,
+    TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA,
+)
 from tracker.exceptions import AgentRunFailedError, DependencySetupExhaustedError, SandboxSetupError
 from tracker.sandbox import DependencySetupMode
 from tracker.types import HarnessConfig
 from tracker.utils import task_execution as task_execution_module
+
+
+def _trusted_bundle(result: dict[str, Any], accounting: bytes) -> dict[str, Any]:
+    contents = {
+        "gateway-run-accounting.json": accounting,
+        "run-report.json": b'{"finality":{"complete":true}}',
+        "vals_format/run_config.json": b'{"schema_version":"vals_run_config.v1"}',
+        "vals_format/turns.jsonl": b'{"type":"assistant"}\n',
+    }
+    return {
+        "schema_version": TRUSTED_EVALUATION_BUNDLE_SCHEMA,
+        "result": result,
+        "artifacts": [
+            {
+                "path": path,
+                "media_type": media_type,
+                "bytes": len(contents[path]),
+                "sha256": hashlib.sha256(contents[path]).hexdigest(),
+                "content_base64": base64.b64encode(contents[path]).decode("ascii"),
+            }
+            for path, media_type in REQUIRED_TRUSTED_EVALUATION_ARTIFACTS.items()
+        ],
+    }
 
 
 class TestTaskExecutionRetry:
@@ -327,6 +357,170 @@ class TestTaskExecutionRetry:
             .order_by(desc(ErrorResult.created_at))
         ).one()
         assert error_message == "grading sandbox was preempted"
+
+    async def test_trusted_evaluation_bundle_resumes_locally_without_public_replay(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        artifact = b'{"final":true,"finalized":true,"attempts":[],"cache_read_tokens":12}'
+        terminal_result = {"task": "full_ladder", "resolved": True, "score": 1.0}
+        task_row.status = TaskStatus.EVALUATING
+        task_row.eval_resume_state = _trusted_bundle(terminal_result, artifact)
+        database_session.add(task_row)
+        database_session.commit()
+        uploads: list[tuple[bytes, str]] = []
+
+        async def _public_replay_must_not_run(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("reserved trusted bundles must resume inside Tracker")
+
+        async def _upload(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+            uploads.append((content, key))
+
+        monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _public_replay_must_not_run, raising=False)
+        monkeypatch.setattr("tracker.evaluation_artifacts.upload_to_s3", _upload)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
+
+        assert result == {"task_0": terminal_result}
+        assert uploads[0] == (artifact, f"benchmarks/{benchmark_id}/task_0/gateway-run-accounting.json")
+        assert len(uploads) == 4
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+        assert task_row.eval_resume_state is not None
+        assert task_row.eval_resume_state["schema_version"] == TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA
+        assert "content_base64" not in task_row.eval_resume_state["artifacts"][0]
+
+        # An explicit automatic retry reuses the compact Tracker-owned state;
+        # it neither calls the public benchmark replay endpoint nor rewrites
+        # the already committed artifact.
+        task_row.status = TaskStatus.EVALUATING
+        database_session.add(task_row)
+        database_session.commit()
+        retried = await run_process_task(
+            start_benchmark_request,
+            task_row,
+            benchmark_id,
+            harness_config,
+            authority,
+        )
+        assert retried == {"task_0": terminal_result}
+        assert len(uploads) == 4
+
+    async def test_evaluation_stream_bundle_uploads_before_finishing_task(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        artifact = b'{"final":true,"finalized":true,"attempts":[],"provider_billed_cost":{"total_ticks":123}}'
+        terminal_result = {"task": "full_ladder", "resolved": False, "score": 0.5}
+        uploads: list[tuple[bytes, str]] = []
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            sandbox = AsyncMock()
+            sandbox.id = "mock-sandbox-id"
+            sandbox.name = "mock-sandbox"
+            yield sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return make_retrieve_task_response(problem_path="/tmp/problem.txt")
+
+        async def _mock_evaluate_instance(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+            kwargs["on_eval_resume_state"](_trusted_bundle(terminal_result, artifact))
+            return terminal_result
+
+        async def _upload(content: bytes, key: str, *_args: Any, **_kwargs: Any) -> None:
+            uploads.append((content, key))
+
+        monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(task_execution_module, "upload_agent_artifacts", AsyncMock())
+        monkeypatch.setattr(task_execution_module, "run_agent", AsyncMock(return_value=(None, 0.0)))
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", AsyncMock(return_value={"status": "ok"}))
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr("tracker.evaluation_artifacts.upload_to_s3", _upload)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
+
+        assert result == {"task_0": terminal_result}
+        assert uploads[0] == (artifact, f"benchmarks/{benchmark_id}/task_0/gateway-run-accounting.json")
+        assert len(uploads) == 4
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+        assert task_row.eval_resume_state is not None
+        assert task_row.eval_resume_state["schema_version"] == TRUSTED_EVALUATION_BUNDLE_UPLOADED_SCHEMA
+
+    async def test_trusted_bundle_checkpoint_failure_aborts_before_result_commit(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        terminal_result = {"task": "full_ladder", "resolved": False, "score": 0.5}
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            sandbox = AsyncMock()
+            sandbox.id = "mock-sandbox-id"
+            sandbox.name = "mock-sandbox"
+            yield sandbox
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return make_retrieve_task_response(problem_path="/tmp/problem.txt")
+
+        async def _mock_evaluate_instance(*_args: Any, **kwargs: Any) -> dict[str, Any]:
+            kwargs["on_eval_resume_state"](
+                _trusted_bundle(
+                    terminal_result,
+                    b'{"final":true,"finalized":true,"attempts":[]}',
+                )
+            )
+            raise AssertionError("terminal result must not be reached when the checkpoint is rejected")
+
+        monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(task_execution_module, "upload_agent_artifacts", AsyncMock())
+        monkeypatch.setattr(task_execution_module, "run_agent", AsyncMock(return_value=(None, 0.0)))
+        monkeypatch.setattr(task_execution_module, "save_eval_resume_state", Mock(return_value=False))
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", AsyncMock(return_value={"status": "ok"}))
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, harness_config, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        assert task_row.eval_resume_state is None
 
     async def test_process_task_spans_timed_status_transitions(
         self,


### PR DESCRIPTION
## Summary
- reserve a strict post-evaluation bundle for the four prompt-free KSP accounting/publication artifacts
- validate exact paths/media, canonical base64, hashes, strict duplicate-free finite JSON, final Gateway attempts, final run-report state, and exact terminal-result equality
- upload the checked bytes under the canonical task prefix while holding the same run/task fence as stop and retry admission
- commit compact artifact references, the evaluation result, and FINISHED together; resume a pending/committed bundle locally without calling a public benchmark replay endpoint

## Why
KSP only learns authoritative Gateway usage after model traffic is stopped and the Gateway has fenced the run. Ordinary sandbox artifacts are collected earlier and are player-writable, so they cannot prove exact cached-token cost or finality. This gives the benchmark-service stream a bounded, crash-safe two-phase handoff to Tracker-owned S3 credentials.

## Validation
- 621 Tracker unit + local API tests passed
- 39 focused trusted-bundle/retry tests passed
- Ruff check/format and basedpyright passed
- PostgreSQL lock-interleaving regression added; local execution is blocked only because Docker is not running, so required CI must run it

## Rollout gates
This is a stacked draft on #691. Do not merge or deploy alone. It requires the reviewed immutable-agent rollout (#690), authoritative Gateway authorize/status/finalize producer (#1066 successor), and the byte-matched KSP evaluator bundle. The maintenance sequence and live dev forced-replacement/accounting canary must pass before production promotion.