### PR TITLE
fix(tracker): finalize forced stops before provider cleanup

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -881,8 +881,8 @@ async def stop_benchmark(
 ) -> StopBenchmarkResponse:
     """
     Stop a benchmark by its id.
-    If force is True, the sandboxes will be stopped and deleted, even if the tasks are in progress;
-    cleanup remains retryable when ownership cannot yet be proven gone.
+    If force is True, the database run is stopped immediately and provider kill signals are sent
+    without waiting for provider teardown to complete.
 
     Usage:
     curl -X POST http://<endpoint>/stop-benchmark/<benchmark_id>?force=true
@@ -926,18 +926,16 @@ async def stop_benchmark(
             detail=f"Run {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress or error run.",
         )
 
-    tasks_were_stopped = await initiate_stop_benchmark(benchmark_row, session, force, org, task_ids=selected_task_ids)
+    await initiate_stop_benchmark(benchmark_row, session, force, org, task_ids=selected_task_ids)
 
     if provider_secret_name is not None:
         await force_stop_sandboxes(
             benchmark_row,
-            session,
             provider_secret_name,
             runtime_resolution.runtime,
             org,
             sandbox_provider=benchmark_row.arguments.sandbox_provider,
             task_ids=selected_task_ids,
-            tasks_were_active_before_stop=tasks_were_stopped,
         )
 
     return StopBenchmarkResponse(

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -881,7 +881,8 @@ async def stop_benchmark(
 ) -> StopBenchmarkResponse:
     """
     Stop a benchmark by its id.
-    If force is True, the sandboxes will be stopped and deleted, even if the tasks are in progress.
+    If force is True, the sandboxes will be stopped and deleted, even if the tasks are in progress;
+    cleanup remains retryable when ownership cannot yet be proven gone.
 
     Usage:
     curl -X POST http://<endpoint>/stop-benchmark/<benchmark_id>?force=true
@@ -925,7 +926,7 @@ async def stop_benchmark(
             detail=f"Run {benchmark_id} is currently in the {benchmark_row.status} state. Can only pause an in progress or error run.",
         )
 
