### PR TITLE
fix(infra): scale prod tracker db and add query observability

### DIFF
--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -29,6 +29,8 @@ class DatabaseConfig:
     allocated_storage_gb: int
     backup_retention_days: int
     connection_alarm_threshold: int
+    performance_insights: bool = False
+    slow_query_log_threshold_ms: int = 1000
 
 
 @dataclass(frozen=True)
@@ -88,10 +90,11 @@ PROD_CONFIG = StageConfig(
     tracker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=1, max_tasks=2),
     worker=ServiceConfig(cpu=8192, memory_mib=32768, min_tasks=4, max_tasks=8),
     database=DatabaseConfig(
-        instance_class="t4g.small",
+        instance_class="m7g.large",
         allocated_storage_gb=20,
         backup_retention_days=7,
         connection_alarm_threshold=135,
+        performance_insights=True,
     ),
     service_log_retention=aws_logs.RetentionDays.ONE_YEAR,
     managed_aws=ManagedAWSRuntimeConfig(

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -129,12 +129,24 @@ class TrackerStack(Stack):
         )
         db_credentials_secret = cast(aws_secretsmanager.ISecret, self.db_credentials)
 
+        db_engine = aws_rds.DatabaseInstanceEngine.postgres(
+            version=aws_rds.PostgresEngineVersion.VER_16,
+        )
+        db_parameter_group = aws_rds.ParameterGroup(
+            self,
+            "TrackerDbParameters",
+            engine=db_engine,
+            description="Tracker Postgres parameters",
+            parameters={
+                "log_min_duration_statement": str(stage_config.database.slow_query_log_threshold_ms),
+            },
+        )
+
         self.database = aws_rds.DatabaseInstance(
             self,
             "TrackerDatabase",
-            engine=aws_rds.DatabaseInstanceEngine.postgres(
-                version=aws_rds.PostgresEngineVersion.VER_16,
-            ),
+            engine=db_engine,
+            parameter_group=db_parameter_group,
             instance_type=aws_ec2.InstanceType(stage_config.database.instance_class),
             vpc=vpc,
             vpc_subnets=aws_ec2.SubnetSelection(subnet_type=aws_ec2.SubnetType.PUBLIC),
@@ -146,6 +158,9 @@ class TrackerStack(Stack):
             deletion_protection=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             backup_retention=Duration.days(stage_config.database.backup_retention_days),
+            enable_performance_insights=stage_config.database.performance_insights,
+            cloudwatch_logs_exports=["postgresql"],
+            cloudwatch_logs_retention=stage_config.service_log_retention,
         )
 
         db_env = {

--- a/services/tracker/src/tracker/database/session.py
+++ b/services/tracker/src/tracker/database/session.py
@@ -10,8 +10,8 @@ _exposed_models: list[type[SQLModel]] = [Benchmark, EvaluationResult, Org, Task]
 
 engine = create_engine(
     DATABASE_URL,
-    pool_size=15,
-    max_overflow=5,
+    pool_size=50,
+    max_overflow=10,
     pool_pre_ping=True,
     pool_recycle=3600,
 )

--- a/services/tracker/src/tracker/database/session.py
+++ b/services/tracker/src/tracker/database/session.py
@@ -10,8 +10,8 @@ _exposed_models: list[type[SQLModel]] = [Benchmark, EvaluationResult, Org, Task]
 
 engine = create_engine(
     DATABASE_URL,
-    pool_size=50,
-    max_overflow=10,
+    pool_size=15,
+    max_overflow=5,
     pool_pre_ping=True,
     pool_recycle=3600,
 )


### PR DESCRIPTION
## Summary

Prod tracker Postgres has been saturated: `CPUCreditBalance` at 0 since Aug 12, sustained ~96% CPU, `DatabaseConnections` peaking at ~175 (alarm threshold 135) and `FreeableMemory` down to ~200 MB on a 2 GiB `db.t4g.small`. Both `Valkyrie-DB-CPU-High` and `Valkyrie-DB-Connections-High` fired. Root cause of the *saturation* is a burstable 2 vCPU / 2 GiB instance backing a 4–8 task worker fleet; the query-level cause is unknown because Performance Insights and slow-query logging were never enabled.

This moves prod to a non-burstable `db.m7g.large` (2 vCPU / 8 GiB, ~$123/mo on-demand vs ~$23/mo today, plus it removes the T4g surplus-credit surcharge already being paid) and turns on the observability needed to name the offending queries next time.

Deliberately not included: the SQLAlchemy pool (`50 + 10` per process) is untouched. Shrinking it was proposed but deferred — Performance Insights should tell us the real per-process concurrency first rather than tuning blind.

Deploy note: the instance-class change is an in-place RDS modify (same logical id `TrackerDatabaseC514B7DD`, `DeletionProtection`/`RETAIN` unchanged — no replacement), but it reboots the instance, so expect ~1–3 min of tracker DB errors. The new parameter group association also applies on that reboot. Best run during a quiet window.

## Changes
- `infra/stage_config.py`: prod `instance_class` `t4g.small` → `m7g.large`; `DatabaseConfig` gains `performance_insights` (prod only) and `slow_query_log_threshold_ms` (default 1000).
- `infra/tracker_stack.py`: RDS instance gets Performance Insights (7-day free tier), a `TrackerDbParameters` parameter group setting `log_min_duration_statement`, and `postgresql` log export to CloudWatch at the stage's log retention.

## Related Issues
n/a — from the #agent-chat load investigation on Aug 17.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing

Not live-tested: applying it requires a prod RDS reboot, which I did not perform. What I verified instead is the synthesized prod CloudFormation template (`infra` unittest harness, `service_templates(PROD)`), which renders:

```json
"TrackerDatabaseC514B7DD": {
  "DBInstanceClass": "db.m7g.large",
  "EnablePerformanceInsights": true,
  "PerformanceInsightsRetentionPeriod": 7,
  "EnableCloudwatchLogsExports": ["postgresql"],
  "DBParameterGroupName": {"Ref": "TrackerDbParameters2A9743DF"},
  "DeletionProtection": true
}
"TrackerDbParameters2A9743DF": {
  "Family": "postgres16",
  "Parameters": {"log_min_duration_statement": "1000"}
}
```

Whether this actually relieves the saturation (CPU off its ceiling, connections settling under 135) can only be confirmed after deploy.

- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

## Human Description

### Why

### How


Link to Devin session: https://app.devin.ai/sessions/0893253f97c1440aa88e8fd8c60c1e71
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->