### PR TITLE
fix(tracker): back off between agent contract upload retries

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -332,6 +332,7 @@ async def create_sandbox(
     retry=retry_if_exception_type(SandboxError) & retry_if_not_exception_type(SandboxSetupError),
     reraise=True,
     stop=stop_after_attempt(3),
+    wait=wait_chain(wait_none(), wait_fixed(30)),
     before_sleep=retry_callback("valkyrie.sandbox.upload"),
 )
 async def upload_agent_artifacts(


### PR DESCRIPTION
## Summary
`upload_agent_artifacts` retries `SandboxError` three times with tenacity's default wait, which is `wait_none()` — all three attempts fire back-to-back, so a transient sandbox network fault is retried while it is still happening. Task `05-065` of run `0db6df96-dad0-44a1-be41-a5ec4de30490` (`fabv2-internal`, `alibaba/qwen3.8-27b`) errored this way: the bootstrap `apt-get update` in the upload script hit `Temporary failure resolving 'deb.debian.org'`, so `unzip` could not be installed and apt exited 100 on every attempt within a couple of seconds.

This gives the upload the same shape of policy `_install_agent_dependencies_with_retries` already uses: retry once immediately (cheap for a one-off exec fault), then wait 30s before the final attempt so a short DNS/mirror blip is outlived.

## Changes
- `services/tracker/src/tracker/sandbox.py`: `wait=wait_chain(wait_none(), wait_fixed(30))` on `upload_agent_artifacts`.

## Related Issues
n/a

## Type of Change
- [x] Bug fix

## Testing
Not live-tested: reproducing it requires a sandbox with broken DNS, and the change only alters sleep duration between existing retries. Attempt count, retry predicate and error semantics are unchanged, and `tests/unit/test_sandbox.py` (58 tests) still passes.

No unit test added — asserting the wait strategy would only restate the literal, not guard a behavior.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

## Human Description
### Why

### How


Link to Devin session: https://app.devin.ai/sessions/817e88810ca0486cbc2312f3fe76da9c
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->