-    await initiate_stop_benchmark(benchmark_row, session, force, org, task_ids=selected_task_ids)
+    tasks_were_stopped = await initiate_stop_benchmark(benchmark_row, session, force, org, task_ids=selected_task_ids)
 
     if provider_secret_name is not None:
         await force_stop_sandboxes(
@@ -936,6 +937,7 @@ async def stop_benchmark(
             org,
             sandbox_provider=benchmark_row.arguments.sandbox_provider,
             task_ids=selected_task_ids,
+            tasks_were_active_before_stop=tasks_were_stopped,
         )
 
     return StopBenchmarkResponse(

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -43,12 +43,7 @@ def apply_stop_benchmark(
     """Apply the Stop state transition without committing the transaction."""
     # Stop and recovery both update the benchmark and its tasks. Lock the benchmark
     # first so every lifecycle transition uses the same lock order.
-    session.exec(
-        select(col(Benchmark.id))
-        .where(col(Benchmark.id) == benchmark_row.id)
-        .where(col(Benchmark.org_id) == org.id)
-        .with_for_update()
-    ).one()
+    fetch_benchmark_row(benchmark_row.id, session, org, for_update=True)
 
     stoppable_statuses = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]
     if force:

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -122,8 +122,8 @@ async def drain_sandboxes(
     """Wait for the executor to delete the sandboxes it owns and return the ones left behind.
 
     The executor cancels stopped tasks within one monitor poll and then tears down each of
-    its sandboxes. Deleting underneath it instead fails whatever command is still in flight,
-    so give it a bounded window before reaping what remains.
+    its sandboxes. The caller must not delete the returned sandboxes if their owner is still
+    active: deleting underneath it instead fails whatever command is still in flight.
     """
     deadline = time.monotonic() + timeout_seconds
     while True:
@@ -143,7 +143,8 @@ async def force_stop_sandboxes(
     task_ids: list[str] | None = None,
 ) -> None:
     """
-    Stops and deletes all sandboxes which are in progress or evaluating.
+    Stops active work and deletes sandboxes only when no owner can still be active.
+    Sandboxes that may still be owned by stopped work are left for executor/orphan cleanup.
     NOTE: If task is not in progress but sandbox exists, we kill it and leave the task status as is.
 
     Raises:
@@ -164,9 +165,20 @@ async def force_stop_sandboxes(
     if task_ids:
         task_update = task_update.where(col(Task.task_id).in_(task_ids))
 
+    active_task_count = select(func.count(col(Task.id))).where(
+        col(Task.benchmark) == benchmark_row.id,
+        col(Task.org_id) == org.id,
+        col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]),
+    )
+    if task_ids:
+        active_task_count = active_task_count.where(col(Task.task_id).in_(task_ids))
+
+    tasks_were_active = session.exec(active_task_count).one() > 0
     session.exec(task_update.values(status=TaskStatus.STOPPED))
 
-    # Only a live dispatch can still be working inside these sandboxes.
+    # A live dispatch is the durable ownership signal for the managed executor. Keep the
+    # pre-stop value so we know whether the dispatch/task could still be cleaning up after
+    # the task rows are marked STOPPED.
     executor_active = active_dispatch_exists(session, benchmark_row.id)
 
     session.commit()
@@ -175,7 +187,23 @@ async def force_stop_sandboxes(
     results: dict[str, str | None] = {}
     try:
         drain_seconds = SANDBOX_DRAIN_TIMEOUT_SECONDS if executor_active else 0.0
-        for sandbox in await drain_sandboxes(benchmark_row, provider, task_ids, drain_seconds):
+        remaining_sandboxes = await drain_sandboxes(benchmark_row, provider, task_ids, drain_seconds)
+
+        # Never reap a sandbox while its owner may still be alive. A dispatch can finish
+        # during the drain, in which case its cleanup is complete and direct deletion is safe.
+        # Without a dispatch, an active task is an older/unmanaged execution path for which
+        # Tracker has no reliable process-liveness signal, so defer cleanup conservatively.
+        owner_still_active = (
+            active_dispatch_exists(session, benchmark_row.id) if executor_active else tasks_were_active
+        )
+        if remaining_sandboxes and owner_still_active:
+            sandbox_names = ", ".join(sandbox.name for sandbox in remaining_sandboxes)
+            logger.warning(
+                f"Deferring force-stop deletion for sandboxes that may still be owned by active work: {sandbox_names}"
+            )
+            remaining_sandboxes = []
+
+        for sandbox in remaining_sandboxes:
             result = await stop_sandbox(sandbox, provider, org)
             results[sandbox.name] = result
     finally:

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -46,8 +46,11 @@ def apply_stop_benchmark(
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
-) -> None:
-    """Apply the Stop state transition without committing the transaction."""
+) -> bool:
+    """Apply the Stop state transition without committing the transaction.
+
+    Returns whether any task that can own a sandbox was transitioned to STOPPED.
+    """
     task_update = (
         update(Task)
         .where(col(Task.benchmark) == benchmark_row.id)
@@ -57,11 +60,22 @@ def apply_stop_benchmark(
     if task_ids:
         task_update = task_update.where(col(Task.task_id).in_(task_ids))
 
+    active_task_count = select(func.count(col(Task.id))).where(
+        col(Task.benchmark) == benchmark_row.id,
+        col(Task.org_id) == org.id,
+        col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.EVALUATING]),
+    )
+    if task_ids:
+        active_task_count = active_task_count.where(col(Task.task_id).in_(task_ids))
+
+    tasks_were_active = session.exec(active_task_count).one() > 0
     result = session.exec(task_update.values(status=TaskStatus.STOPPED))
 
     if task_ids is None and (result.rowcount > 0 or force):
         benchmark_row.status = BenchmarkStatus.STOPPING
         session.add(benchmark_row)
+
+    return tasks_were_active
 
 
 async def initiate_stop_benchmark(
@@ -70,11 +84,15 @@ async def initiate_stop_benchmark(
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
-) -> None:
-    """Initiate Stop without interrupting work that already started unless forced."""
+) -> bool:
+    """Initiate Stop without interrupting work that already started unless forced.
+
+    Returns whether sandbox-owning tasks were active before this transition.
+    """
     try:
-        apply_stop_benchmark(benchmark_row, session, force, org, task_ids)
+        tasks_were_stopped = apply_stop_benchmark(benchmark_row, session, force, org, task_ids)
         session.commit()
+        return tasks_were_stopped
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error stopping run {benchmark_row.id}: {str(e)}") from e
 
@@ -141,10 +159,12 @@ async def force_stop_sandboxes(
     org: Org,
     sandbox_provider: str = "daytona",
     task_ids: list[str] | None = None,
+    tasks_were_active_before_stop: bool | None = None,
 ) -> None:
     """
     Stops active work and deletes sandboxes only when no owner can still be active.
     Sandboxes that may still be owned by stopped work are left for executor/orphan cleanup.
+    A deferred cleanup leaves the benchmark in STOPPING so this operation can be retried.
     NOTE: If task is not in progress but sandbox exists, we kill it and leave the task status as is.
 
     Raises:
@@ -174,6 +194,8 @@ async def force_stop_sandboxes(
         active_task_count = active_task_count.where(col(Task.task_id).in_(task_ids))
 
     tasks_were_active = session.exec(active_task_count).one() > 0
+    if tasks_were_active_before_stop:
+        tasks_were_active = True
     session.exec(task_update.values(status=TaskStatus.STOPPED))
 
     # A live dispatch is the durable ownership signal for the managed executor. Keep the
@@ -185,8 +207,12 @@ async def force_stop_sandboxes(
 
     # Iterate through each running sandbox and stop it, collecting error messages
     results: dict[str, str | None] = {}
+    deletion_deferred = False
     try:
-        drain_seconds = SANDBOX_DRAIN_TIMEOUT_SECONDS if executor_active else 0.0
+        # A retry after a deferred cleanup gets the same grace period even if the
+        # first attempt already revoked the dispatch.
+        retrying_deferred_cleanup = benchmark_row.status == BenchmarkStatus.STOPPING and not executor_active
+        drain_seconds = SANDBOX_DRAIN_TIMEOUT_SECONDS if executor_active or retrying_deferred_cleanup else 0.0
         remaining_sandboxes = await drain_sandboxes(benchmark_row, provider, task_ids, drain_seconds)
 
         # Never reap a sandbox while its owner may still be alive. A dispatch can finish
@@ -201,6 +227,7 @@ async def force_stop_sandboxes(
             logger.warning(
                 f"Deferring force-stop deletion for sandboxes that may still be owned by active work: {sandbox_names}"
             )
+            deletion_deferred = True
             remaining_sandboxes = []
 
         for sandbox in remaining_sandboxes:
@@ -224,7 +251,14 @@ async def force_stop_sandboxes(
         .where(col(Task.status).notin_(finished_statuses))
     ).one()
 
-    if not tasks_still_running:
+    if deletion_deferred:
+        # Keep the run retryable while ownership is ambiguous. A later force stop can
+        # re-list these sandboxes after the owner exits and complete the cleanup.
+        if not tasks_still_running:
+            benchmark_row.status = BenchmarkStatus.STOPPING
+            terminalize_active_dispatches(session, benchmark_row.id)
+            session.add(benchmark_row)
+    elif not tasks_still_running:
         benchmark_row.status = BenchmarkStatus.STOPPED
         terminalize_active_dispatches(session, benchmark_row.id)
         session.add(benchmark_row)

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -41,6 +41,15 @@ def apply_stop_benchmark(
     task_ids: list[str] | None = None,
 ) -> None:
     """Apply the Stop state transition without committing the transaction."""
+    # Stop and recovery both update the benchmark and its tasks. Lock the benchmark
+    # first so every lifecycle transition uses the same lock order.
+    session.exec(
+        select(col(Benchmark.id))
+        .where(col(Benchmark.id) == benchmark_row.id)
+        .where(col(Benchmark.org_id) == org.id)
+        .with_for_update()
+    ).one()
+
     stoppable_statuses = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]
     if force:
         stoppable_statuses.append(TaskStatus.IN_PROGRESS)

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -1,8 +1,6 @@
 """Operations that stop, resume, or retry a run and tear down its sandboxes."""
 
 import asyncio
-import time
-import traceback
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import Any
@@ -10,7 +8,6 @@ from zoneinfo import ZoneInfo
 
 from benchmark_service import (
     Sandbox,
-    SandboxNotFoundError,
     SandboxProvider,
     SandboxQuery,
 )
@@ -25,7 +22,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
-from tracker.executor.dispatch_control import active_dispatch_exists, terminalize_active_dispatches
+from tracker.executor.dispatch_control import terminalize_active_dispatches
 from tracker.exceptions import TrackerServiceError
 from tracker.logging import get_logger
 from tracker.sandbox import delete_sandbox
@@ -35,10 +32,6 @@ from tracker.utils.resources import fetch_benchmark_row, fetch_sandbox_provider_
 
 logger = get_logger(__name__)
 
-# Bounded by the ALB idle timeout the stop request has to answer within.
-SANDBOX_DRAIN_TIMEOUT_SECONDS = 15.0
-SANDBOX_DRAIN_POLL_SECONDS = 3.0
-
 
 def apply_stop_benchmark(
     benchmark_row: Benchmark,
@@ -46,36 +39,41 @@ def apply_stop_benchmark(
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
-) -> bool:
-    """Apply the Stop state transition without committing the transaction.
+) -> None:
+    """Apply the Stop state transition without committing the transaction."""
+    stoppable_statuses = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]
+    if force:
+        stoppable_statuses.append(TaskStatus.IN_PROGRESS)
 
-    Returns whether any task that can own a sandbox was transitioned to STOPPED.
-    """
     task_update = (
         update(Task)
         .where(col(Task.benchmark) == benchmark_row.id)
         .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.EVALUATING]))
+        .where(col(Task.status).in_(stoppable_statuses))
     )
     if task_ids:
         task_update = task_update.where(col(Task.task_id).in_(task_ids))
 
-    active_task_count = select(func.count(col(Task.id))).where(
-        col(Task.benchmark) == benchmark_row.id,
-        col(Task.org_id) == org.id,
-        col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.EVALUATING]),
-    )
-    if task_ids:
-        active_task_count = active_task_count.where(col(Task.task_id).in_(task_ids))
-
-    tasks_were_active = session.exec(active_task_count).one() > 0
     result = session.exec(task_update.values(status=TaskStatus.STOPPED))
 
-    if task_ids is None and (result.rowcount > 0 or force):
+    if force:
+        active_tasks = session.exec(
+            select(func.count(col(Task.id)))
+            .where(col(Task.benchmark) == benchmark_row.id)
+            .where(col(Task.org_id) == org.id)
+            .where(
+                col(Task.status).in_(
+                    [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
+                )
+            )
+        ).one()
+        if active_tasks == 0:
+            benchmark_row.status = BenchmarkStatus.STOPPED
+            terminalize_active_dispatches(session, benchmark_row.id)
+            session.add(benchmark_row)
+    elif task_ids is None and result.rowcount > 0:
         benchmark_row.status = BenchmarkStatus.STOPPING
         session.add(benchmark_row)
-
-    return tasks_were_active
 
 
 async def initiate_stop_benchmark(
@@ -84,28 +82,20 @@ async def initiate_stop_benchmark(
     force: bool,
     org: Org,
     task_ids: list[str] | None = None,
-) -> bool:
-    """Initiate Stop without interrupting work that already started unless forced.
-
-    Returns whether sandbox-owning tasks were active before this transition.
-    """
+) -> None:
+    """Initiate Stop without interrupting work that already started unless forced."""
     try:
-        tasks_were_stopped = apply_stop_benchmark(benchmark_row, session, force, org, task_ids)
+        apply_stop_benchmark(benchmark_row, session, force, org, task_ids)
         session.commit()
-        return tasks_were_stopped
     except Exception as e:
         raise TrackerServiceError(f"Unexpected error stopping run {benchmark_row.id}: {str(e)}") from e
 
 
-async def stop_sandbox(sandbox: Sandbox, provider: SandboxProvider, org: Org) -> str | None:
+async def stop_sandbox(sandbox: Sandbox, provider: SandboxProvider, org: Org) -> None:
     try:
         await delete_sandbox(sandbox, provider, initiated_by="force_stop", org_id=str(org.id))
-        return None
-    except SandboxNotFoundError:
-        logger.warning(f"Sandbox `{sandbox.name}` has already been terminated")
-        return None
-    except Exception as e:
-        return f"{str(e)}: {traceback.format_exc()}"
+    except Exception:
+        logger.exception("Failed to send force-stop signal for sandbox %s", sandbox.name)
 
 
 async def sandbox_generator(
@@ -131,141 +121,29 @@ async def sandbox_generator(
             yield sandbox
 
 
-async def drain_sandboxes(
-    benchmark_row: Benchmark,
-    provider: SandboxProvider,
-    task_ids: list[str] | None,
-    timeout_seconds: float,
-) -> list[Sandbox]:
-    """Wait for the executor to delete the sandboxes it owns and return the ones left behind.
-
-    The executor cancels stopped tasks within one monitor poll and then tears down each of
-    its sandboxes. The caller must not delete the returned sandboxes if their owner is still
-    active: deleting underneath it instead fails whatever command is still in flight.
-    """
-    deadline = time.monotonic() + timeout_seconds
-    while True:
-        remaining = [sandbox async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids)]
-        if not remaining or time.monotonic() >= deadline:
-            return remaining
-        await asyncio.sleep(SANDBOX_DRAIN_POLL_SECONDS)
-
-
 async def force_stop_sandboxes(
     benchmark_row: Benchmark,
-    session: Session,
     sandbox_provider_secret_name: str,
     aws_runtime: AWSRuntime,
     org: Org,
     sandbox_provider: str = "daytona",
     task_ids: list[str] | None = None,
-    tasks_were_active_before_stop: bool | None = None,
 ) -> None:
-    """
-    Stops active work and deletes sandboxes only when no owner can still be active.
-    Sandboxes that may still be owned by stopped work are left for executor/orphan cleanup.
-    A deferred cleanup leaves the benchmark in STOPPING so this operation can be retried.
-    NOTE: If task is not in progress but sandbox exists, we kill it and leave the task status as is.
-
-    Raises:
-        TrackerServiceError: If there are any errors stopping the sandboxes
-    """
+    """Send provider kill signals without coupling provider teardown to DB state."""
     benchmark_service = benchmark_row.benchmark_service()
-    provider = benchmark_service.get_sandbox_provider(
-        fetch_sandbox_provider_config(sandbox_provider_secret_name, aws_runtime.clients, sandbox_provider)
-    )
-
-    # Update all tasks being processed to stopped
-    task_update = (
-        update(Task)
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]))
-    )
-    if task_ids:
-        task_update = task_update.where(col(Task.task_id).in_(task_ids))
-
-    active_task_count = select(func.count(col(Task.id))).where(
-        col(Task.benchmark) == benchmark_row.id,
-        col(Task.org_id) == org.id,
-        col(Task.status).in_([TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]),
-    )
-    if task_ids:
-        active_task_count = active_task_count.where(col(Task.task_id).in_(task_ids))
-
-    tasks_were_active = session.exec(active_task_count).one() > 0
-    if tasks_were_active_before_stop:
-        tasks_were_active = True
-    session.exec(task_update.values(status=TaskStatus.STOPPED))
-
-    # A live dispatch is the durable ownership signal for the managed executor. Keep the
-    # pre-stop value so we know whether the dispatch/task could still be cleaning up after
-    # the task rows are marked STOPPED.
-    executor_active = active_dispatch_exists(session, benchmark_row.id)
-
-    session.commit()
-
-    # Iterate through each running sandbox and stop it, collecting error messages
-    results: dict[str, str | None] = {}
-    deletion_deferred = False
     try:
-        # A retry after a deferred cleanup gets the same grace period even if the
-        # first attempt already revoked the dispatch.
-        retrying_deferred_cleanup = benchmark_row.status == BenchmarkStatus.STOPPING and not executor_active
-        drain_seconds = SANDBOX_DRAIN_TIMEOUT_SECONDS if executor_active or retrying_deferred_cleanup else 0.0
-        remaining_sandboxes = await drain_sandboxes(benchmark_row, provider, task_ids, drain_seconds)
-
-        # Never reap a sandbox while its owner may still be alive. A dispatch can finish
-        # during the drain, in which case its cleanup is complete and direct deletion is safe.
-        # Without a dispatch, an active task is an older/unmanaged execution path for which
-        # Tracker has no reliable process-liveness signal, so defer cleanup conservatively.
-        owner_still_active = (
-            active_dispatch_exists(session, benchmark_row.id) if executor_active else tasks_were_active
+        provider = benchmark_service.get_sandbox_provider(
+            fetch_sandbox_provider_config(sandbox_provider_secret_name, aws_runtime.clients, sandbox_provider)
         )
-        if remaining_sandboxes and owner_still_active:
-            sandbox_names = ", ".join(sandbox.name for sandbox in remaining_sandboxes)
-            logger.warning(
-                f"Deferring force-stop deletion for sandboxes that may still be owned by active work: {sandbox_names}"
-            )
-            deletion_deferred = True
-            remaining_sandboxes = []
-
-        for sandbox in remaining_sandboxes:
-            result = await stop_sandbox(sandbox, provider, org)
-            results[sandbox.name] = result
+        sandboxes = [sandbox async for sandbox in sandbox_generator(benchmark_row, provider, task_ids=task_ids)]
+        await asyncio.gather(*(stop_sandbox(sandbox, provider, org) for sandbox in sandboxes))
+    except Exception:
+        logger.exception("Unable to send force-stop signals for benchmark %s", benchmark_row.id)
     finally:
-        await benchmark_service.close()
-
-    error_message: str = "\n".join(
-        f"{task_alias}: {error_message}" for task_alias, error_message in results.items() if error_message
-    )
-
-    # Sandbox teardown releases the request's original benchmark lock. Reacquire
-    # it so Retry admission cannot land between the runnable check and revocation.
-    benchmark_row = fetch_benchmark_row(benchmark_row.id, session, org, for_update=True)
-    finished_statuses: list[TaskStatus] = [TaskStatus.FINISHED, TaskStatus.ERROR, TaskStatus.STOPPED]
-    tasks_still_running: int = session.exec(
-        select(func.count(col(Task.id)))
-        .where(col(Task.benchmark) == benchmark_row.id)
-        .where(col(Task.org_id) == org.id)
-        .where(col(Task.status).notin_(finished_statuses))
-    ).one()
-
-    if deletion_deferred:
-        # Keep the run retryable while ownership is ambiguous. A later force stop can
-        # re-list these sandboxes after the owner exits and complete the cleanup.
-        if not tasks_still_running:
-            benchmark_row.status = BenchmarkStatus.STOPPING
-            terminalize_active_dispatches(session, benchmark_row.id)
-            session.add(benchmark_row)
-    elif not tasks_still_running:
-        benchmark_row.status = BenchmarkStatus.STOPPED
-        terminalize_active_dispatches(session, benchmark_row.id)
-        session.add(benchmark_row)
-    session.commit()
-
-    if error_message:
-        raise TrackerServiceError(f"Unexpected errors stopping sandboxes:\n{error_message}")
+        try:
+            await benchmark_service.close()
+        except Exception:
+            logger.exception("Unable to close provider client for benchmark %s", benchmark_row.id)
 
 
 async def reset_to_in_progress_status(

--- a/services/tracker/tests/integration/live/sandbox/test_force_stop.py
+++ b/services/tracker/tests/integration/live/sandbox/test_force_stop.py
@@ -13,7 +13,6 @@ from fastapi.testclient import TestClient
 from sqlmodel import Session, col, select
 
 import tracker.utils as tracker_utils
-import tracker.utils.run_control as run_control
 from tests.utils import TEST_ORG_ID, random_task_id
 from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import Benchmark, BenchmarkStatus, Org, Task, TaskStatus
@@ -23,6 +22,7 @@ from tracker.types import HarnessConfig
 from tracker.utils import fetch_sandbox_provider_config, force_stop_sandboxes
 
 process_benchmark = getattr(tracker_utils, "process_benchmark")
+initiate_stop_benchmark = getattr(tracker_utils, "initiate_stop_benchmark")
 
 logger = get_logger(__name__)
 
@@ -118,6 +118,7 @@ class TestForceStop:
         - A task already marked in progress is moved to STOPPED while its sandbox context is active.
         - The created sandbox is deleted and provider lookup raises SandboxNotFoundError.
         """
+        example_benchmark_object.status = BenchmarkStatus.IN_PROGRESS
         database_session.add(example_benchmark_object)
         database_session.commit()
 
@@ -129,7 +130,12 @@ class TestForceStop:
         )
         database_session.add(task)
         database_session.commit()
-
+        await initiate_stop_benchmark(
+            example_benchmark_object,
+            database_session,
+            force=True,
+            org=Org(id=TEST_ORG_ID, name="default"),
+        )
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
         provider_config = fetch_sandbox_provider_config(daytona_secret_name, aws_runtime.clients, "daytona")
         provider = benchmark_service.get_sandbox_provider(provider_config)
@@ -148,7 +154,6 @@ class TestForceStop:
             try:
                 await force_stop_sandboxes(
                     example_benchmark_object,
-                    database_session,
                     daytona_secret_name,
                     aws_runtime,
                     Org(id=TEST_ORG_ID, name="default"),
@@ -204,13 +209,13 @@ class TestForceStop:
         """Verify force_stop_sandboxes handles multiple active sandbox contexts.
 
         Test cases:
-        - In-progress and evaluating task sandboxes are stopped while their contexts are still open.
+        - In-progress and evaluating task sandbox kill signals are sent while their contexts are still open.
         - Deleted sandbox races surface only SandboxNotFoundError and no task error messages are recorded.
         - No benchmark-labeled sandboxes remain after force stop completes.
         """
+        example_benchmark_object.status = BenchmarkStatus.IN_PROGRESS
         database_session.add(example_benchmark_object)
         database_session.commit()
-
         aws_runtime = AWSRuntime.from_harness_config(harness_config)
         provider_config = fetch_sandbox_provider_config(daytona_secret_name, aws_runtime.clients, "daytona")
         provider = benchmark_service.get_sandbox_provider(provider_config)
@@ -255,6 +260,12 @@ class TestForceStop:
             database_session.add(task)
 
         database_session.commit()
+        await initiate_stop_benchmark(
+            example_benchmark_object,
+            database_session,
+            force=True,
+            org=Org(id=TEST_ORG_ID, name="default"),
+        )
 
         sandbox_tasks: list[asyncio.Task[None]] = []
         created_results: list[Optional[BaseException]] = []
@@ -263,7 +274,6 @@ class TestForceStop:
             await _wait_for_sandbox_setup(all_sandboxes_created, sandbox_creation_failed)
             await force_stop_sandboxes(
                 example_benchmark_object,
-                database_session,
                 daytona_secret_name,
                 aws_runtime,
                 Org(id=TEST_ORG_ID, name="default"),
@@ -288,104 +298,6 @@ class TestForceStop:
 
         await _wait_until_no_sandboxes(example_benchmark_object, provider)
 
-    async def test_force_stop_waits_for_the_executor_to_release_its_sandboxes(
-        self,
-        example_benchmark_object: Benchmark,
-        database_session: Session,
-        daytona_secret_name: str,
-        harness_config: HarnessConfig,
-        service_headers: dict[str, str],
-        executor_authority_kwargs: Any,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Verify force stop lets a live executor tear down its own sandboxes instead of racing it.
-
-        One task, so the only sandbox in play belongs to a task that has finished building. A task
-        still inside `create_sandbox` holds a shielded creation that cannot be released until it
-        completes, which is the case the drain window deliberately does not wait for.
-
-        Test cases:
-        - Force stop runs while the executor is still working and deletes no sandbox itself.
-        - The run still reaches STOPPED with no task errors and no sandboxes left behind.
-        """
-        example_benchmark_object.arguments.slice_str = ":1"
-        example_benchmark_object.arguments.concurrency = 1
-        database_session.add(example_benchmark_object)
-        database_session.commit()
-        aws_runtime = AWSRuntime.from_harness_config(harness_config)
-
-        benchmark_service = example_benchmark_object.benchmark_service(service_headers=service_headers)
-        benchmark_task: Optional[asyncio.Task[None]] = None
-        provider: Optional[SandboxProvider] = None
-        reaped: list[str] = []
-        release_sandbox = run_control.stop_sandbox
-
-        async def record_reaped_sandbox(sandbox: Sandbox, sandbox_provider: SandboxProvider, org: Org) -> str | None:
-            reaped.append(sandbox.name)
-            return await release_sandbox(sandbox, sandbox_provider, org)
-
-        monkeypatch.setattr(run_control, "stop_sandbox", record_reaped_sandbox)
-
-        try:
-            verify_response = await benchmark_service.verify_task_ids(
-                task_ids=example_benchmark_object.arguments.task_ids,
-                slice_str=example_benchmark_object.arguments.slice_str,
-            )
-
-            authority_kwargs = executor_authority_kwargs(example_benchmark_object)
-            benchmark_task = asyncio.create_task(
-                process_benchmark(
-                    start_benchmark_request_json=example_benchmark_object.start_benchmark_request(
-                        harness_config, service_headers=service_headers
-                    ).model_dump(),
-                    benchmark_id_str=str(example_benchmark_object.id),
-                    verified_task_ids=verify_response.task_ids,
-                    **authority_kwargs,
-                )
-            )
-
-            provider_config = fetch_sandbox_provider_config(daytona_secret_name, aws_runtime.clients, "daytona")
-            provider = benchmark_service.get_sandbox_provider(provider_config)
-            await _wait_for_running_benchmark(example_benchmark_object, database_session, provider)
-
-            await force_stop_sandboxes(
-                example_benchmark_object,
-                database_session,
-                daytona_secret_name,
-                aws_runtime,
-                Org(id=TEST_ORG_ID, name="default"),
-                sandbox_provider="daytona",
-            )
-
-            assert reaped == [], f"Force stop deleted sandboxes the executor still owned: {', '.join(reaped)}"
-
-            await benchmark_task
-            _assert_no_task_errors(example_benchmark_object, database_session)
-
-            database_session.refresh(example_benchmark_object)
-            assert example_benchmark_object.status == BenchmarkStatus.STOPPED
-
-            await _wait_until_no_sandboxes(example_benchmark_object, provider)
-        finally:
-            monkeypatch.setattr(run_control, "stop_sandbox", release_sandbox)
-            if benchmark_task is not None and not benchmark_task.done():
-                benchmark_task.cancel()
-                await asyncio.gather(benchmark_task, return_exceptions=True)
-
-            try:
-                if provider is not None and await _sandboxes_for_benchmark(example_benchmark_object, provider):
-                    await force_stop_sandboxes(
-                        example_benchmark_object,
-                        database_session,
-                        daytona_secret_name,
-                        aws_runtime,
-                        Org(id=TEST_ORG_ID, name="default"),
-                        sandbox_provider="daytona",
-                    )
-                    await _wait_until_no_sandboxes(example_benchmark_object, provider)
-            finally:
-                await benchmark_service.close()
-
     async def test_force_stop_end_to_end(
         self,
         example_benchmark_object: Benchmark,
@@ -397,11 +309,11 @@ class TestForceStop:
         live_api_client: TestClient,
         executor_authority_kwargs: Any,
     ) -> None:
-        """Verify the HTTP force-stop path interrupts a live benchmark without task errors.
+        """Verify the HTTP force-stop path finalizes DB state before provider teardown completes.
 
         Test cases:
         - A five-task benchmark reaches an in-progress sandbox before the stop endpoint is called.
-        - The force stop endpoint returns success and leaves no active or error tasks.
+        - The force stop endpoint returns success with the benchmark already STOPPED.
         - The benchmark status becomes STOPPED and no benchmark-labeled sandboxes remain.
         """
         example_benchmark_object.arguments.slice_str = ":5"
@@ -442,6 +354,9 @@ class TestForceStop:
             )
             assert response.status_code == 200
             assert response.json() == {"status": "success"}
+            database_session.expire_all()
+            database_session.refresh(example_benchmark_object)
+            assert example_benchmark_object.status == BenchmarkStatus.STOPPED
 
             await benchmark_task
 
@@ -480,7 +395,6 @@ class TestForceStop:
                 if provider is not None and await _sandboxes_for_benchmark(example_benchmark_object, provider):
                     await force_stop_sandboxes(
                         example_benchmark_object,
-                        database_session,
                         daytona_secret_name,
                         aws_runtime,
                         Org(id=TEST_ORG_ID, name="default"),

--- a/services/tracker/tests/integration/local/database/test_release_control.py
+++ b/services/tracker/tests/integration/local/database/test_release_control.py
@@ -612,7 +612,7 @@ def test_whole_stop_and_retry_serialize_on_the_benchmark_row(
     postgres_session.expire_all()
     stored_retry_first = postgres_session.get(Benchmark, retry_first.id)
     assert stored_retry_first is not None
-    assert stored_retry_first.status == BenchmarkStatus.STOPPING
+    assert stored_retry_first.status == BenchmarkStatus.STOPPED
 
 
 def test_maintenance_commit_rejects_start_waiting_on_admission_lock(

--- a/services/tracker/tests/integration/local/database/test_release_control.py
+++ b/services/tracker/tests/integration/local/database/test_release_control.py
@@ -600,7 +600,7 @@ def test_whole_stop_and_retry_serialize_on_the_benchmark_row(
         lambda session: retry(session, stop_first.id),
         postgres_engine,
     )
-    assert sorted(outcomes) == ["first-committed", "second-rejected"]
+    assert sorted(outcomes) == ["first-committed", "second-committed"]
 
     retry_first = add_error_benchmark("retry-first")
     outcomes = _run_while_first_transaction_holds_locks(

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -4,7 +4,6 @@ Exercise run-finalization concurrency against disposable Postgres.
 """
 
 import asyncio
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from threading import Event, Thread
 from time import monotonic, sleep
@@ -21,7 +20,6 @@ from sqlmodel import Session, select
 import tracker.utils.run_control as run_control_module
 import tracker.utils.run_orchestration as run_orchestration_module
 from tests.factories import make_benchmark, make_task
-from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import (
     AgentContractRequest,
     Benchmark,
@@ -42,7 +40,7 @@ from tracker.executor.dispatch_control import admit_recovery_dispatch, terminali
 from tracker.executor.execution_authority import ExecutionAuthority
 from tracker.executor.release_control import promote_release
 from tracker.types import HarnessConfig, StartBenchmarkRequest
-from tracker.utils import force_stop_sandboxes, process_benchmark, reset_to_in_progress_status
+from tracker.utils import initiate_stop_benchmark, process_benchmark, reset_to_in_progress_status
 from tracker.utils.reporting import create_final_view
 from tracker.utils.resources import fetch_benchmark_row
 from tracker.utils.run_orchestration import upload_final_view_if_current
@@ -548,7 +546,6 @@ class TestRunFinalization:
         self,
         postgres_engine: Engine,
         postgres_session: Session,
-        harness_config: HarnessConfig,
         monkeypatch: pytest.MonkeyPatch,
         executor_authority_kwargs: Any,
     ) -> None:
@@ -571,24 +568,6 @@ class TestRunFinalization:
         assert benchmark.current_execution_release_id is not None
         promote_release(postgres_session, benchmark.current_execution_release_id)
         postgres_session.commit()
-
-        class EmptyProvider:
-            async def list_sandboxes(self, *_args: Any, **_kwargs: Any) -> AsyncIterator[Any]:
-                if False:
-                    yield None
-
-        def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
-            return DaytonaProviderConfig(
-                DAYTONA_API_KEY="test-key",
-                DAYTONA_API_URL="https://example.com",
-                DAYTONA_TARGET="test-target",
-            )
-
-        def empty_provider(*_args: Any, **_kwargs: Any) -> EmptyProvider:
-            return EmptyProvider()
-
-        monkeypatch.setattr(run_control_module, "fetch_sandbox_provider_config", provider_config)
-        monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", empty_provider)
 
         retry_ready = Event()
         allow_retry_lock = Event()
@@ -657,12 +636,11 @@ class TestRunFinalization:
         monkeypatch.setattr(run_control_module, "terminalize_active_dispatches", terminalize_with_concurrent_retry)
 
         try:
-            await force_stop_sandboxes(
+            await initiate_stop_benchmark(
                 benchmark,
                 postgres_session,
-                harness_config.sandbox_provider_secret_name,
-                AWSRuntime.from_harness_config(harness_config),
-                org,
+                force=True,
+                org=org,
             )
         finally:
             allow_retry_lock.set()

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -237,7 +237,7 @@ class TestRunRecovery:
 
         Test cases:
         - Graceful stop changes only the selected tasks.
-        - Force stop deletes only the selected task sandbox.
+        - Force stop leaves the selected task sandbox for its active executor to release.
         - Empty and out-of-run selections are rejected.
         - Unselected work and benchmark status remain unchanged.
         """
@@ -342,7 +342,7 @@ class TestRunRecovery:
             "task_force_selected": TaskStatus.STOPPED,
             "task_unselected": TaskStatus.IN_PROGRESS,
         }
-        assert provider.deleted_sandbox_ids == ["sandbox-task_force_selected"]
+        assert provider.deleted_sandbox_ids == []
 
         database_session.refresh(foreign_task)
         assert foreign_task.status == TaskStatus.PENDING
@@ -2393,10 +2393,16 @@ class TestRunRecovery:
         return provider
 
     @pytest.mark.parametrize(
-        ("executor_running", "expected_deletions", "expected_list_calls"),
+        ("executor_running", "task_status", "expected_deletions", "expected_list_calls"),
         [
-            pytest.param(True, [], 2, id="waits_for_executor_teardown"),
-            pytest.param(False, [MockReleasingSandboxProvider.sandbox_id], 1, id="nothing_left_to_race"),
+            pytest.param(True, TaskStatus.IN_PROGRESS, [], 2, id="waits_for_executor_teardown"),
+            pytest.param(
+                False,
+                TaskStatus.FINISHED,
+                [MockReleasingSandboxProvider.sandbox_id],
+                1,
+                id="nothing_left_to_race",
+            ),
         ],
     )
     async def test_force_stop_lets_a_live_executor_release_its_own_sandboxes(
@@ -2407,6 +2413,7 @@ class TestRunRecovery:
         harness_config: HarnessConfig,
         executor_authority: Any,
         executor_running: bool,
+        task_status: TaskStatus,
         expected_deletions: list[str],
         expected_list_calls: int,
     ) -> None:
@@ -2418,6 +2425,9 @@ class TestRunRecovery:
         """
         benchmark_row = example_benchmark_object
         provider = self._arrange_force_stop_race(benchmark_row, database_session, monkeypatch, release_after_polls=1)
+        task = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).one()
+        task.status = task_status
+        database_session.commit()
         if executor_running:
             executor_authority(benchmark_row, session=database_session)
 
@@ -2434,7 +2444,7 @@ class TestRunRecovery:
         database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.STOPPED
 
-    async def test_force_stop_reaps_sandboxes_the_executor_never_releases(
+    async def test_force_stop_defers_sandboxes_the_executor_never_releases(
         self,
         example_benchmark_object: Benchmark,
         database_session: Session,
@@ -2442,7 +2452,7 @@ class TestRunRecovery:
         harness_config: HarnessConfig,
         executor_authority: Any,
     ) -> None:
-        """A stalled executor cannot hold its sandboxes past the drain window."""
+        """A stalled executor's sandboxes are deferred instead of being deleted mid-command."""
         benchmark_row = example_benchmark_object
         provider = self._arrange_force_stop_race(
             benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
@@ -2458,7 +2468,31 @@ class TestRunRecovery:
             self._test_org,
         )
 
-        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
+        assert provider.deleted_sandbox_ids == []
+
+    async def test_force_stop_defers_sandboxes_for_active_tasks_without_dispatch(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """An active task without a dispatch has no safe liveness signal for direct deletion."""
+        benchmark_row = example_benchmark_object
+        provider = self._arrange_force_stop_race(
+            benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
+        )
+        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.0)
+
+        await force_stop_sandboxes(
+            benchmark_row,
+            database_session,
+            harness_config.sandbox_provider_secret_name,
+            AWSRuntime.from_harness_config(harness_config),
+            self._test_org,
+        )
+
+        assert provider.deleted_sandbox_ids == []
 
     async def test_stop_sandbox_audits_forced_stop_deletion(self, monkeypatch: MonkeyPatch) -> None:
         """Forced stop identifies itself and its org on every sandbox deletion."""

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1232,7 +1232,17 @@ class TestRunRecovery:
         benchmark_row.arguments = benchmark_row.arguments.model_copy(
             update={"sandbox_provider": "modal", "sandbox_provider_secret_name": "ModalSecrets"}
         )
-        database_session.add(benchmark_row)
+        database_session.add_all(
+            [
+                benchmark_row,
+                Task(
+                    org_id=TEST_ORG_ID,
+                    task_id="evaluating-task",
+                    benchmark=benchmark_row.id,
+                    status=TaskStatus.EVALUATING,
+                ),
+            ]
+        )
         database_session.commit()
 
         captured: dict[str, object] = {}
@@ -1246,10 +1256,12 @@ class TestRunRecovery:
             *,
             sandbox_provider: str,
             task_ids: list[str] | None = None,
+            tasks_were_active_before_stop: bool | None = None,
         ) -> None:
             captured["sandbox_provider_secret_name"] = sandbox_provider_secret_name
             captured["sandbox_provider"] = sandbox_provider
             captured["task_ids"] = task_ids
+            captured["tasks_were_active_before_stop"] = tasks_were_active_before_stop
 
         monkeypatch.setattr("main.force_stop_sandboxes", _mock_force_stop_sandboxes)
 
@@ -1263,6 +1275,7 @@ class TestRunRecovery:
             "sandbox_provider_secret_name": "ModalSecrets",
             "sandbox_provider": "modal",
             "task_ids": None,
+            "tasks_were_active_before_stop": True,
         }
 
     async def test_force_stop_missing_provider_secret_does_not_mutate_run(
@@ -2457,7 +2470,7 @@ class TestRunRecovery:
         provider = self._arrange_force_stop_race(
             benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
         )
-        executor_authority(benchmark_row, session=database_session)
+        authority = executor_authority(benchmark_row, session=database_session)
         monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.05)
 
         await force_stop_sandboxes(
@@ -2469,6 +2482,25 @@ class TestRunRecovery:
         )
 
         assert provider.deleted_sandbox_ids == []
+        database_session.refresh(benchmark_row)
+        dispatch = database_session.get(ExecutorDispatch, authority.dispatch_id)
+        assert benchmark_row.status == BenchmarkStatus.STOPPING
+        assert dispatch is not None
+        assert dispatch.status == ExecutorDispatchStatus.FAILED
+
+        # The dispatch is revoked without deleting its sandboxes; a retry gets a drain
+        # window before the now-ownerless leftovers are reaped.
+        await force_stop_sandboxes(
+            benchmark_row,
+            database_session,
+            harness_config.sandbox_provider_secret_name,
+            AWSRuntime.from_harness_config(harness_config),
+            self._test_org,
+        )
+
+        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.STOPPED
 
     async def test_force_stop_defers_sandboxes_for_active_tasks_without_dispatch(
         self,
@@ -2493,6 +2525,59 @@ class TestRunRecovery:
         )
 
         assert provider.deleted_sandbox_ids == []
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.STOPPING
+
+        # The retained STOPPING state makes a later force stop an actionable cleanup retry.
+        await force_stop_sandboxes(
+            benchmark_row,
+            database_session,
+            harness_config.sandbox_provider_secret_name,
+            AWSRuntime.from_harness_config(harness_config),
+            self._test_org,
+        )
+
+        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.STOPPED
+
+    async def test_force_stop_uses_task_ownership_captured_before_graceful_stop(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """Preserve BUILDING/EVALUATING ownership across the graceful stop phase."""
+        benchmark_row = example_benchmark_object
+        provider = self._arrange_force_stop_race(
+            benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
+        )
+        task = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).one()
+        task.status = TaskStatus.EVALUATING
+        database_session.commit()
+
+        tasks_were_active = await initiate_stop_benchmark(
+            benchmark_row,
+            database_session,
+            force=True,
+            org=self._test_org,
+        )
+        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.0)
+
+        await force_stop_sandboxes(
+            benchmark_row,
+            database_session,
+            harness_config.sandbox_provider_secret_name,
+            AWSRuntime.from_harness_config(harness_config),
+            self._test_org,
+            tasks_were_active_before_stop=tasks_were_active,
+        )
+
+        assert tasks_were_active is True
+        assert provider.deleted_sandbox_ids == []
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.STOPPING
 
     async def test_stop_sandbox_audits_forced_stop_deletion(self, monkeypatch: MonkeyPatch) -> None:
         """Forced stop identifies itself and its org on every sandbox deletion."""

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -6,7 +6,7 @@ Covers task state transitions, sandbox cleanup, and run-control API behavior.
 """
 
 import asyncio
-from collections.abc import AsyncGenerator, AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from datetime import datetime
 from types import SimpleNamespace
@@ -29,7 +29,7 @@ from main import app
 import tracker.utils as tracker_utils
 from tests.factories import make_benchmark, make_error_result, make_evaluation_result
 from tests.unit.utils.task_execution_support import MockKicker, make_retrieve_task_response
-from tests.utils import TEST_ORG_ID, async_iterator
+from tests.utils import TEST_ORG_ID
 from tracker import config
 from tracker.auth import RequestIdentity
 from tracker.aws.runtime import AWSRuntime
@@ -237,7 +237,7 @@ class TestRunRecovery:
 
         Test cases:
         - Graceful stop changes only the selected tasks.
-        - Force stop leaves the selected task sandbox for its active executor to release.
+        - Force stop deletes only the selected task sandbox.
         - Empty and out-of-run selections are rejected.
         - Unselected work and benchmark status remain unchanged.
         """
