### PR TITLE
ci: add maintenance approval gate

### DIFF
--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -220,9 +220,12 @@ jobs:
           retention-days: 1
 
   classify:
-    name: maintenance-classification
+    name: classify-maintenance
     needs: [synthesize-base, synthesize-head]
     runs-on: ubuntu-24.04-arm
+    outputs:
+      classification: ${{ steps.classification.outputs.classification }}
+      target_branch: ${{ steps.template.outputs.target_branch }}
     steps:
       - name: Checkout trusted classifier
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -321,9 +324,11 @@ jobs:
               }:
                   raise SystemExit(f"{label} artifact manifest does not match trusted event identity")
           print(f"expected_stack_id={expected_stack_id}")
+          print(f"target_branch={target_branch}")
           PY
 
       - name: Classify candidate
+        id: classification
         run: |
           set -euo pipefail
           python3 infra/classify_repository_change.py \
@@ -333,13 +338,70 @@ jobs:
             --executor-head-template "$RUNNER_TEMP/worker-template-head/WorkerStack.template.json" \
             --expected-stack-id "${{ steps.template.outputs.expected_stack_id }}" \
             --output maintenance-classification.json
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import os
 
-      - name: Require force merge for maintenance
+          with open("maintenance-classification.json", encoding="utf-8") as classification_file:
+              payload = json.load(classification_file)
+          classification = payload.get("classification")
+          if classification not in {"safe", "maintenance-required"}:
+              raise SystemExit(f"Unexpected maintenance classification: {classification!r}")
+          if payload.get("base_sha") != os.environ["BASE_SHA"]:
+              raise SystemExit("Maintenance classification base SHA does not match the event")
+          if payload.get("head_sha") != os.environ["HEAD_SHA"]:
+              raise SystemExit("Maintenance classification head SHA does not match the event")
+          print(f"classification={classification}")
+          PY
+
+  approve-maintenance:
+    name: approve-maintenance
+    needs: classify
+    if: needs.classify.outputs.classification == 'maintenance-required'
+    runs-on: ubuntu-24.04-arm
+    permissions: {}
+    environment:
+      name: maintenance-${{ needs.classify.outputs.target_branch }}
+    steps:
+      - name: Record maintenance approval
+        env:
+          APPROVED_SHA: ${{ env.HEAD_SHA }}
+          APPROVED_TARGET: ${{ needs.classify.outputs.target_branch }}
+        run: echo "Maintenance approved for $APPROVED_TARGET at $APPROVED_SHA"
+
+  maintenance-gate:
+    name: maintenance-classification
+    needs: [classify, approve-maintenance]
+    if: always()
+    runs-on: ubuntu-24.04-arm
+    permissions: {}
+    steps:
+      - name: Require a safe or approved maintenance classification
+        env:
+          APPROVAL_RESULT: ${{ needs.approve-maintenance.result }}
+          CLASSIFICATION: ${{ needs.classify.outputs.classification }}
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
         run: |
           set -euo pipefail
-          classification="$(python3 -c 'import json; print(json.load(open("maintenance-classification.json"))["classification"])')"
-          if [[ "$classification" == "safe" ]]; then
-            exit 0
+          if [[ "$CLASSIFY_RESULT" != "success" ]]; then
+            echo "::error::Maintenance classification failed before authorization."
+            exit 1
           fi
-          echo "::error::Maintenance is required. Use an authorized force merge to approve the outage."
-          exit 1
+          case "$CLASSIFICATION" in
+            safe)
+              if [[ "$APPROVAL_RESULT" != "skipped" ]]; then
+                echo "::error::Safe classification produced an unexpected approval result: $APPROVAL_RESULT"
+                exit 1
+              fi
+              ;;
+            maintenance-required)
+              if [[ "$APPROVAL_RESULT" != "success" ]]; then
+                echo "::error::Maintenance approval was not granted."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unexpected maintenance classification: $CLASSIFICATION"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -1,8 +1,7 @@
 name: Maintenance classification
 
 on:
-  # TEMPORARY: run the PR's workflow only to demo approval; restore pull_request_target before merge.
-  pull_request:
+  pull_request_target:
     branches: [dev, prod]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -1,7 +1,8 @@
 name: Maintenance classification
 
 on:
-  pull_request_target:
+  # TEMPORARY: run the PR's workflow only to demo approval; restore pull_request_target before merge.
+  pull_request:
     branches: [dev, prod]
     types: [opened, synchronize, reopened, ready_for_review]
   merge_group:

--- a/docs/executor-releases/README.md
+++ b/docs/executor-releases/README.md
@@ -233,8 +233,12 @@ The `maintenance-classification` job runs the same classifier used by deployment
 New tables, explicitly nullable default-free columns, changes that make an existing
 column nullable, and explicitly non-unique indexes are safe. ExecutorStack and
 release-control changes require executor maintenance. Other migration operations
-require database maintenance. The required check deliberately fails for those
-changes, so an authorized force merge is the maintenance approval.
+require database maintenance. Safe changes pass immediately. Maintenance changes
+wait for a required reviewer on the secretless `maintenance-dev` or
+`maintenance-prod` GitHub Environment; approval makes the required check pass so
+the pull request uses the normal merge path. Rejection keeps the check failed, and
+synthesis, artifact-validation, or classifier infrastructure errors cannot be
+approved.
 
 For an approved maintenance deployment, the existing sealed release task closes
 admission, marks active benchmarks and tasks `STOPPED`, fails queued or running

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -173,6 +173,8 @@ class ExecutorStack(Stack):
                 "STABLE_QUEUE_NAME": "valkyrie-stable",
                 "EXECUTOR_RELEASE_BUCKET": self.executor_release_bucket.bucket_name,
                 "EXECUTOR_RELEASE_PREFIX": EXECUTOR_RELEASE_PREFIX,
