### PR TITLE
fix(tracker): reset terminal runs before empty resume

### DIFF
--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -193,6 +193,14 @@ async def reset_to_in_progress_status(
 
         # Allow re-running the end of the benchmark without running any tasks
         if not existing_rows and not new_task_ids:
+            if benchmark_row.status != BenchmarkStatus.IN_PROGRESS:
+                old_evaluation = benchmark_row.final_evaluation
+                if old_evaluation is not None:
+                    benchmark_row.final_evaluation = None
+                    session.delete(old_evaluation)
+                benchmark_row.status = BenchmarkStatus.IN_PROGRESS
+                benchmark_row.finished_at = None
+                session.add(benchmark_row)
             return []
 
         # Verify the task ids are still valid before priming to resume

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1912,6 +1912,48 @@ class TestRunRecovery:
             assert dispatch.status == ExecutorDispatchStatus.QUEUED
             assert dispatch.kind == dispatch_kind
 
+    async def test_terminal_resume_without_tasks_resets_benchmark_lifecycle(
+        self,
+        example_benchmark_object: Benchmark,
+        database_session: Session,
+        monkeypatch: MonkeyPatch,
+        harness_headers: dict[str, str],
+        mock_kicker: MockKicker,
+    ) -> None:
+        benchmark_row = example_benchmark_object
+        benchmark_row.status = BenchmarkStatus.ERROR
+        benchmark_row.finished_at = datetime.now(ZoneInfo("UTC"))
+        task = Task(
+            org_id=TEST_ORG_ID,
+            task_id="finished-task",
+            benchmark=benchmark_row.id,
+            status=TaskStatus.FINISHED,
+            finished_at=datetime.now(ZoneInfo("UTC")),
+        )
+        old_evaluation = FinalEvaluation(org_id=TEST_ORG_ID, benchmark=benchmark_row.id, final_score=0.5)
+        database_session.add_all([benchmark_row, task, old_evaluation])
+        database_session.commit()
+
+        async def _unexpected_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
+            raise AssertionError("resume without tasks should not verify task ids")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", _unexpected_verify_task_ids)
+
+        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}", headers=harness_headers)
+
+        assert response.status_code == 200
+        assert mock_kicker.queued_calls[0]["verified_task_ids"] == []
+
+        database_session.expire_all()
+        persisted_benchmark = database_session.get(Benchmark, benchmark_row.id)
+        assert persisted_benchmark is not None
+        assert persisted_benchmark.status == BenchmarkStatus.IN_PROGRESS
+        assert persisted_benchmark.finished_at is None
+        assert persisted_benchmark.final_evaluation is None
+        persisted_task = database_session.get(Task, task.id)
+        assert persisted_task is not None
+        assert persisted_task.status == TaskStatus.FINISHED
+
     async def test_terminal_resume_without_active_release_returns_503_without_mutation(
         self,
         example_benchmark_object: Benchmark,

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1950,6 +1950,7 @@ class TestRunRecovery:
         assert persisted_benchmark.status == BenchmarkStatus.IN_PROGRESS
         assert persisted_benchmark.finished_at is None
         assert persisted_benchmark.final_evaluation is None
+
         persisted_task = database_session.get(Task, task.id)
         assert persisted_task is not None
         assert persisted_task.status == TaskStatus.FINISHED

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -366,6 +366,11 @@ class TestRunState:
             headers=harness_headers,
         )
         assert response.status_code == 200
+        database_session.refresh(benchmark_row)
+        assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+        benchmark_row.status = BenchmarkStatus.STOPPED
+        database_session.add(benchmark_row)
+        database_session.commit()
 
         # Ensure that we can recreate the environment the benchmark was started in
         original_start_benchmark_request = StartBenchmarkRequest(

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -366,8 +366,10 @@ class TestRunState:
             headers=harness_headers,
         )
         assert response.status_code == 200
+
         database_session.refresh(benchmark_row)
         assert benchmark_row.status == BenchmarkStatus.IN_PROGRESS
+
         benchmark_row.status = BenchmarkStatus.STOPPED
         database_session.add(benchmark_row)
         database_session.commit()


### PR DESCRIPTION
## Summary