@@ -299,8 +299,6 @@ class TestRunRecovery:
             return provider
 
         monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", get_sandbox_provider)
-        # No executor is running here, so nothing will ever release the sandboxes on its own.
-        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.0)
 
         graceful_response = client.post(
             f"/stop-benchmark/{benchmark_row.id}?force=false",
@@ -342,7 +340,7 @@ class TestRunRecovery:
             "task_force_selected": TaskStatus.STOPPED,
             "task_unselected": TaskStatus.IN_PROGRESS,
         }
-        assert provider.deleted_sandbox_ids == []
+        assert provider.deleted_sandbox_ids == ["sandbox-task_force_selected"]
 
         database_session.refresh(foreign_task)
         assert foreign_task.status == TaskStatus.PENDING
@@ -1249,19 +1247,16 @@ class TestRunRecovery:
 
         async def _mock_force_stop_sandboxes(
             _benchmark_row: Benchmark,
-            _session: Session,
             sandbox_provider_secret_name: str,
             _aws: Any,
             _org: Org,
             *,
             sandbox_provider: str,
             task_ids: list[str] | None = None,
-            tasks_were_active_before_stop: bool | None = None,
         ) -> None:
             captured["sandbox_provider_secret_name"] = sandbox_provider_secret_name
             captured["sandbox_provider"] = sandbox_provider
             captured["task_ids"] = task_ids
