### PR TITLE
fix(tracker): preserve outputs after agent timeout provider failures #patch

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -539,25 +539,27 @@ async def _stream_command_output_with_egress_allowlist(
     command: str,
     on_output: Callable[[str], None],
     allowed_addresses: list[str],
+    agent_timeout: float | None = None,
 ) -> tuple[AgentCausedExitReason | None, float]:
     if not allowed_addresses:
-        return await stream_command_output(sandbox, command, on_output)
+        return await stream_command_output(sandbox, command, on_output, agent_timeout)
 
-    command_completed = False
+    cleanup_must_succeed = False
     try:
         await _apply_egress_allowlist(sandbox, allowed_addresses)
-        result = await stream_command_output(sandbox, command, on_output)
-        command_completed = True
+        result = await stream_command_output(sandbox, command, on_output, agent_timeout)
+        cleanup_must_succeed = result[0] is not AgentCausedExitReason.TIMEOUT
         return result
     finally:
         # After a clean agent run, stale egress rules would affect evaluation; otherwise preserve the original error.
-        await _clear_egress_allowlist(sandbox, fail_on_error=command_completed)
+        await _clear_egress_allowlist(sandbox, fail_on_error=cleanup_must_succeed)
 
 
 async def stream_command_output(
     sandbox: Sandbox,
     command: str,
     on_output: Callable[[str], None],
+    agent_timeout: float | None = None,
 ) -> tuple[AgentCausedExitReason | None, float]:
     # Bounded tail of recent output, kept only for error messages; capped by characters
     # rather than chunk count since a single chunk can be arbitrarily large.
@@ -592,6 +594,10 @@ async def stream_command_output(
         except SandboxNotFoundError:
             raise
         except ProviderSandboxError as e:
+            duration = time.monotonic() - monotonic_start
+            if agent_timeout is not None and duration >= agent_timeout:
+                logger.warning("agent command failed after its timeout; preserving sandbox outputs", exc_info=True)
+                return AgentCausedExitReason.TIMEOUT, duration
             raise SandboxError(str(e)) from e
 
         # Prefer the sandbox-measured duration; fall back to the tracker-side monotonic
@@ -902,6 +908,7 @@ async def run_agent(
         f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}",
         log_output,
         contract.egress_allowlist,
+        agent_timeout,
     )
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -544,7 +544,7 @@ class TestArchiveAndUploadOutput:
 class TestRunAgent:
     """Agent execution, output collection, and runtime command construction."""
 
-    async def test_run_agent_uploads_declared_output_artifacts(
+    async def test_run_agent_uploads_declared_output_artifacts_after_timeout(
         self,
         monkeypatch: pytest.MonkeyPatch,
         aws_runtime: AWSRuntime,
@@ -563,8 +563,8 @@ class TestRunAgent:
                 return ExecResult(exit_code=0, output="")
             raise AssertionError(f"unexpected command: {command}")
 
-        async def fake_stream_command_output(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
-            return None, 0.0
+        async def fake_stream_command_output(*_args: Any, **_kwargs: Any) -> tuple[AgentCausedExitReason, float]:
+            return AgentCausedExitReason.TIMEOUT, 0.0
 
         async def fake_upload_output_artifacts(
             _sandbox: Any,
@@ -689,7 +689,9 @@ class TestRunAgent:
             assert command == "mkdir -p /workspace"
             return ExecResult(exit_code=0)
 
-        async def fake_stream_command_output(sandbox: Any, command: str, _log_output: Any) -> tuple[None, float]:
+        async def fake_stream_command_output(
+            sandbox: Any, command: str, _log_output: Any, _agent_timeout: float | None
+        ) -> tuple[None, float]:
             observed_sandboxes.append(sandbox)
             assert command == "cd /workspace && PYTHONSAFEPATH=1 echo done"
             return None, 0.0
@@ -741,7 +743,9 @@ class TestRunAgent:
             assert command == "mkdir -p /workspace"
             return ExecResult(exit_code=0)
 
-        async def fake_stream_command_output(_sandbox: Any, command: str, _log_output: Any) -> tuple[None, float]:
+        async def fake_stream_command_output(
+            _sandbox: Any, command: str, _log_output: Any, _agent_timeout: float | None
+        ) -> tuple[None, float]:
             observed_commands.append(command)
             return None, 0.0
 
@@ -1641,6 +1645,28 @@ class TestEgressAllowlist:
         mock_sandbox.modify_egress_rules.assert_not_awaited()
         mock_sandbox.clear_egress_rules.assert_not_awaited()
 
+    async def test_timeout_keeps_egress_cleanup_best_effort(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def timed_out_stream(*_args: Any, **_kwargs: Any) -> tuple[AgentCausedExitReason, float]:
+            return AgentCausedExitReason.TIMEOUT, 10.0
+
+        monkeypatch.setattr(sandbox_module, "stream_command_output", timed_out_stream)
+        mock_sandbox = Mock(
+            id="sandbox-123",
+            modify_egress_rules=AsyncMock(),
+            clear_egress_rules=AsyncMock(side_effect=ProviderSandboxError("provider failed")),
+        )
+
+        result = await _stream_command_output_with_egress_allowlist(
+            mock_sandbox,
+            "run-agent.sh",
+            on_output=_ignore_output,
+            allowed_addresses=["https://api.openai.com"],
+            agent_timeout=10.0,
+        )
+
+        assert result == (AgentCausedExitReason.TIMEOUT, 10.0)
+        assert mock_sandbox.clear_egress_rules.await_count == 3
+
     @pytest.mark.parametrize(
         ("provider_error", "expected_error", "message"),
         [
@@ -1734,6 +1760,22 @@ class TestStreamCommandOutputAgentFailure:
         # No crash on int() of the cat error text; duration degrades to the monotonic fallback.
         assert exit_reason is None
         assert duration >= 0
+
+    async def test_provider_failure_after_agent_timeout_is_recoverable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def failed_command(_command: str) -> AsyncIterator[str]:
+            if False:
+                yield ""
+            raise ProviderSandboxError("Daytona PTY exited before writing command status")
+
+        mock_sandbox = Mock(command=failed_command, exec=AsyncMock(return_value=ExecResult(exit_code=0)))
+        monkeypatch.setattr(sandbox_module, "time", Mock(monotonic=Mock(side_effect=(100.0, 110.0))))
+
+        exit_reason, duration = await sandbox_module.stream_command_output(
+            mock_sandbox, "run-agent.sh", on_output=lambda _: None, agent_timeout=10.0
+        )
+
+        assert exit_reason is AgentCausedExitReason.TIMEOUT
+        assert duration == 10.0
 
     @pytest.mark.parametrize("exit_code", [1, 2, 127])
     async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(


### PR DESCRIPTION
## Summary
- Treat a provider failure after the configured agent timeout as a recoverable timeout.
- Continue output upload and evaluation from the existing sandbox.
- Keep provider failures before the timeout fatal.

Context: https://valsai.slack.com/archives/C07RTLD8JN7/p1787075177218369

## Verification
- `uv run pytest services/tracker/tests/unit -q` (616 passed)
- `uv run ruff check services/tracker/src/tracker/sandbox.py services/tracker/tests/unit/test_sandbox.py`
- `uv run basedpyright services/tracker/src/tracker/sandbox.py services/tracker/tests/unit/test_sandbox.py`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->