### PR TITLE
test: trigger maintenance approval

### DIFF
--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -180,6 +180,8 @@ class ExecutorStack(Stack):
                 "STABLE_QUEUE_NAME": "valkyrie-stable",
                 "EXECUTOR_RELEASE_BUCKET": self.executor_release_bucket.bucket_name,
                 "EXECUTOR_RELEASE_PREFIX": EXECUTOR_RELEASE_PREFIX,
+                # TEMPORARY: disposable maintenance-approval probe; do not merge.
+                "MAINTENANCE_APPROVAL_PROBE": "true",
             },
             secrets=db_secrets,
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),


### PR DESCRIPTION
## Summary
Disposable executor-change PR that adds an unused ExecutorHost environment value so the synthesized `ExecutorStack` is classified as maintenance-required.

## Approval demonstration
#695 has merged and this PR now targets `dev`. The trusted maintenance workflow should classify the executor change as maintenance-required, then wait for `@vals-ai/valkyrie` approval on `maintenance-dev`.

## Changes
- Add temporary `MAINTENANCE_APPROVAL_PROBE=true` to the ExecutorHost task definition.
- No runtime code reads the value.

## Testing
GitHub checks run on the pushed branch. The intended evidence is the trusted maintenance workflow reaching the protected `maintenance-dev` approval job.

## Cleanup
This PR is a disposable approval probe. **Do not merge it.** Close it after the demonstration.