-            captured["tasks_were_active_before_stop"] = tasks_were_active_before_stop
 
         monkeypatch.setattr("main.force_stop_sandboxes", _mock_force_stop_sandboxes)
 
@@ -1275,7 +1270,6 @@ class TestRunRecovery:
             "sandbox_provider_secret_name": "ModalSecrets",
             "sandbox_provider": "modal",
             "task_ids": None,
-            "tasks_were_active_before_stop": True,
         }
 
     async def test_force_stop_missing_provider_secret_does_not_mutate_run(
@@ -2309,91 +2303,61 @@ class TestRunRecovery:
         assert lock_execution_authority(database_session, authority).id == benchmark_row.id
         database_session.rollback()
 
-    async def test_force_stop_edge_case(
+    async def test_force_stop_finalizes_database_immediately(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        executor_authority: Any,
+    ) -> None:
+        """Force stop finalizes Valkyrie's run state without waiting for provider teardown."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.add_all(
+            [
+                Task(org_id=TEST_ORG_ID, task_id="pending", benchmark=benchmark_row.id, status=TaskStatus.PENDING),
+                Task(
+                    org_id=TEST_ORG_ID,
+                    task_id="running",
+                    benchmark=benchmark_row.id,
+                    status=TaskStatus.IN_PROGRESS,
+                ),
+                Task(org_id=TEST_ORG_ID, task_id="finished", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+            ]
+        )
+        database_session.commit()
+        authority = executor_authority(benchmark_row, session=database_session)
+
+        await initiate_stop_benchmark(benchmark_row, database_session, force=True, org=self._test_org)
+
+        database_session.refresh(benchmark_row)
+        dispatch = database_session.get(ExecutorDispatch, authority.dispatch_id)
+        statuses = {
+            task.task_id: task.status
+            for task in database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).all()
+        }
+        assert benchmark_row.status == BenchmarkStatus.STOPPED
+        assert statuses == {
+            "pending": TaskStatus.STOPPED,
+            "running": TaskStatus.STOPPED,
+            "finished": TaskStatus.FINISHED,
+        }
+        assert dispatch is not None
+        assert dispatch.status == ExecutorDispatchStatus.FAILED
+
+    async def test_force_stop_sends_provider_signal_without_waiting(
         self,
         example_benchmark_object: Benchmark,
         database_session: Session,
         monkeypatch: MonkeyPatch,
         harness_config: HarnessConfig,
-        executor_authority: Any,
     ) -> None:
-        """Force-stop sandbox cleanup terminalizes the run and its dispatch."""
+        """Provider signaling deletes immediately and does not own the database transition."""
         benchmark_row = example_benchmark_object
         benchmark_row.status = BenchmarkStatus.IN_PROGRESS
         database_session.add(benchmark_row)
         database_session.commit()
-
-        # All tasks are already in a finished state
-        tasks = [
-            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
-            Task(org_id=TEST_ORG_ID, task_id="task_1", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
-            Task(org_id=TEST_ORG_ID, task_id="task_2", benchmark=benchmark_row.id, status=TaskStatus.ERROR),
-            Task(org_id=TEST_ORG_ID, task_id="task_3", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
-        ]
-        database_session.add_all(tasks)
-        database_session.commit()
-        authority = executor_authority(benchmark_row, session=database_session)
-
-        monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-
-        await initiate_stop_benchmark(benchmark_row, database_session, force=True, org=self._test_org)
-        assert benchmark_row.status == BenchmarkStatus.STOPPING
-
-        def _empty_list_sandboxes(*_args: Any, **_kwargs: Any) -> AsyncIterator[None]:
-            return async_iterator(())
-
-        mock_provider = Mock()
-        mock_provider.list_sandboxes = _empty_list_sandboxes
-
-        def _provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
-            return DaytonaProviderConfig(
-                DAYTONA_API_KEY="key",
-                DAYTONA_API_URL="url",
-                DAYTONA_TARGET="target",
-            )
-
-        def _sandbox_provider(*_args: Any, **_kwargs: Any) -> Mock:
-            return mock_provider
-
-        monkeypatch.setattr(
-            "tracker.utils.resources.fetch_sandbox_provider_config",
-            _provider_config,
-        )
-        monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", _sandbox_provider)
-
-        # Force stopping the sandboxes results in the benchmark row being stopped
-        await force_stop_sandboxes(
-            benchmark_row,
-            database_session,
-            harness_config.sandbox_provider_secret_name,
-            AWSRuntime.from_harness_config(harness_config),
-            self._test_org,
-            sandbox_provider="daytona",
-        )
-
-        database_session.refresh(benchmark_row)
-        dispatch = database_session.get(ExecutorDispatch, authority.dispatch_id)
-        assert benchmark_row.status == BenchmarkStatus.STOPPED
-        assert dispatch is not None
-        assert dispatch.status == ExecutorDispatchStatus.FAILED
-
-    def _arrange_force_stop_race(
-        self,
-        benchmark_row: Benchmark,
-        database_session: Session,
-        monkeypatch: MonkeyPatch,
-        release_after_polls: int,
-    ) -> MockReleasingSandboxProvider:
-        """Put one in-progress task and its sandbox in front of a force stop."""
-        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
-        database_session.add(benchmark_row)
-        database_session.add(
-            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.IN_PROGRESS)
-        )
-        database_session.commit()
-
-        provider = MockReleasingSandboxProvider(release_after_polls)
+        provider = MockReleasingSandboxProvider(_NEVER_RELEASED)
         monkeypatch.setattr(
             run_control_module,
             "fetch_sandbox_provider_config",
@@ -2402,182 +2366,52 @@ class TestRunRecovery:
             ),
         )
         monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", lambda *_args, **_kwargs: provider)
-        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_POLL_SECONDS", 0.0)
-        return provider
 
-    @pytest.mark.parametrize(
-        ("executor_running", "task_status", "expected_deletions", "expected_list_calls"),
-        [
-            pytest.param(True, TaskStatus.IN_PROGRESS, [], 2, id="waits_for_executor_teardown"),
-            pytest.param(
-                False,
-                TaskStatus.FINISHED,
-                [MockReleasingSandboxProvider.sandbox_id],
-                1,
-                id="nothing_left_to_race",
+        await force_stop_sandboxes(
+            benchmark_row,
+            harness_config.sandbox_provider_secret_name,
+            AWSRuntime.from_harness_config(harness_config),
+            self._test_org,
+        )
+
+        assert provider.list_calls == 1
+        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+
+    async def test_force_stop_provider_failure_does_not_change_database_result(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_config: HarnessConfig,
+    ) -> None:
+        """A provider failure is logged after the database force stop has already committed."""
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+        database_session.add(benchmark_row)
+        database_session.commit()
+        provider = MockReleasingSandboxProvider(_NEVER_RELEASED)
+        monkeypatch.setattr(
+            run_control_module,
+            "fetch_sandbox_provider_config",
+            lambda *_args, **_kwargs: DaytonaProviderConfig(
+                DAYTONA_API_KEY="key", DAYTONA_API_URL="url", DAYTONA_TARGET="target"
             ),
-        ],
-    )
-    async def test_force_stop_lets_a_live_executor_release_its_own_sandboxes(
-        self,
-        example_benchmark_object: Benchmark,
-        database_session: Session,
-        monkeypatch: MonkeyPatch,
-        harness_config: HarnessConfig,
-        executor_authority: Any,
-        executor_running: bool,
-        task_status: TaskStatus,
-        expected_deletions: list[str],
-        expected_list_calls: int,
-    ) -> None:
-        """Force stop deletes a sandbox only once no executor can still be working inside it.
-
-        Test cases:
-        - A running dispatch gets its teardown window, so the sandbox it releases is never deleted here.
-        - With no dispatch left to race, the sandbox is deleted on the first pass.
-        """
-        benchmark_row = example_benchmark_object
-        provider = self._arrange_force_stop_race(benchmark_row, database_session, monkeypatch, release_after_polls=1)
-        task = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).one()
-        task.status = task_status
-        database_session.commit()
-        if executor_running:
-            executor_authority(benchmark_row, session=database_session)
+        )
+        monkeypatch.setattr(BenchmarkServiceClient, "get_sandbox_provider", lambda *_args, **_kwargs: provider)
+        monkeypatch.setattr(run_control_module, "delete_sandbox", AsyncMock(side_effect=RuntimeError("unavailable")))
 
         await force_stop_sandboxes(
             benchmark_row,
-            database_session,
             harness_config.sandbox_provider_secret_name,
             AWSRuntime.from_harness_config(harness_config),
             self._test_org,
         )
 
-        assert provider.deleted_sandbox_ids == expected_deletions
-        assert provider.list_calls == expected_list_calls
+        assert provider.list_calls == 1
         database_session.refresh(benchmark_row)
-        assert benchmark_row.status == BenchmarkStatus.STOPPED
-
-    async def test_force_stop_defers_sandboxes_the_executor_never_releases(
-        self,
-        example_benchmark_object: Benchmark,
-        database_session: Session,
-        monkeypatch: MonkeyPatch,
-        harness_config: HarnessConfig,
-        executor_authority: Any,
-    ) -> None:
-        """A stalled executor's sandboxes are deferred instead of being deleted mid-command."""
-        benchmark_row = example_benchmark_object
-        provider = self._arrange_force_stop_race(
-            benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
-        )
-        authority = executor_authority(benchmark_row, session=database_session)
-        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.05)
-
-        await force_stop_sandboxes(
-            benchmark_row,
-            database_session,
-            harness_config.sandbox_provider_secret_name,
-            AWSRuntime.from_harness_config(harness_config),
-            self._test_org,
-        )
-
-        assert provider.deleted_sandbox_ids == []
-        database_session.refresh(benchmark_row)
-        dispatch = database_session.get(ExecutorDispatch, authority.dispatch_id)
-        assert benchmark_row.status == BenchmarkStatus.STOPPING
-        assert dispatch is not None
-        assert dispatch.status == ExecutorDispatchStatus.FAILED
-
-        # The dispatch is revoked without deleting its sandboxes; a retry gets a drain
-        # window before the now-ownerless leftovers are reaped.
-        await force_stop_sandboxes(
-            benchmark_row,
-            database_session,
-            harness_config.sandbox_provider_secret_name,
-            AWSRuntime.from_harness_config(harness_config),
-            self._test_org,
-        )
-
-        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
-        database_session.refresh(benchmark_row)
-        assert benchmark_row.status == BenchmarkStatus.STOPPED
-
-    async def test_force_stop_defers_sandboxes_for_active_tasks_without_dispatch(
-        self,
-        example_benchmark_object: Benchmark,
-        database_session: Session,
-        monkeypatch: MonkeyPatch,
-        harness_config: HarnessConfig,
-    ) -> None:
-        """An active task without a dispatch has no safe liveness signal for direct deletion."""
-        benchmark_row = example_benchmark_object
-        provider = self._arrange_force_stop_race(
-            benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
-        )
-        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.0)
-
-        await force_stop_sandboxes(
-            benchmark_row,
-            database_session,
-            harness_config.sandbox_provider_secret_name,
-            AWSRuntime.from_harness_config(harness_config),
-            self._test_org,
-        )
-
-        assert provider.deleted_sandbox_ids == []
-        database_session.refresh(benchmark_row)
-        assert benchmark_row.status == BenchmarkStatus.STOPPING
-
-        # The retained STOPPING state makes a later force stop an actionable cleanup retry.
-        await force_stop_sandboxes(
-            benchmark_row,
-            database_session,
-            harness_config.sandbox_provider_secret_name,
-            AWSRuntime.from_harness_config(harness_config),
-            self._test_org,
-        )
-
-        assert provider.deleted_sandbox_ids == [MockReleasingSandboxProvider.sandbox_id]
-        database_session.refresh(benchmark_row)
-        assert benchmark_row.status == BenchmarkStatus.STOPPED
-
-    async def test_force_stop_uses_task_ownership_captured_before_graceful_stop(
-        self,
-        example_benchmark_object: Benchmark,
-        database_session: Session,
-        monkeypatch: MonkeyPatch,
-        harness_config: HarnessConfig,
-    ) -> None:
-        """Preserve BUILDING/EVALUATING ownership across the graceful stop phase."""
-        benchmark_row = example_benchmark_object
-        provider = self._arrange_force_stop_race(
-            benchmark_row, database_session, monkeypatch, release_after_polls=_NEVER_RELEASED
-        )
-        task = database_session.exec(select(Task).where(Task.benchmark == benchmark_row.id)).one()
-        task.status = TaskStatus.EVALUATING
-        database_session.commit()
-
-        tasks_were_active = await initiate_stop_benchmark(
-            benchmark_row,
-            database_session,
-            force=True,
-            org=self._test_org,
-        )
-        monkeypatch.setattr(run_control_module, "SANDBOX_DRAIN_TIMEOUT_SECONDS", 0.0)
-
-        await force_stop_sandboxes(
-            benchmark_row,
-            database_session,
-            harness_config.sandbox_provider_secret_name,
-            AWSRuntime.from_harness_config(harness_config),
-            self._test_org,
-            tasks_were_active_before_stop=tasks_were_active,
-        )
-
-        assert tasks_were_active is True
-        assert provider.deleted_sandbox_ids == []
-        database_session.refresh(benchmark_row)
-        assert benchmark_row.status == BenchmarkStatus.STOPPING
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
 
     async def test_stop_sandbox_audits_forced_stop_deletion(self, monkeypatch: MonkeyPatch) -> None:
         """Forced stop identifies itself and its org on every sandbox deletion."""


