### PR TITLE
change: enable managed aws execution in dev #minor

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,6 +109,8 @@ jobs:
               CDK_DEFAULT_REGION=us-east-1 \
               AWS_REGION=us-east-1 \
               STAGE="$stage" \
+              AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+              AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
               SENTRY_DSN_SECRET_NAME=offline-synth \
               DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
               DESCOPE_PROJECT_ID=offline-synth \
@@ -237,6 +239,8 @@ jobs:
       id-token: write
     env:
       AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       CDK_DEFAULT_ACCOUNT: ${{ secrets.DEV_ACCOUNT_ID }}
@@ -358,6 +362,8 @@ jobs:
       id-token: write
     env:
       AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       CDK_DEFAULT_ACCOUNT: ${{ secrets.DEV_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -242,7 +242,6 @@ jobs:
       AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
       AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
       AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
-      AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       CDK_DEFAULT_ACCOUNT: ${{ secrets.DEV_ACCOUNT_ID }}
@@ -271,8 +270,8 @@ jobs:
             echo "::error::The dev Environment must define DESCOPE_MANAGEMENT_KEY_SECRET_NAME before planning or deploying."
             exit 1
           fi
-          if [[ "$OPERATION" != "credentials-only" && ( -z "$AWS_DEPLOYMENT_ROLE_ORG_IDS" || -z "$AWS_TRACKER_SECRET_NAME_PREFIXES" || -z "$AWS_EXECUTOR_SECRET_NAME_PREFIXES" ) ]]; then
-            echo "::error::The dev Environment must define AWS_DEPLOYMENT_ROLE_ORG_IDS, AWS_TRACKER_SECRET_NAME_PREFIXES, and AWS_EXECUTOR_SECRET_NAME_PREFIXES before planning or deploying."
+          if [[ "$OPERATION" != "credentials-only" && ( -z "$AWS_DEPLOYMENT_ROLE_ORG_IDS" || -z "$AWS_TRACKER_SECRET_NAME_PREFIXES" ) ]]; then
+            echo "::error::The dev Environment must define AWS_DEPLOYMENT_ROLE_ORG_IDS and AWS_TRACKER_SECRET_NAME_PREFIXES before planning or deploying."
             exit 1
           fi
           if [[ ! "$DEV_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
@@ -370,7 +369,6 @@ jobs:
       AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
       AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
       AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
-      AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       CDK_DEFAULT_ACCOUNT: ${{ secrets.DEV_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -110,6 +110,7 @@ jobs:
               AWS_REGION=us-east-1 \
               STAGE="$stage" \
               AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+              AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
               AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
               SENTRY_DSN_SECRET_NAME=offline-synth \
               DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
@@ -240,6 +241,7 @@ jobs:
     env:
       AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
       AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
@@ -267,6 +269,10 @@ jobs:
           fi
           if [[ "$OPERATION" != "credentials-only" && -z "$DESCOPE_MANAGEMENT_KEY_SECRET_NAME" ]]; then
             echo "::error::The dev Environment must define DESCOPE_MANAGEMENT_KEY_SECRET_NAME before planning or deploying."
+            exit 1
+          fi
+          if [[ "$OPERATION" != "credentials-only" && ( -z "$AWS_DEPLOYMENT_ROLE_ORG_IDS" || -z "$AWS_TRACKER_SECRET_NAME_PREFIXES" || -z "$AWS_EXECUTOR_SECRET_NAME_PREFIXES" ) ]]; then
+            echo "::error::The dev Environment must define AWS_DEPLOYMENT_ROLE_ORG_IDS, AWS_TRACKER_SECRET_NAME_PREFIXES, and AWS_EXECUTOR_SECRET_NAME_PREFIXES before planning or deploying."
             exit 1
           fi
           if [[ ! "$DEV_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
@@ -363,6 +369,7 @@ jobs:
     env:
       AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
       AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -84,6 +84,8 @@ jobs:
             CDK_DEFAULT_REGION=us-east-1 \
             AWS_REGION=us-east-1 \
             STAGE="$stage" \
+            AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+            AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
             SENTRY_DSN_SECRET_NAME=offline-synth \
             DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
             DESCOPE_PROJECT_ID=offline-synth \
@@ -185,6 +187,8 @@ jobs:
             CDK_DEFAULT_REGION=us-east-1 \
             AWS_REGION=us-east-1 \
             STAGE="$stage" \
+            AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+            AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
             SENTRY_DSN_SECRET_NAME=offline-synth \
             DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
             DESCOPE_PROJECT_ID=offline-synth \

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -85,6 +85,7 @@ jobs:
             AWS_REGION=us-east-1 \
             STAGE="$stage" \
             AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+            AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
             AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
             SENTRY_DSN_SECRET_NAME=offline-synth \
             DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
@@ -188,6 +189,7 @@ jobs:
             AWS_REGION=us-east-1 \
             STAGE="$stage" \
             AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+            AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
             AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
             SENTRY_DSN_SECRET_NAME=offline-synth \
             DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \

--- a/infra/README.md
+++ b/infra/README.md
@@ -39,8 +39,9 @@ Managed AWS execution also requires these dev Environment secrets:
   to submit managed runs
 - `AWS_TRACKER_SECRET_NAME_PREFIXES` -- comma-separated Secrets Manager name
   prefixes the Tracker may resolve for benchmark-service authentication
-- `AWS_EXECUTOR_SECRET_NAME_PREFIXES` -- comma-separated Secrets Manager name
-  prefixes the executor may resolve for sandbox providers
+
+The dev ExecutorHost task role can read every Secrets Manager secret in the dev
+account and Region. Production and release-test do not receive this access.
 
 To enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the
 name of an account-local Secrets Manager secret containing the DSN. Production
@@ -108,14 +109,13 @@ export DESCOPE_PROJECT_ID="dev-project-id"
 export DESCOPE_MANAGEMENT_KEY_SECRET_NAME="dev-descope-management-key-secret"
 export AWS_DEPLOYMENT_ROLE_ORG_IDS="00000000-0000-0000-0000-000000000001"
 export AWS_TRACKER_SECRET_NAME_PREFIXES="benchmark-services/"
-export AWS_EXECUTOR_SECRET_NAME_PREFIXES="AgenticHarnessSecrets"
 ```
 
    In GitHub, the corresponding values are under **Settings → Environments →
    dev → Environment secrets**. GitHub does not reveal stored secret values, so
    an administrator must obtain the approved values from the deployment owner.
 
-   **Done when** -- All six variables print as non-empty when checked locally;
+   **Done when** -- All five variables print as non-empty when checked locally;
    do not print their values into shared logs.
 
 2. Plan the intended scope.

--- a/infra/README.md
+++ b/infra/README.md
@@ -32,9 +32,18 @@ so CDK DNS validation can complete. Configure the protected `dev` GitHub
 Environment with the `AWS_REGION=us-east-1` variable and the `DEV_ACCOUNT_ID`,
 `AWS_DEPLOY_ROLE_ARN`, `DESCOPE_PROJECT_ID`, and
 `DESCOPE_MANAGEMENT_KEY_SECRET_NAME` secrets (the last one names an
-account-local Secrets Manager secret holding the Descope management key). To
-enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the name
-of an account-local Secrets Manager secret containing the DSN. Production
+account-local Secrets Manager secret holding the Descope management key).
+Managed AWS execution also requires these dev Environment secrets:
+
+- `AWS_DEPLOYMENT_ROLE_ORG_IDS` -- comma-separated organization UUIDs allowed
+  to submit managed runs
+- `AWS_TRACKER_SECRET_NAME_PREFIXES` -- comma-separated Secrets Manager name
+  prefixes the Tracker may resolve for benchmark-service authentication
+- `AWS_EXECUTOR_SECRET_NAME_PREFIXES` -- comma-separated Secrets Manager name
+  prefixes the executor may resolve for sandbox providers
+
+To enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the
+name of an account-local Secrets Manager secret containing the DSN. Production
 requires `SENTRY_DSN_SECRET_NAME`, and `DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
 whenever `AUTH_REQUIRED` is `true`. The dev Environment holds every dev
 deployment input as an Environment secret except `AWS_REGION`, which stays a
@@ -85,20 +94,63 @@ executor work fails closed until the bootstrap publishes the stage's sealed
 release-control SSM parameter. Later workflow deployments keep existing
 executions pinned while previous releases drain normally.
 
-For a local plan or an administrator break-glass deployment, pass the target
-explicitly. The preflight rejects the wrong account, Region, or STS identity.
+For a local plan or an administrator break-glass deployment, follow these
+steps. The preflight rejects the wrong account, Region, or STS identity.
+
+1. Export the target account and deployment-owned managed AWS inventory.
+
+   **Why** -- Local CDK commands cannot read GitHub Environment secrets. The
+   deployment must receive the same organization and secret namespaces as CI.
 
 ```bash
 export DEV_ACCOUNT_ID=123456789012
 export DESCOPE_PROJECT_ID="dev-project-id"
 export DESCOPE_MANAGEMENT_KEY_SECRET_NAME="dev-descope-management-key-secret"
+export AWS_DEPLOYMENT_ROLE_ORG_IDS="00000000-0000-0000-0000-000000000001"
+export AWS_TRACKER_SECRET_NAME_PREFIXES="benchmark-services/"
+export AWS_EXECUTOR_SECRET_NAME_PREFIXES="AgenticHarnessSecrets"
+```
+
+   In GitHub, the corresponding values are under **Settings → Environments →
+   dev → Environment secrets**. GitHub does not reveal stored secret values, so
+   an administrator must obtain the approved values from the deployment owner.
+
+   **Done when** -- All six variables print as non-empty when checked locally;
+   do not print their values into shared logs.
+
+2. Plan the intended scope.
+
+   **Why** -- The plan verifies the account boundary and shows the exact
+   CloudFormation changes before any resource is modified.
+
+```bash
 
 make plan STAGE=dev SCOPE=all AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
+```
+
+   Console alternative: run **Actions → Deploy to AWS → Run workflow** on
+   `dev`, choose `plan`, and select the intended scope.
+
+   **Done when** -- The plan targets the expected dev account and contains only
+   the intended stack changes.
+
+3. Deploy the approved scope only when break-glass access is authorized.
+
+   **Why** -- Direct deployment bypasses the normal branch-push workflow and is
+   reserved for recovery operations.
+
+```bash
 
 make deploy STAGE=dev SCOPE=shared AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
 ```
+
+   This step is CLI-only because the manual GitHub workflow intentionally does
+   not offer deployment. Normal deployments come from a merge to `dev`.
+
+   **Done when** -- CDK reports the selected stack deployed in the expected dev
+   account and its CloudFormation events contain no failed resources.
 
 `release-test` is an isolated, dev-sized deployment in the account selected by
 `DEV_ACCOUNT_ID`. It uses `-release-test` resource names and

--- a/infra/runtime_iam.py
+++ b/infra/runtime_iam.py
@@ -68,7 +68,10 @@ def create_executor_task_role(
         )
     )
     _add_benchmark_log_access(role, stage, config.benchmark_log_group_prefix)
-    _add_secret_access(role, config.executor_secret_name_prefixes)
+    if config.executor_all_secret_access:
+        _add_all_secret_access(role)
+    else:
+        _add_secret_access(role, config.executor_secret_name_prefixes)
     _add_lambda_access(role, config.executor_lambda_function_name_patterns)
     _add_kms_access(role, config.kms_key_arns)
     return role
@@ -143,6 +146,23 @@ def _add_secret_access(role: aws_iam.Role, secret_name_prefixes: tuple[str, ...]
                     arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
                 )
                 for prefix in secret_name_prefixes
+            ],
+        )
+    )
+
+
+def _add_all_secret_access(role: aws_iam.Role) -> None:
+    stack = cdk.Stack.of(role)
+    role.add_to_policy(
+        aws_iam.PolicyStatement(
+            actions=["secretsmanager:GetSecretValue"],
+            resources=[
+                stack.format_arn(
+                    service="secretsmanager",
+                    resource="secret",
+                    resource_name="*",
+                    arn_format=cdk.ArnFormat.COLON_RESOURCE_NAME,
+                )
             ],
         )
     )

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from uuid import UUID
 
 from aws_cdk import aws_logs
@@ -114,9 +115,7 @@ DEV_CONFIG = StageConfig(
     managed_aws=ManagedAWSRuntimeConfig(
         benchmark_log_group_prefix="/valkyrie/benchmarks",
         benchmark_log_retention_days=7,
-        deployment_role_org_ids=("431bc4f8-c66b-47eb-8d53-2c4622be04e6",),
         submissions_enabled=True,
-        executor_secret_name_prefixes=("AgenticHarnessSecrets",),
     ),
 )
 
@@ -144,9 +143,32 @@ _STAGE_CONFIGS = {
 
 def config_for(stage: Stage) -> StageConfig:
     try:
-        return _STAGE_CONFIGS[stage.name]
+        config = _STAGE_CONFIGS[stage.name]
     except KeyError:
         raise ValueError(f"unknown stage {stage.name!r}; expected {PROD!r}, {DEV!r}, or 'release-test'") from None
+
+    if stage.name != DEV:
+        return config
+
+    deployment_role_org_ids = _csv_environment("AWS_DEPLOYMENT_ROLE_ORG_IDS")
+    executor_secret_name_prefixes = _csv_environment("AWS_EXECUTOR_SECRET_NAME_PREFIXES")
+    if config.managed_aws.submissions_enabled:
+        if not deployment_role_org_ids:
+            raise ValueError("Development deployments require AWS_DEPLOYMENT_ROLE_ORG_IDS.")
+        if not executor_secret_name_prefixes:
+            raise ValueError("Development deployments require AWS_EXECUTOR_SECRET_NAME_PREFIXES.")
+    return replace(
+        config,
+        managed_aws=replace(
+            config.managed_aws,
+            deployment_role_org_ids=deployment_role_org_ids,
+            executor_secret_name_prefixes=executor_secret_name_prefixes,
+        ),
+    )
+
+
+def _csv_environment(name: str) -> tuple[str, ...]:
+    return tuple(value.strip() for value in os.environ.get(name, "").split(",") if value.strip())
 
 
 def benchmark_service_base_url(stage: Stage) -> str | None:

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -114,6 +114,9 @@ DEV_CONFIG = StageConfig(
     managed_aws=ManagedAWSRuntimeConfig(
         benchmark_log_group_prefix="/valkyrie/benchmarks",
         benchmark_log_retention_days=7,
+        deployment_role_org_ids=("431bc4f8-c66b-47eb-8d53-2c4622be04e6",),
+        submissions_enabled=True,
+        executor_secret_name_prefixes=("AgenticHarnessSecrets",),
     ),
 )
 
@@ -123,7 +126,10 @@ RELEASE_TEST_CONFIG = StageConfig(
     worker=DEV_CONFIG.worker,
     database=DEV_CONFIG.database,
     service_log_retention=DEV_CONFIG.service_log_retention,
-    managed_aws=DEV_CONFIG.managed_aws,
+    managed_aws=ManagedAWSRuntimeConfig(
+        benchmark_log_group_prefix="/valkyrie/benchmarks",
+        benchmark_log_retention_days=7,
+    ),
 )
 
 RELEASE_TEST_BENCHMARK_SERVICE_BASE_URL = "benchmarks.vals.ai"

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -42,6 +42,7 @@ class ManagedAWSRuntimeConfig:
     submissions_enabled: bool = False
     tracker_secret_name_prefixes: tuple[str, ...] = ()
     executor_secret_name_prefixes: tuple[str, ...] = ()
+    executor_all_secret_access: bool = False
     tracker_lambda_function_name_patterns: tuple[str, ...] = ()
     executor_lambda_function_name_patterns: tuple[str, ...] = ()
     kms_key_arns: tuple[str, ...] = ()
@@ -62,6 +63,9 @@ class ManagedAWSRuntimeConfig:
         ):
             if any(_SECRET_NAME_PREFIX_PATTERN.fullmatch(prefix) is None for prefix in prefixes):
                 raise ValueError(f"{field_name} must contain literal, non-empty Secrets Manager name prefixes")
+
+        if self.executor_all_secret_access and self.executor_secret_name_prefixes:
+            raise ValueError("executor_all_secret_access cannot be combined with executor_secret_name_prefixes")
 
         for field_name, patterns in (
             ("tracker_lambda_function_name_patterns", self.tracker_lambda_function_name_patterns),
@@ -118,6 +122,7 @@ DEV_CONFIG = StageConfig(
         benchmark_log_group_prefix="/valkyrie/benchmarks",
         benchmark_log_retention_days=7,
         submissions_enabled=True,
+        executor_all_secret_access=True,
     ),
 )
 
@@ -154,25 +159,20 @@ def config_for(stage: Stage) -> StageConfig:
 
     deployment_role_org_ids = _csv_environment("AWS_DEPLOYMENT_ROLE_ORG_IDS")
     tracker_secret_name_prefixes = _csv_environment("AWS_TRACKER_SECRET_NAME_PREFIXES")
-    executor_secret_name_prefixes = _csv_environment("AWS_EXECUTOR_SECRET_NAME_PREFIXES")
     if os.environ.get("DESCOPE_PROJECT_ID") == _OFFLINE_SYNTH_SECRET_PREFIX:
         deployment_role_org_ids = deployment_role_org_ids or (_OFFLINE_SYNTH_ORG_ID,)
         tracker_secret_name_prefixes = tracker_secret_name_prefixes or (_OFFLINE_SYNTH_SECRET_PREFIX,)
-        executor_secret_name_prefixes = executor_secret_name_prefixes or (_OFFLINE_SYNTH_SECRET_PREFIX,)
     if config.managed_aws.submissions_enabled:
         if not deployment_role_org_ids:
             raise ValueError("Development deployments require AWS_DEPLOYMENT_ROLE_ORG_IDS.")
         if not tracker_secret_name_prefixes:
             raise ValueError("Development deployments require AWS_TRACKER_SECRET_NAME_PREFIXES.")
-        if not executor_secret_name_prefixes:
-            raise ValueError("Development deployments require AWS_EXECUTOR_SECRET_NAME_PREFIXES.")
     return replace(
         config,
         managed_aws=replace(
             config.managed_aws,
             deployment_role_org_ids=deployment_role_org_ids,
             tracker_secret_name_prefixes=tracker_secret_name_prefixes,
-            executor_secret_name_prefixes=executor_secret_name_prefixes,
         ),
     )
 

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -14,6 +14,8 @@ from stage import DEV, PROD, RELEASE_TEST, Stage
 _SECRET_NAME_PREFIX_PATTERN = re.compile(r"[A-Za-z0-9/_+=.@-]+")
 _LAMBDA_FUNCTION_NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\*?")
 _KMS_KEY_ARN_PATTERN = re.compile(r"arn:[^:]+:kms:[^:]+:[0-9]{12}:key/[A-Za-z0-9-]+")
+_OFFLINE_SYNTH_ORG_ID = "00000000-0000-0000-0000-000000000001"
+_OFFLINE_SYNTH_SECRET_PREFIX = "offline-synth"
 
 
 @dataclass(frozen=True)
@@ -151,10 +153,17 @@ def config_for(stage: Stage) -> StageConfig:
         return config
 
     deployment_role_org_ids = _csv_environment("AWS_DEPLOYMENT_ROLE_ORG_IDS")
+    tracker_secret_name_prefixes = _csv_environment("AWS_TRACKER_SECRET_NAME_PREFIXES")
     executor_secret_name_prefixes = _csv_environment("AWS_EXECUTOR_SECRET_NAME_PREFIXES")
+    if os.environ.get("DESCOPE_PROJECT_ID") == _OFFLINE_SYNTH_SECRET_PREFIX:
+        deployment_role_org_ids = deployment_role_org_ids or (_OFFLINE_SYNTH_ORG_ID,)
+        tracker_secret_name_prefixes = tracker_secret_name_prefixes or (_OFFLINE_SYNTH_SECRET_PREFIX,)
+        executor_secret_name_prefixes = executor_secret_name_prefixes or (_OFFLINE_SYNTH_SECRET_PREFIX,)
     if config.managed_aws.submissions_enabled:
         if not deployment_role_org_ids:
             raise ValueError("Development deployments require AWS_DEPLOYMENT_ROLE_ORG_IDS.")
+        if not tracker_secret_name_prefixes:
+            raise ValueError("Development deployments require AWS_TRACKER_SECRET_NAME_PREFIXES.")
         if not executor_secret_name_prefixes:
             raise ValueError("Development deployments require AWS_EXECUTOR_SECRET_NAME_PREFIXES.")
     return replace(
@@ -162,6 +171,7 @@ def config_for(stage: Stage) -> StageConfig:
         managed_aws=replace(
             config.managed_aws,
             deployment_role_org_ids=deployment_role_org_ids,
+            tracker_secret_name_prefixes=tracker_secret_name_prefixes,
             executor_secret_name_prefixes=executor_secret_name_prefixes,
         ),
     )

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -42,10 +42,7 @@ class DeployWorkflowTest(unittest.TestCase):
             "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
             dev_core,
         )
-        self.assertIn(
-            "AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}",
-            dev_core,
-        )
+        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", dev_core)
         self.assertIn("Deploy dev core stacks", dev_core)
         self.assertNotIn("services/executor_artifact/build.py", dev_core)
         self.assertNotIn("executor_release/main.py", dev_core)
@@ -115,10 +112,7 @@ class DeployWorkflowTest(unittest.TestCase):
             "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
             dev_executor,
         )
-        self.assertIn(
-            "AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}",
-            dev_executor,
-        )
+        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", dev_executor)
         self.assertIn("needs: [classify-deployment, deploy-production-core]", prod_executor)
         self.assertIn("environment: prod", prod_executor)
         self.assertNotIn("production-executor-approval", workflow)

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -34,6 +34,14 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("database_maintenance_required != 'true'", dev_core)
         self.assertIn("environment: dev", dev_core)
         self.assertIn("SCOPE: ${{ github.event_name == 'push' && 'core' || inputs.scope }}", dev_core)
+        self.assertIn(
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
+            dev_core,
+        )
+        self.assertIn(
+            "AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}",
+            dev_core,
+        )
         self.assertIn("Deploy dev core stacks", dev_core)
         self.assertNotIn("services/executor_artifact/build.py", dev_core)
         self.assertNotIn("executor_release/main.py", dev_core)
@@ -95,6 +103,14 @@ class DeployWorkflowTest(unittest.TestCase):
 
         self.assertIn("needs: [classify-deployment, run-dev-operation]", dev_executor)
         self.assertIn("environment: dev", dev_executor)
+        self.assertIn(
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
+            dev_executor,
+        )
+        self.assertIn(
+            "AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}",
+            dev_executor,
+        )
         self.assertIn("needs: [classify-deployment, deploy-production-core]", prod_executor)
         self.assertIn("environment: prod", prod_executor)
         self.assertNotIn("production-executor-approval", workflow)
@@ -249,6 +265,19 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("synthesize-head:", classification_workflow)
         self.assertIn("needs: [synthesize-base, synthesize-head]", classification_workflow)
         self.assertEqual(classification_workflow.count("enable-cache: false"), 2)
+        self.assertEqual(
+            classification_workflow.count("AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001"),
+            2,
+        )
+        self.assertEqual(
+            classification_workflow.count("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth"),
+            2,
+        )
+        self.assertIn(
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001",
+            workflow,
+        )
+        self.assertIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth", workflow)
         self.assertNotIn("id-token: write", classification_workflow)
         trusted_checkout = classification_workflow.split("      - name: Checkout trusted classifier", maxsplit=1)[
             1

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -39,6 +39,10 @@ class DeployWorkflowTest(unittest.TestCase):
             dev_core,
         )
         self.assertIn(
+            "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
+            dev_core,
+        )
+        self.assertIn(
             "AWS_EXECUTOR_SECRET_NAME_PREFIXES: ${{ secrets.AWS_EXECUTOR_SECRET_NAME_PREFIXES }}",
             dev_core,
         )
@@ -105,6 +109,10 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("environment: dev", dev_executor)
         self.assertIn(
             "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
+            dev_executor,
+        )
+        self.assertIn(
+            "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
             dev_executor,
         )
         self.assertIn(
@@ -273,11 +281,16 @@ class DeployWorkflowTest(unittest.TestCase):
             classification_workflow.count("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth"),
             2,
         )
+        self.assertEqual(
+            classification_workflow.count("AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth"),
+            2,
+        )
         self.assertIn(
             "AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001",
             workflow,
         )
         self.assertIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth", workflow)
+        self.assertIn("AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth", workflow)
         self.assertNotIn("id-token: write", classification_workflow)
         trusted_checkout = classification_workflow.split("      - name: Checkout trusted classifier", maxsplit=1)[
             1

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -63,6 +63,8 @@ DEV_TRACKER_CONTRACT_PARAMETERS = {
 EXECUTOR_CONTRACT_PARAMETERS = {executor_release_launch_parameter(DEV)}
 DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
 DEV_AUTH_ENV = {
+    "AWS_DEPLOYMENT_ROLE_ORG_IDS": "00000000-0000-0000-0000-000000000001",
+    "AWS_EXECUTOR_SECRET_NAME_PREFIXES": "test-executor-secret",
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
 }
@@ -367,7 +369,11 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         self.assertNotIn("s3:DeleteObject", policies)
 
     def test_dev_tracker_requires_descope_project(self) -> None:
-        with mock.patch.dict(os.environ, {}, clear=True):
+        managed_runtime_environment = {
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS": DEV_AUTH_ENV["AWS_DEPLOYMENT_ROLE_ORG_IDS"],
+            "AWS_EXECUTOR_SECRET_NAME_PREFIXES": DEV_AUTH_ENV["AWS_EXECUTOR_SECRET_NAME_PREFIXES"],
+        }
+        with mock.patch.dict(os.environ, managed_runtime_environment, clear=True):
             with self.assertRaisesRegex(ValueError, "Development deployments require DESCOPE_PROJECT_ID"):
                 dev_tracker_template()
 

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -65,7 +65,6 @@ DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
 DEV_AUTH_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": "00000000-0000-0000-0000-000000000001",
     "AWS_TRACKER_SECRET_NAME_PREFIXES": "test-tracker-secret",
-    "AWS_EXECUTOR_SECRET_NAME_PREFIXES": "test-executor-secret",
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
 }
@@ -373,7 +372,6 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         managed_runtime_environment = {
             "AWS_DEPLOYMENT_ROLE_ORG_IDS": DEV_AUTH_ENV["AWS_DEPLOYMENT_ROLE_ORG_IDS"],
             "AWS_TRACKER_SECRET_NAME_PREFIXES": DEV_AUTH_ENV["AWS_TRACKER_SECRET_NAME_PREFIXES"],
-            "AWS_EXECUTOR_SECRET_NAME_PREFIXES": DEV_AUTH_ENV["AWS_EXECUTOR_SECRET_NAME_PREFIXES"],
         }
         with mock.patch.dict(os.environ, managed_runtime_environment, clear=True):
             with self.assertRaisesRegex(ValueError, "Development deployments require DESCOPE_PROJECT_ID"):

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -64,6 +64,7 @@ EXECUTOR_CONTRACT_PARAMETERS = {executor_release_launch_parameter(DEV)}
 DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
 DEV_AUTH_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": "00000000-0000-0000-0000-000000000001",
+    "AWS_TRACKER_SECRET_NAME_PREFIXES": "test-tracker-secret",
     "AWS_EXECUTOR_SECRET_NAME_PREFIXES": "test-executor-secret",
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
@@ -371,6 +372,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
     def test_dev_tracker_requires_descope_project(self) -> None:
         managed_runtime_environment = {
             "AWS_DEPLOYMENT_ROLE_ORG_IDS": DEV_AUTH_ENV["AWS_DEPLOYMENT_ROLE_ORG_IDS"],
+            "AWS_TRACKER_SECRET_NAME_PREFIXES": DEV_AUTH_ENV["AWS_TRACKER_SECRET_NAME_PREFIXES"],
             "AWS_EXECUTOR_SECRET_NAME_PREFIXES": DEV_AUTH_ENV["AWS_EXECUTOR_SECRET_NAME_PREFIXES"],
         }
         with mock.patch.dict(os.environ, managed_runtime_environment, clear=True):

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -44,9 +44,11 @@ TEST_DEPLOYMENT_SLACK_ENV = {
 }
 TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
 TEST_MANAGED_ORG_ID = "00000000-0000-0000-0000-000000000001"
+TEST_TRACKER_SECRET_NAME_PREFIX = "test-tracker-secret"
 TEST_EXECUTOR_SECRET_NAME_PREFIX = "test-executor-secret"
 TEST_DEV_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": TEST_MANAGED_ORG_ID,
+    "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
     "AWS_EXECUTOR_SECRET_NAME_PREFIXES": TEST_EXECUTOR_SECRET_NAME_PREFIX,
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
@@ -224,13 +226,25 @@ def service_templates(
 
 class MonitoringStackTest(unittest.TestCase):
     def test_dev_managed_runtime_requires_deployment_authority(self) -> None:
-        for variable in ("AWS_DEPLOYMENT_ROLE_ORG_IDS", "AWS_EXECUTOR_SECRET_NAME_PREFIXES"):
+        for variable in (
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS",
+            "AWS_TRACKER_SECRET_NAME_PREFIXES",
+            "AWS_EXECUTOR_SECRET_NAME_PREFIXES",
+        ):
             with self.subTest(variable=variable):
                 environment = dict(TEST_DEV_ENV)
                 environment.pop(variable)
                 with mock.patch.dict(os.environ, environment, clear=True):
                     with self.assertRaisesRegex(ValueError, variable):
                         config_for(Stage(DEV))
+
+    def test_offline_synth_uses_safe_managed_runtime_placeholders(self) -> None:
+        with mock.patch.dict(os.environ, {"DESCOPE_PROJECT_ID": "offline-synth"}, clear=True):
+            managed_aws = config_for(Stage(DEV)).managed_aws
+
+        self.assertEqual(managed_aws.deployment_role_org_ids, (TEST_MANAGED_ORG_ID,))
+        self.assertEqual(managed_aws.tracker_secret_name_prefixes, ("offline-synth",))
+        self.assertEqual(managed_aws.executor_secret_name_prefixes, ("offline-synth",))
 
     def test_dev_stack_ids_are_valk_scoped(self) -> None:
         self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -31,7 +31,7 @@ from monitoring_stack import MonitoringStack
 from shared import SharedStack
 from executor_stack import ExecutorStack
 from stage import DEV, DEV_STACK_PREFIX, PROD, RELEASE_TEST, Stage
-from stage_config import DEV_CONFIG
+from stage_config import DEV_CONFIG, config_for
 from tracker_stack import TrackerStack
 
 TEST_ALERTS_SLACK_ENV = {
@@ -43,7 +43,11 @@ TEST_DEPLOYMENT_SLACK_ENV = {
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
 }
 TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
+TEST_MANAGED_ORG_ID = "00000000-0000-0000-0000-000000000001"
+TEST_EXECUTOR_SECRET_NAME_PREFIX = "test-executor-secret"
 TEST_DEV_ENV = {
+    "AWS_DEPLOYMENT_ROLE_ORG_IDS": TEST_MANAGED_ORG_ID,
+    "AWS_EXECUTOR_SECRET_NAME_PREFIXES": TEST_EXECUTOR_SECRET_NAME_PREFIX,
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
 }
@@ -219,6 +223,15 @@ def service_templates(
 
 
 class MonitoringStackTest(unittest.TestCase):
+    def test_dev_managed_runtime_requires_deployment_authority(self) -> None:
+        for variable in ("AWS_DEPLOYMENT_ROLE_ORG_IDS", "AWS_EXECUTOR_SECRET_NAME_PREFIXES"):
+            with self.subTest(variable=variable):
+                environment = dict(TEST_DEV_ENV)
+                environment.pop(variable)
+                with mock.patch.dict(os.environ, environment, clear=True):
+                    with self.assertRaisesRegex(ValueError, variable):
+                        config_for(Stage(DEV))
+
     def test_dev_stack_ids_are_valk_scoped(self) -> None:
         self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")
         self.assertEqual(Stage(DEV).stack_id("TrackerStack"), f"{DEV_STACK_PREFIX}TrackerStack")
@@ -593,7 +606,7 @@ class MonitoringStackTest(unittest.TestCase):
     def test_dev_stage_wires_stage_config_to_resources(self) -> None:
         with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
             tracker_template, executor_template, _ = service_templates(DEV)
-        with mock.patch.dict(os.environ, TEST_ALERTS_SLACK_ENV, clear=True):
+        with mock.patch.dict(os.environ, {**TEST_DEV_ENV, **TEST_ALERTS_SLACK_ENV}, clear=True):
             monitoring_template = _monitoring_template(DEV)
 
         tracker_template.has_resource_properties(

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -45,11 +45,9 @@ TEST_DEPLOYMENT_SLACK_ENV = {
 TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
 TEST_MANAGED_ORG_ID = "00000000-0000-0000-0000-000000000001"
 TEST_TRACKER_SECRET_NAME_PREFIX = "test-tracker-secret"
-TEST_EXECUTOR_SECRET_NAME_PREFIX = "test-executor-secret"
 TEST_DEV_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": TEST_MANAGED_ORG_ID,
     "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
-    "AWS_EXECUTOR_SECRET_NAME_PREFIXES": TEST_EXECUTOR_SECRET_NAME_PREFIX,
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
 }
@@ -229,7 +227,6 @@ class MonitoringStackTest(unittest.TestCase):
         for variable in (
             "AWS_DEPLOYMENT_ROLE_ORG_IDS",
             "AWS_TRACKER_SECRET_NAME_PREFIXES",
-            "AWS_EXECUTOR_SECRET_NAME_PREFIXES",
         ):
             with self.subTest(variable=variable):
                 environment = dict(TEST_DEV_ENV)
@@ -244,7 +241,8 @@ class MonitoringStackTest(unittest.TestCase):
 
         self.assertEqual(managed_aws.deployment_role_org_ids, (TEST_MANAGED_ORG_ID,))
         self.assertEqual(managed_aws.tracker_secret_name_prefixes, ("offline-synth",))
-        self.assertEqual(managed_aws.executor_secret_name_prefixes, ("offline-synth",))
+        self.assertEqual(managed_aws.executor_secret_name_prefixes, ())
+        self.assertTrue(managed_aws.executor_all_secret_access)
 
     def test_dev_stack_ids_are_valk_scoped(self) -> None:
         self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -9,12 +9,13 @@ import aws_cdk as cdk
 from aws_cdk import assertions, aws_s3
 
 from runtime_iam import create_executor_task_role, create_tracker_task_role
-from stage import DEV, Stage
+from stage import DEV, RELEASE_TEST, Stage
 from stage_config import ManagedAWSRuntimeConfig
 from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
     TEST_DEV_ENV,
+    TEST_RELEASE_TEST_ENV,
     JsonObject,
     service_templates,
 )
@@ -91,18 +92,21 @@ class RuntimeIamTest(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, field_name):
                     replace(config, **{field_name: value})
 
-    def test_managed_runtime_task_roles_are_scoped_and_closed_by_default(self) -> None:
+    def test_dev_managed_runtime_is_enabled_for_the_configured_org(self) -> None:
         with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
             tracker_template, executor_template, _ = service_templates(DEV)
 
         expected_environment = assertions.Match.array_with(
             [
-                {"Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS", "Value": ""},
+                {
+                    "Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS",
+                    "Value": "431bc4f8-c66b-47eb-8d53-2c4622be04e6",
+                },
                 {"Name": "AWS_DEPLOYMENT_REGION", "Value": TEST_AWS_REGION},
                 assertions.Match.object_like({"Name": "AWS_DEPLOYMENT_S3_BUCKET"}),
                 {"Name": "AWS_DEPLOYMENT_LOG_GROUP", "Value": "/valkyrie/benchmarks-dev"},
                 {"Name": "AWS_DEPLOYMENT_LOG_RETENTION_DAYS", "Value": "7"},
-                {"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "false"},
+                {"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "true"},
             ]
         )
 
@@ -125,6 +129,7 @@ class RuntimeIamTest(unittest.TestCase):
                 expected_actions
                 | {
                     "s3:AbortMultipartUpload",
+                    "secretsmanager:GetSecretValue",
                     "logs:CreateLogGroup",
                     "logs:PutRetentionPolicy",
                     "logs:CreateLogStream",
@@ -212,6 +217,12 @@ class RuntimeIamTest(unittest.TestCase):
                         self.assertEqual(_statement_actions(statement), {"ecs:UpdateTaskProtection"})
 
                 if role_name.startswith("ValkyrieExecutor"):
+                    secret_statement = next(
+                        statement
+                        for statement in statements
+                        if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
+                    )
+                    self.assertIn("secret:AgenticHarnessSecrets*", json.dumps(secret_statement["Resource"]))
                     log_statement = next(
                         statement for statement in statements if "logs:CreateLogStream" in _statement_actions(statement)
                     )
@@ -221,6 +232,34 @@ class RuntimeIamTest(unittest.TestCase):
                     )
                     self.assertIn("/valkyrie/benchmarks-dev/*", json.dumps(log_statement["Resource"]))
                     self.assertNotIn(":log-stream:", json.dumps(log_statement["Resource"]))
+
+    def test_release_test_managed_runtime_remains_closed(self) -> None:
+        with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):
+            tracker_template, executor_template, _ = service_templates(RELEASE_TEST)
+
+        expected_environment = assertions.Match.array_with(
+            [
+                {"Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS", "Value": ""},
+                {"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "false"},
+            ]
+        )
+        for template, role_name in (
+            (tracker_template, "ValkyrieTrackerTaskRole-release-test"),
+            (executor_template, "ValkyrieExecutorTaskRole-release-test"),
+        ):
+            template.has_resource_properties(
+                "AWS::ECS::TaskDefinition",
+                {
+                    "ContainerDefinitions": assertions.Match.array_with(
+                        [assertions.Match.object_like({"Environment": expected_environment})]
+                    )
+                },
+            )
+            role_logical_id, _ = _named_role(template, role_name)
+            actions = set[str]().union(
+                *(_statement_actions(statement) for statement in _role_policy_statements(template, role_logical_id))
+            )
+            self.assertNotIn("secretsmanager:GetSecretValue", actions)
 
     def test_managed_runtime_optional_grants_are_limited_to_configured_resources(self) -> None:
         app = cdk.App()

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -15,6 +15,8 @@ from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
     TEST_DEV_ENV,
+    TEST_EXECUTOR_SECRET_NAME_PREFIX,
+    TEST_MANAGED_ORG_ID,
     TEST_RELEASE_TEST_ENV,
     JsonObject,
     service_templates,
@@ -100,7 +102,7 @@ class RuntimeIamTest(unittest.TestCase):
             [
                 {
                     "Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS",
-                    "Value": "431bc4f8-c66b-47eb-8d53-2c4622be04e6",
+                    "Value": TEST_MANAGED_ORG_ID,
                 },
                 {"Name": "AWS_DEPLOYMENT_REGION", "Value": TEST_AWS_REGION},
                 assertions.Match.object_like({"Name": "AWS_DEPLOYMENT_S3_BUCKET"}),
@@ -222,7 +224,10 @@ class RuntimeIamTest(unittest.TestCase):
                         for statement in statements
                         if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
                     )
-                    self.assertIn("secret:AgenticHarnessSecrets*", json.dumps(secret_statement["Resource"]))
+                    self.assertIn(
+                        f"secret:{TEST_EXECUTOR_SECRET_NAME_PREFIX}*",
+                        json.dumps(secret_statement["Resource"]),
+                    )
                     log_statement = next(
                         statement for statement in statements if "logs:CreateLogStream" in _statement_actions(statement)
                     )

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -18,6 +18,7 @@ from test_monitoring_stack import (
     TEST_EXECUTOR_SECRET_NAME_PREFIX,
     TEST_MANAGED_ORG_ID,
     TEST_RELEASE_TEST_ENV,
+    TEST_TRACKER_SECRET_NAME_PREFIX,
     JsonObject,
     service_templates,
 )
@@ -122,7 +123,7 @@ class RuntimeIamTest(unittest.TestCase):
                 tracker_template,
                 "ValkyrieTrackerTaskRole-dev",
                 "TrackerTaskRoleArn",
-                expected_actions | {"s3:DeleteObject", "s3:DeleteObjectVersion"},
+                expected_actions | {"s3:DeleteObject", "s3:DeleteObjectVersion", "secretsmanager:GetSecretValue"},
             ),
             (
                 executor_template,
@@ -218,14 +219,18 @@ class RuntimeIamTest(unittest.TestCase):
                     if resources == "*" or (isinstance(resources, list) and "*" in resources):
                         self.assertEqual(_statement_actions(statement), {"ecs:UpdateTaskProtection"})
 
+                secret_statement = next(
+                    statement
+                    for statement in statements
+                    if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
+                )
                 if role_name.startswith("ValkyrieExecutor"):
-                    secret_statement = next(
-                        statement
-                        for statement in statements
-                        if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
-                    )
                     self.assertIn(
                         f"secret:{TEST_EXECUTOR_SECRET_NAME_PREFIX}*",
+                        json.dumps(secret_statement["Resource"]),
+                    )
+                    self.assertNotIn(
+                        f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*",
                         json.dumps(secret_statement["Resource"]),
                     )
                     log_statement = next(
@@ -237,6 +242,15 @@ class RuntimeIamTest(unittest.TestCase):
                     )
                     self.assertIn("/valkyrie/benchmarks-dev/*", json.dumps(log_statement["Resource"]))
                     self.assertNotIn(":log-stream:", json.dumps(log_statement["Resource"]))
+                else:
+                    self.assertIn(
+                        f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*",
+                        json.dumps(secret_statement["Resource"]),
+                    )
+                    self.assertNotIn(
+                        f"secret:{TEST_EXECUTOR_SECRET_NAME_PREFIX}*",
+                        json.dumps(secret_statement["Resource"]),
+                    )
 
     def test_release_test_managed_runtime_remains_closed(self) -> None:
         with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -15,7 +15,6 @@ from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
     TEST_DEV_ENV,
-    TEST_EXECUTOR_SECRET_NAME_PREFIX,
     TEST_MANAGED_ORG_ID,
     TEST_RELEASE_TEST_ENV,
     TEST_TRACKER_SECRET_NAME_PREFIX,
@@ -94,6 +93,13 @@ class RuntimeIamTest(unittest.TestCase):
             with self.subTest(field=field_name, value=value):
                 with self.assertRaisesRegex(ValueError, field_name):
                     replace(config, **{field_name: value})
+
+        with self.assertRaisesRegex(ValueError, "executor_all_secret_access"):
+            replace(
+                config,
+                executor_all_secret_access=True,
+                executor_secret_name_prefixes=("valkyrie/executor/",),
+            )
 
     def test_dev_managed_runtime_is_enabled_for_the_configured_org(self) -> None:
         with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
@@ -225,14 +231,10 @@ class RuntimeIamTest(unittest.TestCase):
                     if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
                 )
                 if role_name.startswith("ValkyrieExecutor"):
-                    self.assertIn(
-                        f"secret:{TEST_EXECUTOR_SECRET_NAME_PREFIX}*",
-                        json.dumps(secret_statement["Resource"]),
-                    )
-                    self.assertNotIn(
-                        f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*",
-                        json.dumps(secret_statement["Resource"]),
-                    )
+                    secret_resources = json.dumps(secret_statement["Resource"])
+                    self.assertIn("secretsmanager", secret_resources)
+                    self.assertIn("secret:*", secret_resources)
+                    self.assertNotIn(TEST_TRACKER_SECRET_NAME_PREFIX, secret_resources)
                     log_statement = next(
                         statement for statement in statements if "logs:CreateLogStream" in _statement_actions(statement)
                     )
@@ -243,14 +245,9 @@ class RuntimeIamTest(unittest.TestCase):
                     self.assertIn("/valkyrie/benchmarks-dev/*", json.dumps(log_statement["Resource"]))
                     self.assertNotIn(":log-stream:", json.dumps(log_statement["Resource"]))
                 else:
-                    self.assertIn(
-                        f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*",
-                        json.dumps(secret_statement["Resource"]),
-                    )
-                    self.assertNotIn(
-                        f"secret:{TEST_EXECUTOR_SECRET_NAME_PREFIX}*",
-                        json.dumps(secret_statement["Resource"]),
-                    )
+                    secret_resources = json.dumps(secret_statement["Resource"])
+                    self.assertIn("secretsmanager", secret_resources)
+                    self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
 
     def test_release_test_managed_runtime_remains_closed(self) -> None:
         with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):

--- a/services/tracker/src/tracker/aws/resolver.py
+++ b/services/tracker/src/tracker/aws/resolver.py
@@ -285,9 +285,9 @@ def resolve_agent_library_aws_runtime(
 
 
 def resolve_aws_runtime_metadata(org_id: UUID) -> AWSResources | None:
-    """Return non-secret deployment resource locations for an eligible organization."""
+    """Return deployment resources when managed submissions are available to the organization."""
     try:
-        if not organization_can_use_managed_aws(org_id):
+        if not config.AWS_MANAGED_SUBMISSIONS_ENABLED or not organization_can_use_managed_aws(org_id):
             return None
         return _managed_resources()
     except ManagedAWSConfigurationError as exc:

--- a/services/tracker/tests/unit/test_aws_runtime_resolver.py
+++ b/services/tracker/tests/unit/test_aws_runtime_resolver.py
@@ -14,7 +14,6 @@ from main import app
 from tracker import config
 from tracker.aws.clients import DefaultChainAWSClientProvider, ExplicitCredentialsAWSClientProvider
 from tracker.aws.resolver import (
-    resolve_aws_runtime_metadata,
     resolve_run_metadata_aws_runtime,
     resolve_run_aws_runtime,
     resolve_start_aws_runtime,
@@ -225,16 +224,38 @@ def test_run_runtime_rejects_managed_run_for_ineligible_org(monkeypatch: pytest.
     assert exc_info.value.status_code == 403
 
 
-@pytest.mark.parametrize("eligible", [True, False])
-def test_deployment_runtime_metadata_requires_eligible_org(
+@pytest.mark.parametrize(
+    ("eligible", "submissions_enabled", "expected_mode"),
+    [
+        pytest.param(True, True, "managed", id="eligible-and-open"),
+        pytest.param(True, False, "access_key", id="eligible-but-closed"),
+        pytest.param(False, True, "access_key", id="ineligible"),
+    ],
+)
+def test_aws_runtime_metadata_reflects_managed_submission_availability(
     monkeypatch: pytest.MonkeyPatch,
     eligible: bool,
+    submissions_enabled: bool,
+    expected_mode: Literal["access_key", "managed"],
 ) -> None:
-    _configure_managed_runtime(monkeypatch, eligible=eligible, submissions_enabled=False)
+    _configure_managed_runtime(
+        monkeypatch,
+        eligible=eligible,
+        submissions_enabled=submissions_enabled,
+    )
 
-    resources = resolve_aws_runtime_metadata(_ORG_ID)
+    response = TestClient(app).get("/aws-runtime")
 
-    assert (resources.s3_bucket if resources is not None else None) == ("deployment-bucket" if eligible else None)
+    assert response.status_code == 200
+    assert response.json() == (
+        {
+            "mode": "managed",
+            "region": "deployment-region",
+            "s3_bucket": "deployment-bucket",
+        }
+        if expected_mode == "managed"
+        else {"mode": "access_key", "region": None, "s3_bucket": None}
+    )
 
 
 def _mapping_keys(value: Any) -> Iterator[str]:


### PR DESCRIPTION
## Human Description

### Why

Managed AWS execution is implemented but remains closed in every environment. This change activates it in dev for the `vals.ai` organization and makes the runtime metadata endpoint report managed mode only when a request can actually start a managed run.

The Tracker and ExecutorHost receive the same organization allowlist and global submission gate. The executor task role can read all secrets in dev. Production stays closed. Release-test now has its own explicit closed configuration instead of inheriting dev rollout settings.

---

Managed AWS submissions can now be exercised in dev by allowlisted organizations using direct API requests without harness credentials. The Tracker retains prefix-scoped access to benchmark-service authentication secrets. The ExecutorHost can read all Secrets Manager secrets in the dev account and Region so agent contracts can resolve provider, agent, and webhook secrets without deployment inventory. Production and release-test remain closed.

## What changed

- Enable managed AWS submissions in dev for the `vals.ai` organization.
- Read the organization allowlist and Tracker secret prefixes from dev Environment secrets.
- Grant the dev ExecutorHost access to all Secrets Manager secrets in the dev account and Region. Tag-scoped access is tracked in vals-ai/valkyrie-ticket-library#218.
- Keep production and release-test closed with no managed organization or broad secret access.
- Return access-key metadata whenever either the organization allowlist or global submission gate blocks managed starts.
- Keep the standard CLI on the existing access-key path. The initial managed canary uses direct API requests without harness headers or a harness configuration.

## How to review

Start with `infra/stage_config.py` for the dev-only activation and `infra/runtime_iam.py` for the role boundary. Confirm the Tracker policy remains limited to configured service-authentication prefixes while the dev ExecutorHost policy grants only `secretsmanager:GetSecretValue` across secrets in the current dev account and Region. Then inspect `tracker/aws/resolver.py` for the metadata gate and the deployment workflows for the required dev inputs. Production and release-test must remain closed.

## Testing

Not yet live-tested. After this PR deploys to dev, call `GET /aws-runtime` with the `vals.ai` API key and no harness headers. Then start one credential-free `dummy` run through the API and one legacy access-key control run. Confirm the managed run uses the dev S3 bucket, CloudWatch log group, and required Secrets Manager values. Confirm the standard CLI continues to select the access-key path.

Design: not architectural (activates the existing managed AWS design in dev and aligns its metadata with the existing gate)
