### PR TITLE
fix(tracker): reactivate terminal runs when resuming with no runnable tasks

### DIFF
--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -191,17 +191,6 @@ async def reset_to_in_progress_status(
         else:
             new_task_ids = [tid for tid in rerun_task_ids if tid not in existing_by_task_id]
 
-        # Allow re-running the end of the benchmark without running any tasks
-        if not existing_rows and not new_task_ids:
-            return []
-
-        # Verify the task ids are still valid before priming to resume
-        # Raises if any task ids are invalid
-        all_requested_task_ids = [task.task_id for task in existing_rows] + new_task_ids
-        verify_response = await benchmark_service.verify_task_ids(
-            task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
-        )
-
         old_evaluation = benchmark_row.final_evaluation
         if old_evaluation is not None:
             benchmark_row.final_evaluation = None
@@ -212,6 +201,17 @@ async def reset_to_in_progress_status(
             benchmark_row.status = BenchmarkStatus.IN_PROGRESS
         benchmark_row.finished_at = None
         session.add(benchmark_row)
+
+        # Allow re-running the end of the benchmark without running any tasks
+        if not existing_rows and not new_task_ids:
+            return []
+
+        # Verify the task ids are still valid before priming to resume
+        # Raises if any task ids are invalid
+        all_requested_task_ids = [task.task_id for task in existing_rows] + new_task_ids
+        verify_response = await benchmark_service.verify_task_ids(
+            task_ids=all_requested_task_ids, slice_str=None, dataset=benchmark_row.arguments.dataset
+        )
 
         for task in existing_rows:
             task.status = (

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -816,6 +816,42 @@ class TestRunRecovery:
         }
 
     @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_resume_with_no_runnable_tasks_reactivates_terminal_run(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+    ) -> None:
+        """Re-running only the end of a terminal run must leave it IN_PROGRESS.
+
+        A run whose tasks all FINISHED but whose final score failed has nothing to
+        re-run; clearing finished_at while the status is still terminal violates
+        benchmark_finished_requires_timestamp.
+        """
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.ERROR
+        benchmark_row.finished_at = datetime.now(ZoneInfo("UTC"))
+        database_session.add(benchmark_row)
+        database_session.add(
+            Task(org_id=TEST_ORG_ID, task_id="task_0", benchmark=benchmark_row.id, status=TaskStatus.FINISHED),
+        )
+        database_session.commit()
+
+        verified_task_ids = await reset_to_in_progress_status(
+            benchmark_row=benchmark_row,
+            session=database_session,
+            benchmark_service=benchmark_row.benchmark_service(),
+            retry=False,
+            retry_mode=RetryMode.AUTO,
+            rerun_task_ids=[],
+            org=self._test_org,
+        )
+        database_session.commit()
+
+        assert verified_task_ids == []
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+        assert benchmark_row.finished_at is None
+
+    @pytest.mark.usefixtures("process_benchmark_env")
     async def test_error_retry_with_task_ids_only_resets_requested_tasks(
         self,
         example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -367,6 +367,15 @@ class TestRunState:
         )
         assert response.status_code == 200
 
+        # That resume dispatched a new execution, so the run is active again
+        benchmark_row = fetch_benchmark_row(benchmark_row.id, database_session, self._test_org)
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+
+        # Back to a terminal run for the task id validation cases below
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
+
         # Ensure that we can recreate the environment the benchmark was started in
         original_start_benchmark_request = StartBenchmarkRequest(
             contract=contract,


### PR DESCRIPTION
## Summary
`POST /retry-or-resume-benchmark/{id}` 500s for a terminal run whose tasks are all `FINISHED` and whose only failure was the final score — exactly the state of the qwen3.8-27b SNAP run `b9514fba-7551-4939-9b74-4c6c449290d8` (`230/230` finished, `Final score failed with status code 500`), which cannot be finalized today.

`reset_to_in_progress_status` returned early when there was nothing to re-run, leaving `status` terminal, and `admit_recovery_dispatch` then cleared `finished_at`, producing a row that Postgres rejects:

```
CheckViolation: new row for relation "benchmark" violates check constraint "benchmark_finished_requires_timestamp"
```

Fix: reactivate the run (drop the stale final evaluation, set `IN_PROGRESS`, clear `finished_at`) *before* the no-runnable-tasks early return, so the row is internally consistent whichever path is taken. Runs with retryable work are unaffected — same statements, just ordered earlier.

## Changes
- `services/tracker/src/tracker/utils/run_control.py`: move the final-evaluation cleanup and `status`/`finished_at` reset above the early return for the finalize-only case.
- `services/tracker/tests/unit/utils/test_run_recovery.py`: regression test — resuming a terminal run with only `FINISHED` tasks leaves it `IN_PROGRESS` with `finished_at is None` (fails on `dev` with the check violation).
- `services/tracker/tests/unit/utils/test_run_state.py`: the existing edge-case test asserted the old behavior implicitly (the run stayed `STOPPED` after a finalize-only resume, so a later request took the terminal path); it now asserts the run is reactivated and resets it to `STOPPED` for the task-id validation cases that follow.

## Related Issues
Sentry: https://vals-ai.sentry.io/issues/VALKYRIE-DX

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

Unit tests (local): `cd services/tracker && uv run pytest tests/unit -q` → `616 passed`. Lint/types: `uv run ruff check`, `ruff format --check`, `uv run basedpyright src/tracker/utils/run_control.py` all clean.

Not live-tested: the failing path is in the hosted tracker, so verifying the real SNAP resume requires this change deployed. Once it is, `uv run valk run resume b9514fba-7551-4939-9b74-4c6c449290d8` should finalize instead of returning `Internal Server Error`.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/ce7ef89facc947f58424e63bb845d712
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/710" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->