### PR DESCRIPTION
## Problem

EMB timeouts take the force-stop path. Provider teardown errors can then surface as obscure `Broken TTY` or Daytona failures instead of a clear timeout outcome such as “Agent didn't finish in time.” Other benchmark paths had addressed this behavior, but EMB still exposed the gap.

This PR is the short-term fix: make our database state authoritative immediately while allowing provider cleanup to finish independently. A longer-term timeout-specific error/lifecycle treatment can follow separately.

## Summary

- Force-stop finalizes Valkyrie database state immediately: active tasks become `STOPPED`, the whole run becomes `STOPPED`, and its active dispatches become `FAILED`.
- Provider cleanup is isolated from run state: after the database commit, force-stop sends Daytona deletion signals without draining or waiting for sandbox destruction.
- Provider failures are logged without changing the already-final database result.
- Graceful stop keeps its existing `STOPPING` behavior; selected-task force does not revoke a shared dispatch while other tasks remain active.

## Verification

- `uv run pytest tests/unit -q` — 575 passed
- Focused recovery/state/dispatch tests — 72 passed
- Ruff and `git diff --check` — passed
- CI `tracker-live-integration-tests` — passed
- Postgres integration tests were collected but not executed locally because Docker is unavailable.
- Local live Daytona tests were not executed because `TEST_DAYTONA_SECRET_NAME` is unavailable.