### PR TITLE
feat(tracker): expose managed task logs #minor

### DIFF
--- a/services/tracker/openapi.json
+++ b/services/tracker/openapi.json
@@ -1,0 +1,3814 @@
+{
+  "components": {
+    "schemas": {
+      "AWSCredentials": {
+        "properties": {
+          "aws_access_key_id": {
+            "title": "Aws Access Key Id",
+            "type": "string"
+          },
+          "aws_default_region": {
+            "title": "Aws Default Region",
+            "type": "string"
+          },
+          "aws_secret_access_key": {
+            "title": "Aws Secret Access Key",
+            "type": "string"
+          },
+          "aws_session_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aws Session Token"
+          }
+        },
+        "required": [
+          "aws_access_key_id",
+          "aws_secret_access_key",
+          "aws_default_region"
+        ],
+        "title": "AWSCredentials",
+        "type": "object"
+      },
+      "AWSRuntimeResponse": {
+        "properties": {
+          "mode": {
+            "enum": [
+              "access_key",
+              "managed"
+            ],
+            "title": "Mode",
+            "type": "string"
+          },
+          "region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Region"
+          },
+          "s3_bucket": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "S3 Bucket"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "title": "AWSRuntimeResponse",
+        "type": "object"
+      },
+      "AgentContractRequest-Input": {
+        "properties": {
+          "egress_allowlist": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Egress Allowlist",
+            "type": "array"
+          },
+          "final_output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Output"
+          },
+          "install_cmd": {
+            "default": "",
+            "title": "Install Cmd",
+            "type": "string"
+          },
+          "kwargs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Kwargs",
+            "type": "object"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "output_artifacts": {
+            "default": [],
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputArtifact-Input"
+                }
+              ]
+            },
+            "title": "Output Artifacts",
+            "type": "array"
+          },
+          "run_cmd": {
+            "default": "",
+            "title": "Run Cmd",
+            "type": "string"
+          },
+          "secrets": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Secrets",
+            "type": "object"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "AgentContractRequest",
+        "type": "object"
+      },
+      "AgentContractRequest-Output": {
+        "properties": {
+          "egress_allowlist": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Egress Allowlist",
+            "type": "array"
+          },
+          "final_output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Output"
+          },
+          "install_cmd": {
+            "default": "",
+            "title": "Install Cmd",
+            "type": "string"
+          },
+          "kwargs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Kwargs",
+            "type": "object"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "output_artifacts": {
+            "default": [],
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/OutputArtifact-Output"
+                }
+              ]
+            },
+            "title": "Output Artifacts",
+            "type": "array"
+          },
+          "run_cmd": {
+            "default": "",
+            "title": "Run Cmd",
+            "type": "string"
+          },
+          "secrets": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Secrets",
+            "type": "object"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "AgentContractRequest",
+        "type": "object"
+      },
+      "AgentDownloadURLResponse": {
+        "properties": {
+          "download_url": {
+            "title": "Download Url",
+            "type": "string"
+          },
+          "expires_in": {
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "download_url",
+          "expires_in"
+        ],
+        "title": "AgentDownloadURLResponse",
+        "type": "object"
+      },
+      "AgentEntry": {
+        "properties": {
+          "last_modified": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Modified"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "AgentEntry",
+        "type": "object"
+      },
+      "AgentsResponse": {
+        "properties": {
+          "agents": {
+            "items": {
+              "$ref": "#/components/schemas/AgentEntry"
+            },
+            "title": "Agents",
+            "type": "array"
+          }
+        },
+        "required": [
+          "agents"
+        ],
+        "title": "AgentsResponse",
+        "type": "object"
+      },
+      "AnalyzeBenchmarkRequest": {
+        "properties": {
+          "lambda_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lambda Function"
+          },
+          "no_cache": {
+            "default": false,
+            "title": "No Cache",
+            "type": "boolean"
+          }
+        },
+        "title": "AnalyzeBenchmarkRequest",
+        "type": "object"
+      },
+      "AverageTaskBreakdown": {
+        "properties": {
+          "agent_run_duration": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Run Duration"
+          },
+          "evaluation_run_duration": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Run Duration"
+          },
+          "sandbox_build_duration": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Build Duration"
+          },
+          "sandbox_run_duration": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Run Duration"
+          }
+        },
+        "required": [
+          "sandbox_build_duration",
+          "agent_run_duration",
+          "evaluation_run_duration",
+          "sandbox_run_duration"
+        ],
+        "title": "AverageTaskBreakdown",
+        "type": "object"
+      },
+      "BenchmarkArguments": {
+        "additionalProperties": false,
+        "properties": {
+          "concurrency": {
+            "title": "Concurrency",
+            "type": "integer"
+          },
+          "contract": {
+            "$ref": "#/components/schemas/AgentContractRequest-Output"
+          },
+          "dataset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset"
+          },
+          "lambda_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lambda Function"
+          },
+          "sandbox_provider": {
+            "default": "daytona",
+            "title": "Sandbox Provider",
+            "type": "string"
+          },
+          "sandbox_provider_secret_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Provider Secret Name"
+          },
+          "slice_str": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slice Str"
+          },
+          "task_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Ids"
+          }
+        },
+        "required": [
+          "contract",
+          "concurrency"
+        ],
+        "title": "BenchmarkArguments",
+        "type": "object"
+      },
+      "BenchmarkServiceCatalogResponse": {
+        "properties": {
+          "services": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkServiceEntry"
+            },
+            "title": "Services",
+            "type": "array"
+          }
+        },
+        "required": [
+          "services"
+        ],
+        "title": "BenchmarkServiceCatalogResponse",
+        "type": "object"
+      },
+      "BenchmarkServiceEntry": {
+        "properties": {
+          "auth_header_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auth Header Name"
+          },
+          "auth_secret_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Auth Secret Name"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url"
+        ],
+        "title": "BenchmarkServiceEntry",
+        "type": "object"
+      },
+      "BenchmarkServiceHealth": {
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "healthy": {
+            "title": "Healthy",
+            "type": "boolean"
+          },
+          "latency_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latency Ms"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "url": {
+            "title": "Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "url",
+          "healthy",
+          "latency_ms"
+        ],
+        "title": "BenchmarkServiceHealth",
+        "type": "object"
+      },
+      "BenchmarkServicesRequest": {
+        "properties": {
+          "services": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkServiceEntry"
+            },
+            "title": "Services",
+            "type": "array"
+          }
+        },
+        "title": "BenchmarkServicesRequest",
+        "type": "object"
+      },
+      "BenchmarkServicesResponse": {
+        "properties": {
+          "services": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkServiceHealth"
+            },
+            "title": "Services",
+            "type": "array"
+          }
+        },
+        "required": [
+          "services"
+        ],
+        "title": "BenchmarkServicesResponse",
+        "type": "object"
+      },
+      "BenchmarkStatus": {
+        "enum": [
+          "IN_PROGRESS",
+          "STOPPING",
+          "STOPPED",
+          "FINISHED",
+          "ERROR"
+        ],
+        "title": "BenchmarkStatus",
+        "type": "string"
+      },
+      "BenchmarkStatusEntry": {
+        "properties": {
+          "current_execution_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Execution Release Id"
+          },
+          "executor_artifact_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Artifact Digest"
+          },
+          "executor_protocol_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Protocol Version"
+          },
+          "executor_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Release Id"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "finished_tasks": {
+            "title": "Finished Tasks",
+            "type": "integer"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BenchmarkStatus"
+          },
+          "task_state_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Task State Counts",
+            "type": "object"
+          },
+          "total_tasks": {
+            "title": "Total Tasks",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "finished_at",
+          "total_tasks",
+          "finished_tasks"
+        ],
+        "title": "BenchmarkStatusEntry",
+        "type": "object"
+      },
+      "BenchmarkStatusResponse": {
+        "properties": {
+          "entries": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkStatusEntry"
+            },
+            "title": "Entries",
+            "type": "array"
+          }
+        },
+        "required": [
+          "entries"
+        ],
+        "title": "BenchmarkStatusResponse",
+        "type": "object"
+      },
+      "BenchmarkTableRow": {
+        "properties": {
+          "agent_name": {
+            "title": "Agent Name",
+            "type": "string"
+          },
+          "current_execution_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Execution Release Id"
+          },
+          "dataset": {
+            "default": "default",
+            "title": "Dataset",
+            "type": "string"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "executor_artifact_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Artifact Digest"
+          },
+          "executor_protocol_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Protocol Version"
+          },
+          "executor_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Release Id"
+          },
+          "final_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Score"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "finished_tasks": {
+            "title": "Finished Tasks",
+            "type": "integer"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string"
+          },
+          "started_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started By Email"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BenchmarkStatus"
+          },
+          "task_state_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Task State Counts",
+            "type": "object"
+          },
+          "total_tasks": {
+            "title": "Total Tasks",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "agent_name",
+          "model",
+          "started_by_email",
+          "started_at",
+          "finished_at",
+          "status",
+          "total_tasks",
+          "finished_tasks"
+        ],
+        "title": "BenchmarkTableRow",
+        "type": "object"
+      },
+      "Body_retry_or_resume_benchmark": {
+        "properties": {
+          "benchmark_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Benchmark Url"
+          },
+          "secrets": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Secrets",
+            "type": "object"
+          },
+          "service_headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "default": {},
+            "title": "Service Headers",
+            "type": "object"
+          },
+          "task_ids": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Task Ids",
+            "type": "array"
+          }
+        },
+        "title": "Body_retry_or_resume_benchmark",
+        "type": "object"
+      },
+      "Body_stop_benchmark": {
+        "properties": {
+          "task_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Ids"
+          }
+        },
+        "title": "Body_stop_benchmark",
+        "type": "object"
+      },
+      "FetchBenchmarkMetadataResponse": {
+        "properties": {
+          "benchmark_arguments": {
+            "$ref": "#/components/schemas/BenchmarkArguments"
+          },
+          "benchmark_id": {
+            "format": "uuid",
+            "title": "Benchmark Id",
+            "type": "string"
+          },
+          "benchmark_name": {
+            "title": "Benchmark Name",
+            "type": "string"
+          },
+          "current_execution_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Execution Release Id"
+          },
+          "executor_artifact_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Artifact Digest"
+          },
+          "executor_artifact_uri": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Artifact Uri"
+          },
+          "executor_protocol_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Protocol Version"
+          },
+          "executor_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Release Id"
+          },
+          "started_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started By Email"
+          }
+        },
+        "required": [
+          "benchmark_id",
+          "benchmark_name",
+          "benchmark_arguments"
+        ],
+        "title": "FetchBenchmarkMetadataResponse",
+        "type": "object"
+      },
+      "FetchBenchmarkTasksRequest": {
+        "properties": {
+          "benchmark_name": {
+            "title": "Benchmark Name",
+            "type": "string"
+          },
+          "custom_benchmark_service": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Benchmark Service"
+          },
+          "dataset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset"
+          },
+          "service_headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Service Headers",
+            "type": "object"
+          }
+        },
+        "required": [
+          "benchmark_name"
+        ],
+        "title": "FetchBenchmarkTasksRequest",
+        "type": "object"
+      },
+      "FetchBenchmarksResponse": {
+        "properties": {
+          "benchmarks": {
+            "items": {
+              "$ref": "#/components/schemas/BenchmarkTableRow"
+            },
+            "title": "Benchmarks",
+            "type": "array"
+          },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
+          "total_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Count"
+          }
+        },
+        "required": [
+          "benchmarks"
+        ],
+        "title": "FetchBenchmarksResponse",
+        "type": "object"
+      },
+      "FilterOptionsResponse": {
+        "properties": {
+          "agent_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Agent Names",
+            "type": "array"
+          },
+          "benchmark_names": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Benchmark Names",
+            "type": "array"
+          }
+        },
+        "required": [
+          "benchmark_names",
+          "agent_names"
+        ],
+        "title": "FilterOptionsResponse",
+        "type": "object"
+      },
+      "FinalEvaluation": {
+        "properties": {
+          "benchmark": {
+            "title": "Benchmark",
+            "type": "string"
+          },
+          "final_score": {
+            "title": "Final Score",
+            "type": "number"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "org_id": {
+            "format": "uuid",
+            "title": "Org Id",
+            "type": "string"
+          },
+          "properties": {
+            "additionalProperties": true,
+            "title": "Properties",
+            "type": "object"
+          }
+        },
+        "required": [
+          "org_id",
+          "benchmark",
+          "final_score"
+        ],
+        "title": "FinalEvaluation",
+        "type": "object"
+      },
+      "FinalViewResponse": {
+        "properties": {
+          "average_task_breakdown": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AverageTaskBreakdown"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "benchmark_arguments": {
+            "$ref": "#/components/schemas/BenchmarkArguments"
+          },
+          "benchmark_id": {
+            "format": "uuid",
+            "title": "Benchmark Id",
+            "type": "string"
+          },
+          "benchmark_name": {
+            "title": "Benchmark Name",
+            "type": "string"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "evaluation_results": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Results"
+          },
+          "final_evaluation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FinalEvaluation"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "started_at": {
+            "format": "date-time",
+            "title": "Started At",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BenchmarkStatus"
+          },
+          "task_errors": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Errors"
+          },
+          "tasks_stopped": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tasks Stopped"
+          }
+        },
+        "required": [
+          "benchmark_id",
+          "benchmark_name",
+          "started_at",
+          "finished_at",
+          "status",
+          "error_message",
+          "benchmark_arguments",
+          "tasks_stopped",
+          "final_evaluation",
+          "average_task_breakdown",
+          "evaluation_results",
+          "task_errors"
+        ],
+        "title": "FinalViewResponse",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "HarnessConfig": {
+        "properties": {
+          "aws": {
+            "$ref": "#/components/schemas/AWSCredentials"
+          },
+          "log_group": {
+            "title": "Log Group",
+            "type": "string"
+          },
+          "log_retention_policy": {
+            "title": "Log Retention Policy",
+            "type": "integer"
+          },
+          "s3_bucket": {
+            "title": "S3 Bucket",
+            "type": "string"
+          },
+          "sandbox_provider_secret_name": {
+            "title": "Sandbox Provider Secret Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "aws",
+          "s3_bucket",
+          "log_group",
+          "log_retention_policy",
+          "sandbox_provider_secret_name"
+        ],
+        "title": "HarnessConfig",
+        "type": "object"
+      },
+      "Order": {
+        "enum": [
+          "asc",
+          "desc"
+        ],
+        "title": "Order",
+        "type": "string"
+      },
+      "OutputArtifact-Input": {
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "required": {
+            "default": true,
+            "title": "Required",
+            "type": "boolean"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          }
+        },
+        "required": [
+          "path"
+        ],
+        "title": "OutputArtifact",
+        "type": "object"
+      },
+      "OutputArtifact-Output": {
+        "additionalProperties": true,
+        "type": "object"
+      },
+      "RetryMode": {
+        "enum": [
+          "auto",
+          "from_scratch"
+        ],
+        "title": "RetryMode",
+        "type": "string"
+      },
+      "RetryOrResumeBenchmarkResponse": {
+        "properties": {
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "RetryOrResumeBenchmarkResponse",
+        "type": "object"
+      },
+      "S3UploadResultsResponse": {
+        "properties": {
+          "console_url": {
+            "title": "Console Url",
+            "type": "string"
+          },
+          "expires_in": {
+            "default": 86400,
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "presigned_url": {
+            "title": "Presigned Url",
+            "type": "string"
+          },
+          "s3_url": {
+            "title": "S3 Url",
+            "type": "string"
+          }
+        },
+        "required": [
+          "s3_url",
+          "presigned_url",
+          "console_url"
+        ],
+        "title": "S3UploadResultsResponse",
+        "type": "object"
+      },
+      "SingleBenchmarkResponse": {
+        "description": "Single-run view: BenchmarkTableRow fields plus optional final_score.",
+        "properties": {
+          "agent_name": {
+            "title": "Agent Name",
+            "type": "string"
+          },
+          "cloudwatch_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cloudwatch Url"
+          },
+          "current_execution_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Execution Release Id"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "executor_artifact_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Artifact Digest"
+          },
+          "executor_protocol_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Protocol Version"
+          },
+          "executor_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Release Id"
+          },
+          "final_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Final Score"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "finished_tasks": {
+            "title": "Finished Tasks",
+            "type": "integer"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "s3_bucket_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "S3 Bucket Url"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string"
+          },
+          "started_by_email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started By Email"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BenchmarkStatus"
+          },
+          "task_state_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Task State Counts",
+            "type": "object"
+          },
+          "total_tasks": {
+            "title": "Total Tasks",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "agent_name",
+          "model",
+          "started_at",
+          "finished_at",
+          "status",
+          "total_tasks",
+          "finished_tasks"
+        ],
+        "title": "SingleBenchmarkResponse",
+        "type": "object"
+      },
+      "SingleTaskResponse": {
+        "properties": {
+          "agent_caused_exit_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Caused Exit Reason"
+          },
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "evaluation_result": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Result"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TaskStatus"
+          },
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "task_id",
+          "status",
+          "started_at",
+          "finished_at",
+          "error_message",
+          "evaluation_result",
+          "agent_caused_exit_reason"
+        ],
+        "title": "SingleTaskResponse",
+        "type": "object"
+      },
+      "StartBenchmarkRequest": {
+        "properties": {
+          "benchmark_name": {
+            "title": "Benchmark Name",
+            "type": "string"
+          },
+          "concurrency": {
+            "default": 5,
+            "title": "Concurrency",
+            "type": "integer"
+          },
+          "contract": {
+            "$ref": "#/components/schemas/AgentContractRequest-Input"
+          },
+          "custom_benchmark_service": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Custom Benchmark Service"
+          },
+          "dataset": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset"
+          },
+          "harness_config": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/HarnessConfig"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "lambda_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lambda Function"
+          },
+          "sandbox_provider": {
+            "default": "daytona",
+            "title": "Sandbox Provider",
+            "type": "string"
+          },
+          "sandbox_provider_secret_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sandbox Provider Secret Name"
+          },
+          "service_auth_header_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Auth Header Name"
+          },
+          "service_auth_secret_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Service Auth Secret Name"
+          },
+          "service_headers": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Service Headers",
+            "type": "object"
+          },
+          "slice_str": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Slice Str"
+          },
+          "task_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Ids"
+          },
+          "webhook_intervals": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Intervals"
+          },
+          "webhook_secret_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Webhook Secret Name"
+          }
+        },
+        "required": [
+          "contract",
+          "benchmark_name"
+        ],
+        "title": "StartBenchmarkRequest",
+        "type": "object"
+      },
+      "StartBenchmarkResponse": {
+        "properties": {
+          "agent_name": {
+            "title": "Agent Name",
+            "type": "string"
+          },
+          "benchmark_id": {
+            "format": "uuid",
+            "title": "Benchmark Id",
+            "type": "string"
+          },
+          "benchmark_name": {
+            "title": "Benchmark Name",
+            "type": "string"
+          },
+          "cloudwatch_url": {
+            "title": "Cloudwatch Url",
+            "type": "string"
+          },
+          "concurrency": {
+            "title": "Concurrency",
+            "type": "integer"
+          },
+          "current_execution_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Current Execution Release Id"
+          },
+          "executor_artifact_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Artifact Digest"
+          },
+          "executor_protocol_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Protocol Version"
+          },
+          "executor_release_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Executor Release Id"
+          },
+          "s3_bucket_url": {
+            "title": "S3 Bucket Url",
+            "type": "string"
+          },
+          "started_at": {
+            "format": "date-time",
+            "title": "Started At",
+            "type": "string"
+          },
+          "task_count": {
+            "title": "Task Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "benchmark_name",
+          "agent_name",
+          "benchmark_id",
+          "concurrency",
+          "started_at",
+          "task_count",
+          "cloudwatch_url",
+          "s3_bucket_url"
+        ],
+        "title": "StartBenchmarkResponse",
+        "type": "object"
+      },
+      "StopBenchmarkResponse": {
+        "properties": {
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "StopBenchmarkResponse",
+        "type": "object"
+      },
+      "TaskArtifactsResponse": {
+        "properties": {
+          "agent_output_expires_in": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Output Expires In"
+          },
+          "agent_output_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Output Url"
+          },
+          "cloudwatch_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cloudwatch Url"
+          }
+        },
+        "required": [
+          "cloudwatch_url",
+          "agent_output_url",
+          "agent_output_expires_in"
+        ],
+        "title": "TaskArtifactsResponse",
+        "type": "object"
+      },
+      "TaskLogAttempt": {
+        "properties": {
+          "current": {
+            "title": "Current",
+            "type": "boolean"
+          },
+          "first_event_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Event At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "last_event_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Event At"
+          },
+          "started_at": {
+            "format": "date-time",
+            "title": "Started At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "started_at",
+          "first_event_at",
+          "last_event_at",
+          "current"
+        ],
+        "title": "TaskLogAttempt",
+        "type": "object"
+      },
+      "TaskLogAttemptsResponse": {
+        "properties": {
+          "attempts": {
+            "items": {
+              "$ref": "#/components/schemas/TaskLogAttempt"
+            },
+            "title": "Attempts",
+            "type": "array"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "attempts",
+          "truncated"
+        ],
+        "title": "TaskLogAttemptsResponse",
+        "type": "object"
+      },
+      "TaskLogEvent": {
+        "properties": {
+          "ingestion_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingestion Time"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          }
+        },
+        "required": [
+          "timestamp",
+          "ingestion_time",
+          "message"
+        ],
+        "title": "TaskLogEvent",
+        "type": "object"
+      },
+      "TaskLogEventsResponse": {
+        "properties": {
+          "events": {
+            "items": {
+              "$ref": "#/components/schemas/TaskLogEvent"
+            },
+            "title": "Events",
+            "type": "array"
+          },
+          "newer_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Newer Cursor"
+          },
+          "older_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Older Cursor"
+          }
+        },
+        "required": [
+          "events",
+          "older_cursor",
+          "newer_cursor"
+        ],
+        "title": "TaskLogEventsResponse",
+        "type": "object"
+      },
+      "TaskStatus": {
+        "enum": [
+          "PENDING",
+          "BUILDING",
+          "IN_PROGRESS",
+          "EVALUATING",
+          "STOPPED",
+          "FINISHED",
+          "ERROR"
+        ],
+        "title": "TaskStatus",
+        "type": "string"
+      },
+      "TaskSummary": {
+        "properties": {
+          "error_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Message"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "started_at": {
+            "title": "Started At",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/TaskStatus"
+          },
+          "task_id": {
+            "title": "Task Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "task_id",
+          "status",
+          "started_at",
+          "finished_at"
+        ],
+        "title": "TaskSummary",
+        "type": "object"
+      },
+      "TasksResponse": {
+        "properties": {
+          "tasks": {
+            "items": {
+              "$ref": "#/components/schemas/TaskSummary"
+            },
+            "title": "Tasks",
+            "type": "array"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "tasks",
+          "total_count"
+        ],
+        "title": "TasksResponse",
+        "type": "object"
+      },
+      "UpdateBenchmarkConcurrencyRequest": {
+        "properties": {
+          "concurrency": {
+            "minimum": 1.0,
+            "title": "Concurrency",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "concurrency"
+        ],
+        "title": "UpdateBenchmarkConcurrencyRequest",
+        "type": "object"
+      },
+      "UpdateBenchmarkConcurrencyResponse": {
+        "properties": {
+          "benchmark_id": {
+            "format": "uuid",
+            "title": "Benchmark Id",
+            "type": "string"
+          },
+          "concurrency": {
+            "title": "Concurrency",
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/BenchmarkStatus"
+          }
+        },
+        "required": [
+          "benchmark_id",
+          "status",
+          "concurrency"
+        ],
+        "title": "UpdateBenchmarkConcurrencyResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "ctx": {
+            "title": "Context",
+            "type": "object"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "VerifyTaskIdsResponse": {
+        "description": "Response containing verified task IDs that exist in your benchmark.",
+        "properties": {
+          "task_ids": {
+            "description": "List of verified task IDs that exist in the benchmark",
+            "items": {
+              "type": "string"
+            },
+            "title": "Task Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "task_ids"
+        ],
+        "title": "VerifyTaskIdsResponse",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "FastAPI",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/agents": {
+      "get": {
+        "description": "List agent zips under the org's S3 bucket.",
+        "operationId": "list_agents_endpoint",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "List Agents Endpoint"
+      }
+    },
+    "/agents/{name}/download-url": {
+      "get": {
+        "description": "Return a 5-minute presigned URL to download agents/<name>.zip.",
+        "operationId": "get_agent_download_url",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDownloadURLResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Agent Download Url"
+      }
+    },
+    "/analyze-benchmark/{benchmark_id}": {
+      "post": {
+        "description": "Invoke the Docent analyzer Lambda for a benchmark and emit SSE-formatted progress events\n(started/heartbeat/done/error) that clients consume as buffered text (the response is read\nin full; the terminal done/error event carries the result).\n\nCache short-circuit: when the benchmark already has docent_reading_status=DONE and\nno_cache=false, returns the existing reading_plan_url without invoking the Lambda.",
+        "operationId": "analyze_benchmark",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnalyzeBenchmarkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Analyze Benchmark"
+      }
+    },
+    "/aws-runtime": {
+      "get": {
+        "description": "Return managed AWS resource locations without credential material.",
+        "operationId": "fetch_aws_runtime_metadata",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AWSRuntimeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Fetch Aws Runtime Metadata"
+      }
+    },
+    "/benchmark-services": {
+      "get": {
+        "description": "Fetch catalog benchmark services visible to the caller.",
+        "operationId": "catalog_benchmark_services",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BenchmarkServiceCatalogResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Catalog Benchmark Services"
+      },
+      "post": {
+        "description": "Health-check the caller-provided benchmark services with concurrent pings.",
+        "operationId": "list_benchmark_services",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BenchmarkServicesRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BenchmarkServicesResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Benchmark Services"
+      }
+    },
+    "/benchmarks/filter-options": {
+      "get": {
+        "description": "Distinct benchmark + agent names in this org, for the runs-list filter dropdowns.",
+        "operationId": "get_filter_options",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterOptionsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Get Filter Options"
+      }
+    },
+    "/benchmarks/status": {
+      "get": {
+        "description": "Return status + task-count breakdown for the listed benchmark ids.",
+        "operationId": "get_benchmarks_status",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "ids",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Ids",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BenchmarkStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Benchmarks Status"
+      }
+    },
+    "/benchmarks/{benchmark_id}": {
+      "get": {
+        "description": "Fetch a single benchmark with task counts + final score for the SingleRun page.",
+        "operationId": "get_single_benchmark",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleBenchmarkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Single Benchmark"
+      }
+    },
+    "/benchmarks/{benchmark_id}/concurrency": {
+      "patch": {
+        "operationId": "patch_benchmark_concurrency",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateBenchmarkConcurrencyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpdateBenchmarkConcurrencyResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Patch Benchmark Concurrency"
+      }
+    },
+    "/benchmarks/{benchmark_id}/tasks": {
+      "get": {
+        "description": "Paginated tasks for a benchmark, with optional status filter + task-id search.\n\nsort=status desc surfaces errors first (attention priority). Default: started_at desc.",
+        "operationId": "get_benchmark_tasks",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Status",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "task_id_search",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Task Id Search"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "default": "started_at",
+              "enum": [
+                "task_id",
+                "started_at",
+                "duration",
+                "status"
+              ],
+              "title": "Sort",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_dir",
+            "required": false,
+            "schema": {
+              "default": "desc",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "title": "Sort Dir",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TasksResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Benchmark Tasks"
+      }
+    },
+    "/benchmarks/{benchmark_id}/tasks/{task_id}": {
+      "get": {
+        "description": "Fetch a single task's status + evaluation result for the SingleTask page.",
+        "operationId": "get_single_task",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleTaskResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Single Task"
+      }
+    },
+    "/benchmarks/{benchmark_id}/tasks/{task_id}/artifacts": {
+      "get": {
+        "description": "CloudWatch URL + presigned URL for the agent's output tarball, for the SingleTask page.",
+        "operationId": "get_task_artifacts",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskArtifactsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Task Artifacts"
+      }
+    },
+    "/benchmarks/{benchmark_id}/tasks/{task_id}/logs/attempts": {
+      "get": {
+        "description": "List CloudWatch log attempts through the run's persisted AWS runtime.",
+        "operationId": "get_task_log_attempts",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskLogAttemptsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Task Log Attempts"
+      }
+    },
+    "/benchmarks/{benchmark_id}/tasks/{task_id}/logs/events": {
+      "get": {
+        "description": "Read one bounded CloudWatch page through the run's persisted AWS runtime.",
+        "operationId": "get_task_log_events",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "task_id",
+            "required": true,
+            "schema": {
+              "title": "Task Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "attempt_id",
+            "required": true,
+            "schema": {
+              "pattern": "^[0-9a-f]{1,16}$",
+              "title": "Attempt Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "direction",
+            "required": false,
+            "schema": {
+              "default": "initial",
+              "enum": [
+                "initial",
+                "older",
+                "newer"
+              ],
+              "title": "Direction",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 4096,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskLogEventsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Task Log Events"
+      }
+    },
+    "/check-results-exist": {
+      "get": {
+        "description": "Check if the benchmark's final view already exists in S3.\n\nUsage:\ncurl -X GET http://<endpoint>/check-results-exist?benchmark_id=<uuid>\n\nReturns:\n    {\"exists\": true/false}",
+        "operationId": "check_results_exist",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "boolean"
+                  },
+                  "title": "Response Check Results Exist",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Check Results Exist"
+      }
+    },
+    "/fetch-benchmark": {
+      "get": {
+        "description": "Fetch a benchmark by its id.\n\nUsage:\ncurl -X GET http://<endpoint>/fetch-benchmark/<benchmark_id>?connect=true\n\nReturns:\n    FetchBenchmarkResponse\n\nReturns:\n- 200 OK if benchmark is found\n- 404 Not Found if benchmark is not found",
+        "operationId": "fetch_benchmark",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "connect",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Connect",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fetch Benchmark"
+      }
+    },
+    "/fetch-benchmark-metadata/{benchmark_id}": {
+      "get": {
+        "description": "Fetch benchmark metadata by its id.\n\nUsage:\ncurl -X GET http://<endpoint>/fetch-benchmark-metadata/<benchmark_id>\n\nReturns:\n    FetchBenchmarkMetadataResponse",
+        "operationId": "fetch_benchmark_metadata",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchBenchmarkMetadataResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fetch Benchmark Metadata"
+      }
+    },
+    "/fetch-benchmark-tasks": {
+      "post": {
+        "description": "Fetch all task ids for a benchmark dataset.",
+        "operationId": "fetch_benchmark_tasks",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FetchBenchmarkTasksRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VerifyTaskIdsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fetch Benchmark Tasks"
+      }
+    },
+    "/fetch-benchmarks": {
+      "get": {
+        "description": "Fetch benchmarks based on the request parameters.\n\nUsage:\ncurl -X GET http://<endpoint>/fetch-benchmarks?agent_name=claude_code&benchmark_name=swebench&status=IN_PROGRESS&order_by=DESC&limit=5&offset=0",
+        "operationId": "fetch_benchmarks",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "agent_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "benchmark_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Benchmark Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "$ref": "#/components/schemas/BenchmarkStatus"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "started_by",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Started By"
+            }
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dataset",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Dataset"
+            }
+          },
+          {
+            "in": "query",
+            "name": "label",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Label"
+            }
+          },
+          {
+            "in": "query",
+            "name": "started_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Started After"
+            }
+          },
+          {
+            "in": "query",
+            "name": "started_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Started Before"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Order",
+              "default": "desc"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Cursor"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "maximum": 500,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "required": false,
+            "schema": {
+              "default": 0,
+              "minimum": 0,
+              "title": "Offset",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FetchBenchmarksResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fetch Benchmarks"
+      }
+    },
+    "/fetch-run-outputs/{benchmark_id}": {
+      "get": {
+        "description": "Stream a tar file with run outputs to the client.\n\nUsage:\ncurl -X GET http://<endpoint>/fetch-run-outputs/<benchmark_id>\n\nReturns:\n    StreamingResponse",
+        "operationId": "fetch_run_outputs",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "task_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Task Ids"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Fetch Run Outputs"
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Health check to ensure that the tracker service is running correctly.\n\nUsage:\ncurl -X GET http://<endpoint>/health\n\nReturns:\n{\n    \"status\": \"ok\"\n}\n\nReturns:\n- 200 OK if the server is running and database is accessible\n- 503 Service Unavailable if the database is not accessible",
+        "operationId": "health_check",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "title": "Response Health Check",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health Check"
+      }
+    },
+    "/init": {
+      "post": {
+        "description": "Initialize org for hosted mode. Validates Descope key and creates org if needed.",
+        "operationId": "init_org",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ]
+                  },
+                  "title": "Response Init Org",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Init Org"
+      }
+    },
+    "/retrieve-results": {
+      "get": {
+        "description": "Retrieve the results of a benchmark by its id. When task_ids is non-empty, the final view is\nfiltered to that subset and the final score is recomputed over the subset; the persisted\nFinalEvaluation / per-task rows are left untouched.\n\nNote: with `s3=True` the S3 final view at the canonical key is overwritten with whatever was\njust computed (full or subset). The DB remains source of truth, so re-running without\ntask_ids re-uploads the canonical full view.\n\nUsage:\ncurl -X GET http://<endpoint>/retrieve-results?benchmark_id=<uuid>&s3=false\ncurl -X GET 'http://<endpoint>/retrieve-results?benchmark_id=<uuid>&task_ids=task_1&task_ids=task_2'",
+        "operationId": "retrieve_results",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "s3",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "S3",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "task_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Task Ids"
+            }
+          },
+          {
+            "in": "query",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/FinalViewResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/S3UploadResultsResponse"
+                    }
+                  ],
+                  "title": "Response Retrieve Results"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retrieve Results"
+      }
+    },
+    "/retry-or-resume-benchmark/{benchmark_id}": {
+      "post": {
+        "description": "Retry or resume a benchmark run by its id.\n\nUsage:\ncurl -X POST http://<endpoint>/retry-or-resume-benchmark/<benchmark_id>?retry=true&concurrency=20\n  -d '{\"task_ids\": [\"task_id_1\", \"task_id_2\"]}'\n\nArgs:\n    benchmark_id: The benchmark ID to retry/resume\n    retry: If true, retry failed tasks. If false, resume from where it left off\n    concurrency: Optional new concurrency level (overrides original value)\n    task_ids: Optional list of specific task IDs to run. If a task id is not yet\n        registered but is valid in the current dataset, a fresh PENDING row is created.\n    benchmark_url: Optional replacement benchmark service URL stored on the run.\n\nReturns:\n    RetryOrResumeBenchmarkResponse",
+        "operationId": "retry_or_resume_benchmark",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "retry",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Retry",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "retry_mode",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/RetryMode",
+              "default": "auto"
+            }
+          },
+          {
+            "in": "query",
+            "name": "concurrency",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Concurrency"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_retry_or_resume_benchmark"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetryOrResumeBenchmarkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Retry Or Resume Benchmark"
+      }
+    },
+    "/start-benchmark": {
+      "post": {
+        "description": "Start a benchmark run with the uploaded contract.\n\nUsage:\ncurl -X POST http://<endpoint>/start-benchmark       -H \"Content-Type: application/json\"       -d '{\"agent_name\": \"claude_code\", \"benchmark_name\": \"swebench\", \"task_ids\": [\"astropy__astropy-12907\"]}'\n\nReturns:\n    StartBenchmarkResponse\n\nReturns:\n- 200 OK if benchmark starts successfully\n- 400 Bad Request if parameters are invalid\n- 500 Internal Server Error if benchmark fails to start",
+        "operationId": "start_benchmark",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/StartBenchmarkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StartBenchmarkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Start Benchmark"
+      }
+    },
+    "/stop-benchmark/{benchmark_id}": {
+      "post": {
+        "description": "Stop a benchmark by its id.\nIf force is True, the database run is stopped immediately and provider kill signals are sent\nwithout waiting for provider teardown to complete.\n\nUsage:\ncurl -X POST http://<endpoint>/stop-benchmark/<benchmark_id>?force=true\n\nReturns:\n    StopBenchmarkResponse",
+        "operationId": "stop_benchmark",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "benchmark_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Benchmark Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Force",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_stop_benchmark"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StopBenchmarkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Stop Benchmark"
+      }
+    }
+  }
+}

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
-from typing import cast
+from datetime import datetime, timezone
+from typing import Literal, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException
+from botocore.exceptions import BotoCoreError, ClientError
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlmodel import Session, col, desc, select
 
 from tracker.api.dependencies import RunAWSDependency
 from tracker.auth import get_current_org
