### PR TITLE
chore(sdk): support Python 3.11 (0.2.7)

### DIFF
--- a/.github/workflows/sdk-package.yml
+++ b/.github/workflows/sdk-package.yml
@@ -146,7 +146,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.11", "3.13", "3.14"]
 
     steps:
       - name: Set up Python

--- a/docs/sdk/README.md
+++ b/docs/sdk/README.md
@@ -1,6 +1,6 @@
 # Python SDK
 
-Use Valkyrie's async Python SDK to manage runs from Python. The SDK requires Python 3.12 or newer.
+Use Valkyrie's async Python SDK to manage runs from Python. The SDK requires Python 3.11 or newer.
 
 ## Installation
 

--- a/packages/valkyrie-sdk/pyproject.toml
+++ b/packages/valkyrie-sdk/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "valkyrie-sdk"
-version = "0.2.6"
+version = "0.2.7"
 description = "Async Python SDK for managing Valkyrie benchmark runs"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 license = "AGPL-3.0-only"
 license-files = ["LICENSE"]
 dependencies = [
@@ -45,7 +45,7 @@ include = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.format]
 quote-style = "double"
@@ -53,7 +53,7 @@ indent-style = "space"
 
 [tool.basedpyright]
 typeCheckingMode = "strict"
-pythonVersion = "3.12"
+pythonVersion = "3.11"
 include = ["src"]
 reportExplicitAny = false
 reportAny = false

--- a/tests/unit/sdk/test_artifact_validation.py
+++ b/tests/unit/sdk/test_artifact_validation.py
@@ -23,7 +23,7 @@ Name: valkyrie-sdk
 Version: {SDK_VERSION}
 License-Expression: AGPL-3.0-only
 License-File: LICENSE
-Requires-Python: >=3.12
+Requires-Python: >=3.11
 Requires-Dist: httpx<1,>=0.28.1
 Requires-Dist: pydantic<3,>=2
 Requires-Dist: pyyaml<7,>=6.0.3
@@ -80,9 +80,9 @@ def test_sdk_package_configuration_matches_release_boundaries() -> None:
         sdk_project = tomllib.load(sdk_file)
 
     assert root_project["project"]["requires-python"] == ">=3.12,<3.13"
-    assert sdk_project["project"]["requires-python"] == ">=3.12"
+    assert sdk_project["project"]["requires-python"] == ">=3.11"
     assert root_project["tool"]["basedpyright"]["pythonVersion"] == "3.12"
-    assert sdk_project["tool"]["basedpyright"]["pythonVersion"] == "3.12"
+    assert sdk_project["tool"]["basedpyright"]["pythonVersion"] == "3.11"
     assert sdk_project["build-system"]["requires"] == ["hatchling==1.27.0"]
     assert (PACKAGE_ROOT / ".gitignore").read_text(encoding="utf-8") == ".ruff_cache/\n__pycache__/\ndist/\n"
 

--- a/tests/unit/sdk/test_workflows.py
+++ b/tests/unit/sdk/test_workflows.py
@@ -87,9 +87,9 @@ def test_workflows_verify_the_exact_artifacts() -> None:
     assert upload["with"]["name"] == "valkyrie-sdk-${{ steps.version.outputs.version }}"
 
 
-def test_sdk_ci_checks_newer_python_versions() -> None:
+def test_sdk_ci_checks_supported_python_versions() -> None:
     compatibility = load("sdk-package.yml")["jobs"]["compatibility"]
     assert compatibility["needs"] == "package"
-    assert compatibility["strategy"]["matrix"]["python-version"] == ["3.13", "3.14"]
+    assert compatibility["strategy"]["matrix"]["python-version"] == ["3.11", "3.13", "3.14"]
     install = next(step["run"] for step in compatibility["steps"] if step["name"] == "Install and import SDK")
     assert "--prerelease=disallow" in install

--- a/uv.lock
+++ b/uv.lock
@@ -2540,7 +2540,7 @@ dev = [
 
 [[package]]
 name = "valkyrie-sdk"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "packages/valkyrie-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

`valkyrie-sdk` declared `requires-python = ">=3.12"` only because it inherits the Valkyrie workspace's own pin — the SDK source itself uses nothing newer than 3.11. That pin blocks consumers still on 3.11, specifically `benchmarks/benchmark-be` (vals-ai/benchmarks#2666), which is switching its Valkyrie launcher from shelling out to `valk` to `ValkyrieClient.runs.start(...)` and cannot resolve the SDK today.

This lowers the SDK floor to 3.11 (version `0.2.7`) and adds 3.11 to the packaging compatibility matrix so the floor stays enforced. The workspace/root interpreter, Tracker, and CLI are untouched — only the standalone package's metadata, its ruff/basedpyright target, and CI change.

## Changes

- `packages/valkyrie-sdk/pyproject.toml`: `requires-python = ">=3.11"`, ruff `py311`, basedpyright `pythonVersion = "3.11"`, version `0.2.6` → `0.2.7`.
- `.github/workflows/sdk-package.yml`: compatibility matrix `["3.13", "3.14"]` → `["3.11", "3.13", "3.14"]`, so the wheel is installed and imported on the new floor.
- `tests/unit/sdk/{test_artifact_validation,test_workflows}.py`: release-boundary and CI-matrix expectations follow the new floor.
- `docs/sdk/README.md`: the one sentence stating the required Python version.

Note the SDK's basedpyright target is now 3.11 while the root stays 3.12, so 3.12-only syntax/stdlib in `packages/valkyrie-sdk/src` now fails type checking — that is the point of the change.

## Related Issues

Closes #

Unblocks vals-ai/benchmarks#2666 (`bench-valk-run` on the SDK) and vals-ai/valkyrie-ticket-library#46.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing

Built the 0.2.7 distributions from this branch and installed the wheel into a clean Python 3.11 venv (the version this PR newly allows), then imported and constructed the client against the local hosted config:

```
$ uv build --package valkyrie-sdk --no-sources --out-dir /tmp/sdkdist
Successfully built /tmp/sdkdist/valkyrie_sdk-0.2.7.tar.gz
Successfully built /tmp/sdkdist/valkyrie_sdk-0.2.7-py3-none-any.whl

$ uv venv /tmp/sdk311v --python 3.11 && uv pip install --python /tmp/sdk311v/bin/python --prerelease=disallow /tmp/sdkdist/*.whl
 + valkyrie-sdk==0.2.7 (from file:///tmp/sdkdist/valkyrie_sdk-0.2.7-py3-none-any.whl)

$ /tmp/sdk311v/bin/python -VV
Python 3.11.12 (main, May 30 2025, 05:38:39) [Clang 20.1.4 ]

$ /tmp/sdk311v/bin/python -c "from valkyrie.sdk import ValkyrieClient; ..."
<class 'valkyrie.sdk.client.ValkyrieClient'>
valkyrie-sdk 0.2.7 >=3.11

$ /tmp/sdk311v/bin/python -c "async with ValkyrieClient.from_config(path='~/.config/valkyrie/valkyrie.yaml') as c: ..."
client ok: ValkyrieClient runs resource: RunsResource
```

No live Tracker call was made from 3.11 — no run was started, fetched, or mutated, so the wire path on 3.11 is verified only up to client construction against the hosted config.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/d85ab9af74ef44ea8773d347b32fba89
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->