### PR TITLE
fix(tracker): restore single Alembic head

### DIFF
--- a/services/tracker/src/tracker/database/migrations/versions/50c3051116fa_merge_task_failure_and_managed_aws_heads.py
+++ b/services/tracker/src/tracker/database/migrations/versions/50c3051116fa_merge_task_failure_and_managed_aws_heads.py
@@ -1,0 +1,29 @@
+"""merge task failure and managed AWS heads
+
+Revision ID: 50c3051116fa
+Revises: a3f4b5c6d7e8, e5f6a7b8c9d0
+Create Date: 2026-08-19 00:15:58.535240
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '50c3051116fa'
+down_revision: Union[str, Sequence[str], None] = ('a3f4b5c6d7e8', 'e5f6a7b8c9d0')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/services/tracker/src/tracker/database/migrations/versions/50c3051116fa_merge_task_failure_and_managed_aws_heads.py
+++ b/services/tracker/src/tracker/database/migrations/versions/50c3051116fa_merge_task_failure_and_managed_aws_heads.py
@@ -5,8 +5,8 @@ Revises: a3f4b5c6d7e8, e5f6a7b8c9d0
 Create Date: 2026-08-19 00:15:58.535240
 
 """
-from typing import Sequence, Union
 
+from typing import Sequence, Union
 
 
 # revision identifiers, used by Alembic.

--- a/services/tracker/src/tracker/database/migrations/versions/50c3051116fa_merge_task_failure_and_managed_aws_heads.py
+++ b/services/tracker/src/tracker/database/migrations/versions/50c3051116fa_merge_task_failure_and_managed_aws_heads.py
@@ -7,14 +7,11 @@ Create Date: 2026-08-19 00:15:58.535240
 """
 from typing import Sequence, Union
 
-from alembic import op
-import sqlalchemy as sa
-import sqlmodel
 
 
 # revision identifiers, used by Alembic.
-revision: str = '50c3051116fa'
-down_revision: Union[str, Sequence[str], None] = ('a3f4b5c6d7e8', 'e5f6a7b8c9d0')
+revision: str = "50c3051116fa"
+down_revision: Union[str, Sequence[str], None] = ("a3f4b5c6d7e8", "e5f6a7b8c9d0")
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/tracker/src/tracker/database/migrations/versions/a3f4b5c6d7e8_add_task_attempt_failure_history.py
+++ b/services/tracker/src/tracker/database/migrations/versions/a3f4b5c6d7e8_add_task_attempt_failure_history.py
@@ -1,7 +1,7 @@
 """Add factual task error provenance.
 
 Revision ID: a3f4b5c6d7e8
-Revises: f0a1b2c3d4e5
+Revises: e5f6a7b8c9d0
 Create Date: 2026-08-13 00:00:00.000000
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "a3f4b5c6d7e8"
-down_revision: Union[str, Sequence[str], None] = "f0a1b2c3d4e5"
+down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/tracker/src/tracker/database/migrations/versions/a3f4b5c6d7e8_add_task_attempt_failure_history.py
+++ b/services/tracker/src/tracker/database/migrations/versions/a3f4b5c6d7e8_add_task_attempt_failure_history.py
@@ -1,7 +1,7 @@
 """Add factual task error provenance.
 
 Revision ID: a3f4b5c6d7e8
-Revises: e5f6a7b8c9d0
+Revises: f0a1b2c3d4e5
 Create Date: 2026-08-13 00:00:00.000000
 """
 
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "a3f4b5c6d7e8"
-down_revision: Union[str, Sequence[str], None] = "e5f6a7b8c9d0"
+down_revision: Union[str, Sequence[str], None] = "f0a1b2c3d4e5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/services/tracker/tests/integration/local/database/test_migrations.py
+++ b/services/tracker/tests/integration/local/database/test_migrations.py
@@ -11,6 +11,8 @@ from time import monotonic, sleep
 from uuid import uuid4
 
 import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import inspect, text
 from sqlmodel import Session, create_engine
 from testcontainers.postgres import PostgresContainer
@@ -33,6 +35,12 @@ _PREVIOUS_REVISION = "d8e9f0a1b2c3"
 _MAINTENANCE_REVISION = "f0a1b2c3d4e5"
 _ERROR_RESULT_PROVENANCE_REVISION = "a3f4b5c6d7e8"
 _MIGRATION_ADVISORY_LOCK_ID = 0x56414C4B59524945
+
+
+def test_migration_graph_has_single_head() -> None:
+    heads = ScriptDirectory.from_config(Config(str(_ALEMBIC_INI))).get_heads()
+
+    assert len(heads) == 1, f"Expected one Alembic head, found {heads}"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changed

- Reparent the undeployed failure-provenance migration onto the current Alembic head.
- Add a database-free regression test requiring exactly one Alembic head.

## Why

The development Tracker rollout for merge `c8145fc5` failed during startup because migrations `a3f4b5c6d7e8` and `e5f6a7b8c9d0` both declared `f0a1b2c3d4e5` as their parent. Alembic aborted before applying the new migration. Reparenting the undeployed migration restores the linear graph:

`f0a1b2c3d4e5 -> e5f6a7b8c9d0 -> a3f4b5c6d7e8`

No database stamp, manual SQL, migration operation, or deployment configuration changes are included.

## How tested

- `uv run alembic heads --verbose`
- `uv run pytest tests/integration/local/database/test_migrations.py::test_migration_graph_has_single_head tests/integration/local/database/test_migrations.py::test_error_result_provenance_migration_preserves_legacy_rows`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->