-from tracker.aws.cloudwatch_logs import get_benchmark_log_url
+from tracker.aws.cloudwatch_logs import get_benchmark_log_url, sanitize_log_stream_name
 from tracker.aws.s3 import S3_BENCHMARKS_PREFIX, create_presigned_url, s3_object_exists
 from tracker.database.models import (
     Benchmark,
@@ -21,9 +23,18 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.database.session import get_session
-from tracker.types import SingleTaskResponse, TaskArtifactsResponse
+from tracker.types import (
+    SingleTaskResponse,
+    TaskArtifactsResponse,
+    TaskLogAttempt,
+    TaskLogAttemptsResponse,
+    TaskLogEvent,
+    TaskLogEventsResponse,
+)
 
 router = APIRouter(prefix="/benchmarks")
+_MAX_LOG_ATTEMPTS = 2_000
+_MAX_LOG_RESPONSE_BYTES = 1_900_000
 
 
 def _load_task_or_404(benchmark_id: UUID, task_id: str, org: Org, session: Session) -> tuple[Benchmark, Task]:
@@ -149,3 +160,200 @@ async def get_task_artifacts(
         agent_output_url=agent_output_url,
         agent_output_expires_in=ttl_seconds,
     )
+
+
+@router.get(
+    "/{benchmark_id}/tasks/{task_id:path}/logs/attempts",
+    response_model=TaskLogAttemptsResponse,
+)
+def get_task_log_attempts(
+    benchmark_id: UUID,
+    task_id: str,
+    run_context: RunAWSDependency,
+    org: Org = Depends(get_current_org),
+    session: Session = Depends(get_session),
+) -> TaskLogAttemptsResponse:
+    """List CloudWatch log attempts through the run's persisted AWS runtime."""
+    task = _load_task_for_benchmark_or_404(run_context.benchmark, task_id, org, session)
+    runtime = run_context.aws_runtime
+    client = runtime.clients.cloudwatch_logs_client()
+    prefix = sanitize_log_stream_name(task.task_id)
+    current_stream = _task_log_stream_name(task)
+    reserved_stream_names = _reserved_log_stream_names(session, run_context.benchmark.id, org.id)
+    streams: list[dict[str, object]] = []
+    token: str | None = None
+
+    try:
+        while len(streams) < _MAX_LOG_ATTEMPTS:
+            request: dict[str, object] = {
+                "logGroupName": _log_group_name(benchmark_id, runtime.resources.log_group),
+                "logStreamNamePrefix": prefix,
+                "limit": 50,
+            }
+            if token:
+                request["nextToken"] = token
+            response = client.describe_log_streams(**request)
+            streams.extend(cast(list[dict[str, object]], response.get("logStreams", [])))
+            token = cast(str | None, response.get("nextToken"))
+            if not token:
+                break
+    except (BotoCoreError, ClientError) as error:
+        if _is_missing_log_group(error):
+            return TaskLogAttemptsResponse(attempts=[], truncated=False)
+        raise HTTPException(status_code=502, detail="Task logs could not be loaded.") from error
+
+    attempts = [
+        attempt
+        for stream in streams[:_MAX_LOG_ATTEMPTS]
+        if (attempt := _task_log_attempt(stream, prefix, current_stream, reserved_stream_names)) is not None
+    ]
+    attempts.sort(key=lambda attempt: attempt.started_at, reverse=True)
+    return TaskLogAttemptsResponse(
+        attempts=attempts,
+        truncated=token is not None or len(streams) > _MAX_LOG_ATTEMPTS,
+    )
+
+
+@router.get(
+    "/{benchmark_id}/tasks/{task_id:path}/logs/events",
+    response_model=TaskLogEventsResponse,
+)
+def get_task_log_events(
+    benchmark_id: UUID,
+    task_id: str,
+    run_context: RunAWSDependency,
+    attempt_id: str = Query(pattern=r"^[0-9a-f]{1,16}$"),
+    direction: Literal["initial", "older", "newer"] = "initial",
+    cursor: str | None = Query(default=None, max_length=4_096),
+    org: Org = Depends(get_current_org),
+    session: Session = Depends(get_session),
+) -> TaskLogEventsResponse:
+    """Read one bounded CloudWatch page through the run's persisted AWS runtime."""
+    task = _load_task_for_benchmark_or_404(run_context.benchmark, task_id, org, session)
+    if direction != "initial" and cursor is None:
+        raise HTTPException(status_code=400, detail="A cursor is required for this log direction.")
+    if direction == "initial" and cursor is not None:
+        raise HTTPException(status_code=400, detail="Initial log reads cannot include a cursor.")
+
+    runtime = run_context.aws_runtime
+    stream_name = _attempt_stream_name(sanitize_log_stream_name(task.task_id), attempt_id)
+    if stream_name in _reserved_log_stream_names(session, run_context.benchmark.id, org.id):
+        raise HTTPException(status_code=404, detail="Task log attempt not found.")
+    request: dict[str, object] = {
+        "logGroupName": _log_group_name(benchmark_id, runtime.resources.log_group),
+        "logStreamName": stream_name,
+        "startFromHead": direction == "newer",
+    }
+    if cursor:
+        request["nextToken"] = cursor
+
+    limit = 100
+    try:
+        while True:
+            response = runtime.clients.cloudwatch_logs_client().get_log_events(**request, limit=limit)
+            result = _task_log_events(response, direction, cursor)
+            if len(result.model_dump_json().encode()) <= _MAX_LOG_RESPONSE_BYTES:
+                return result
+            if limit == 1:
+                raise HTTPException(status_code=502, detail="A task log event is too large.")
+            limit = max(1, limit // 2)
+    except (BotoCoreError, ClientError) as error:
+        if _is_missing_log_group(error):
+            return TaskLogEventsResponse(events=[], older_cursor=None, newer_cursor=None)
+        raise HTTPException(status_code=502, detail="Task logs could not be loaded.") from error
+
+
+def _reserved_log_stream_names(session: Session, benchmark_id: UUID, org_id: UUID) -> set[str]:
+    task_ids = session.exec(
+        select(Task.task_id).where(Task.benchmark == benchmark_id).where(Task.org_id == org_id)
+    ).all()
+    return {sanitize_log_stream_name(task_id) for task_id in task_ids}
+
+
+def _task_log_stream_name(task: Task) -> str:
+    suffix = f"{int(task.started_at.timestamp() * 1_000_000):x}"
+    return f"{sanitize_log_stream_name(task.task_id)}_{suffix}"
+
+
+def _attempt_stream_name(prefix: str, attempt_id: str) -> str:
+    return f"{prefix}_{attempt_id}"
+
+
+def _log_group_name(benchmark_id: UUID, root: str) -> str:
+    return f"{root}/{benchmark_id}"
+
+
+def _task_log_attempt(
+    stream: dict[str, object],
+    prefix: str,
+    current_stream: str,
+    reserved_stream_names: set[str],
+) -> TaskLogAttempt | None:
+    name = stream.get("logStreamName")
+    if not isinstance(name, str) or name in reserved_stream_names:
+        return None
+    attempt_id = _attempt_id(prefix, name)
+    if attempt_id is None:
+        return None
+    started_at = _attempt_started_at(attempt_id)
+    if started_at is None:
+        return None
+    return TaskLogAttempt(
+        id=attempt_id,
+        started_at=started_at,
+        first_event_at=_event_time(stream.get("firstEventTimestamp")),
+        last_event_at=_event_time(stream.get("lastEventTimestamp")),
+        current=name == current_stream,
+    )
+
+
+def _attempt_id(prefix: str, stream_name: str) -> str | None:
+    marker = f"{prefix}_"
+    if not stream_name.startswith(marker):
+        return None
+    suffix = stream_name[len(marker) :]
+    if not 1 <= len(suffix) <= 16:
+        return None
+    return suffix if all(character in "0123456789abcdef" for character in suffix) else None
+
+
+def _attempt_started_at(attempt_id: str) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(int(attempt_id, 16) / 1_000_000, timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def _task_log_events(
+    response: dict[str, object],
+    direction: Literal["initial", "older", "newer"],
+    cursor: str | None,
+) -> TaskLogEventsResponse:
+    events: list[TaskLogEvent] = []
+    for event in cast(list[dict[str, object]], response.get("events", [])):
+        timestamp = _event_time(event.get("timestamp"))
+        message = event.get("message")
+        if timestamp is None or not isinstance(message, str):
+            raise HTTPException(status_code=502, detail="CloudWatch returned an incomplete log event.")
+        events.append(
+            TaskLogEvent(
+                timestamp=timestamp,
+                ingestion_time=_event_time(event.get("ingestionTime")),
+                message=message,
+            )
+        )
+    older_cursor = cast(str | None, response.get("nextBackwardToken"))
+    newer_cursor = cast(str | None, response.get("nextForwardToken"))
+    if direction == "older" and older_cursor == cursor:
+        older_cursor = None
+    return TaskLogEventsResponse(events=events, older_cursor=older_cursor, newer_cursor=newer_cursor)
+
+
+def _event_time(value: object) -> datetime | None:
+    if not isinstance(value, int | float):
+        return None
+    return datetime.fromtimestamp(value / 1_000, timezone.utc)
+
+
+def _is_missing_log_group(error: BotoCoreError | ClientError) -> bool:
+    return isinstance(error, ClientError) and error.response.get("Error", {}).get("Code") == "ResourceNotFoundException"

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -1,4 +1,3 @@
-import re
 import time
 from collections.abc import Callable
 from functools import wraps
@@ -16,16 +15,9 @@ _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
 
-def _sanitize_log_stream_name(task_id: str) -> str:
-    """Make a task_id safe to use as a CloudWatch logStreamName.
-
-    AWS requires log stream names to match the regex ``[^:*]*`` (no ``:`` or
-    ``*``). Some task ids carry these characters (e.g. model-suffixed ids like
-    ``provider/model:fast``), which makes ``CreateLogStream`` raise
-    ``InvalidParameterException`` and silently drops the run's logs. Replace the
-    forbidden characters so logging degrades gracefully instead of failing.
-    """
-    return re.sub(r"[:*]", "_", task_id)
+def sanitize_log_stream_name(task_id: str) -> str:
+    """Encode a task ID without changing common CloudWatch-safe IDs."""
+    return quote(task_id, safe="/-_.~")
 
 
 def handle_cloudwatch_error(message: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
@@ -60,7 +52,7 @@ def get_benchmark_log_url(benchmark_id: str, resources: AWSResources, task_id: s
     base = f"https://{safe_region}.console.aws.amazon.com/cloudwatch/home?region={safe_region}"
     encoded_log_group = f"{safe_log_group}$252F{safe_benchmark_id}"
     if task_id:
-        safe_task_id = quote(_sanitize_log_stream_name(task_id), safe="-_.")
+        safe_task_id = quote(sanitize_log_stream_name(task_id), safe="-_.")
         return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}/log-events/{safe_task_id}"
 
     return f"{base}#logsV2:log-groups/log-group/{encoded_log_group}"
@@ -117,7 +109,7 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
 
     client = runtime.clients.cloudwatch_logs_client()
     log_group_name = f"{runtime.resources.log_group}/{benchmark_id}"
-    stream_name = _sanitize_log_stream_name(task_id)
+    stream_name = sanitize_log_stream_name(task_id)
 
     if stream_key not in _created_streams:
         try:

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -486,3 +486,28 @@ class TaskArtifactsResponse(BaseModel):
     cloudwatch_url: str | None
     agent_output_url: str | None
     agent_output_expires_in: int | None
+
+
+class TaskLogAttempt(BaseModel):
+    id: str
+    started_at: datetime
+    first_event_at: datetime | None
+    last_event_at: datetime | None
+    current: bool
+
+
+class TaskLogAttemptsResponse(BaseModel):
+    attempts: list[TaskLogAttempt]
+    truncated: bool
+
+
+class TaskLogEvent(BaseModel):
+    timestamp: datetime
+    ingestion_time: datetime | None
+    message: str
+
+
+class TaskLogEventsResponse(BaseModel):
+    events: list[TaskLogEvent]
+    older_cursor: str | None
+    newer_cursor: str | None

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -10,6 +10,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from pathlib import Path
 from types import TracebackType
 from typing import Any, cast
 from uuid import UUID
@@ -18,6 +19,7 @@ from zoneinfo import ZoneInfo
 import logfire
 import sentry_sdk
 from benchmark_service import (
+    Sandbox,
     SandboxNotFoundError,
     SandboxProviderConfig,
     SandboxRecoveryAttempt,
@@ -30,9 +32,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
 from tracker.aws.cloudwatch_logs import write_benchmark_log_event
 from tracker.aws.runtime import AWSRuntime
-from tracker.aws.s3 import (
-    get_agent_result_s3_key,
-)
+from tracker.aws.s3 import get_agent_result_s3_key, upload_to_s3
 from tracker.aws.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
 from tracker.database.models import (
@@ -78,6 +78,21 @@ def _normalized_attempt_time(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value
     return value.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+
+
+async def upload_task_definition(
+    sandbox: Sandbox,
+    benchmark_id: UUID,
+    task_id: str,
+    problem_path: str,
+    aws_runtime: AWSRuntime,
+) -> None:
+    definition_name = f"task_definition{Path(problem_path).suffix or '.txt'}"
+    await upload_to_s3(
+        await sandbox.download_file(problem_path),
+        get_agent_result_s3_key(str(benchmark_id), task_id, definition_name),
+        aws_runtime,
+    )
 
 
 def _exception_message(exc: BaseException) -> str:
@@ -830,6 +845,13 @@ async def _process_task_attempt(
                 # outage metadata in its restored volume. A later loss is a
                 # distinct outage and must receive a new identity.
                 recovery_attempt.mark_replacement_ready()
+                await upload_task_definition(
+                    sandbox,
+                    benchmark_id,
+                    task_id,
+                    task_data.problem_path,
+                    aws_runtime,
+                )
 
                 # Force flush the logs if anything has been buffered
                 buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)

--- a/services/tracker/tests/unit/api/test_single_task.py
+++ b/services/tracker/tests/unit/api/test_single_task.py
@@ -5,18 +5,21 @@ Cover task details and artifact-link behavior.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from unittest.mock import ANY, AsyncMock, Mock
 from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 import pytest
+from botocore.exceptions import ClientError
 from fastapi.testclient import TestClient
 from sqlmodel import Session
 
 import tracker.api.single_task as single_task_module
 from main import app
 from tests.factories import make_error_result, make_evaluation_result, make_task
+from tracker.aws.clients import ExplicitCredentialsAWSClientProvider
 from tracker.database.models import (
     AgentCausedExitReason,
     Benchmark,
@@ -25,6 +28,10 @@ from tracker.database.models import (
 )
 
 _client = TestClient(app)
+
+
+def _cloudwatch_client(client: Mock) -> Callable[[ExplicitCredentialsAWSClientProvider], Mock]:
+    return lambda _provider: client
 
 
 def test_single_task_returns_latest_terminal_result_and_enforces_org_scope(
@@ -166,3 +173,231 @@ def test_task_artifacts_only_presign_existing_output(
     assert missing_response.json()["agent_output_url"] is None
     assert missing_response.json()["agent_output_expires_in"] is None
     assert create_presigned_url.await_count == 1
+
+
+def test_task_logs_use_the_run_aws_runtime(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_headers: dict[str, str],
+) -> None:
+    """Log attempts and cursor pages must use the same scoped runtime as artifacts."""
+    benchmark = example_benchmark_object
+    started_at = datetime(2026, 8, 19, 12, 30, tzinfo=ZoneInfo("UTC"))
+    task = make_task(benchmark, "suite/task:managed", started_at=started_at)
+    database_session.add_all([benchmark, task])
+    database_session.commit()
+
+    suffix = f"{int(started_at.timestamp() * 1_000_000):x}"
+    stream_name = f"suite/task%3Amanaged_{suffix}"
+    cloudwatch = Mock()
+    cloudwatch.describe_log_streams.return_value = {
+        "logStreams": [
+            {
+                "logStreamName": stream_name,
+                "creationTime": int(started_at.timestamp() * 1_000),
+                "firstEventTimestamp": int(started_at.timestamp() * 1_000),
+                "lastEventTimestamp": int(started_at.timestamp() * 1_000) + 500,
+            }
+        ]
+    }
+    cloudwatch.get_log_events.return_value = {
+        "events": [
+            {
+                "timestamp": int(started_at.timestamp() * 1_000),
+                "ingestionTime": int(started_at.timestamp() * 1_000) + 100,
+                "message": "starting task",
+            }
+        ],
+        "nextBackwardToken": "older",
+        "nextForwardToken": "newer",
+    }
+    monkeypatch.setattr(
+        ExplicitCredentialsAWSClientProvider,
+        "cloudwatch_logs_client",
+        _cloudwatch_client(cloudwatch),
+    )
+
+    attempts = _client.get(
+        f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/logs/attempts",
+        headers=harness_headers,
+    )
+    events = _client.get(
+        f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/logs/events",
+        params={"attempt_id": suffix},
+        headers=harness_headers,
+    )
+
+    assert attempts.status_code == 200
+    assert attempts.json() == {
+        "attempts": [
+            {
+                "id": suffix,
+                "started_at": "2026-08-19T12:30:00Z",
+                "first_event_at": "2026-08-19T12:30:00Z",
+                "last_event_at": "2026-08-19T12:30:00.500000Z",
+                "current": True,
+            }
+        ],
+        "truncated": False,
+    }
+    assert events.status_code == 200
+    assert events.json()["events"] == [
+        {
+            "timestamp": "2026-08-19T12:30:00Z",
+            "ingestion_time": "2026-08-19T12:30:00.100000Z",
+            "message": "starting task",
+        }
+    ]
+    assert events.json()["newer_cursor"] == "newer"
+    assert cloudwatch.describe_log_streams.call_args.kwargs["logStreamNamePrefix"] == "suite/task%3Amanaged"
+    assert cloudwatch.get_log_events.call_args.kwargs["logStreamName"] == stream_name
+
+
+def test_task_log_attempts_page_cloudwatch_and_ignore_other_streams(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_headers: dict[str, str],
+) -> None:
+    benchmark = example_benchmark_object
+    started_at = datetime(2026, 8, 19, 12, 30, tzinfo=ZoneInfo("UTC"))
+    task = make_task(benchmark, "task", started_at=started_at)
+    sibling = make_task(benchmark, "task_deadbeef", started_at=started_at)
+    database_session.add_all([benchmark, task, sibling])
+    database_session.commit()
+
+    cloudwatch = Mock()
+    cloudwatch.describe_log_streams.side_effect = [
+        {
+            "logStreams": [
+                {"logStreamName": f"task_{int(started_at.timestamp() * 1_000_000):x}"},
+                {"logStreamName": "task"},
+                {"logStreamName": "task_ffffffffffffffffffff"},
+                {"logStreamName": "task_deadbeef"},
+                {},
+            ],
+            "nextToken": "page-2",
+        },
+        {"logStreams": []},
+    ]
+    monkeypatch.setattr(
+        ExplicitCredentialsAWSClientProvider,
+        "cloudwatch_logs_client",
+        _cloudwatch_client(cloudwatch),
+    )
+
+    response = _client.get(
+        f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/logs/attempts",
+        headers=harness_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["attempts"] == [
+        {
+            "id": f"{int(started_at.timestamp() * 1_000_000):x}",
+            "started_at": "2026-08-19T12:30:00Z",
+            "first_event_at": None,
+            "last_event_at": None,
+            "current": True,
+        }
+    ]
+    assert cloudwatch.describe_log_streams.call_args_list[1].kwargs["nextToken"] == "page-2"
+    collision = _client.get(
+        f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/logs/events",
+        params={"attempt_id": "deadbeef"},
+        headers=harness_headers,
+    )
+    assert collision.status_code == 404
+
+
+def test_task_log_events_validate_cursors_and_handle_missing_streams(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_headers: dict[str, str],
+) -> None:
+    benchmark = example_benchmark_object
+    task = make_task(benchmark, "task")
+    database_session.add_all([benchmark, task])
+    database_session.commit()
+
+    missing = ClientError(
+        {"Error": {"Code": "ResourceNotFoundException", "Message": "missing"}},
+        "GetLogEvents",
+    )
+    cloudwatch = Mock()
+    cloudwatch.describe_log_streams.side_effect = missing
+    cloudwatch.get_log_events.side_effect = missing
+    monkeypatch.setattr(
+        ExplicitCredentialsAWSClientProvider,
+        "cloudwatch_logs_client",
+        _cloudwatch_client(cloudwatch),
+    )
+    base = f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/logs"
+
+    no_cursor = _client.get(
+        f"{base}/events",
+        params={"attempt_id": "deadbeef", "direction": "newer"},
+        headers=harness_headers,
+    )
+    initial_cursor = _client.get(
+        f"{base}/events",
+        params={"attempt_id": "deadbeef", "direction": "initial", "cursor": "token"},
+        headers=harness_headers,
+    )
+    attempts = _client.get(f"{base}/attempts", headers=harness_headers)
+    events = _client.get(
+        f"{base}/events",
+        params={"attempt_id": "deadbeef"},
+        headers=harness_headers,
+    )
+    cloudwatch.get_log_events.side_effect = None
+    cloudwatch.get_log_events.return_value = {
+        "events": [],
+        "nextBackwardToken": "older",
+        "nextForwardToken": "tail",
+    }
+    tail = _client.get(
+        f"{base}/events",
+        params={
+            "attempt_id": "deadbeef",
+            "direction": "newer",
+            "cursor": "tail",
+        },
+        headers=harness_headers,
+    )
+
+    assert no_cursor.status_code == 400
+    assert initial_cursor.status_code == 400
+    assert attempts.json() == {"attempts": [], "truncated": False}
+    assert events.json() == {"events": [], "older_cursor": None, "newer_cursor": None}
+    assert tail.json()["newer_cursor"] == "tail"
+
+
+def test_task_log_events_reject_incomplete_cloudwatch_events(
+    database_session: Session,
+    example_benchmark_object: Benchmark,
+    monkeypatch: pytest.MonkeyPatch,
+    harness_headers: dict[str, str],
+) -> None:
+    benchmark = example_benchmark_object
+    task = make_task(benchmark, "task")
+    database_session.add_all([benchmark, task])
+    database_session.commit()
+
+    cloudwatch = Mock()
+    cloudwatch.get_log_events.return_value = {"events": [{"timestamp": 1}]}
+    monkeypatch.setattr(
+        ExplicitCredentialsAWSClientProvider,
+        "cloudwatch_logs_client",
+        _cloudwatch_client(cloudwatch),
+    )
+
+    response = _client.get(
+        f"/benchmarks/{benchmark.id}/tasks/{task.task_id}/logs/events",
+        params={"attempt_id": "deadbeef"},
+        headers=harness_headers,
+    )
+
+    assert response.status_code == 502

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -27,7 +27,7 @@ from tracker.aws.s3 import handle_s3_error
 from tracker.exceptions import CloudWatchError, S3Error
 from tracker.types import AWSCredentials
 
-_sanitize_log_stream_name = getattr(cloudwatch_logs, "_sanitize_log_stream_name")
+sanitize_log_stream_name = cloudwatch_logs.sanitize_log_stream_name
 
 _AWS = AWSCredentials(
     aws_access_key_id="test-key",
@@ -214,25 +214,25 @@ class TestCloudWatchClient:
 
 
 class TestSanitizeLogStreamName:
-    """logStreamName must satisfy AWS constraint [^:*]* (no ':' or '*')."""
+    """logStreamName must satisfy AWS constraint [^:*]* without collisions."""
 
-    def test_replaces_colon(self) -> None:
-        assert _sanitize_log_stream_name("provider/model:fast") == "provider/model_fast"
+    def test_encodes_colon(self) -> None:
+        assert sanitize_log_stream_name("provider/model:fast") == "provider/model%3Afast"
 
-    def test_replaces_asterisk(self) -> None:
-        assert _sanitize_log_stream_name("task*glob") == "task_glob"
+    def test_encodes_asterisk(self) -> None:
+        assert sanitize_log_stream_name("task*glob") == "task%2Aglob"
 
-    def test_replaces_both_and_multiple(self) -> None:
-        assert _sanitize_log_stream_name("a:b:c*d") == "a_b_c_d"
+    def test_encodes_both_and_multiple(self) -> None:
+        assert sanitize_log_stream_name("a:b:c*d") == "a%3Ab%3Ac%2Ad"
 
     def test_preserves_clean_name(self) -> None:
         # plain ids and the allowed '/' are left intact
-        assert _sanitize_log_stream_name("water_intake_tracker") == "water_intake_tracker"
-        assert _sanitize_log_stream_name("group/sub/name") == "group/sub/name"
+        assert sanitize_log_stream_name("water_intake_tracker") == "water_intake_tracker"
+        assert sanitize_log_stream_name("group/sub/name") == "group/sub/name"
 
     def test_result_matches_aws_constraint(self) -> None:
         for raw in ["openai/gpt-5.5", "laguna-xs.2:fast", "x*:y", "plain_id"]:
-            assert re.fullmatch(r"[^:*]*", _sanitize_log_stream_name(raw))
+            assert re.fullmatch(r"[^:*]*", sanitize_log_stream_name(raw))
 
 
 class TestGetBenchmarkLogUrl:
@@ -240,8 +240,8 @@ class TestGetBenchmarkLogUrl:
 
     def test_sanitizes_task_id_in_url(self) -> None:
         url = get_benchmark_log_url("bench123", _AWS_RESOURCES, task_id="provider/model:fast")
-        # task id is sanitized before being url-quoted into the log-events path
-        assert "model_fast" in url
+        # The hash URL quotes the percent-encoded CloudWatch stream name again.
+        assert "model%253Afast" in url
         assert "model:fast" not in url
 
     def test_no_task_id_omits_log_events(self) -> None:
@@ -270,9 +270,9 @@ class TestWriteBenchmarkLogEvent:
         write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
         client.create_log_stream.assert_called_once_with(
-            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
+            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model%3Afast"
         )
-        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
+        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model%3Afast"
 
     def test_create_stream_botocore_error_reports_sanitized_name(
         self,
@@ -284,5 +284,5 @@ class TestWriteBenchmarkLogEvent:
         with pytest.raises(CloudWatchError) as exc_info:
             write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
-        assert "provider/model_fast" in str(exc_info.value)
+        assert "provider/model%3Afast" in str(exc_info.value)
         client.put_log_events.assert_not_called()

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -197,6 +197,7 @@ def mock_sandbox_operations(monkeypatch: pytest.MonkeyPatch) -> None:
         return None, 0.0
 
     monkeypatch.setattr("tracker.utils.task_execution.upload_agent_artifacts", _noop)
+    monkeypatch.setattr("tracker.utils.task_execution.upload_task_definition", _noop)
     monkeypatch.setattr("tracker.utils.task_execution.run_agent", _noop_run_agent)
 
 

--- a/services/tracker/tests/unit/utils/test_task_execution.py
+++ b/services/tracker/tests/unit/utils/test_task_execution.py
@@ -5,16 +5,44 @@ Run: uv run pytest tests/unit/utils/test_task_execution.py
 
 import asyncio
 from typing import Any
-from unittest.mock import MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
 import pytest
 from sqlmodel import Session
 
 from tests.utils import TEST_ORG_ID
+from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import Benchmark, Org, Task, TaskStatus
 from tracker.executor.execution_authority import ExecutionAuthority
 from tracker.utils import ResizableLimiter, TaskMonitor, TrackedTask, TrackedTaskStatus
+from tracker.utils.task_execution import upload_task_definition
+
+
+async def test_upload_task_definition_preserves_the_problem_file_type(
+    monkeypatch: pytest.MonkeyPatch,
+    aws_runtime: AWSRuntime,
+) -> None:
+    sandbox = Mock()
+    sandbox.download_file = AsyncMock(return_value=b"task definition")
+    upload = AsyncMock()
+    monkeypatch.setattr("tracker.utils.task_execution.upload_to_s3", upload)
+    benchmark_id = uuid4()
+
+    await upload_task_definition(
+        sandbox,
+        benchmark_id,
+        "suite/task",
+        "/workspace/problem.md",
+        aws_runtime,
+    )
+
+    sandbox.download_file.assert_awaited_once_with("/workspace/problem.md")
+    upload.assert_awaited_once_with(
+        b"task definition",
+        f"benchmarks/{benchmark_id}/suite/task/task_definition.md",
+        aws_runtime,
+    )
 
 
 class TestTaskExecution:

--- a/tests/contract/test_sdk_tracker_contract.py
+++ b/tests/contract/test_sdk_tracker_contract.py
@@ -181,6 +181,8 @@ MODEL_PAIRS = (
 INTERNAL_ROUTES = {
     ("/aws-runtime", "get"),
     ("/benchmarks/{benchmark_id}/concurrency", "patch"),
+    ("/benchmarks/{benchmark_id}/tasks/{task_id}/logs/attempts", "get"),
+    ("/benchmarks/{benchmark_id}/tasks/{task_id}/logs/events", "get"),
     ("/benchmarks/filter-options", "get"),
     ("/health", "get"),
     ("/init", "post"),


### PR DESCRIPTION
## Summary

- expose task log attempts through each run's persisted AWS runtime
- expose bounded cursor pages for task log events
- support managed and legacy AWS authority without returning credentials
- support task IDs that contain `/`
- save each benchmark problem statement as a task artifact

## Checks

- `uv run ruff check ...`
- `uv run basedpyright ...`
- `uv run pytest tests/unit -q` — 620 passed