`POST /retry-or-resume-benchmark` (i.e. `valk run resume <run_id>`) returns 500 for a terminal run whose tasks have all finished — the "re-run only the end of the benchmark" case, which is how you regenerate a final score after a benchmark-service failure without re-running any tasks.

`reset_to_in_progress_status` has an early return for that case (`if not existing_rows and not new_task_ids: return []`) which fires *before* the block that drops the stale `final_evaluation`, moves status out of the terminal state, and clears `finished_at`. `retry_or_resume_benchmark` only short-circuits when the pre-action status was `IN_PROGRESS`, so for a terminal run it proceeds into `admit_recovery_dispatch`, which sets `finished_at = None` while status is still `ERROR`/`FINISHED` — violating the `Benchmark` check constraint `(status != 'FINISHED' AND status != 'ERROR') OR (finished_at IS NOT NULL)`:

```
psycopg2.errors.CheckViolation: new row for relation "benchmark" violates check constraint
  "benchmark_finished_requires_timestamp"
[SQL: UPDATE benchmark SET finished_at=NULL WHERE benchmark.id = ...]
```

The fix performs the same lifecycle reset on the no-tasks path, so the benchmark is never left terminal-with-null-`finished_at`. `verify_task_ids` is still skipped there — there are no task ids to verify.

## Changes

- `services/tracker/src/tracker/utils/run_control.py`: on the empty resume path, if the benchmark is not `IN_PROGRESS`, delete the stale `final_evaluation`, set status `IN_PROGRESS`, and clear `finished_at` before returning no task ids.
- `services/tracker/tests/unit/utils/test_run_recovery.py`: regression test — `ERROR` benchmark with all tasks `FINISHED`, resume with no task ids returns 200, dispatch is admitted with empty `verified_task_ids`, benchmark ends `IN_PROGRESS` with `finished_at is None` and no final evaluation, task stays `FINISHED`, and `verify_task_ids` is never called.
- `services/tracker/tests/unit/utils/test_run_state.py`: the sequential edge-case test now asserts the intended `IN_PROGRESS` state after an empty terminal resume before continuing with its later cases.

Note: the unit setup runs on SQLite, which does not enforce the Postgres check constraint, so the regression test asserts the lifecycle invariants and successful dispatch rather than the constraint itself.

## Related Issues

Found while diagnosing SNAP runs finishing 230/230 but marked `ERROR` (Slack #general, run `b9514fba-7551-4939-9b74-4c6c449290d8`). The `ERROR` itself was a platform `uploadRun` test-id-space bug fixed by platform #2546; this is the separate tracker bug that blocked re-finalizing the affected run.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [x] Manually tested

Verified against a local tracker on real Postgres (`services/tracker/docker-compose.yml`), where the CHECK constraint is actually enforced, unlike the SQLite unit setup. Seeded a benchmark in the affected state (`status=ERROR`, `finished_at` set, one `FINISHED` task, one stale `finalevaluation`) and ran `TRACKER_SERVICE_URL=http://localhost:8000 uv run valk run resume <run_id>`:

- with this PR: exit 0, `POST /retry-or-resume-benchmark/... 200`; benchmark ends `IN_PROGRESS` with `finished_at` NULL, stale `finalevaluation` deleted, task still `FINISHED` (not reset to PENDING), `RESUME` dispatch QUEUED.
- with only the `run_control.py` hunk reverted to `origin/dev`: `Error: Failed to start run: Internal Server Error`, `500`, and `psycopg2.errors.CheckViolation ... benchmark_finished_requires_timestamp` with `finished_at=None` while status is `ERROR` — the same failure seen on bench for run `b9514fba-7551-4939-9b74-4c6c449290d8` (1:38pm PT 2026-08-19, CloudWatch `/valkyrie/tracker`). Request rolls back, DB state unchanged.

Full commands, logs and DB state are in a [PR comment](https://github.com/vals-ai/Valkyrie/pull/715#issuecomment-5348688012). Not yet exercised against a deployed tracker — that needs a tracker deploy.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

## Human Description

### Why

<!-- author to fill in -->

### How

<!-- author to fill in -->


Link to Devin session: https://app.devin.ai/sessions/8ca3989df7aa4da984d1e3931a93ef54
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/715" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->