+                # TEMPORARY: remove before merging the maintenance-approval rollout PR.
+                "MAINTENANCE_APPROVAL_PROBE": "true",
             },
             secrets=db_secrets,
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -173,8 +173,6 @@ class ExecutorStack(Stack):
                 "STABLE_QUEUE_NAME": "valkyrie-stable",
                 "EXECUTOR_RELEASE_BUCKET": self.executor_release_bucket.bucket_name,
                 "EXECUTOR_RELEASE_PREFIX": EXECUTOR_RELEASE_PREFIX,
-                # TEMPORARY: remove before merging the maintenance-approval rollout PR.
-                "MAINTENANCE_APPROVAL_PROBE": "true",
             },
             secrets=db_secrets,
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -301,6 +301,32 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertNotIn("checks: write", classification_workflow)
         self.assertNotIn("actions/github-script", classification_workflow)
 
+    def test_maintenance_classification_waits_for_environment_approval(self) -> None:
+        workflow = (ROOT / ".github" / "workflows" / "maintenance-classification.yaml").read_text(
+            encoding="utf-8"
+        )
+        classifier = workflow.split("  classify:", maxsplit=1)[1].split("  approve-maintenance:", maxsplit=1)[0]
+        approval = workflow.split("  approve-maintenance:", maxsplit=1)[1].split(
+            "  maintenance-gate:", maxsplit=1
+        )[0]
+        gate = workflow.split("  maintenance-gate:", maxsplit=1)[1]
+
+        self.assertIn("classification: ${{ steps.classification.outputs.classification }}", classifier)
+        self.assertIn("target_branch: ${{ steps.template.outputs.target_branch }}", classifier)
+        self.assertIn('classification not in {"safe", "maintenance-required"}', classifier)
+        self.assertIn('payload.get("base_sha") != os.environ["BASE_SHA"]', classifier)
+        self.assertIn('payload.get("head_sha") != os.environ["HEAD_SHA"]', classifier)
+        self.assertIn("if: needs.classify.outputs.classification == 'maintenance-required'", approval)
+        self.assertIn("name: maintenance-${{ needs.classify.outputs.target_branch }}", approval)
+        self.assertIn("permissions: {}", approval)
+        self.assertIn("name: maintenance-classification", gate)
+        self.assertIn("needs: [classify, approve-maintenance]", gate)
+        self.assertIn("if: always()", gate)
+        self.assertIn('if [[ "$CLASSIFY_RESULT" != "success" ]]', gate)
+        self.assertIn("maintenance-required)", gate)
+        self.assertIn('if [[ "$APPROVAL_RESULT" != "success" ]]', gate)
+        self.assertNotIn("force merge", workflow.lower())
+
     def test_executor_build_check_covers_real_arm_images_and_pex(self) -> None:
         workflow = EXECUTOR_BUILD_WORKFLOW.read_text(encoding="utf-8")
 

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -302,13 +302,9 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertNotIn("actions/github-script", classification_workflow)
 
     def test_maintenance_classification_waits_for_environment_approval(self) -> None:
-        workflow = (ROOT / ".github" / "workflows" / "maintenance-classification.yaml").read_text(
-            encoding="utf-8"
-        )
+        workflow = (ROOT / ".github" / "workflows" / "maintenance-classification.yaml").read_text(encoding="utf-8")
         classifier = workflow.split("  classify:", maxsplit=1)[1].split("  approve-maintenance:", maxsplit=1)[0]
-        approval = workflow.split("  approve-maintenance:", maxsplit=1)[1].split(
-            "  maintenance-gate:", maxsplit=1
-        )[0]
+        approval = workflow.split("  approve-maintenance:", maxsplit=1)[1].split("  maintenance-gate:", maxsplit=1)[0]
         gate = workflow.split("  maintenance-gate:", maxsplit=1)[1]
 
         self.assertIn("classification: ${{ steps.classification.outputs.classification }}", classifier)


### PR DESCRIPTION
## Summary
Replace the intentional maintenance-check failure with a pre-merge GitHub Environment approval gate. Maintenance changes wait for an authorized reviewer and then use the normal merge path; classifier and infrastructure failures remain non-approvable.

## Changes
- Split trusted classification from the required `maintenance-classification` aggregation job.
- Wait on `maintenance-dev` or `maintenance-prod` only for `maintenance-required` candidates.
- Preserve fail-closed handling for synthesis, artifact validation, classifier, rejection, and unexpected states.
- Document the reviewer approval flow.
- Add a structural workflow contract test.

## Rollout configuration
The secretless `maintenance-dev` and `maintenance-prod` Environments are configured with `@vals-ai/valkyrie` as the required reviewer and prevent self-review enabled.

`maintenance-classification` is currently required only by the `Dev` ruleset. Add it to the `Prod` ruleset when the updated workflow reaches `prod` if production PRs must use the same gate.

## Related Issues
None.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Verification performed:
- Environment approval flow demonstrated on the draft PR
- YAML parse: passed
- `git diff --check`: passed
- Temporary trigger and ExecutorHost probe removed from the final diff
- Tests, standalone typechecks, linters, and formatters were not run for the final cleanup

## Checklist
- [x] Self-reviewed the diff
- [x] Temporary demo code removed
- [x] Docs updated if needed
