### PR TITLE
feat: correlate run telemetry end to end

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ services/*
 !services/executor_host/
 services/executor_host/*
 !services/executor_host/Dockerfile
+!services/executor_host/__init__.py
+!services/executor_host/observability.py
 !services/executor_host/requirements.txt
 !services/executor_host/supervisor.py
 !services/tracker/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -272,6 +272,10 @@ jobs:
             echo "::error::The dev Environment must define DESCOPE_MANAGEMENT_KEY_SECRET_NAME before planning or deploying."
             exit 1
           fi
+          if [[ "$OPERATION" != "credentials-only" && -z "$SENTRY_DSN_SECRET_NAME" ]]; then
+            echo "::error::The dev Environment must define SENTRY_DSN_SECRET_NAME before planning or deploying."
+            exit 1
+          fi
           if [[ "$OPERATION" != "credentials-only" && ( -z "$AWS_DEPLOYMENT_ROLE_ORG_IDS" || -z "$AWS_TRACKER_SECRET_NAME_PREFIXES" ) ]]; then
             echo "::error::The dev Environment must define AWS_DEPLOYMENT_ROLE_ORG_IDS and AWS_TRACKER_SECRET_NAME_PREFIXES before planning or deploying."
             exit 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -214,6 +214,7 @@ jobs:
           DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
         working-directory: infra
         run: >-
           make deploy
@@ -253,6 +254,7 @@ jobs:
       PRODUCTION_ACCOUNT_ID: "613431292675"
       SCOPE: ${{ github.event_name == 'push' && 'core' || inputs.scope }}
       SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+      SENTRY_RELEASE: ${{ github.sha }}
 
     steps:
       - name: Validate dev configuration
@@ -378,6 +380,7 @@ jobs:
       DEV_ACCOUNT_ID: ${{ secrets.DEV_ACCOUNT_ID }}
       EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/dev/executor-release/launch-config
       SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+      SENTRY_RELEASE: ${{ github.sha }}
 
     steps:
       - name: Verify current dev executor revision
@@ -705,6 +708,7 @@ jobs:
           DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
         working-directory: infra
         run: make deploy STAGE=prod SCOPE=core AWS_REGION="$AWS_REGION"
 
@@ -717,6 +721,7 @@ jobs:
           DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
           SANDBOX_CLEANUP_ENABLED: ${{ vars.SANDBOX_CLEANUP_ENABLED }}
           SANDBOX_CLEANUP_PROVIDER: ${{ vars.SANDBOX_CLEANUP_PROVIDER }}
           SANDBOX_CLEANUP_SECRET_NAME: ${{ secrets.SANDBOX_CLEANUP_SECRET_NAME }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -384,7 +384,6 @@ jobs:
       DEV_ACCOUNT_ID: ${{ secrets.DEV_ACCOUNT_ID }}
       EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/dev/executor-release/launch-config
       SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
-      SENTRY_RELEASE: ${{ github.sha }}
 
     steps:
       - name: Verify current dev executor revision
@@ -725,7 +724,6 @@ jobs:
           DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
-          SENTRY_RELEASE: ${{ github.sha }}
           SANDBOX_CLEANUP_ENABLED: ${{ vars.SANDBOX_CLEANUP_ENABLED }}
           SANDBOX_CLEANUP_PROVIDER: ${{ vars.SANDBOX_CLEANUP_PROVIDER }}
           SANDBOX_CLEANUP_SECRET_NAME: ${{ secrets.SANDBOX_CLEANUP_SECRET_NAME }}

--- a/.github/workflows/executor-build.yaml
+++ b/.github/workflows/executor-build.yaml
@@ -12,6 +12,7 @@ on:
       - "services/executor_artifact/**"
       - "services/executor_host/**"
       - "services/tracker/**"
+      - "tests/integration/observability/**"
       - "tests/unit/executor_host/**"
   # Runs on every PR so the required check is always reported; the guard below
   # skips the (slow) build when the PR does not touch executor-related paths.
@@ -44,7 +45,7 @@ jobs:
             echo "Could not compute the PR diff; running the build to be safe."
             echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          if printf '%s\n' "$changed" | grep -qE '^(\.dockerignore|\.github/workflows/(executor-build|deploy)\.yaml|infra/(executor_stack|tracker_stack)\.py|services/(executor_artifact|executor_host|tracker)/|tests/unit/executor_host/)'; then
+          if printf '%s\n' "$changed" | grep -qE '^(\.dockerignore|\.github/workflows/(executor-build|deploy)\.yaml|infra/(executor_stack|tracker_stack)\.py|services/(executor_artifact|executor_host|tracker)/|tests/(integration/observability|unit/executor_host)/)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "No executor-related changes; skipping build."
@@ -87,9 +88,9 @@ jobs:
         if: steps.rel.outputs.relevant == 'true'
         run: uv sync --frozen
 
-      - name: Run executor support unit tests
+      - name: Run executor support tests
         if: steps.rel.outputs.relevant == 'true'
-        run: uv run pytest tests/unit/executor_host services/executor_artifact/tests
+        run: uv run pytest tests/unit/executor_host tests/integration/observability services/executor_artifact/tests
 
       - name: Build and inspect immutable executor PEX
         if: steps.rel.outputs.relevant == 'true'

--- a/infra/README.md
+++ b/infra/README.md
@@ -50,7 +50,9 @@ whenever `AUTH_REQUIRED` is `true`. The dev Environment holds every dev
 deployment input as an Environment secret except `AWS_REGION`, which stays a
 variable. The production jobs read repository-level secrets; the
 `SANDBOX_CLEANUP_ENABLED` and `SANDBOX_CLEANUP_PROVIDER` toggles stay
-variables.
+variables. The Sentry DSN is injected into both Tracker and ExecutorHost. The
+host propagates each run's trace and request context into its immutable executor
+artifact.
 
 Before production executor activation, configure the protected `prod` GitHub
 Environment used by both production deploy jobs. Both AWS accounts must already

--- a/infra/README.md
+++ b/infra/README.md
@@ -43,9 +43,9 @@ Managed AWS execution also requires these dev Environment secrets:
 The dev ExecutorHost task role can read every Secrets Manager secret in the dev
 account and Region. Production and release-test do not receive this access.
 
-To enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the
-name of an account-local Secrets Manager secret containing the DSN. Production
-requires `SENTRY_DSN_SECRET_NAME`, and `DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
+Dev and production require `SENTRY_DSN_SECRET_NAME` to name an account-local
+Secrets Manager secret containing the DSN. Production also requires
+`DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
 whenever `AUTH_REQUIRED` is `true`. The dev Environment holds every dev
 deployment input as an Environment secret except `AWS_REGION`, which stays a
 variable. The production jobs read repository-level secrets; the

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -141,6 +141,19 @@ class ExecutorStack(Stack):
             "DB_PASSWORD": aws_ecs.Secret.from_secrets_manager(db_credentials_secret, field="password"),
         }
 
+        sentry_secret_name = os.environ.get("SENTRY_DSN_SECRET_NAME", "")
+        if stage.is_prod and not sentry_secret_name:
+            raise ValueError("Production deployments require SENTRY_DSN_SECRET_NAME.")
+
+        sentry_secrets: dict[str, aws_ecs.Secret] = {}
+        if sentry_secret_name:
+            sentry_secret = aws_secretsmanager.Secret.from_secret_name_v2(
+                self,
+                "ExecutorSentryDsnSecret",
+                sentry_secret_name,
+            )
+            sentry_secrets["SENTRY_DSN"] = aws_ecs.Secret.from_secrets_manager(sentry_secret)
+
         aws_logs.LogGroup(
             self,
             "WorkerLogGroup",
@@ -180,8 +193,9 @@ class ExecutorStack(Stack):
                 "STABLE_QUEUE_NAME": "valkyrie-stable",
                 "EXECUTOR_RELEASE_BUCKET": self.executor_release_bucket.bucket_name,
                 "EXECUTOR_RELEASE_PREFIX": EXECUTOR_RELEASE_PREFIX,
+                "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
             },
-            secrets=db_secrets,
+            secrets={**db_secrets, **sentry_secrets},
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),
         )
         self.executor_task_role.add_to_policy(

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -23,7 +23,7 @@ from aws_cdk import (
     aws_sqs,
     aws_ssm,
 )
-from aws_cdk.aws_ecr_assets import Platform
+from aws_cdk.aws_ecr_assets import DockerImageAsset, Platform
 from constants import (
     DOCKER_ASSET_EXCLUDES,
     EXECUTOR_HOST_LOG_GROUP_NAME,
@@ -108,14 +108,19 @@ class ExecutorStack(Stack):
                     "Release-test ExecutorStack requires an executor-host repository and immutable image tag"
                 )
             executor_host_image = aws_ecs.ContainerImage.from_ecr_repository(executor_host_repository, image_tag)
+            executor_host_release = image_tag
         else:
-            executor_host_image = aws_ecs.ContainerImage.from_asset(
-                "..",
+            executor_host_asset = DockerImageAsset(
+                self,
+                "ExecutorHostImageAsset",
+                directory="..",
                 file="services/executor_host/Dockerfile",
                 platform=Platform.LINUX_ARM64,
                 exclude=list(DOCKER_ASSET_EXCLUDES),
                 ignore_mode=cdk.IgnoreMode.DOCKER,
             )
+            executor_host_image = aws_ecs.ContainerImage.from_docker_image_asset(executor_host_asset)
+            executor_host_release = executor_host_asset.asset_hash
 
         benchmark_service_url = benchmark_service_base_url(stage)
         bucket = aws_s3.Bucket.from_bucket_name(self, "ManagedRuntimeBucket", bucket_name)
@@ -142,8 +147,8 @@ class ExecutorStack(Stack):
         }
 
         sentry_secret_name = os.environ.get("SENTRY_DSN_SECRET_NAME", "")
-        if stage.is_prod and not sentry_secret_name:
-            raise ValueError("Production deployments require SENTRY_DSN_SECRET_NAME.")
+        if not stage.is_release_test and not sentry_secret_name:
+            raise ValueError("Dev and production deployments require SENTRY_DSN_SECRET_NAME.")
 
         sentry_secrets: dict[str, aws_ecs.Secret] = {}
         if sentry_secret_name:
@@ -193,7 +198,7 @@ class ExecutorStack(Stack):
                 "STABLE_QUEUE_NAME": "valkyrie-stable",
                 "EXECUTOR_RELEASE_BUCKET": self.executor_release_bucket.bucket_name,
                 "EXECUTOR_RELEASE_PREFIX": EXECUTOR_RELEASE_PREFIX,
-                "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
+                "SENTRY_RELEASE": f"executor-host@{executor_host_release}",
             },
             secrets={**db_secrets, **sentry_secrets},
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -369,7 +369,13 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn('"services/tracker/**"', workflow)
         self.assertIn('".dockerignore"', workflow)
         self.assertIn("PYTHONPATH=services/tracker/src python services/executor_artifact/build.py", workflow)
-        self.assertIn("uv run pytest tests/unit/executor_host services/executor_artifact/tests", workflow)
+        self.assertIn("uv run pytest", workflow)
+        for test_path in (
+            "tests/unit/executor_host",
+            "tests/integration/observability",
+            "services/executor_artifact/tests",
+        ):
+            self.assertIn(test_path, workflow)
         self.assertIn(
             "docker build --platform linux/arm64 -t valkyrie-tracker:ci services/tracker",
             workflow,

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -1,4 +1,7 @@
-"""Tests for deployment workflow contracts."""
+"""Tests for deployment workflow contracts.
+
+Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_deploy_workflow.py
+"""
 
 import unittest
 from pathlib import Path

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -1,4 +1,7 @@
-"""Tests for the development account infrastructure boundary."""
+"""Tests for the development account infrastructure boundary.
+
+Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_dev_account.py
+"""
 
 import json
 import os

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -62,11 +62,13 @@ DEV_TRACKER_CONTRACT_PARAMETERS = {
 }
 EXECUTOR_CONTRACT_PARAMETERS = {executor_release_launch_parameter(DEV)}
 DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
+SENTRY_DSN_SECRET_NAME = "example/sentry-dsn"
 DEV_AUTH_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": "00000000-0000-0000-0000-000000000001",
     "AWS_TRACKER_SECRET_NAME_PREFIXES": "test-tracker-secret",
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
+    "SENTRY_DSN_SECRET_NAME": SENTRY_DSN_SECRET_NAME,
 }
 
 
@@ -87,36 +89,37 @@ def dev_shared_stack() -> tuple[cdk.App, SharedStack]:
 
 
 def dev_service_templates() -> tuple[assertions.Template, assertions.Template]:
-    app, shared = dev_shared_stack()
-    stage = Stage(DEV)
-    tracker = TrackerStack(
-        app,
-        stage.stack_id("TrackerStack"),
-        stage=stage,
-        vpc=shared.vpc,
-        cluster=shared.cluster,
-        namespace=shared.namespace,
-        hosted_zone=shared.hosted_zone,
-        bucket_name=shared.bucket_name,
-        redis_url=shared.redis_url,
-        redis_security_group=shared.redis_security_group,
-        env=TEST_ENV,
-    )
-    executor = ExecutorStack(
-        app,
-        stage.stack_id("WorkerStack"),
-        stage=stage,
-        vpc=shared.vpc,
-        cluster=shared.cluster,
-        namespace=shared.namespace,
-        redis_url=shared.redis_url,
-        bucket_name=shared.bucket_name,
-        database=tracker.database,
-        db_credentials=tracker.db_credentials,
-        tracker_service=tracker.tracker_fargate_service,
-        tracker_image=tracker.tracker_image,
-        env=TEST_ENV,
-    )
+    with mock.patch.dict(os.environ, {"SENTRY_DSN_SECRET_NAME": SENTRY_DSN_SECRET_NAME}, clear=False):
+        app, shared = dev_shared_stack()
+        stage = Stage(DEV)
+        tracker = TrackerStack(
+            app,
+            stage.stack_id("TrackerStack"),
+            stage=stage,
+            vpc=shared.vpc,
+            cluster=shared.cluster,
+            namespace=shared.namespace,
+            hosted_zone=shared.hosted_zone,
+            bucket_name=shared.bucket_name,
+            redis_url=shared.redis_url,
+            redis_security_group=shared.redis_security_group,
+            env=TEST_ENV,
+        )
+        executor = ExecutorStack(
+            app,
+            stage.stack_id("WorkerStack"),
+            stage=stage,
+            vpc=shared.vpc,
+            cluster=shared.cluster,
+            namespace=shared.namespace,
+            redis_url=shared.redis_url,
+            bucket_name=shared.bucket_name,
+            database=tracker.database,
+            db_credentials=tracker.db_credentials,
+            tracker_service=tracker.tracker_fargate_service,
+            tracker_image=tracker.tracker_image,
+            env=TEST_ENV,
+        )
     return assertions.Template.from_stack(tracker), assertions.Template.from_stack(executor)
 
 
@@ -236,7 +239,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         self.assertNotIn("agents/*", json.dumps(delete_statements[0]["Resource"]))
         self.assertIn(DESCOPE_MANAGEMENT_KEY_SECRET_NAME, rendered)
         self.assertNotIn("/vals/dev/descope/project-id", rendered)
-        self.assertNotIn("SENTRY_DSN", rendered)
+        self.assertIn("SENTRY_DSN", rendered)
         self.assertNotIn("/valkyrie/dev/dns/tracker/certificate-arn", rendered)
         certificates = tracker_template.find_resources("AWS::CertificateManager::Certificate")
         self.assertEqual(len(certificates), 1)

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -1,3 +1,8 @@
+"""Tests for the monitoring stack.
+
+Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_monitoring_stack.py
+"""
+
 import json
 import os
 import unittest

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -809,10 +809,14 @@ class MonitoringStackTest(unittest.TestCase):
                 },
             )
 
-    def test_production_requires_sentry_secret(self) -> None:
-        with mock.patch.dict(os.environ, {}, clear=True):
-            with self.assertRaisesRegex(ValueError, "require SENTRY_DSN_SECRET_NAME"):
-                service_templates(PROD)
+    def test_deployed_stages_require_sentry_secret(self) -> None:
+        for stage, environment in ((DEV, TEST_DEV_ENV), (PROD, TEST_PROD_ENV)):
+            environment_without_sentry = {
+                key: value for key, value in environment.items() if key != "SENTRY_DSN_SECRET_NAME"
+            }
+            with self.subTest(stage=stage), mock.patch.dict(os.environ, environment_without_sentry, clear=True):
+                with self.assertRaisesRegex(ValueError, "require SENTRY_DSN_SECRET_NAME"):
+                    service_templates(stage)
 
     def test_dev_sentry_secret_is_injected(self) -> None:
         custom_sentry_secret_name = "custom/dev-sentry-dsn"
@@ -832,13 +836,6 @@ class MonitoringStackTest(unittest.TestCase):
                         [
                             assertions.Match.object_like(
                                 {
-                                    "Environment": assertions.Match.array_with(
-                                        [
-                                            assertions.Match.object_like(
-                                                {"Name": "SENTRY_RELEASE", "Value": "deployment-sha"}
-                                            )
-                                        ]
-                                    ),
                                     "Secrets": assertions.Match.array_with(
                                         [assertions.Match.object_like({"Name": "SENTRY_DSN"})]
                                     ),
@@ -848,6 +845,49 @@ class MonitoringStackTest(unittest.TestCase):
                     )
                 },
             )
+        tracker_template.has_resource_properties(
+            "AWS::ECS::TaskDefinition",
+            {
+                "ContainerDefinitions": assertions.Match.array_with(
+                    [
+                        assertions.Match.object_like(
+                            {
+                                "Environment": assertions.Match.array_with(
+                                    [
+                                        assertions.Match.object_like(
+                                            {"Name": "SENTRY_RELEASE", "Value": "deployment-sha"}
+                                        )
+                                    ]
+                                )
+                            }
+                        )
+                    ]
+                )
+            },
+        )
+        executor_template.has_resource_properties(
+            "AWS::ECS::TaskDefinition",
+            {
+                "ContainerDefinitions": assertions.Match.array_with(
+                    [
+                        assertions.Match.object_like(
+                            {
+                                "Environment": assertions.Match.array_with(
+                                    [
+                                        assertions.Match.object_like(
+                                            {
+                                                "Name": "SENTRY_RELEASE",
+                                                "Value": assertions.Match.string_like_regexp("executor-host@.+"),
+                                            }
+                                        )
+                                    ]
+                                )
+                            }
+                        )
+                    ]
+                )
+            },
+        )
         sentry_value_from = [
             secret["ValueFrom"]
             for template in (tracker_template, executor_template)

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -818,36 +818,45 @@ class MonitoringStackTest(unittest.TestCase):
         sentry_environment = {
             **TEST_DEV_ENV,
             "SENTRY_DSN_SECRET_NAME": custom_sentry_secret_name,
+            "SENTRY_RELEASE": "deployment-sha",
         }
         with mock.patch.dict(os.environ, sentry_environment, clear=True):
             tracker_template, executor_template, _ = service_templates(DEV)
 
-        tracker_template.has_resource_properties(
-            "AWS::ECS::TaskDefinition",
-            {
-                "ContainerDefinitions": assertions.Match.array_with(
-                    [
-                        assertions.Match.object_like(
-                            {
-                                "Secrets": assertions.Match.array_with(
-                                    [assertions.Match.object_like({"Name": "SENTRY_DSN"})]
-                                )
-                            }
-                        )
-                    ]
-                )
-            },
-        )
+        for template in (tracker_template, executor_template):
+            template.has_resource_properties(
+                "AWS::ECS::TaskDefinition",
+                {
+                    "ContainerDefinitions": assertions.Match.array_with(
+                        [
+                            assertions.Match.object_like(
+                                {
+                                    "Environment": assertions.Match.array_with(
+                                        [
+                                            assertions.Match.object_like(
+                                                {"Name": "SENTRY_RELEASE", "Value": "deployment-sha"}
+                                            )
+                                        ]
+                                    ),
+                                    "Secrets": assertions.Match.array_with(
+                                        [assertions.Match.object_like({"Name": "SENTRY_DSN"})]
+                                    ),
+                                }
+                            )
+                        ]
+                    )
+                },
+            )
         sentry_value_from = [
             secret["ValueFrom"]
-            for task_definition in tracker_template.find_resources("AWS::ECS::TaskDefinition").values()
+            for template in (tracker_template, executor_template)
+            for task_definition in template.find_resources("AWS::ECS::TaskDefinition").values()
             for container in task_definition["Properties"]["ContainerDefinitions"]
             for secret in container.get("Secrets", [])
             if secret["Name"] == "SENTRY_DSN"
         ]
-        self.assertEqual(len(sentry_value_from), 1)
-        self.assertIn(custom_sentry_secret_name, str(sentry_value_from[0]))
-        self.assertNotIn("SENTRY_DSN", str(executor_template.to_json()))
+        self.assertEqual(len(sentry_value_from), 2)
+        self.assertTrue(all(custom_sentry_secret_name in str(value) for value in sentry_value_from))
 
 
 if __name__ == "__main__":

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -43,6 +43,7 @@ TEST_DEPLOYMENT_SLACK_ENV = {
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
 }
 TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
+TEST_SENTRY_DSN_SECRET_NAME = "example/sentry-dsn"
 TEST_MANAGED_ORG_ID = "00000000-0000-0000-0000-000000000001"
 TEST_TRACKER_SECRET_NAME_PREFIX = "test-tracker-secret"
 TEST_DEV_ENV = {
@@ -50,8 +51,9 @@ TEST_DEV_ENV = {
     "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
+    "SENTRY_DSN_SECRET_NAME": TEST_SENTRY_DSN_SECRET_NAME,
 }
-TEST_PROD_ENV = {"SENTRY_DSN_SECRET_NAME": "example/sentry-dsn"}
+TEST_PROD_ENV = {"SENTRY_DSN_SECRET_NAME": TEST_SENTRY_DSN_SECRET_NAME}
 TEST_RELEASE_TEST_ENV = {
     "DESCOPE_PROJECT_ID": "release-test",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
@@ -807,12 +809,12 @@ class MonitoringStackTest(unittest.TestCase):
                 },
             )
 
-    def test_dev_sentry_secret_is_optional(self) -> None:
-        with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
-            tracker_template, executor_template, _ = service_templates(DEV)
+    def test_production_requires_sentry_secret(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaisesRegex(ValueError, "require SENTRY_DSN_SECRET_NAME"):
+                service_templates(PROD)
 
-        self.assertNotIn("SENTRY_DSN", str(tracker_template.to_json()))
-        self.assertNotIn("SENTRY_DSN", str(executor_template.to_json()))
+    def test_dev_sentry_secret_is_injected(self) -> None:
 
         custom_sentry_secret_name = "custom/dev-sentry-dsn"
         sentry_environment = {

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -160,8 +160,8 @@ class TrackerStack(Stack):
         }
 
         sentry_secret_name = os.environ.get("SENTRY_DSN_SECRET_NAME", "")
-        if stage.is_prod and not sentry_secret_name:
-            raise ValueError("Production deployments require SENTRY_DSN_SECRET_NAME.")
+        if not stage.is_release_test and not sentry_secret_name:
+            raise ValueError("Dev and production deployments require SENTRY_DSN_SECRET_NAME.")
 
         sentry_secrets: dict[str, aws_ecs.Secret] = {}
         if sentry_secret_name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ venvPath="."
 venv=".venv"
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
+extraPaths = ["services/tracker/src"]
 
 reportExplicitAny = false
 reportAny = false
@@ -77,7 +78,7 @@ packages = ["src/valkyrie"]
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]
-pythonpath = ["."]
+pythonpath = [".", "services/tracker/src"]
 
 # Async test configuration
 asyncio_mode = "auto"

--- a/services/executor_host/Dockerfile
+++ b/services/executor_host/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY services/executor_host/requirements.txt ./
 RUN pip install --no-cache-dir --require-hashes -r requirements.txt
 
-COPY services/executor_host/supervisor.py ./
+COPY services/executor_host/__init__.py services/executor_host/observability.py services/executor_host/supervisor.py ./services/executor_host/
 COPY services/tracker/src/executor_protocol.py ./
 RUN useradd --create-home --uid 10001 executor \
     && mkdir -p /var/cache/valkyrie-executors \
@@ -17,4 +17,4 @@ ENV STABLE_QUEUE_NAME=valkyrie-stable
 
 USER executor
 
-CMD ["python", "-m", "taskiq", "worker", "--workers", "1", "--no-configure-logging", "supervisor:broker", "supervisor"]
+CMD ["python", "-m", "taskiq", "worker", "--workers", "1", "--no-configure-logging", "services.executor_host.supervisor:broker", "services.executor_host.supervisor"]

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from typing import Generator
 
 import sentry_sdk
+from sentry_sdk.consts import SPANSTATUS
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 from executor_protocol import ExecutorTelemetryContext
@@ -101,7 +102,7 @@ def dispatch_observability_context(
     release_id: str,
     telemetry_context: ExecutorTelemetryContext,
 ) -> Generator[ExecutorTelemetryContext, None, None]:
-    """Bind one dispatch and continue its trace into the executor artifact."""
+    """Bind one dispatch and create the child executor trace context."""
     tokens = [
         request_id_var.set(telemetry_context["request_id"]),
         benchmark_id_var.set(benchmark_id),
@@ -114,7 +115,7 @@ def dispatch_observability_context(
             transaction = sentry_sdk.continue_trace(
                 telemetry_context["trace_headers"],
                 op="queue.process",
-                name="executor_host.dispatch",
+                name="executor_host.dispatch.accepted",
             )
             with sentry_sdk.start_transaction(transaction):
                 trace_headers = dict(telemetry_context["trace_headers"])
@@ -124,10 +125,34 @@ def dispatch_observability_context(
                     trace_headers["sentry-trace"] = sentry_trace
                 if baggage := sentry_sdk.get_baggage():
                     trace_headers["baggage"] = baggage
-                yield {
+                child_context: ExecutorTelemetryContext = {
                     "request_id": telemetry_context["request_id"],
                     "trace_headers": trace_headers,
                 }
+            yield child_context
     finally:
         for token in reversed(tokens):
             token.var.reset(token)
+
+
+def record_dispatch_completion(telemetry_context: ExecutorTelemetryContext) -> None:
+    """Record the terminal host signal without holding a transaction across execution."""
+    transaction = sentry_sdk.continue_trace(
+        telemetry_context["trace_headers"],
+        op="queue.process",
+        name="executor_host.dispatch.completed",
+    )
+    with sentry_sdk.start_transaction(transaction):
+        pass
+
+
+def capture_dispatch_error(error: BaseException, telemetry_context: ExecutorTelemetryContext) -> None:
+    """Capture a host dispatch error on a bounded trace segment."""
+    transaction = sentry_sdk.continue_trace(
+        telemetry_context["trace_headers"],
+        op="queue.process",
+        name="executor_host.dispatch.failed",
+    )
+    with sentry_sdk.start_transaction(transaction) as span:
+        span.set_status(SPANSTATUS.INTERNAL_ERROR)
+        sentry_sdk.capture_exception(error)

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -83,6 +83,8 @@ def configure_observability() -> None:
             ],
         )
     except Exception as error:
+        if os.environ.get("ENVIRONMENT") == "production":
+            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.") from None
         logging.getLogger(__name__).warning(
             "Failed to initialize Sentry: %s: %s",
             type(error).__name__,

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -21,6 +21,7 @@ request_id_var = contextvars.ContextVar("request_id", default="")
 benchmark_id_var = contextvars.ContextVar("benchmark_id", default="")
 dispatch_id_var = contextvars.ContextVar("executor_dispatch_id", default="")
 release_id_var = contextvars.ContextVar("executor_release_id", default="")
+logger = logging.getLogger(__name__)
 
 
 def _context_fields() -> dict[str, str]:
@@ -146,6 +147,18 @@ def record_dispatch_completion(telemetry_context: ExecutorTelemetryContext) -> N
         pass
 
 
+def record_dispatch_cancellation(telemetry_context: ExecutorTelemetryContext) -> None:
+    """Record a cancelled host dispatch without creating an error issue."""
+    transaction = sentry_sdk.continue_trace(
+        telemetry_context["trace_headers"],
+        op="queue.process",
+        name="executor_host.dispatch.cancelled",
+    )
+    with sentry_sdk.start_transaction(transaction) as span:
+        span.set_status(SPANSTATUS.CANCELLED)
+        logger.info("Executor dispatch cancelled")
+
+
 def capture_dispatch_error(error: BaseException, telemetry_context: ExecutorTelemetryContext) -> None:
     """Capture a host dispatch error on a bounded trace segment."""
     transaction = sentry_sdk.continue_trace(
@@ -155,4 +168,8 @@ def capture_dispatch_error(error: BaseException, telemetry_context: ExecutorTele
     )
     with sentry_sdk.start_transaction(transaction) as span:
         span.set_status(SPANSTATUS.INTERNAL_ERROR)
+        logger.error(
+            "Executor dispatch failed",
+            exc_info=(type(error), error, error.__traceback__),
+        )
         sentry_sdk.capture_exception(error)

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -66,8 +66,6 @@ def configure_observability() -> None:
 
     dsn = os.environ.get("SENTRY_DSN", "")
     if not dsn:
-        if os.environ.get("ENVIRONMENT") == "production":
-            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.")
         return
     try:
         sentry_sdk.init(
@@ -87,9 +85,7 @@ def configure_observability() -> None:
             ],
         )
     except Exception as error:
-        if os.environ.get("ENVIRONMENT") == "production":
-            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.") from None
-        logging.getLogger(__name__).warning(
+        logger.warning(
             "Failed to initialize Sentry: %s: %s",
             type(error).__name__,
             error,
@@ -111,65 +107,134 @@ def dispatch_observability_context(
         release_id_var.set(release_id),
     ]
     try:
-        with sentry_sdk.new_scope() as scope:
-            scope.set_tags({key: value for key, value in _context_fields().items() if value})
-            transaction = sentry_sdk.continue_trace(
-                telemetry_context["trace_headers"],
-                op="queue.process",
-                name="executor_host.dispatch.accepted",
-            )
-            with sentry_sdk.start_transaction(transaction):
-                trace_headers = dict(telemetry_context["trace_headers"])
-                if sentry_trace := sentry_sdk.get_traceparent():
-                    trace_headers.pop("traceparent", None)
-                    trace_headers.pop("tracestate", None)
-                    trace_headers["sentry-trace"] = sentry_trace
-                if baggage := sentry_sdk.get_baggage():
-                    trace_headers["baggage"] = baggage
-                child_context: ExecutorTelemetryContext = {
-                    "request_id": telemetry_context["request_id"],
-                    "trace_headers": trace_headers,
-                }
+        with _dispatch_sentry_scope():
+            child_context = _accepted_telemetry_context(telemetry_context)
             yield child_context
     finally:
         for token in reversed(tokens):
             token.var.reset(token)
 
 
+@contextmanager
+def _dispatch_sentry_scope() -> Generator[None, None, None]:
+    scope_manager = None
+    scope_entered = False
+    try:
+        scope_manager = sentry_sdk.new_scope()
+        scope = scope_manager.__enter__()
+        scope_entered = True
+        scope.set_tags({key: value for key, value in _context_fields().items() if value})
+    except Exception as error:
+        logger.warning("Failed to bind executor dispatch telemetry: %s: %s", type(error).__name__, error)
+
+    try:
+        yield
+    except BaseException as error:
+        if scope_manager is not None and scope_entered:
+            try:
+                scope_manager.__exit__(type(error), error, error.__traceback__)
+            except Exception as telemetry_error:
+                logger.warning(
+                    "Failed to release executor dispatch telemetry: %s: %s",
+                    type(telemetry_error).__name__,
+                    telemetry_error,
+                )
+        raise
+    else:
+        if scope_manager is not None and scope_entered:
+            try:
+                scope_manager.__exit__(None, None, None)
+            except Exception as error:
+                logger.warning("Failed to release executor dispatch telemetry: %s: %s", type(error).__name__, error)
+
+
+def _accepted_telemetry_context(telemetry_context: ExecutorTelemetryContext) -> ExecutorTelemetryContext:
+    try:
+        transaction = sentry_sdk.continue_trace(
+            telemetry_context["trace_headers"],
+            op="queue.process",
+            name="executor_host.dispatch.accepted",
+        )
+        with sentry_sdk.start_transaction(transaction):
+            trace_headers = dict(telemetry_context["trace_headers"])
+            if sentry_trace := sentry_sdk.get_traceparent():
+                trace_headers.pop("traceparent", None)
+                trace_headers.pop("tracestate", None)
+                trace_headers["sentry-trace"] = sentry_trace
+            if baggage := sentry_sdk.get_baggage():
+                trace_headers["baggage"] = baggage
+            child_context: ExecutorTelemetryContext = {
+                "request_id": telemetry_context["request_id"],
+                "trace_headers": trace_headers,
+            }
+        return child_context
+    except Exception as error:
+        logger.warning(
+            "Failed to record executor dispatch acceptance: %s: %s",
+            type(error).__name__,
+            error,
+        )
+        return {
+            "request_id": telemetry_context["request_id"],
+            "trace_headers": dict(telemetry_context["trace_headers"]),
+        }
+
+
+def _record_terminal_transaction(
+    telemetry_context: ExecutorTelemetryContext,
+    *,
+    name: str,
+    status: str | None = None,
+    error: BaseException | None = None,
+) -> None:
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tags({key: value for key, value in _context_fields().items() if value})
+            transaction = sentry_sdk.continue_trace(
+                telemetry_context["trace_headers"],
+                op="queue.process",
+                name=name,
+            )
+            with sentry_sdk.start_transaction(transaction) as span:
+                if status is not None:
+                    span.set_status(status)
+                if error is not None:
+                    sentry_sdk.capture_exception(error)
+    except Exception as telemetry_error:
+        logger.warning(
+            "Failed to record executor dispatch telemetry: %s: %s",
+            type(telemetry_error).__name__,
+            telemetry_error,
+        )
+
+
 def record_dispatch_completion(telemetry_context: ExecutorTelemetryContext) -> None:
     """Record the terminal host signal without holding a transaction across execution."""
-    transaction = sentry_sdk.continue_trace(
-        telemetry_context["trace_headers"],
-        op="queue.process",
+    _record_terminal_transaction(
+        telemetry_context,
         name="executor_host.dispatch.completed",
     )
-    with sentry_sdk.start_transaction(transaction):
-        pass
 
 
 def record_dispatch_cancellation(telemetry_context: ExecutorTelemetryContext) -> None:
     """Record a cancelled host dispatch without creating an error issue."""
-    transaction = sentry_sdk.continue_trace(
-        telemetry_context["trace_headers"],
-        op="queue.process",
+    logger.info("Executor dispatch cancelled")
+    _record_terminal_transaction(
+        telemetry_context,
         name="executor_host.dispatch.cancelled",
+        status=SPANSTATUS.CANCELLED,
     )
-    with sentry_sdk.start_transaction(transaction) as span:
-        span.set_status(SPANSTATUS.CANCELLED)
-        logger.info("Executor dispatch cancelled")
 
 
 def capture_dispatch_error(error: BaseException, telemetry_context: ExecutorTelemetryContext) -> None:
     """Capture a host dispatch error on a bounded trace segment."""
-    transaction = sentry_sdk.continue_trace(
-        telemetry_context["trace_headers"],
-        op="queue.process",
-        name="executor_host.dispatch.failed",
+    logger.error(
+        "Executor dispatch failed",
+        exc_info=(type(error), error, error.__traceback__),
     )
-    with sentry_sdk.start_transaction(transaction) as span:
-        span.set_status(SPANSTATUS.INTERNAL_ERROR)
-        logger.error(
-            "Executor dispatch failed",
-            exc_info=(type(error), error, error.__traceback__),
-        )
-        sentry_sdk.capture_exception(error)
+    _record_terminal_transaction(
+        telemetry_context,
+        name="executor_host.dispatch.failed",
+        status=SPANSTATUS.INTERNAL_ERROR,
+        error=error,
+    )

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -64,6 +64,8 @@ def configure_observability() -> None:
 
     dsn = os.environ.get("SENTRY_DSN", "")
     if not dsn:
+        if os.environ.get("ENVIRONMENT") == "production":
+            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.")
         return
     try:
         sentry_sdk.init(

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -1,0 +1,129 @@
+"""Structured logging and Sentry correlation for the stable executor host."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import sys
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Generator
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from executor_protocol import ExecutorTelemetryContext
+
+request_id_var = contextvars.ContextVar("request_id", default="")
+benchmark_id_var = contextvars.ContextVar("benchmark_id", default="")
+dispatch_id_var = contextvars.ContextVar("executor_dispatch_id", default="")
+release_id_var = contextvars.ContextVar("executor_release_id", default="")
+
+
+def _context_fields() -> dict[str, str]:
+    return {
+        "request_id": request_id_var.get(),
+        "benchmark_id": benchmark_id_var.get(),
+        "executor_dispatch_id": dispatch_id_var.get(),
+        "executor_release_id": release_id_var.get(),
+    }
+
+
+class _ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        for key, value in _context_fields().items():
+            if not getattr(record, key, None):
+                setattr(record, key, value)
+        return True
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            **{key: getattr(record, key, "") for key in _context_fields()},
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def configure_observability() -> None:
+    """Configure CloudWatch JSON logs and Sentry for the host process."""
+    handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(_ContextFilter())
+    handler.setFormatter(_JsonFormatter())
+    root_logger = logging.getLogger()
+    root_logger.handlers = [handler]
+    root_logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+    dsn = os.environ.get("SENTRY_DSN", "")
+    if not dsn:
+        return
+    try:
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.environ.get("ENVIRONMENT", "development"),
+            release=os.environ.get("SENTRY_RELEASE") or None,
+            server_name="valkyrie-executor-host",
+            enable_logs=True,
+            send_default_pii=False,
+            traces_sample_rate=1.0,
+            integrations=[
+                LoggingIntegration(
+                    level=logging.INFO,
+                    event_level=None,
+                    sentry_logs_level=logging.INFO,
+                )
+            ],
+        )
+    except Exception as error:
+        logging.getLogger(__name__).warning(
+            "Failed to initialize Sentry: %s: %s",
+            type(error).__name__,
+            error,
+        )
+
+
+@contextmanager
+def dispatch_observability_context(
+    benchmark_id: str,
+    dispatch_id: str,
+    release_id: str,
+    telemetry_context: ExecutorTelemetryContext,
+) -> Generator[ExecutorTelemetryContext, None, None]:
+    """Bind one dispatch and continue its trace into the executor artifact."""
+    tokens = [
+        request_id_var.set(telemetry_context["request_id"]),
+        benchmark_id_var.set(benchmark_id),
+        dispatch_id_var.set(dispatch_id),
+        release_id_var.set(release_id),
+    ]
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tags({key: value for key, value in _context_fields().items() if value})
+            transaction = sentry_sdk.continue_trace(
+                telemetry_context["trace_headers"],
+                op="queue.process",
+                name="executor_host.dispatch",
+            )
+            with sentry_sdk.start_transaction(transaction):
+                trace_headers = dict(telemetry_context["trace_headers"])
+                if sentry_trace := sentry_sdk.get_traceparent():
+                    trace_headers.pop("traceparent", None)
+                    trace_headers.pop("tracestate", None)
+                    trace_headers["sentry-trace"] = sentry_trace
+                if baggage := sentry_sdk.get_baggage():
+                    trace_headers["baggage"] = baggage
+                yield {
+                    "request_id": telemetry_context["request_id"],
+                    "trace_headers": trace_headers,
+                }
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)

--- a/services/executor_host/pyproject.toml
+++ b/services/executor_host/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = "==3.12.*"
 dependencies = [
   "boto3==1.43.0",
   "psycopg2-binary==2.9.11",
+  "sentry-sdk==2.58.0",
   "taskiq==0.12.1",
   "taskiq-redis==1.2.2",
 ]

--- a/services/executor_host/requirements.txt
+++ b/services/executor_host/requirements.txt
@@ -51,6 +51,10 @@ botocore==1.43.51 \
     # via
     #   boto3
     #   s3transfer
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
+    --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
+    # via sentry-sdk
 frozenlist==1.8.0 \
     --hash=sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d \
     --hash=sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b \
@@ -196,6 +200,10 @@ s3transfer==0.17.1 \
     --hash=sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e \
     --hash=sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c
     # via boto3
+sentry-sdk==2.58.0 \
+    --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
+    --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
+    # via valkyrie-executor-host
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -231,7 +239,9 @@ typing-inspection==0.4.2 \
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
-    # via botocore
+    # via
+    #   botocore
+    #   sentry-sdk
 yarl==1.24.5 \
     --hash=sha256:3363fcc96e665878946ad7a106b9a13eac0541766a690ef287c0232ac768b6ec \
     --hash=sha256:377fe3732edbaf78ee74efdf2c9f49f6e99f20e7f9d2649fda3eb4badd77d76e \

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -12,14 +12,16 @@ import sys
 import tempfile
 import urllib.request
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Mapping, Protocol, Unpack, cast
 
 import boto3
 import psycopg2  # pyright: ignore[reportMissingModuleSource]
+import sentry_sdk
 from psycopg2.extensions import connection as PostgresConnection  # pyright: ignore[reportMissingModuleSource]
 from redis.asyncio import Redis
+from taskiq import TaskiqEvents
 from taskiq_redis import RedisStreamBroker
 from executor_protocol import (
     DEFAULT_EXECUTOR_RELEASE_PREFIX,
@@ -27,8 +29,13 @@ from executor_protocol import (
     EXECUTOR_TASK_NAME,
     SUPPORTED_PROTOCOL_VERSIONS,
     ExecutorPayload,
+    ExecutorTelemetryContext,
     validate_executor_artifact_uri,
     validate_executor_digest,
+)
+from services.executor_host.observability import (
+    configure_observability,
+    dispatch_observability_context,
 )
 
 logger = logging.getLogger(__name__)
@@ -167,10 +174,12 @@ class DispatchAuthority:
 class ExecutorProcessPayload:
     benchmark_id: str
     verified_task_ids: list[str]
+    telemetry_context: ExecutorTelemetryContext
     arguments: dict[str, object]
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, object]) -> ExecutorProcessPayload:
+        telemetry_context = _telemetry_context(payload.get("telemetry_context_json"))
         execution_context = payload.get("execution_context_json")
         access_key_values = (
             payload.get("start_benchmark_request_json"),
@@ -196,6 +205,7 @@ class ExecutorProcessPayload:
                 "benchmark_id_str": benchmark_id,
                 "verified_task_ids": raw_task_ids,
             }
+        arguments["telemetry_context_json"] = telemetry_context
         if not isinstance(benchmark_id, str) or not benchmark_id:
             raise ValueError("Executor payload has no valid benchmark ID")
         verified_task_ids = (
@@ -204,8 +214,27 @@ class ExecutorProcessPayload:
         return cls(
             benchmark_id=benchmark_id,
             verified_task_ids=verified_task_ids,
+            telemetry_context=telemetry_context,
             arguments=arguments,
         )
+
+
+def _telemetry_context(value: object) -> ExecutorTelemetryContext:
+    if not isinstance(value, Mapping):
+        return {"request_id": "", "trace_headers": {}}
+
+    telemetry_context = cast(Mapping[object, object], value)
+    request_id = telemetry_context.get("request_id")
+    raw_trace_headers = telemetry_context.get("trace_headers")
+    trace_headers = (
+        {str(key): str(header) for key, header in cast(Mapping[object, object], raw_trace_headers).items()}
+        if isinstance(raw_trace_headers, Mapping)
+        else {}
+    )
+    return {
+        "request_id": str(request_id) if request_id else "",
+        "trace_headers": trace_headers,
+    }
 
 
 class ExecutorDispatchStore(Protocol):
@@ -578,6 +607,7 @@ class ExecutorSupervisor:
                 str(artifact_path),
                 str(payload_path),
                 start_new_session=True,
+                env={**os.environ, "SENTRY_RELEASE": dispatch.release_id},
             )
             try:
                 return_code = await self._wait_with_authority(process, is_current)
@@ -672,6 +702,13 @@ broker = DeleteAfterAckRedisStreamBroker(
     consumer_group_name=QUEUE_NAME,
     idle_timeout=86400000,
 )
+
+
+@broker.on_event(TaskiqEvents.WORKER_STARTUP)
+async def _init_worker_observability(*_args: object, **_kwargs: object) -> None:  # pyright: ignore[reportUnusedFunction]
+    configure_observability()
+
+
 supervisor = ExecutorSupervisor(CACHE_DIR)
 dispatch_store = PostgresExecutorDispatchStore.from_environment()
 
@@ -765,10 +802,30 @@ async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
     dispatch_id = _required_string(raw_payload, "executor_dispatch_id")
     dispatch = ArtifactDispatch.from_payload(raw_payload)
     process_payload = ExecutorProcessPayload.from_payload(raw_payload)
-    await run_executor_dispatch(
-        supervisor,
-        dispatch_store,
-        executor_dispatch_id=dispatch_id,
-        dispatch=dispatch,
-        process_payload=process_payload,
-    )
+    with dispatch_observability_context(
+        process_payload.benchmark_id,
+        dispatch_id,
+        dispatch.release_id,
+        process_payload.telemetry_context,
+    ) as child_telemetry_context:
+        process_payload = replace(
+            process_payload,
+            telemetry_context=child_telemetry_context,
+            arguments={
+                **process_payload.arguments,
+                "telemetry_context_json": child_telemetry_context,
+            },
+        )
+        try:
+            await run_executor_dispatch(
+                supervisor,
+                dispatch_store,
+                executor_dispatch_id=dispatch_id,
+                dispatch=dispatch,
+                process_payload=process_payload,
+            )
+        except asyncio.CancelledError:
+            raise
+        except BaseException as error:
+            sentry_sdk.capture_exception(error)
+            raise

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -237,6 +237,21 @@ def _telemetry_context(value: object) -> ExecutorTelemetryContext:
     }
 
 
+def _payload_benchmark_id(payload: Mapping[str, object]) -> str:
+    benchmark_id = payload.get("benchmark_id_str")
+    if benchmark_id:
+        return str(benchmark_id)
+    execution_context = payload.get("execution_context_json")
+    if isinstance(execution_context, Mapping):
+        benchmark_id = cast(Mapping[object, object], execution_context).get("benchmark_id")
+    return str(benchmark_id) if benchmark_id else ""
+
+
+def _payload_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    return str(value) if value else ""
+
+
 class ExecutorDispatchStore(Protocol):
     async def claim(
         self,
@@ -799,24 +814,24 @@ async def run_executor_dispatch(
 @broker.task(EXECUTOR_TASK_NAME)
 async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
     raw_payload: dict[str, object] = dict(payload)
-    dispatch_id = _required_string(raw_payload, "executor_dispatch_id")
-    dispatch = ArtifactDispatch.from_payload(raw_payload)
-    process_payload = ExecutorProcessPayload.from_payload(raw_payload)
     with dispatch_observability_context(
-        process_payload.benchmark_id,
-        dispatch_id,
-        dispatch.release_id,
-        process_payload.telemetry_context,
+        _payload_benchmark_id(raw_payload),
+        _payload_string(raw_payload, "executor_dispatch_id"),
+        _payload_string(raw_payload, "executor_release_id"),
+        _telemetry_context(raw_payload.get("telemetry_context_json")),
     ) as child_telemetry_context:
-        process_payload = replace(
-            process_payload,
-            telemetry_context=child_telemetry_context,
-            arguments={
-                **process_payload.arguments,
-                "telemetry_context_json": child_telemetry_context,
-            },
-        )
         try:
+            dispatch_id = _required_string(raw_payload, "executor_dispatch_id")
+            dispatch = ArtifactDispatch.from_payload(raw_payload)
+            process_payload = ExecutorProcessPayload.from_payload(raw_payload)
+            process_payload = replace(
+                process_payload,
+                telemetry_context=child_telemetry_context,
+                arguments={
+                    **process_payload.arguments,
+                    "telemetry_context_json": child_telemetry_context,
+                },
+            )
             await run_executor_dispatch(
                 supervisor,
                 dispatch_store,

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -18,7 +18,6 @@ from typing import Mapping, Protocol, Unpack, cast
 
 import boto3
 import psycopg2  # pyright: ignore[reportMissingModuleSource]
-import sentry_sdk
 from psycopg2.extensions import connection as PostgresConnection  # pyright: ignore[reportMissingModuleSource]
 from redis.asyncio import Redis
 from taskiq import TaskiqEvents
@@ -34,8 +33,10 @@ from executor_protocol import (
     validate_executor_digest,
 )
 from services.executor_host.observability import (
+    capture_dispatch_error,
     configure_observability,
     dispatch_observability_context,
+    record_dispatch_completion,
 )
 
 logger = logging.getLogger(__name__)
@@ -839,8 +840,9 @@ async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
                 dispatch=dispatch,
                 process_payload=process_payload,
             )
+            record_dispatch_completion(child_telemetry_context)
         except asyncio.CancelledError:
             raise
         except BaseException as error:
-            sentry_sdk.capture_exception(error)
+            capture_dispatch_error(error, child_telemetry_context)
             raise

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -28,7 +28,8 @@ from executor_protocol import (
     EXECUTOR_TASK_NAME,
     SUPPORTED_PROTOCOL_VERSIONS,
     ExecutorPayload,
-    ExecutorTelemetryContext,
+    executor_payload_benchmark_id,
+    normalize_executor_telemetry_context,
     validate_executor_artifact_uri,
     validate_executor_digest,
 )
@@ -176,12 +177,11 @@ class DispatchAuthority:
 class ExecutorProcessPayload:
     benchmark_id: str
     verified_task_ids: list[str]
-    telemetry_context: ExecutorTelemetryContext
     arguments: dict[str, object]
 
     @classmethod
     def from_payload(cls, payload: Mapping[str, object]) -> ExecutorProcessPayload:
-        telemetry_context = _telemetry_context(payload.get("telemetry_context_json"))
+        telemetry_context = normalize_executor_telemetry_context(payload.get("telemetry_context_json"))
         execution_context = payload.get("execution_context_json")
         access_key_values = (
             payload.get("start_benchmark_request_json"),
@@ -216,37 +216,8 @@ class ExecutorProcessPayload:
         return cls(
             benchmark_id=benchmark_id,
             verified_task_ids=verified_task_ids,
-            telemetry_context=telemetry_context,
             arguments=arguments,
         )
-
-
-def _telemetry_context(value: object) -> ExecutorTelemetryContext:
-    if not isinstance(value, Mapping):
-        return {"request_id": "", "trace_headers": {}}
-
-    telemetry_context = cast(Mapping[object, object], value)
-    request_id = telemetry_context.get("request_id")
-    raw_trace_headers = telemetry_context.get("trace_headers")
-    trace_headers = (
-        {str(key): str(header) for key, header in cast(Mapping[object, object], raw_trace_headers).items()}
-        if isinstance(raw_trace_headers, Mapping)
-        else {}
-    )
-    return {
-        "request_id": str(request_id) if request_id else "",
-        "trace_headers": trace_headers,
-    }
-
-
-def _payload_benchmark_id(payload: Mapping[str, object]) -> str:
-    benchmark_id = payload.get("benchmark_id_str")
-    if benchmark_id:
-        return str(benchmark_id)
-    execution_context = payload.get("execution_context_json")
-    if isinstance(execution_context, Mapping):
-        benchmark_id = cast(Mapping[object, object], execution_context).get("benchmark_id")
-    return str(benchmark_id) if benchmark_id else ""
 
 
 def _payload_string(payload: Mapping[str, object], key: str) -> str:
@@ -817,10 +788,10 @@ async def run_executor_dispatch(
 async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
     raw_payload: dict[str, object] = dict(payload)
     with dispatch_observability_context(
-        _payload_benchmark_id(raw_payload),
+        executor_payload_benchmark_id(raw_payload),
         _payload_string(raw_payload, "executor_dispatch_id"),
         _payload_string(raw_payload, "executor_release_id"),
-        _telemetry_context(raw_payload.get("telemetry_context_json")),
+        normalize_executor_telemetry_context(raw_payload.get("telemetry_context_json")),
     ) as child_telemetry_context:
         try:
             dispatch_id = _required_string(raw_payload, "executor_dispatch_id")
@@ -828,7 +799,6 @@ async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
             process_payload = ExecutorProcessPayload.from_payload(raw_payload)
             process_payload = replace(
                 process_payload,
-                telemetry_context=child_telemetry_context,
                 arguments={
                     **process_payload.arguments,
                     "telemetry_context_json": child_telemetry_context,

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -36,6 +36,7 @@ from services.executor_host.observability import (
     capture_dispatch_error,
     configure_observability,
     dispatch_observability_context,
+    record_dispatch_cancellation,
     record_dispatch_completion,
 )
 
@@ -842,6 +843,7 @@ async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
             )
             record_dispatch_completion(child_telemetry_context)
         except asyncio.CancelledError:
+            record_dispatch_cancellation(child_telemetry_context)
             raise
         except BaseException as error:
             capture_dispatch_error(error, child_telemetry_context)

--- a/services/executor_host/uv.lock
+++ b/services/executor_host/uv.lock
@@ -120,6 +120,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -340,6 +349,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +447,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "psycopg2-binary" },
+    { name = "sentry-sdk" },
     { name = "taskiq" },
     { name = "taskiq-redis" },
 ]
@@ -433,6 +456,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = "==1.43.0" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
+    { name = "sentry-sdk", specifier = "==2.58.0" },
     { name = "taskiq", specifier = "==0.12.1" },
     { name = "taskiq-redis", specifier = "==1.2.2" },
 ]

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -626,7 +626,7 @@ async def start_benchmark(
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         raise TrackerServiceError("Failed to admit benchmark execution") from exc
 
-    bind_benchmark_id(benchmark_row.id)
+    await bind_benchmark_id(benchmark_row.id)
 
     if run_starter.access_key_id is not None and run_starter.email is None:
         logger.warning(

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -5,7 +5,7 @@ import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Annotated, Any, cast
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 import httpx
@@ -24,6 +24,7 @@ from sqlmodel import Session, col, select
 from tracker.api.agents import router as agents_router
 from tracker.api.benchmark_services import router as benchmark_services_router
 from tracker.api.benchmarks_status import router as benchmarks_status_router
+from tracker.api.dependencies import TrackedBenchmarkId, bind_benchmark_id
 from tracker.api.dependencies import RunAWSDependency
 from tracker.api.filter_options import router as filter_options_router
 from tracker.api.single_benchmark import router as single_benchmark_router
@@ -95,8 +96,8 @@ from tracker.docent_analysis import (
     analyze_event_stream,
 )
 from tracker.exceptions import TrackerServiceError
-from executor_protocol import EXECUTOR_TASK_NAME, executor_task_signature
-from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
+from executor_protocol import EXECUTOR_TASK_NAME, ExecutorTelemetryContext, executor_task_signature
+from tracker.logging import configure_logging, get_logger, request_id_var
 from tracker.executor.release_control import MaintenanceModeError, ReleaseControlError, lock_executor_admission
 from tracker.executor.release_retirement import AutomaticReleaseRetirement
 from tracker.middleware import RequestContextMiddleware
@@ -192,20 +193,14 @@ class HealthCheckFilter(logging.Filter):
 logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 
-def bind_benchmark_id(benchmark_id: UUID) -> UUID:
-    """Dependency that binds benchmark_id to the logging context."""
-    benchmark_id_var.set(str(benchmark_id))
-    return benchmark_id
-
-
-TrackedBenchmarkId = Annotated[UUID, Depends(bind_benchmark_id)]
-
-
-def _taskiq_labels() -> dict[str, str]:
-    """Labels attached to a kicked task: current request id + injected OTel trace context."""
-    trace_context: dict[str, str] = {}
-    inject(trace_context)
-    return {"request_id": request_id_var.get(), **trace_context}
+def _executor_telemetry_context() -> ExecutorTelemetryContext:
+    """Capture request and distributed trace context for the executor process."""
+    trace_headers: dict[str, str] = {}
+    inject(trace_headers)
+    return {
+        "request_id": request_id_var.get(),
+        "trace_headers": trace_headers,
+    }
 
 
 def _process_benchmark_kwargs(
@@ -236,13 +231,19 @@ async def _enqueue_executor_dispatch(
     payload: dict[str, Any],
     verified_task_ids: list[str],
 ) -> None:
+    telemetry_context = _executor_telemetry_context()
+    taskiq_labels = {
+        "request_id": telemetry_context["request_id"],
+        **telemetry_context["trace_headers"],
+    }
     for attempt in range(3):
         try:
             await (
                 process_benchmark.kicker()
-                .with_labels(**_taskiq_labels())
+                .with_labels(**taskiq_labels)
                 .kiq(
                     **payload,
+                    telemetry_context_json=telemetry_context,
                     executor_dispatch_id=str(dispatch.id),
                     executor_release_id=dispatch.executor_release_id,
                     executor_artifact_uri=dispatch.executor_artifact_uri,
@@ -625,7 +626,7 @@ async def start_benchmark(
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         raise TrackerServiceError("Failed to admit benchmark execution") from exc
 
-    benchmark_id_var.set(str(benchmark_row.id))
+    bind_benchmark_id(benchmark_row.id)
 
     if run_starter.access_key_id is not None and run_starter.email is None:
         logger.warning(

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -77,7 +77,7 @@ venvPath = "."
 venv = ".venv"
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
-extraPaths = ["../.."]
+extraPaths = ["src", "../.."]
 
 reportExplicitAny = false
 reportAny = false
@@ -89,7 +89,7 @@ exclude = ["src/tracker/database/migrations/versions"]
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 asyncio_mode = "auto"
-pythonpath = [".", "../.."]
+pythonpath = [".", "src", "../.."]
 env = ["BROKER_ENVIRONMENT=testing"]
 [tool.coverage.run]
 source = ["src/tracker", "main"]

--- a/services/tracker/src/executor_protocol.py
+++ b/services/tracker/src/executor_protocol.py
@@ -1,7 +1,8 @@
 """Shared Tracker-to-ExecutorHost wire contract."""
 
+from collections.abc import Mapping
 from enum import Enum
-from typing import Any, NotRequired, TypedDict, Unpack
+from typing import Any, NotRequired, TypedDict, Unpack, cast
 from urllib.parse import urlparse
 
 EXECUTOR_TASK_NAME = "tracker.utils:process_benchmark"
@@ -43,6 +44,39 @@ class ExecutorPayload(TypedDict):
 async def executor_task_signature(**_payload: Unpack[ExecutorPayload]) -> None:
     """Provide the producer's typed Taskiq signature; this body never executes."""
     raise RuntimeError("Executor task signatures cannot execute in Tracker")
+
+
+def executor_payload_benchmark_id(payload: Mapping[str, object]) -> str:
+    """Return the benchmark ID from either supported executor payload shape."""
+    benchmark_id = payload.get("benchmark_id_str")
+    if benchmark_id:
+        return str(benchmark_id)
+
+    execution_context = payload.get("execution_context_json")
+    if isinstance(execution_context, Mapping):
+        benchmark_id = cast(Mapping[object, object], execution_context).get("benchmark_id")
+
+    return str(benchmark_id) if benchmark_id else ""
+
+
+def normalize_executor_telemetry_context(value: object) -> ExecutorTelemetryContext:
+    """Normalize optional telemetry fields at the executor wire boundary."""
+    if not isinstance(value, Mapping):
+        return {"request_id": "", "trace_headers": {}}
+
+    telemetry_context = cast(Mapping[object, object], value)
+    request_id = telemetry_context.get("request_id")
+    raw_trace_headers = telemetry_context.get("trace_headers")
+    trace_headers = (
+        {str(key): str(header) for key, header in cast(Mapping[object, object], raw_trace_headers).items()}
+        if isinstance(raw_trace_headers, Mapping)
+        else {}
+    )
+
+    return {
+        "request_id": str(request_id) if request_id else "",
+        "trace_headers": trace_headers,
+    }
 
 
 def validate_executor_digest(digest: str) -> str:

--- a/services/tracker/src/executor_protocol.py
+++ b/services/tracker/src/executor_protocol.py
@@ -19,6 +19,11 @@ class ExecutorDispatchStatus(str, Enum):
     FAILED = "FAILED"
 
 
+class ExecutorTelemetryContext(TypedDict):
+    request_id: str
+    trace_headers: dict[str, str]
+
+
 class ExecutorPayload(TypedDict):
     # Exactly one execution shape is set: access-key runs carry the first three
     # fields; managed runs carry only execution_context_json. Dispatch fields
@@ -27,6 +32,7 @@ class ExecutorPayload(TypedDict):
     benchmark_id_str: NotRequired[str | None]
     verified_task_ids: NotRequired[list[str] | None]
     execution_context_json: NotRequired[dict[str, Any] | None]
+    telemetry_context_json: NotRequired[ExecutorTelemetryContext | None]
     executor_dispatch_id: str
     executor_release_id: str
     executor_artifact_uri: str

--- a/services/tracker/src/tracker/api/dependencies.py
+++ b/services/tracker/src/tracker/api/dependencies.py
@@ -13,6 +13,19 @@ from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import Benchmark, Org
 from tracker.database.scoping import get_scoped
 from tracker.database.session import get_session
+from tracker.logging import benchmark_id_var
+from opentelemetry import trace
+
+
+def bind_benchmark_id(benchmark_id: UUID) -> UUID:
+    """Bind a route's run identifier to logs, errors, and the active request span."""
+    value = str(benchmark_id)
+    benchmark_id_var.set(value)
+    trace.get_current_span().set_attribute("benchmark_id", value)
+    return benchmark_id
+
+
+TrackedBenchmarkId = Annotated[UUID, Depends(bind_benchmark_id)]
 
 
 def get_agent_library_aws_runtime(
@@ -32,7 +45,7 @@ class RunAWSContext:
 
 
 def get_run_aws_context(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     request: Request,
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),

--- a/services/tracker/src/tracker/api/dependencies.py
+++ b/services/tracker/src/tracker/api/dependencies.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends, Request
+from opentelemetry import trace
 from sqlmodel import Session
 
 from tracker.auth import get_current_org
@@ -14,10 +15,9 @@ from tracker.database.models import Benchmark, Org
 from tracker.database.scoping import get_scoped
 from tracker.database.session import get_session
 from tracker.logging import benchmark_id_var
-from opentelemetry import trace
 
 
-def bind_benchmark_id(benchmark_id: UUID) -> UUID:
+async def bind_benchmark_id(benchmark_id: UUID) -> UUID:
     """Bind a route's run identifier to logs, errors, and the active request span."""
     value = str(benchmark_id)
     benchmark_id_var.set(value)

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from typing import Literal
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import case
 from sqlmodel import Session, col, desc, func, select
 
 from tracker.api.parsing import parse_csv
+from tracker.api.dependencies import TrackedBenchmarkId
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.resolver import resolve_run_metadata_aws_runtime
@@ -46,7 +45,7 @@ _STATUS_SORT_PRIORITY = case(
 
 @router.get("/{benchmark_id}", response_model=SingleBenchmarkResponse)
 def get_single_benchmark(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     request: Request,
     org: Org = Depends(get_current_org),
     session: Session = Depends(get_session),
@@ -103,7 +102,7 @@ def get_single_benchmark(
 
 @router.get("/{benchmark_id}/tasks", response_model=TasksResponse)
 def get_benchmark_tasks(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     status: str = Query(default=""),
     task_id_search: str | None = None,
     sort: Literal["task_id", "started_at", "duration", "status"] = Query(default="started_at"),

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, col, desc, select
 
-from tracker.api.dependencies import RunAWSDependency
+from tracker.api.dependencies import RunAWSDependency, TrackedBenchmarkId
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.s3 import S3_BENCHMARKS_PREFIX, create_presigned_url, s3_object_exists
@@ -85,7 +85,7 @@ def _fetch_result_objects(session: Session, task: Task, org: Org) -> tuple[Evalu
     response_model=SingleTaskResponse,
 )
 def get_single_task(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     task_id: str,
     org: Org = Depends(get_current_org),
     session: Session = Depends(get_session),
@@ -114,7 +114,7 @@ def get_single_task(
     response_model=TaskArtifactsResponse,
 )
 async def get_task_artifacts(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     task_id: str,
     run_context: RunAWSDependency,
     org: Org = Depends(get_current_org),

--- a/services/tracker/src/tracker/aws/clients.py
+++ b/services/tracker/src/tracker/aws/clients.py
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
     from tracker.types import AWSCredentials
 
 _HIGH_CONCURRENCY_CLIENT_CONFIG = Config(max_pool_connections=200)
+_CLOUDWATCH_LOGS_CLIENT_CONFIG = Config(
+    max_pool_connections=200,
+    connect_timeout=5,
+    read_timeout=5,
+    retries={"mode": "standard", "total_max_attempts": 2},
+)
 _S3_CLIENT_CONFIG = Config(max_pool_connections=200, retries={"mode": "standard"})
 _DEFAULT_CHAIN_MAXIMUM_PRESIGN_TTL_SECONDS = 3600
 
@@ -46,7 +52,7 @@ class AWSClientProvider(ABC):
     def cloudwatch_logs_client(self) -> Any:
         return _boto3_client(
             "logs",
-            config=_HIGH_CONCURRENCY_CLIENT_CONFIG,
+            config=_CLOUDWATCH_LOGS_CLIENT_CONFIG,
             **self._client_kwargs(),
         )
 

--- a/services/tracker/src/tracker/aws/clients.py
+++ b/services/tracker/src/tracker/aws/clients.py
@@ -15,12 +15,6 @@ if TYPE_CHECKING:
     from tracker.types import AWSCredentials
 
 _HIGH_CONCURRENCY_CLIENT_CONFIG = Config(max_pool_connections=200)
-_CLOUDWATCH_LOGS_CLIENT_CONFIG = Config(
-    max_pool_connections=200,
-    connect_timeout=5,
-    read_timeout=5,
-    retries={"mode": "standard", "total_max_attempts": 2},
-)
 _S3_CLIENT_CONFIG = Config(max_pool_connections=200, retries={"mode": "standard"})
 _DEFAULT_CHAIN_MAXIMUM_PRESIGN_TTL_SECONDS = 3600
 
@@ -52,7 +46,7 @@ class AWSClientProvider(ABC):
     def cloudwatch_logs_client(self) -> Any:
         return _boto3_client(
             "logs",
-            config=_CLOUDWATCH_LOGS_CLIENT_CONFIG,
+            config=_HIGH_CONCURRENCY_CLIENT_CONFIG,
             **self._client_kwargs(),
         )
 

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -12,28 +12,20 @@ from tracker.aws.runtime import AWSResources, AWSRuntime
 from tracker.exceptions import CloudWatchError
 
 _created_streams: set[str] = set()
-_created_log_groups: set[str] = set()
-_MAX_LOG_EVENT_MESSAGE_BYTES = 1_048_576 - 26
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
 
 def _sanitize_log_stream_name(task_id: str) -> str:
-    """Replace characters CloudWatch forbids in log stream names."""
+    """Make a task_id safe to use as a CloudWatch logStreamName.
+
+    AWS requires log stream names to match the regex ``[^:*]*`` (no ``:`` or
+    ``*``). Some task ids carry these characters (e.g. model-suffixed ids like
+    ``provider/model:fast``), which makes ``CreateLogStream`` raise
+    ``InvalidParameterException`` and silently drops the run's logs. Replace the
+    forbidden characters so logging degrades gracefully instead of failing.
+    """
     return re.sub(r"[:*]", "_", task_id)
-
-
-def _split_log_message(message: str) -> list[str]:
-    encoded = message.encode("utf-8")
-    chunks: list[str] = []
-    start = 0
-    while start < len(encoded):
-        end = min(start + _MAX_LOG_EVENT_MESSAGE_BYTES, len(encoded))
-        while end < len(encoded) and encoded[end] & 0b1100_0000 == 0b1000_0000:
-            end -= 1
-        chunks.append(encoded[start:end].decode("utf-8"))
-        start = end
-    return chunks
 
 
 def handle_cloudwatch_error(message: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
@@ -127,10 +119,6 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
     log_group_name = f"{runtime.resources.log_group}/{benchmark_id}"
     stream_name = _sanitize_log_stream_name(task_id)
 
-    if benchmark_id not in _created_log_groups:
-        create_benchmark_log_group(benchmark_id, runtime)
-        _created_log_groups.add(benchmark_id)
-
     if stream_key not in _created_streams:
         try:
             client.create_log_stream(logGroupName=log_group_name, logStreamName=stream_name)  # pyright: ignore[reportUnknownMemberType]
@@ -141,12 +129,11 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
             raise CloudWatchError(f"Failed to create log stream '{stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
-    for chunk in _split_log_message(message):
-        try:
-            client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-                logGroupName=log_group_name,
-                logStreamName=stream_name,
-                logEvents=[{"timestamp": int(time.time() * 1000), "message": chunk}],
-            )
-        except (ClientError, BotoCoreError) as e:
-            raise CloudWatchError(f"Failed to put log event: {e}") from e
+    try:
+        client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
+            logGroupName=log_group_name,
+            logStreamName=stream_name,
+            logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
+        )
+    except (ClientError, BotoCoreError) as e:
+        raise CloudWatchError(f"Failed to put log event: {e}") from e

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -1,4 +1,3 @@
-import re
 import time
 from collections.abc import Callable
 from functools import wraps
@@ -17,15 +16,8 @@ _R = TypeVar("_R")
 
 
 def _sanitize_log_stream_name(task_id: str) -> str:
-    """Make a task_id safe to use as a CloudWatch logStreamName.
-
-    AWS requires log stream names to match the regex ``[^:*]*`` (no ``:`` or
-    ``*``). Some task ids carry these characters (e.g. model-suffixed ids like
-    ``provider/model:fast``), which makes ``CreateLogStream`` raise
-    ``InvalidParameterException`` and silently drops the run's logs. Replace the
-    forbidden characters so logging degrades gracefully instead of failing.
-    """
-    return re.sub(r"[:*]", "_", task_id)
+    """Encode forbidden characters without merging distinct task IDs."""
+    return quote(task_id, safe="/-_.")
 
 
 def handle_cloudwatch_error(message: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -11,6 +11,7 @@ from tracker.aws.runtime import AWSResources, AWSRuntime
 from tracker.exceptions import CloudWatchError
 
 _created_streams: set[str] = set()
+_MAX_LOG_EVENT_MESSAGE_BYTES = 1_048_576 - 26
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
@@ -18,6 +19,19 @@ _R = TypeVar("_R")
 def _sanitize_log_stream_name(task_id: str) -> str:
     """Encode forbidden characters without merging distinct task IDs."""
     return quote(task_id, safe="/-_.")
+
+
+def _split_log_message(message: str) -> list[str]:
+    encoded = message.encode("utf-8")
+    chunks: list[str] = []
+    start = 0
+    while start < len(encoded):
+        end = min(start + _MAX_LOG_EVENT_MESSAGE_BYTES, len(encoded))
+        while end < len(encoded) and encoded[end] & 0b1100_0000 == 0b1000_0000:
+            end -= 1
+        chunks.append(encoded[start:end].decode("utf-8"))
+        start = end
+    return chunks
 
 
 def handle_cloudwatch_error(message: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
@@ -121,11 +135,12 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
             raise CloudWatchError(f"Failed to create log stream '{stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
-    try:
-        client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group_name,
-            logStreamName=stream_name,
-            logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
-        )
-    except (ClientError, BotoCoreError) as e:
-        raise CloudWatchError(f"Failed to put log event: {e}") from e
+    for chunk in _split_log_message(message):
+        try:
+            client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
+                logGroupName=log_group_name,
+                logStreamName=stream_name,
+                logEvents=[{"timestamp": int(time.time() * 1000), "message": chunk}],
+            )
+        except (ClientError, BotoCoreError) as e:
+            raise CloudWatchError(f"Failed to put log event: {e}") from e

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -1,3 +1,4 @@
+import re
 import time
 from collections.abc import Callable
 from functools import wraps
@@ -11,14 +12,15 @@ from tracker.aws.runtime import AWSResources, AWSRuntime
 from tracker.exceptions import CloudWatchError
 
 _created_streams: set[str] = set()
+_created_log_groups: set[str] = set()
 _MAX_LOG_EVENT_MESSAGE_BYTES = 1_048_576 - 26
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
 
 def _sanitize_log_stream_name(task_id: str) -> str:
-    """Encode forbidden characters without merging distinct task IDs."""
-    return quote(task_id, safe="/-_.")
+    """Replace characters CloudWatch forbids in log stream names."""
+    return re.sub(r"[:*]", "_", task_id)
 
 
 def _split_log_message(message: str) -> list[str]:
@@ -124,6 +126,10 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
     client = runtime.clients.cloudwatch_logs_client()
     log_group_name = f"{runtime.resources.log_group}/{benchmark_id}"
     stream_name = _sanitize_log_stream_name(task_id)
+
+    if benchmark_id not in _created_log_groups:
+        create_benchmark_log_group(benchmark_id, runtime)
+        _created_log_groups.add(benchmark_id)
 
     if stream_key not in _created_streams:
         try:

--- a/services/tracker/src/tracker/executor/entrypoint.py
+++ b/services/tracker/src/tracker/executor/entrypoint.py
@@ -16,47 +16,30 @@ import sentry_sdk
 from opentelemetry.context import attach, detach
 from opentelemetry.propagate import extract
 
-from executor_protocol import SUPPORTED_PROTOCOL_VERSION
+from executor_protocol import (
+    SUPPORTED_PROTOCOL_VERSION,
+    executor_payload_benchmark_id,
+    normalize_executor_telemetry_context,
+)
 from tracker.config import ENVIRONMENT
 from tracker.logging import benchmark_id_var, request_id_var, task_id_var
 from tracker.observability import configure_observability
+from tracker.observability.sentry import capture_exception
 from tracker.utils.run_orchestration import process_benchmark
 
 logger = logging.getLogger(__name__)
 
 
-def _benchmark_id(payload: Mapping[str, object]) -> str:
-    benchmark_id = payload.get("benchmark_id_str")
-    if benchmark_id:
-        return str(benchmark_id)
-    execution_context = payload.get("execution_context_json")
-    if isinstance(execution_context, Mapping):
-        benchmark_id = cast(Mapping[object, object], execution_context).get("benchmark_id")
-        if benchmark_id:
-            return str(benchmark_id)
-    return ""
-
-
 @contextmanager
 def _executor_context(payload: Mapping[str, object]) -> Generator[None, None, None]:
-    telemetry_context = payload.get("telemetry_context_json")
-    request_id = ""
-    trace_headers: dict[str, str] = {}
-    if isinstance(telemetry_context, Mapping):
-        normalized_context = cast(Mapping[object, object], telemetry_context)
-        raw_request_id = normalized_context.get("request_id")
-        request_id = str(raw_request_id) if raw_request_id else ""
-        raw_trace_headers = normalized_context.get("trace_headers")
-        if isinstance(raw_trace_headers, Mapping):
-            trace_headers = {
-                str(key): str(value) for key, value in cast(Mapping[object, object], raw_trace_headers).items()
-            }
+    telemetry_context = normalize_executor_telemetry_context(payload.get("telemetry_context_json"))
 
     context_tokens = [
-        request_id_var.set(request_id),
-        benchmark_id_var.set(_benchmark_id(payload)),
+        request_id_var.set(telemetry_context["request_id"]),
+        benchmark_id_var.set(executor_payload_benchmark_id(payload)),
         task_id_var.set(""),
     ]
+    trace_headers = telemetry_context["trace_headers"]
     otel_token = attach(extract(trace_headers)) if trace_headers else None
     try:
         yield
@@ -85,7 +68,7 @@ async def _run_executor(payload: dict[str, Any]) -> None:
         except asyncio.CancelledError:
             return
         except Exception as error:
-            sentry_sdk.capture_exception(error)
+            capture_exception(error)
             raise
         finally:
             loop.remove_signal_handler(signal.SIGTERM)

--- a/services/tracker/src/tracker/executor/entrypoint.py
+++ b/services/tracker/src/tracker/executor/entrypoint.py
@@ -5,32 +5,101 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import signal
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Generator, Mapping, cast
+
+import logfire
+import sentry_sdk
+from opentelemetry.context import attach, detach
+from opentelemetry.propagate import extract
 
 from executor_protocol import SUPPORTED_PROTOCOL_VERSION
+from tracker.config import ENVIRONMENT
+from tracker.logging import benchmark_id_var, request_id_var, task_id_var
+from tracker.observability import configure_observability
 from tracker.utils.run_orchestration import process_benchmark
+
+logger = logging.getLogger(__name__)
+
+
+def _benchmark_id(payload: Mapping[str, object]) -> str:
+    benchmark_id = payload.get("benchmark_id_str")
+    if benchmark_id:
+        return str(benchmark_id)
+    execution_context = payload.get("execution_context_json")
+    if isinstance(execution_context, Mapping):
+        benchmark_id = cast(Mapping[object, object], execution_context).get("benchmark_id")
+        if benchmark_id:
+            return str(benchmark_id)
+    return ""
+
+
+@contextmanager
+def _executor_context(payload: Mapping[str, object]) -> Generator[None, None, None]:
+    telemetry_context = payload.get("telemetry_context_json")
+    request_id = ""
+    trace_headers: dict[str, str] = {}
+    if isinstance(telemetry_context, Mapping):
+        normalized_context = cast(Mapping[object, object], telemetry_context)
+        raw_request_id = normalized_context.get("request_id")
+        request_id = str(raw_request_id) if raw_request_id else ""
+        raw_trace_headers = normalized_context.get("trace_headers")
+        if isinstance(raw_trace_headers, Mapping):
+            trace_headers = {
+                str(key): str(value) for key, value in cast(Mapping[object, object], raw_trace_headers).items()
+            }
+
+    context_tokens = [
+        request_id_var.set(request_id),
+        benchmark_id_var.set(_benchmark_id(payload)),
+        task_id_var.set(""),
+    ]
+    otel_token = attach(extract(trace_headers)) if trace_headers else None
+    try:
+        yield
+    finally:
+        if otel_token is not None:
+            detach(otel_token)
+        for token in reversed(context_tokens):
+            token.var.reset(token)
 
 
 async def _run_executor(payload: dict[str, Any]) -> None:
-    task = asyncio.create_task(
-        process_benchmark(
-            start_benchmark_request_json=payload.get("start_benchmark_request_json"),
-            benchmark_id_str=payload.get("benchmark_id_str"),
-            verified_task_ids=payload.get("verified_task_ids"),
-            execution_context_json=payload.get("execution_context_json"),
-            executor_dispatch_id=payload["executor_dispatch_id"],
+    with _executor_context(payload):
+        task = asyncio.create_task(
+            process_benchmark(
+                start_benchmark_request_json=payload.get("start_benchmark_request_json"),
+                benchmark_id_str=payload.get("benchmark_id_str"),
+                verified_task_ids=payload.get("verified_task_ids"),
+                execution_context_json=payload.get("execution_context_json"),
+                executor_dispatch_id=payload["executor_dispatch_id"],
+            )
         )
-    )
-    loop = asyncio.get_running_loop()
-    loop.add_signal_handler(signal.SIGTERM, task.cancel)
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, task.cancel)
+        try:
+            await task
+        except asyncio.CancelledError:
+            return
+        except Exception as error:
+            sentry_sdk.capture_exception(error)
+            raise
+        finally:
+            loop.remove_signal_handler(signal.SIGTERM)
+
+
+def _flush_observability() -> None:
     try:
-        await task
-    except asyncio.CancelledError:
-        return
-    finally:
-        loop.remove_signal_handler(signal.SIGTERM)
+        logfire.force_flush(timeout_millis=3000)
+    except Exception as error:
+        logger.warning("Failed to flush executor traces: %s: %s", type(error).__name__, error)
+    try:
+        sentry_sdk.flush(timeout=3)
+    except Exception as error:
+        logger.warning("Failed to flush executor Sentry events: %s: %s", type(error).__name__, error)
 
 
 def main() -> None:
@@ -48,7 +117,11 @@ def main() -> None:
     if not isinstance(decoded, dict):
         raise SystemExit("Invalid executor payload: expected object")
     payload = cast(dict[str, Any], decoded)
-    asyncio.run(_run_executor(payload))
+    configure_observability("valkyrie-executor", environment=ENVIRONMENT)
+    try:
+        asyncio.run(_run_executor(payload))
+    finally:
+        _flush_observability()
 
 
 if __name__ == "__main__":

--- a/services/tracker/src/tracker/middleware/logging_context.py
+++ b/services/tracker/src/tracker/middleware/logging_context.py
@@ -1,19 +1,11 @@
 """Taskiq middleware that sets logging context vars for executor jobs."""
 
-from typing import Any, cast
+from typing import Any
 
 from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
 
+from executor_protocol import executor_payload_benchmark_id
 from tracker.logging import benchmark_id_var, request_id_var, task_id_var
-
-
-def _benchmark_id_from_message(message: TaskiqMessage) -> str:
-    benchmark_id = message.kwargs.get("benchmark_id_str")
-    if not benchmark_id:
-        execution_context = message.kwargs.get("execution_context_json")
-        if isinstance(execution_context, dict):
-            benchmark_id = cast(dict[str, Any], execution_context).get("benchmark_id")
-    return str(benchmark_id) if benchmark_id else ""
 
 
 class LoggingContextMiddleware(TaskiqMiddleware):
@@ -24,7 +16,7 @@ class LoggingContextMiddleware(TaskiqMiddleware):
         benchmark_id_var.set("")
         task_id_var.set("")
 
-        benchmark_id = _benchmark_id_from_message(message)
+        benchmark_id = executor_payload_benchmark_id(message.kwargs)
         if benchmark_id:
             benchmark_id_var.set(benchmark_id)
 

--- a/services/tracker/src/tracker/observability/__init__.py
+++ b/services/tracker/src/tracker/observability/__init__.py
@@ -1,5 +1,6 @@
 """Observability setup and runtime helpers for the tracker service."""
 
+import logging
 import time
 
 from tracker.observability.metrics import distribution, gauge, incr
@@ -7,11 +8,20 @@ from tracker.observability.retry import retry_callback
 from tracker.observability.sentry import init_sentry, set_sandbox_context
 from tracker.observability.tracing import configure_tracing, error_span
 
+logger = logging.getLogger(__name__)
+
 
 def configure_observability(service_name: str, environment: str) -> None:
     """Configure Sentry first, then OTel/Logfire tracing for this process."""
-    init_sentry(service_name, environment=environment)
-    configure_tracing(service_name, environment=environment)
+    try:
+        init_sentry(service_name, environment=environment)
+    except Exception as error:
+        logger.warning("Failed to initialize Sentry: %s: %s", type(error).__name__, error)
+
+    try:
+        configure_tracing(service_name, environment=environment)
+    except Exception as error:
+        logger.warning("Failed to initialize tracing: %s: %s", type(error).__name__, error)
 
 
 def elapsed_ms(start: float) -> float:

--- a/services/tracker/src/tracker/observability/__init__.py
+++ b/services/tracker/src/tracker/observability/__init__.py
@@ -5,7 +5,7 @@ import time
 from tracker.observability.metrics import distribution, gauge, incr
 from tracker.observability.retry import retry_callback
 from tracker.observability.sentry import init_sentry, set_sandbox_context
-from tracker.observability.tracing import configure_tracing
+from tracker.observability.tracing import configure_tracing, error_span
 
 
 def configure_observability(service_name: str, environment: str) -> None:
@@ -24,6 +24,7 @@ __all__ = [
     "configure_tracing",
     "distribution",
     "elapsed_ms",
+    "error_span",
     "gauge",
     "incr",
     "init_sentry",

--- a/services/tracker/src/tracker/observability/metrics.py
+++ b/services/tracker/src/tracker/observability/metrics.py
@@ -11,9 +11,12 @@ logger = logging.getLogger(__name__)
 # High-cardinality diagnostic fields belong in logs, spans, or Sentry context,
 # not metric attributes where they create one time series per task/session/etc.
 _BANNED_TAG_KEYS = {
+    "benchmark_id",
     "command",
     "error_message",
+    "org_id",
     "request_id",
+    "run_id",
     "sandbox_id",
     "session_id",
     "task_id",

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -44,6 +44,10 @@ def _apply_current_otel_trace_context(telemetry: dict[str, Any]) -> None:
 
 
 def _before_send_log(log: Log, _hint: Hint) -> Log | None:
+    attributes = log.setdefault("attributes", {})
+    for key, value in get_context_tags().items():
+        if value:
+            attributes[key] = value
     _apply_current_otel_trace_context(cast(dict[str, Any], log))
     return log
 
@@ -73,10 +77,10 @@ def init_sentry(service_name: str, environment: str) -> None:
             before_send=_before_send,
             before_send_log=_before_send_log,
             integrations=[
-                # level=None / event_level=None: spans carry context and we capture_exception explicitly,
-                # so we only want LoggingIntegration for shipping log records to Sentry Logs.
+                # INFO records become both searchable logs and breadcrumbs. Explicit exception
+                # capture owns issue creation so an error log cannot create a duplicate issue.
                 LoggingIntegration(
-                    level=None,
+                    level=logging.INFO,
                     event_level=None,
                     sentry_logs_level=logging.INFO,
                 ),

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -97,7 +97,9 @@ def init_sentry(service_name: str, environment: str) -> None:
             ],
         )
     except Exception as e:
-        # A malformed SENTRY_DSN or invalid integration shouldn't crash service startup.
+        if environment == "production":
+            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.") from None
+        # Non-production environments stay available for configuration repair.
         logger.warning("Failed to initialize Sentry: %s: %s", type(e).__name__, e)
 
 

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -53,7 +53,7 @@ def _before_send_log(log: Log, _hint: Hint) -> Log | None:
 
 
 def init_sentry(service_name: str, environment: str) -> None:
-    """Initialize Sentry SDK. No-op if SENTRY_DSN is not set.
+    """Initialize Sentry SDK when configured and require it in production.
 
     Args:
         service_name: Identifies the process in Sentry (e.g. "valkyrie-tracker").
@@ -61,6 +61,8 @@ def init_sentry(service_name: str, environment: str) -> None:
     """
     dsn = os.environ.get("SENTRY_DSN", "")
     if not dsn:
+        if environment == "production":
+            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.")
         return
 
     try:

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -53,7 +53,7 @@ def _before_send_log(log: Log, _hint: Hint) -> Log | None:
 
 
 def init_sentry(service_name: str, environment: str) -> None:
-    """Initialize Sentry SDK when configured and require it in production.
+    """Initialize Sentry SDK when configured.
 
     Args:
         service_name: Identifies the process in Sentry (e.g. "valkyrie-tracker").
@@ -61,8 +61,6 @@ def init_sentry(service_name: str, environment: str) -> None:
     """
     dsn = os.environ.get("SENTRY_DSN", "")
     if not dsn:
-        if environment == "production":
-            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.")
         return
 
     try:
@@ -99,10 +97,15 @@ def init_sentry(service_name: str, environment: str) -> None:
             ],
         )
     except Exception as e:
-        if environment == "production":
-            raise RuntimeError("Sentry could not start. Check the production DSN secret and deploy again.") from None
-        # Non-production environments stay available for configuration repair.
         logger.warning("Failed to initialize Sentry: %s: %s", type(e).__name__, e)
+
+
+def capture_exception(error: BaseException) -> None:
+    """Capture an exception without allowing Sentry failures to escape."""
+    try:
+        sentry_sdk.capture_exception(error)
+    except Exception as telemetry_error:
+        logger.warning("Failed to capture exception: %s: %s", type(telemetry_error).__name__, telemetry_error)
 
 
 def set_sandbox_context(sandbox: Any, *, image: str | None = None) -> None:

--- a/services/tracker/src/tracker/observability/tracing.py
+++ b/services/tracker/src/tracker/observability/tracing.py
@@ -16,6 +16,9 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from sentry_sdk.integrations.opentelemetry import SentryPropagator, SentrySpanProcessor
 
 from tracker.logging.context import get_context_tags
+from tracker.logging.logger import get_logger
+
+logger = get_logger(__name__)
 
 _EXCLUDED_SPAN_NAMES = frozenset(
     {
@@ -26,12 +29,49 @@ _EXCLUDED_SPAN_NAMES = frozenset(
 
 
 @contextmanager
+def observability_span(name: str, **attributes: Any) -> Generator[None, None, None]:
+    """Create a span without allowing telemetry failures to escape."""
+    span_manager = None
+    span_entered = False
+    try:
+        span_manager = logfire.span(name, **attributes)
+        span_manager.__enter__()
+        span_entered = True
+    except Exception as error:
+        logger.warning("Failed to start observability span %s: %s: %s", name, type(error).__name__, error)
+
+    try:
+        yield
+    except BaseException as error:
+        if span_manager is not None and span_entered:
+            try:
+                span_manager.__exit__(type(error), error, error.__traceback__)
+            except Exception as telemetry_error:
+                logger.warning(
+                    "Failed to finish observability span %s: %s: %s",
+                    name,
+                    type(telemetry_error).__name__,
+                    telemetry_error,
+                )
+        raise
+    else:
+        if span_manager is not None and span_entered:
+            try:
+                span_manager.__exit__(None, None, None)
+            except Exception as error:
+                logger.warning("Failed to finish observability span %s: %s: %s", name, type(error).__name__, error)
+
+
+@contextmanager
 def error_span(name: str, exc: BaseException, **attributes: Any) -> Generator[None, None, None]:
     """Create a bounded error span for a handled exception."""
-    with logfire.span(name, **attributes):
+    with observability_span(name, **attributes):
         span = trace.get_current_span()
-        span.record_exception(exc)
-        span.set_status(Status(StatusCode.ERROR))
+        try:
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR))
+        except Exception as error:
+            logger.warning("Failed to annotate observability span %s: %s: %s", name, type(error).__name__, error)
         yield
 
 

--- a/services/tracker/src/tracker/observability/tracing.py
+++ b/services/tracker/src/tracker/observability/tracing.py
@@ -8,13 +8,8 @@ from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sentry_sdk.integrations.opentelemetry import SentryPropagator, SentrySpanProcessor
-from sentry_sdk.integrations.opentelemetry import span_processor as _sentry_span_processor
 
 from tracker.logging.context import get_context_tags
-
-# SentrySpanProcessor drops spans from its in-memory map after 10 minutes by default, which
-# silently loses long-running parents like process_benchmark / process_task. Bump to 4 hours.
-_sentry_span_processor.SPAN_MAX_TIME_OPEN_MINUTES = 240
 
 _EXCLUDED_SPAN_NAMES = frozenset(
     {

--- a/services/tracker/src/tracker/observability/tracing.py
+++ b/services/tracker/src/tracker/observability/tracing.py
@@ -1,11 +1,17 @@
 """Tracing configuration: OTel instrumentation (via logfire) with Sentry as the backend."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
 import logfire
+from opentelemetry import trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.context import Context
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import Status, StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sentry_sdk.integrations.opentelemetry import SentryPropagator, SentrySpanProcessor
 
@@ -17,6 +23,16 @@ _EXCLUDED_SPAN_NAMES = frozenset(
         "AsyncSandbox.refresh_data",
     }
 )
+
+
+@contextmanager
+def error_span(name: str, exc: BaseException, **attributes: Any) -> Generator[None, None, None]:
+    """Create a bounded error span for a handled exception."""
+    with logfire.span(name, **attributes):
+        span = trace.get_current_span()
+        span.record_exception(exc)
+        span.set_status(Status(StatusCode.ERROR))
+        yield
 
 
 class _ContextVarSpanProcessor(SpanProcessor):

--- a/services/tracker/src/tracker/observability/tracing.py
+++ b/services/tracker/src/tracker/observability/tracing.py
@@ -16,6 +16,13 @@ from tracker.logging.context import get_context_tags
 # silently loses long-running parents like process_benchmark / process_task. Bump to 4 hours.
 _sentry_span_processor.SPAN_MAX_TIME_OPEN_MINUTES = 240
 
+_EXCLUDED_SPAN_NAMES = frozenset(
+    {
+        "AsyncProcess.exec",
+        "AsyncSandbox.refresh_data",
+    }
+)
+
 
 class _ContextVarSpanProcessor(SpanProcessor):
     """Attaches request/benchmark/task context vars to every span as attributes."""
@@ -36,6 +43,35 @@ class _ContextVarSpanProcessor(SpanProcessor):
         return True
 
 
+class _FilteredSentrySpanProcessor(SpanProcessor):
+    """Drop low-level polling span subtrees before exporting them to Sentry."""
+
+    def __init__(self) -> None:
+        self._delegate = SentrySpanProcessor()
+        self._excluded_span_ids: set[int] = set()
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        parent_span_id = span.parent.span_id if span.parent is not None else None
+        span_id = span.get_span_context().span_id
+        if span.name in _EXCLUDED_SPAN_NAMES or parent_span_id in self._excluded_span_ids:
+            self._excluded_span_ids.add(span_id)
+            return
+        self._delegate.on_start(span, parent_context)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        span_id = span.get_span_context().span_id
+        if span_id in self._excluded_span_ids:
+            self._excluded_span_ids.discard(span_id)
+            return
+        self._delegate.on_end(span)
+
+    def shutdown(self) -> None:
+        self._delegate.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self._delegate.force_flush(timeout_millis)
+
+
 def configure_tracing(service_name: str, environment: str) -> None:
     """Configure OTel tracing. Call after init_sentry() and before any instrument_*() hooks."""
     logfire.configure(
@@ -46,7 +82,7 @@ def configure_tracing(service_name: str, environment: str) -> None:
         distributed_tracing=True,
         # configure_logging() owns stdout.
         console=False,
-        additional_span_processors=[_ContextVarSpanProcessor(), SentrySpanProcessor()],
+        additional_span_processors=[_ContextVarSpanProcessor(), _FilteredSentrySpanProcessor()],
     )
     # Composite: inject both W3C traceparent/tracestate (for non-Sentry peers like Daytona /
     # benchmark_service) and Sentry's sentry-trace/baggage. Extract honors whichever headers arrive.

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Any, Sequence, cast
 from uuid import UUID
 
-import logfire
 import sentry_sdk
 from benchmark_service import SandboxProviderConfig
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
@@ -41,6 +40,7 @@ from tracker.executor.execution_authority import ExecutionAuthority, lock_execut
 from executor_protocol import EXECUTOR_TASK_NAME
 from tracker.logging import get_logger
 from tracker.notifications import NotificationContext, SlackNotifier
+from tracker.observability import error_span
 from tracker.outbound_security import validate_custom_service_destination
 from tracker.types import (
     FinalViewResponse,
@@ -74,8 +74,9 @@ def _capture_run_error(
     operation: str,
     cause_code: str | None = None,
 ) -> None:
-    with logfire.span(
+    with error_span(
         "run.error",
+        exc,
         benchmark_id=str(benchmark_id),
         producer=producer,
         operation=operation,

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -13,12 +13,10 @@ import sentry_sdk
 from benchmark_service import SandboxProviderConfig
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from botocore.config import Config
-from opentelemetry import trace
 from pydantic import ValidationError
 from sqlmodel import Session, col, desc, func, select
 
 from tracker._lambda import dry_run_lambda, invoke_lambda
-from tracker.aws.cloudwatch_logs import create_benchmark_log_group
 from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import fetch_aws_secret, resolve_secrets
@@ -41,6 +39,8 @@ from executor_protocol import EXECUTOR_TASK_NAME
 from tracker.logging import get_logger
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import error_span
+from tracker.observability.sentry import capture_exception
+from tracker.observability.tracing import observability_span
 from tracker.outbound_security import validate_custom_service_destination
 from tracker.types import (
     FinalViewResponse,
@@ -94,7 +94,17 @@ def _capture_run_error(
                 "cause_code": cause_code or "",
             },
         )
-        sentry_sdk.capture_exception(exc)
+        capture_exception(exc)
+
+
+def _record_run_finalized(benchmark_id: UUID, status: BenchmarkStatus, authority: ExecutionAuthority) -> None:
+    with observability_span(
+        "run.finalized",
+        benchmark_id=str(benchmark_id),
+        status=status.value,
+        executor_dispatch_id=str(authority.dispatch_id),
+    ):
+        pass
 
 
 def set_benchmark_final_status(
@@ -146,6 +156,7 @@ def set_benchmark_final_status(
     benchmark_row.error_message = None
     session.add(benchmark_row)
     session.commit()
+    _record_run_finalized(benchmark_row.id, benchmark_status, authority)
 
 
 def create_task_rows(
@@ -383,7 +394,6 @@ def _preflight_managed_aws(
     runtime: AWSRuntime,
 ) -> SandboxProviderConfig:
     """Verify executor-owned AWS access before starting sandbox work."""
-    create_benchmark_log_group(str(execution.benchmark_id), runtime)
     request = execution.request
     provider_secret_name = request.sandbox_provider_secret_name
     if provider_secret_name is None:
@@ -455,15 +465,15 @@ async def process_benchmark(
 
         sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
         sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
-        trace.get_current_span().set_attributes(
-            {
-                "benchmark_id": str(benchmark_id),
-                "benchmark_name": start_benchmark_request.benchmark_name,
-                "agent_name": start_benchmark_request.contract.name,
-                "task_count": len(verified_task_ids),
-                "executor_dispatch_id": executor_dispatch_id,
-            }
-        )
+        with observability_span(
+            "run.started",
+            benchmark_id=str(benchmark_id),
+            benchmark_name=start_benchmark_request.benchmark_name,
+            agent_name=start_benchmark_request.contract.name,
+            task_count=len(verified_task_ids),
+            executor_dispatch_id=executor_dispatch_id,
+        ):
+            pass
 
         if execution.aws_managed != benchmark_row.aws_managed:
             queued_mode = "managed" if execution.aws_managed else "access-key"
@@ -498,9 +508,6 @@ async def process_benchmark(
                 clients=aws_runtime.clients,
                 intervals=start_benchmark_request.webhook_intervals,
             )
-
-        if not execution.aws_managed:
-            create_benchmark_log_group(str(benchmark_id), aws_runtime)
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:
@@ -759,6 +766,8 @@ def commit_benchmark_error(
         cause_code=cause_code,
     )
     session.commit()
+    if committed and benchmark_row.status == BenchmarkStatus.ERROR:
+        _record_run_finalized(benchmark_row.id, BenchmarkStatus.ERROR, authority)
     return committed
 
 
@@ -824,4 +833,6 @@ def catch_errors_during_cleanup(
         error_type="UndetectedExecutorExit",
     )
     session.commit()
+    if committed and benchmark_row.status == BenchmarkStatus.ERROR:
+        _record_run_finalized(benchmark_id, BenchmarkStatus.ERROR, authority)
     return committed

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from typing import Any, Sequence, cast
 from uuid import UUID
 
-import logfire
 import sentry_sdk
 from benchmark_service import SandboxProviderConfig
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
@@ -64,6 +63,28 @@ _SANDBOX_CREATION_CAP: int = 10
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
 # Limit non-idempotent completion callbacks to one attempt and a 60-second read.
 _COMPLETION_CALLBACK_CONFIG = Config(read_timeout=60, retries={"total_max_attempts": 1})
+
+
+def _capture_run_error(
+    exc: BaseException,
+    benchmark_id: UUID,
+    *,
+    producer: str,
+    operation: str,
+    cause_code: str | None = None,
+) -> None:
+    logger.error(
+        "Run execution failed",
+        exc_info=(type(exc), exc, exc.__traceback__),
+        extra={
+            "benchmark_id": str(benchmark_id),
+            "producer": producer,
+            "operation": operation,
+            "error_type": type(exc).__name__,
+            "cause_code": cause_code or "",
+        },
+    )
+    sentry_sdk.capture_exception(exc)
 
 
 def set_benchmark_final_status(
@@ -382,7 +403,6 @@ async def hold_dispatch_authority(
 
 # Keep the Tracker producer and ExecutorHost on one stable Taskiq wire name.
 @broker.task(EXECUTOR_TASK_NAME)
-@logfire.instrument("process_benchmark", extract_args=("benchmark_id_str", "verified_task_ids"))
 async def process_benchmark(
     start_benchmark_request_json: dict[str, Any] | None = None,
     benchmark_id_str: str | None = None,
@@ -608,7 +628,13 @@ async def process_benchmark(
     except ExecutionAuthorityRevoked:
         finalization_deferred = True
     except BenchmarkServiceUnauthenticatedError as e:
-        logfire.warn("process_benchmark failed due to benchmark service auth error")
+        _capture_run_error(
+            e,
+            benchmark_id,
+            producer="benchmark_service",
+            operation="authenticate",
+            cause_code="authentication_failed",
+        )
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"
@@ -625,6 +651,12 @@ async def process_benchmark(
                 task_ids=verified_task_ids,
             )
     except BenchmarkServiceError as e:
+        _capture_run_error(
+            e,
+            benchmark_id,
+            producer="benchmark_service",
+            operation="process_benchmark",
+        )
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = str(e)
@@ -639,8 +671,7 @@ async def process_benchmark(
                 task_ids=verified_task_ids,
             )
     except Exception as e:
-        logfire.exception("process_benchmark failed")
-        sentry_sdk.capture_exception(e)
+        _capture_run_error(e, benchmark_id, producer="tracker", operation="process_benchmark")
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import Any, Sequence, cast
 from uuid import UUID
 
+import logfire
 import sentry_sdk
 from benchmark_service import SandboxProviderConfig
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
@@ -73,18 +74,26 @@ def _capture_run_error(
     operation: str,
     cause_code: str | None = None,
 ) -> None:
-    logger.error(
-        "Run execution failed",
-        exc_info=(type(exc), exc, exc.__traceback__),
-        extra={
-            "benchmark_id": str(benchmark_id),
-            "producer": producer,
-            "operation": operation,
-            "error_type": type(exc).__name__,
-            "cause_code": cause_code or "",
-        },
-    )
-    sentry_sdk.capture_exception(exc)
+    with logfire.span(
+        "run.error",
+        benchmark_id=str(benchmark_id),
+        producer=producer,
+        operation=operation,
+        error_type=type(exc).__name__,
+        cause_code=cause_code or "",
+    ):
+        logger.error(
+            "Run execution failed",
+            exc_info=(type(exc), exc, exc.__traceback__),
+            extra={
+                "benchmark_id": str(benchmark_id),
+                "producer": producer,
+                "operation": operation,
+                "error_type": type(exc).__name__,
+                "cause_code": cause_code or "",
+            },
+        )
+        sentry_sdk.capture_exception(exc)
 
 
 def set_benchmark_final_status(

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 from sqlmodel import Session, col, desc, func, select
 
 from tracker._lambda import dry_run_lambda, invoke_lambda
+from tracker.aws.cloudwatch_logs import create_benchmark_log_group
 from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import fetch_aws_secret, resolve_secrets
@@ -394,6 +395,7 @@ def _preflight_managed_aws(
     runtime: AWSRuntime,
 ) -> SandboxProviderConfig:
     """Verify executor-owned AWS access before starting sandbox work."""
+    create_benchmark_log_group(str(execution.benchmark_id), runtime)
     request = execution.request
     provider_secret_name = request.sandbox_provider_secret_name
     if provider_secret_name is None:
@@ -508,6 +510,9 @@ async def process_benchmark(
                 clients=aws_runtime.clients,
                 intervals=start_benchmark_request.webhook_intervals,
             )
+
+        if not execution.aws_managed:
+            create_benchmark_log_group(str(benchmark_id), aws_runtime)
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -135,17 +135,18 @@ def _observe_task_retry(attempt: SandboxRecoveryAttempt, exc: BaseException) -> 
     """Emit the retry telemetry the Tenacity before_sleep hook owned before recovery
     moved into the benchmark-service client."""
     error_class = type(exc).__name__
-    logger.warning(
-        "retry.before_sleep",
-        extra={
-            "metric": _TASK_RETRY_METRIC,
-            "fn": "_process_task_attempt",
-            "attempt": attempt.number,
-            "idle_for": _SANDBOX_RETRY_DELAY_SECONDS,
-            "error_class": error_class,
-        },
-    )
-    incr(f"{_TASK_RETRY_METRIC}.retry", tags={"error_class": error_class})
+    with logfire.span("task.retry", attempt=attempt.number, error_class=error_class):
+        logger.warning(
+            "retry.before_sleep",
+            extra={
+                "metric": _TASK_RETRY_METRIC,
+                "fn": "_process_task_attempt",
+                "attempt": attempt.number,
+                "idle_for": _SANDBOX_RETRY_DELAY_SECONDS,
+                "error_class": error_class,
+            },
+        )
+        incr(f"{_TASK_RETRY_METRIC}.retry", tags={"error_class": error_class})
 
 
 class TrackedTaskStatus(str, Enum):
@@ -650,11 +651,16 @@ async def _process_task_attempt(
             try:
                 completed.result()
             except Exception as error:
-                logger.exception(
-                    "Failed to write task output to CloudWatch",
-                    extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
-                )
-                sentry_sdk.capture_exception(error)
+                with logfire.span(
+                    "task.output_write.error",
+                    benchmark_id=str(benchmark_id),
+                    task_id=task_id,
+                ):
+                    logger.exception(
+                        "Failed to write task output to CloudWatch",
+                        extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
+                    )
+                    sentry_sdk.capture_exception(error)
 
         write.add_done_callback(handle_completion)
 
@@ -701,19 +707,28 @@ async def _process_task_attempt(
         operation: str,
         cause_code: str | None = None,
     ) -> dict[str, dict[str, Any] | None]:
-        logger.error(
-            "Task execution failed",
-            exc_info=(type(exc), exc, exc.__traceback__),
-            extra={
-                "benchmark_id": str(benchmark_id),
-                "task_id": task_id,
-                "producer": producer,
-                "operation": operation,
-                "error_type": type(exc).__name__,
-                "cause_code": cause_code or "",
-            },
-        )
-        sentry_sdk.capture_exception(exc)
+        with logfire.span(
+            "task.error",
+            benchmark_id=str(benchmark_id),
+            task_id=task_id,
+            producer=producer,
+            operation=operation,
+            error_type=type(exc).__name__,
+            cause_code=cause_code or "",
+        ):
+            logger.error(
+                "Task execution failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+                extra={
+                    "benchmark_id": str(benchmark_id),
+                    "task_id": task_id,
+                    "producer": producer,
+                    "operation": operation,
+                    "error_type": type(exc).__name__,
+                    "cause_code": cause_code or "",
+                },
+            )
+            sentry_sdk.capture_exception(exc)
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
             commit_task_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -55,7 +55,7 @@ from tracker.exceptions import (
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
-from tracker.observability import elapsed_ms, incr
+from tracker.observability import elapsed_ms, error_span, incr
 from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     StartBenchmarkRequest,
@@ -651,8 +651,9 @@ async def _process_task_attempt(
             try:
                 completed.result()
             except Exception as error:
-                with logfire.span(
+                with error_span(
                     "task.output_write.error",
+                    error,
                     benchmark_id=str(benchmark_id),
                     task_id=task_id,
                 ):
@@ -707,8 +708,9 @@ async def _process_task_attempt(
         operation: str,
         cause_code: str | None = None,
     ) -> dict[str, dict[str, Any] | None]:
-        with logfire.span(
+        with error_span(
             "task.error",
+            exc,
             benchmark_id=str(benchmark_id),
             task_id=task_id,
             producer=producer,

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -23,7 +23,6 @@ from benchmark_service import (
     SandboxRecoveryAttempt,
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from opentelemetry import trace
 from pydantic import ValidationError
 from sqlmodel import Session, col, select, update
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
@@ -56,6 +55,8 @@ from tracker.executor.execution_authority import ExecutionAuthority, lock_execut
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, error_span, incr
+from tracker.observability.sentry import capture_exception
+from tracker.observability.tracing import observability_span
 from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     StartBenchmarkRequest,
@@ -67,6 +68,9 @@ logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
 _SANDBOX_RETRY_DELAY_SECONDS: float = 2
+_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS: float = 10
+_CLOUDWATCH_LOG_WRITE_ATTEMPTS: int = 3
+_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS: float = 0.25
 
 
 @dataclass
@@ -135,7 +139,7 @@ def _observe_task_retry(attempt: SandboxRecoveryAttempt, exc: BaseException) -> 
     """Emit the retry telemetry the Tenacity before_sleep hook owned before recovery
     moved into the benchmark-service client."""
     error_class = type(exc).__name__
-    with logfire.span("task.retry", attempt=attempt.number, error_class=error_class):
+    with observability_span("task.retry", attempt=attempt.number, error_class=error_class):
         logger.warning(
             "retry.before_sleep",
             extra={
@@ -237,7 +241,7 @@ class TrackedTask:
             error_message = f"Task error was not handled: {_exception_message(e)}\n{traceback.format_exc()}"
             logger.error(error_message)
             logfire.exception("tracked_task_run failed")
-            sentry_sdk.capture_exception(e)
+            capture_exception(e)
             with Session(bind=engine) as session:
                 task = fetch_task_row(task_row.id, session, self._org)
                 commit_task_error(
@@ -407,7 +411,14 @@ def buffer_logs(
     async def write_in_order() -> None:
         if previous_write is not None:
             await asyncio.gather(previous_write, return_exceptions=True)
-        await loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+        for attempt in range(1, _CLOUDWATCH_LOG_WRITE_ATTEMPTS + 1):
+            try:
+                await loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+                return
+            except Exception:
+                if attempt == _CLOUDWATCH_LOG_WRITE_ATTEMPTS:
+                    raise
+                await asyncio.sleep(_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS)
 
     return asyncio.create_task(write_in_order())
 
@@ -461,7 +472,7 @@ def _commit_task_status(
     if error_message is not None:
         span_attributes["has_error_message"] = True
 
-    with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
+    with observability_span("task.status_transition", **span_attributes):
         try:
             lock_execution_authority(session, authority)
         except ExecutionAuthorityRevoked:
@@ -522,6 +533,15 @@ async def process_task(
     """Process one task while retaining dependency recovery state across sandbox attempts."""
     dependency_setup_recovery = _DependencySetupRecoveryState()
 
+    with observability_span(
+        "task.started",
+        benchmark_id=str(benchmark_id),
+        task_id=task_id,
+        benchmark_name=start_benchmark_request.benchmark_name,
+        agent_name=start_benchmark_request.contract.name,
+    ):
+        pass
+
     async def run_attempt(
         recovery_attempt: SandboxRecoveryAttempt,
     ) -> dict[str, dict[str, Any] | None]:
@@ -545,7 +565,7 @@ async def process_task(
         if isinstance(exc, SandboxSetupError):
             _record_failure_before_retry(task_row, authority, exc, attempt.number)
 
-    return await benchmark_service.run_with_sandbox_recovery(
+    result = await benchmark_service.run_with_sandbox_recovery(
         task_id=task_id,
         run_id=str(benchmark_id),
         operation=run_attempt,
@@ -555,6 +575,16 @@ async def process_task(
         retry_delay_s=_SANDBOX_RETRY_DELAY_SECONDS,
         on_retry=record_attempt_failure,
     )
+
+    if result.get(task_id) is not None:
+        with observability_span(
+            "task.completed",
+            benchmark_id=str(benchmark_id),
+            task_id=task_id,
+        ):
+            pass
+
+    return result
 
 
 async def _process_task_attempt(
@@ -580,14 +610,6 @@ async def _process_task_attempt(
     task_id_var.set(task_id)
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
-    trace.get_current_span().set_attributes(
-        {
-            "task_id": task_id,
-            "benchmark_id": str(benchmark_id),
-            "benchmark_name": start_benchmark_request.benchmark_name,
-            "agent_name": start_benchmark_request.contract.name,
-        }
-    )
 
     requested_attempt_started_at = task_row.started_at
     with Session(bind=engine) as task_session:
@@ -614,7 +636,6 @@ async def _process_task_attempt(
     task_stream_name = f"{task_id}_{stream_suffix}"
     stream_key: str = f"{benchmark_id}:{task_stream_name}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
-    pending_log_writes: set[asyncio.Future[None]] = set()
     latest_log_write: asyncio.Future[None] | None = None
 
     logger.info(
@@ -644,12 +665,12 @@ async def _process_task_attempt(
         if write is None:
             return
         latest_log_write = write
-        pending_log_writes.add(write)
 
         def handle_completion(completed: asyncio.Future[None]) -> None:
-            pending_log_writes.discard(completed)
             try:
                 completed.result()
+            except asyncio.CancelledError:
+                return
             except Exception as error:
                 with error_span(
                     "task.output_write.error",
@@ -661,7 +682,7 @@ async def _process_task_attempt(
                         "Failed to write task output to CloudWatch",
                         extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
                     )
-                    sentry_sdk.capture_exception(error)
+                    capture_exception(error)
 
         write.add_done_callback(handle_completion)
 
@@ -730,7 +751,7 @@ async def _process_task_attempt(
                     "cause_code": cause_code or "",
                 },
             )
-            sentry_sdk.capture_exception(exc)
+            capture_exception(exc)
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
             commit_task_error(
@@ -1147,8 +1168,16 @@ async def _process_task_attempt(
         with suppress(asyncio.CancelledError):
             await flush_task
         schedule_log_flush(force=True)
-        if pending_log_writes:
-            await asyncio.gather(*pending_log_writes, return_exceptions=True)
+        if latest_log_write is not None:
+            try:
+                await asyncio.wait_for(latest_log_write, timeout=_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logger.warning(
+                    "Timed out waiting for task output to flush to CloudWatch",
+                    extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
+                )
+            except Exception:
+                pass
 
 
 def commit_task_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -634,11 +634,12 @@ async def _process_task_attempt(
             pending_log_writes.discard(completed)
             try:
                 completed.result()
-            except Exception:
+            except Exception as error:
                 logger.exception(
                     "Failed to write task output to CloudWatch",
                     extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
                 )
+                sentry_sdk.capture_exception(error)
 
         write.add_done_callback(handle_completion)
 
@@ -685,6 +686,19 @@ async def _process_task_attempt(
         operation: str,
         cause_code: str | None = None,
     ) -> dict[str, dict[str, Any] | None]:
+        logger.error(
+            "Task execution failed",
+            exc_info=(type(exc), exc, exc.__traceback__),
+            extra={
+                "benchmark_id": str(benchmark_id),
+                "task_id": task_id,
+                "producer": producer,
+                "operation": operation,
+                "error_type": type(exc).__name__,
+                "cause_code": cause_code or "",
+            },
+        )
+        sentry_sdk.capture_exception(exc)
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
             commit_task_error(
@@ -1093,9 +1107,6 @@ async def _process_task_attempt(
             return {task_id: None}
         logfire.exception("process_task failed")
         error_message = _exception_message(e)
-        logger.error(error_message, exc_info=True)
-
-        sentry_sdk.capture_exception(e)
 
         # include the error message
         log_output(f"\n[ERROR] {error_message}")

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -28,7 +28,7 @@ from pydantic import ValidationError
 from sqlmodel import Session, col, select, update
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
-from tracker.aws.cloudwatch_logs import write_benchmark_log_event
+from tracker.aws.cloudwatch_logs import get_benchmark_log_url, write_benchmark_log_event
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.s3 import (
     get_agent_result_s3_key,
@@ -388,12 +388,12 @@ def buffer_logs(
     stream_key: str,
     aws_runtime: AWSRuntime,
     force_flush: bool = False,
-) -> None:
+) -> asyncio.Future[None] | None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
     """
     if not log_queue.full() and not force_flush:
-        return
+        return None
 
     messages: list[str] = []
     while not log_queue.empty():
@@ -401,7 +401,7 @@ def buffer_logs(
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+    return loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
 
 
 def save_eval_resume_state(
@@ -604,17 +604,50 @@ async def _process_task_attempt(
     # Setup logging infrastructure before try block so it's always available
     # Suffix is required to version control streams, never delete between retries
     stream_suffix = f"{int(task_row.started_at.timestamp() * 1_000_000):x}"
-    stream_key: str = f"{benchmark_id}:{task_id}_{stream_suffix}"
+    task_stream_name = f"{task_id}_{stream_suffix}"
+    stream_key: str = f"{benchmark_id}:{task_stream_name}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
+    pending_log_writes: set[asyncio.Future[None]] = set()
+
+    logger.info(
+        "Task output stream selected",
+        extra={
+            "benchmark_id": str(benchmark_id),
+            "task_id": task_id,
+            "cloudwatch_log_url": get_benchmark_log_url(
+                str(benchmark_id),
+                aws_runtime.resources,
+                task_stream_name,
+            ),
+        },
+    )
 
     last_log_time: float = time.monotonic()
+
+    def schedule_log_flush(*, force: bool = False) -> None:
+        write = buffer_logs(log_queue, stream_key, aws_runtime, force_flush=force)
+        if write is None:
+            return
+        pending_log_writes.add(write)
+
+        def handle_completion(completed: asyncio.Future[None]) -> None:
+            pending_log_writes.discard(completed)
+            try:
+                completed.result()
+            except Exception:
+                logger.exception(
+                    "Failed to write task output to CloudWatch",
+                    extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
+                )
+
+        write.add_done_callback(handle_completion)
 
     # Collects the logs and dumps them when the queue is full
     def log_output(data: str) -> None:
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        buffer_logs(log_queue, stream_key, aws_runtime)
+        schedule_log_flush()
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -622,7 +655,7 @@ async def _process_task_attempt(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                schedule_log_flush(force=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
@@ -832,7 +865,7 @@ async def _process_task_attempt(
                 recovery_attempt.mark_replacement_ready()
 
                 # Force flush the logs if anything has been buffered
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                schedule_log_flush(force=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -912,7 +945,7 @@ async def _process_task_attempt(
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                schedule_log_flush(force=True)
 
                 # Save the evaluation result to the database with the task row
                 # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
@@ -1077,7 +1110,9 @@ async def _process_task_attempt(
         flush_task.cancel()
         with suppress(asyncio.CancelledError):
             await flush_task
-        buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+        schedule_log_flush(force=True)
+        if pending_log_writes:
+            await asyncio.gather(*pending_log_writes, return_exceptions=True)
 
 
 def commit_task_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -68,9 +68,6 @@ logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
 _SANDBOX_RETRY_DELAY_SECONDS: float = 2
-_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS: float = 10
-_CLOUDWATCH_LOG_WRITE_ATTEMPTS: int = 3
-_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS: float = 0.25
 
 
 @dataclass
@@ -393,13 +390,12 @@ def buffer_logs(
     stream_key: str,
     aws_runtime: AWSRuntime,
     force_flush: bool = False,
-    previous_write: asyncio.Future[None] | None = None,
-) -> asyncio.Future[None] | None:
+) -> None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
     """
     if not log_queue.full() and not force_flush:
-        return None
+        return
 
     messages: list[str] = []
     while not log_queue.empty():
@@ -407,20 +403,7 @@ def buffer_logs(
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-
-    async def write_in_order() -> None:
-        if previous_write is not None:
-            await asyncio.gather(previous_write, return_exceptions=True)
-        for attempt in range(1, _CLOUDWATCH_LOG_WRITE_ATTEMPTS + 1):
-            try:
-                await loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
-                return
-            except Exception:
-                if attempt == _CLOUDWATCH_LOG_WRITE_ATTEMPTS:
-                    raise
-                await asyncio.sleep(_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS)
-
-    return asyncio.create_task(write_in_order())
+    loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
 
 
 def save_eval_resume_state(
@@ -636,7 +619,6 @@ async def _process_task_attempt(
     task_stream_name = f"{task_id}_{stream_suffix}"
     stream_key: str = f"{benchmark_id}:{task_stream_name}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
-    latest_log_write: asyncio.Future[None] | None = None
 
     logger.info(
         "Task output stream selected",
@@ -653,45 +635,12 @@ async def _process_task_attempt(
 
     last_log_time: float = time.monotonic()
 
-    def schedule_log_flush(*, force: bool = False) -> None:
-        nonlocal latest_log_write
-        write = buffer_logs(
-            log_queue,
-            stream_key,
-            aws_runtime,
-            force_flush=force,
-            previous_write=latest_log_write,
-        )
-        if write is None:
-            return
-        latest_log_write = write
-
-        def handle_completion(completed: asyncio.Future[None]) -> None:
-            try:
-                completed.result()
-            except asyncio.CancelledError:
-                return
-            except Exception as error:
-                with error_span(
-                    "task.output_write.error",
-                    error,
-                    benchmark_id=str(benchmark_id),
-                    task_id=task_id,
-                ):
-                    logger.exception(
-                        "Failed to write task output to CloudWatch",
-                        extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
-                    )
-                    capture_exception(error)
-
-        write.add_done_callback(handle_completion)
-
     # Collects the logs and dumps them when the queue is full
     def log_output(data: str) -> None:
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        schedule_log_flush()
+        buffer_logs(log_queue, stream_key, aws_runtime)
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -699,7 +648,7 @@ async def _process_task_attempt(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                schedule_log_flush(force=True)
+                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
@@ -932,7 +881,7 @@ async def _process_task_attempt(
                 recovery_attempt.mark_replacement_ready()
 
                 # Force flush the logs if anything has been buffered
-                schedule_log_flush(force=True)
+                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -1012,7 +961,7 @@ async def _process_task_attempt(
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                schedule_log_flush(force=True)
+                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
 
                 # Save the evaluation result to the database with the task row
                 # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
@@ -1167,17 +1116,7 @@ async def _process_task_attempt(
         flush_task.cancel()
         with suppress(asyncio.CancelledError):
             await flush_task
-        schedule_log_flush(force=True)
-        if latest_log_write is not None:
-            try:
-                await asyncio.wait_for(latest_log_write, timeout=_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS)
-            except TimeoutError:
-                logger.warning(
-                    "Timed out waiting for task output to flush to CloudWatch",
-                    extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
-                )
-            except Exception:
-                pass
+        buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
 
 
 def commit_task_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -388,6 +388,7 @@ def buffer_logs(
     stream_key: str,
     aws_runtime: AWSRuntime,
     force_flush: bool = False,
+    previous_write: asyncio.Future[None] | None = None,
 ) -> asyncio.Future[None] | None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
@@ -401,7 +402,13 @@ def buffer_logs(
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-    return loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+
+    async def write_in_order() -> None:
+        if previous_write is not None:
+            await asyncio.gather(previous_write, return_exceptions=True)
+        await loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+
+    return asyncio.create_task(write_in_order())
 
 
 def save_eval_resume_state(
@@ -499,7 +506,6 @@ def commit_task_status_transition(
     )
 
 
-@logfire.instrument("process_task", extract_args=("benchmark_id", "task_id"))
 async def process_task(
     task_row: Task,
     start_benchmark_request: StartBenchmarkRequest,
@@ -608,6 +614,7 @@ async def _process_task_attempt(
     stream_key: str = f"{benchmark_id}:{task_stream_name}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
     pending_log_writes: set[asyncio.Future[None]] = set()
+    latest_log_write: asyncio.Future[None] | None = None
 
     logger.info(
         "Task output stream selected",
@@ -625,9 +632,17 @@ async def _process_task_attempt(
     last_log_time: float = time.monotonic()
 
     def schedule_log_flush(*, force: bool = False) -> None:
-        write = buffer_logs(log_queue, stream_key, aws_runtime, force_flush=force)
+        nonlocal latest_log_write
+        write = buffer_logs(
+            log_queue,
+            stream_key,
+            aws_runtime,
+            force_flush=force,
+            previous_write=latest_log_write,
+        )
         if write is None:
             return
+        latest_log_write = write
         pending_log_writes.add(write)
 
         def handle_completion(completed: asyncio.Future[None]) -> None:
@@ -1016,21 +1031,14 @@ async def _process_task_attempt(
             raise
 
         error_message = _exception_message(e)
-        logger.error(error_message)
         log_output(f"\n[ERROR] {error_message}")
-        with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(
-                task,
-                task_session,
-                error_message,
-                producer="sandbox_provider",
-                operation="sandbox_recovery",
-                error_type=type(e).__name__,
-                expected_started_at=attempt_started_at,
-                authority=authority,
-            )
-        return {task_id: None}
+
+        return commit_terminal_error(
+            e,
+            error_message,
+            producer="sandbox_provider",
+            operation="sandbox_recovery",
+        )
     except OutputArtifactError as e:
         if task_is_stopped():
             return {task_id: None}

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -254,6 +254,9 @@ class TestRunFinalization:
         async def skip_cloud_operation(*_args: Any, **_kwargs: Any) -> None:
             return None
 
+        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
+            return "test-log-group"
+
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -305,6 +308,7 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[scored_task.task_id], final_score=0.25, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
+        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_retry_task)
@@ -387,6 +391,9 @@ class TestRunFinalization:
             upload_calls += 1
             return None
 
+        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
+            return "test-log-group"
+
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -414,6 +421,7 @@ class TestRunFinalization:
             await both_monitors_arrived.wait()
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
+        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(TaskMonitor, "track_tasks", synchronized_track_tasks)
@@ -528,6 +536,9 @@ class TestRunFinalization:
             side_effects["notification"]["calls"] += 1
             side_effects["notification"]["lock_held"] = assert_lock_held(benchmark.id)
 
+        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
+            return "test-log-group"
+
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -539,6 +550,7 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[task.task_id], final_score=1.0, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
+        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", assert_upload_lock_held)
         monkeypatch.setattr(run_orchestration_module, "invoke_lambda", assert_lambda_lock_held)
@@ -626,6 +638,9 @@ class TestRunFinalization:
             benchmarks.append((benchmark, expected_summary))
         postgres_session.commit()
 
+        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
+            return "test-log-group"
+
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -635,6 +650,7 @@ class TestRunFinalization:
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
 
+        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
 
         for benchmark, expected_summary in benchmarks:

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -1,6 +1,6 @@
-"""Run with `uv run pytest tests/integration/local/database/test_run_finalization.py`.
+"""Exercise run-finalization concurrency against disposable Postgres.
 
-Exercise run-finalization concurrency against disposable Postgres.
+Run: uv run pytest tests/integration/local/database/test_run_finalization.py
 """
 
 import asyncio
@@ -254,9 +254,6 @@ class TestRunFinalization:
         async def skip_cloud_operation(*_args: Any, **_kwargs: Any) -> None:
             return None
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -308,7 +305,6 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[scored_task.task_id], final_score=0.25, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_retry_task)
@@ -391,9 +387,6 @@ class TestRunFinalization:
             upload_calls += 1
             return None
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -421,7 +414,6 @@ class TestRunFinalization:
             await both_monitors_arrived.wait()
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(TaskMonitor, "track_tasks", synchronized_track_tasks)
@@ -536,9 +528,6 @@ class TestRunFinalization:
             side_effects["notification"]["calls"] += 1
             side_effects["notification"]["lock_held"] = assert_lock_held(benchmark.id)
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -550,7 +539,6 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[task.task_id], final_score=1.0, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", assert_upload_lock_held)
         monkeypatch.setattr(run_orchestration_module, "invoke_lambda", assert_lambda_lock_held)
@@ -638,9 +626,6 @@ class TestRunFinalization:
             benchmarks.append((benchmark, expected_summary))
         postgres_session.commit()
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -650,7 +635,6 @@ class TestRunFinalization:
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
 
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
 
         for benchmark, expected_summary in benchmarks:

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -184,19 +184,6 @@ class TestS3ClientRetry:
 class TestCloudWatchClient:
     """CloudWatch exception translation at the client boundary."""
 
-    def test_uses_short_failure_timeouts(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        boto_client_factory = MagicMock()
-        monkeypatch.setattr(aws_clients.boto3, "client", boto_client_factory)
-        provider = DefaultChainAWSClientProvider(region="us-east-1")
-
-        provider.cloudwatch_logs_client()
-
-        config = boto_client_factory.call_args.kwargs["config"]
-        assert config.connect_timeout == 5
-        assert config.read_timeout == 5
-        assert config.retries["total_max_attempts"] == 2
-        assert config.retries["mode"] == "standard"
-
     def test_cloudwatch_error_with_client(self) -> None:
         """Test that ClientError is caught buy the decorator"""
         client_error = ClientError({"Error": {"Code": "404", "Message": "Not found"}}, "CreateLogStream")
@@ -269,7 +256,6 @@ class TestWriteBenchmarkLogEvent:
         client_provider = MagicMock(spec=AWSClientProvider)
         client_provider.cloudwatch_logs_client.return_value = client
         monkeypatch.setattr(cloudwatch_logs, "_created_streams", set[str]())
-        monkeypatch.setattr(cloudwatch_logs, "_created_log_groups", set[str]())
         runtime = AWSRuntime(
             resources=_AWS_RESOURCES,
             clients=cast(AWSClientProvider, client_provider),
@@ -278,28 +264,14 @@ class TestWriteBenchmarkLogEvent:
 
     def test_creates_stream_and_puts_event_with_sanitized_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client, runtime = self._runtime_with_mock_client(monkeypatch)
-        create_log_group = MagicMock()
-        monkeypatch.setattr(cloudwatch_logs, "create_benchmark_log_group", create_log_group)
 
         # stream_key splits on the first ':' -> task_id keeps its own ':'
         write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
-        create_log_group.assert_called_once_with("bench123", runtime)
         client.create_log_stream.assert_called_once_with(
             logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
         )
         assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
-
-    def test_splits_oversized_utf8_messages_without_losing_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        client, runtime = self._runtime_with_mock_client(monkeypatch)
-        message = "a" * 1_048_540 + "🙂" * 20
-
-        write_benchmark_log_event("bench123:task-1", message, runtime)
-
-        written = [call.kwargs["logEvents"][0]["message"] for call in client.put_log_events.call_args_list]
-        assert len(written) == 2
-        assert "".join(written) == message
-        assert all(len(chunk.encode("utf-8")) <= 1_048_550 for chunk in written)
 
     def test_create_stream_botocore_error_reports_sanitized_name(
         self,
@@ -313,16 +285,3 @@ class TestWriteBenchmarkLogEvent:
 
         assert "provider/model_fast" in str(exc_info.value)
         client.put_log_events.assert_not_called()
-
-    def test_log_group_failure_prevents_only_the_background_write(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        client, runtime = self._runtime_with_mock_client(monkeypatch)
-        monkeypatch.setattr(
-            cloudwatch_logs,
-            "create_benchmark_log_group",
-            MagicMock(side_effect=CloudWatchError("Failed to create log group")),
-        )
-
-        with pytest.raises(CloudWatchError, match="Failed to create log group"):
-            write_benchmark_log_event("bench123:task-1", "hello", runtime)
-
-        client.create_log_stream.assert_not_called()

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -273,6 +273,17 @@ class TestWriteBenchmarkLogEvent:
         )
         assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model%3Afast"
 
+    def test_splits_oversized_utf8_messages_without_losing_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, runtime = self._runtime_with_mock_client(monkeypatch)
+        message = "a" * 1_048_540 + "🙂" * 20
+
+        write_benchmark_log_event("bench123:task-1", message, runtime)
+
+        written = [call.kwargs["logEvents"][0]["message"] for call in client.put_log_events.call_args_list]
+        assert len(written) == 2
+        assert "".join(written) == message
+        assert all(len(chunk.encode("utf-8")) <= 1_048_550 for chunk in written)
+
     def test_create_stream_botocore_error_reports_sanitized_name(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -217,13 +217,13 @@ class TestSanitizeLogStreamName:
     """logStreamName must satisfy AWS constraint [^:*]* (no ':' or '*')."""
 
     def test_replaces_colon(self) -> None:
-        assert _sanitize_log_stream_name("provider/model:fast") == "provider/model_fast"
+        assert _sanitize_log_stream_name("provider/model:fast") == "provider/model%3Afast"
 
     def test_replaces_asterisk(self) -> None:
-        assert _sanitize_log_stream_name("task*glob") == "task_glob"
+        assert _sanitize_log_stream_name("task*glob") == "task%2Aglob"
 
     def test_replaces_both_and_multiple(self) -> None:
-        assert _sanitize_log_stream_name("a:b:c*d") == "a_b_c_d"
+        assert _sanitize_log_stream_name("a:b:c*d") == "a%3Ab%3Ac%2Ad"
 
     def test_preserves_clean_name(self) -> None:
         # plain ids and the allowed '/' are left intact
@@ -240,8 +240,7 @@ class TestGetBenchmarkLogUrl:
 
     def test_sanitizes_task_id_in_url(self) -> None:
         url = get_benchmark_log_url("bench123", _AWS_RESOURCES, task_id="provider/model:fast")
-        # task id is sanitized before being url-quoted into the log-events path
-        assert "model_fast" in url
+        assert "provider%2Fmodel%253Afast" in url
         assert "model:fast" not in url
 
     def test_no_task_id_omits_log_events(self) -> None:
@@ -270,9 +269,9 @@ class TestWriteBenchmarkLogEvent:
         write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
         client.create_log_stream.assert_called_once_with(
-            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
+            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model%3Afast"
         )
-        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
+        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model%3Afast"
 
     def test_create_stream_botocore_error_reports_sanitized_name(
         self,
@@ -284,5 +283,5 @@ class TestWriteBenchmarkLogEvent:
         with pytest.raises(CloudWatchError) as exc_info:
             write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
-        assert "provider/model_fast" in str(exc_info.value)
+        assert "provider/model%3Afast" in str(exc_info.value)
         client.put_log_events.assert_not_called()

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -184,6 +184,19 @@ class TestS3ClientRetry:
 class TestCloudWatchClient:
     """CloudWatch exception translation at the client boundary."""
 
+    def test_uses_short_failure_timeouts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        boto_client_factory = MagicMock()
+        monkeypatch.setattr(aws_clients.boto3, "client", boto_client_factory)
+        provider = DefaultChainAWSClientProvider(region="us-east-1")
+
+        provider.cloudwatch_logs_client()
+
+        config = boto_client_factory.call_args.kwargs["config"]
+        assert config.connect_timeout == 5
+        assert config.read_timeout == 5
+        assert config.retries["total_max_attempts"] == 2
+        assert config.retries["mode"] == "standard"
+
     def test_cloudwatch_error_with_client(self) -> None:
         """Test that ClientError is caught buy the decorator"""
         client_error = ClientError({"Error": {"Code": "404", "Message": "Not found"}}, "CreateLogStream")
@@ -217,13 +230,13 @@ class TestSanitizeLogStreamName:
     """logStreamName must satisfy AWS constraint [^:*]* (no ':' or '*')."""
 
     def test_replaces_colon(self) -> None:
-        assert _sanitize_log_stream_name("provider/model:fast") == "provider/model%3Afast"
+        assert _sanitize_log_stream_name("provider/model:fast") == "provider/model_fast"
 
     def test_replaces_asterisk(self) -> None:
-        assert _sanitize_log_stream_name("task*glob") == "task%2Aglob"
+        assert _sanitize_log_stream_name("task*glob") == "task_glob"
 
     def test_replaces_both_and_multiple(self) -> None:
-        assert _sanitize_log_stream_name("a:b:c*d") == "a%3Ab%3Ac%2Ad"
+        assert _sanitize_log_stream_name("a:b:c*d") == "a_b_c_d"
 
     def test_preserves_clean_name(self) -> None:
         # plain ids and the allowed '/' are left intact
@@ -240,7 +253,7 @@ class TestGetBenchmarkLogUrl:
 
     def test_sanitizes_task_id_in_url(self) -> None:
         url = get_benchmark_log_url("bench123", _AWS_RESOURCES, task_id="provider/model:fast")
-        assert "provider%2Fmodel%253Afast" in url
+        assert "provider%2Fmodel_fast" in url
         assert "model:fast" not in url
 
     def test_no_task_id_omits_log_events(self) -> None:
@@ -256,6 +269,7 @@ class TestWriteBenchmarkLogEvent:
         client_provider = MagicMock(spec=AWSClientProvider)
         client_provider.cloudwatch_logs_client.return_value = client
         monkeypatch.setattr(cloudwatch_logs, "_created_streams", set[str]())
+        monkeypatch.setattr(cloudwatch_logs, "_created_log_groups", set[str]())
         runtime = AWSRuntime(
             resources=_AWS_RESOURCES,
             clients=cast(AWSClientProvider, client_provider),
@@ -264,14 +278,17 @@ class TestWriteBenchmarkLogEvent:
 
     def test_creates_stream_and_puts_event_with_sanitized_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client, runtime = self._runtime_with_mock_client(monkeypatch)
+        create_log_group = MagicMock()
+        monkeypatch.setattr(cloudwatch_logs, "create_benchmark_log_group", create_log_group)
 
         # stream_key splits on the first ':' -> task_id keeps its own ':'
         write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
+        create_log_group.assert_called_once_with("bench123", runtime)
         client.create_log_stream.assert_called_once_with(
-            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model%3Afast"
+            logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
         )
-        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model%3Afast"
+        assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
 
     def test_splits_oversized_utf8_messages_without_losing_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client, runtime = self._runtime_with_mock_client(monkeypatch)
@@ -294,5 +311,18 @@ class TestWriteBenchmarkLogEvent:
         with pytest.raises(CloudWatchError) as exc_info:
             write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
-        assert "provider/model%3Afast" in str(exc_info.value)
+        assert "provider/model_fast" in str(exc_info.value)
         client.put_log_events.assert_not_called()
+
+    def test_log_group_failure_prevents_only_the_background_write(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, runtime = self._runtime_with_mock_client(monkeypatch)
+        monkeypatch.setattr(
+            cloudwatch_logs,
+            "create_benchmark_log_group",
+            MagicMock(side_effect=CloudWatchError("Failed to create log group")),
+        )
+
+        with pytest.raises(CloudWatchError, match="Failed to create log group"):
+            write_benchmark_log_event("bench123:task-1", "hello", runtime)
+
+        client.create_log_stream.assert_not_called()

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -179,7 +179,6 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.write_benchmark_log_event", _mock_write_benchmark_log_event)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.utils.task_execution.write_benchmark_log_event", _mock_write_benchmark_log_event)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", _mock_upload_final_view)
     monkeypatch.setattr("tracker.aws.secrets.fetch_aws_secret", _mock_fetch_aws_secret)

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -179,6 +179,7 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.write_benchmark_log_event", _mock_write_benchmark_log_event)
+    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.utils.task_execution.write_benchmark_log_event", _mock_write_benchmark_log_event)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", _mock_upload_final_view)
     monkeypatch.setattr("tracker.aws.secrets.fetch_aws_secret", _mock_fetch_aws_secret)

--- a/services/tracker/tests/unit/executor/test_entrypoint.py
+++ b/services/tracker/tests/unit/executor/test_entrypoint.py
@@ -4,14 +4,29 @@ import asyncio
 import json
 import signal
 import sys
-from pathlib import Path
 from collections.abc import Callable
-from unittest.mock import AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+import sentry_sdk
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from opentelemetry.trace.propagation import set_span_in_context
 from pytest import MonkeyPatch
 
+from tracker.config import ENVIRONMENT
 from tracker.executor import entrypoint as executor_entrypoint
+from tracker.logging import benchmark_id_var, request_id_var, task_id_var
+
+
+@pytest.fixture(autouse=True)
+def observability(monkeypatch: MonkeyPatch) -> tuple[Mock, Mock]:
+    configure = Mock()
+    flush = Mock()
+    monkeypatch.setattr(executor_entrypoint, "configure_observability", configure)
+    monkeypatch.setattr(executor_entrypoint, "_flush_observability", flush)
+    return configure, flush
 
 
 @pytest.mark.asyncio
@@ -58,7 +73,40 @@ async def test_sigterm_cancels_executor_and_awaits_cleanup(monkeypatch: MonkeyPa
     assert cleaned_up.is_set()
 
 
-def test_main_forwards_executor_payload(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_unhandled_executor_error_is_captured_with_run_context(monkeypatch: MonkeyPatch) -> None:
+    error = RuntimeError("executor failed")
+
+    async def process_benchmark(**_payload: object) -> None:
+        raise error
+
+    captured_context: dict[str, str] = {}
+
+    def capture_exception(captured_error: BaseException) -> None:
+        assert captured_error is error
+        captured_context["benchmark_id"] = benchmark_id_var.get()
+        captured_context["request_id"] = request_id_var.get()
+
+    monkeypatch.setattr(executor_entrypoint, "process_benchmark", process_benchmark)
+    monkeypatch.setattr(sentry_sdk, "capture_exception", capture_exception)
+
+    with pytest.raises(RuntimeError, match="executor failed"):
+        await executor_entrypoint._run_executor(  # pyright: ignore[reportPrivateUsage]
+            {
+                "benchmark_id_str": "benchmark-id",
+                "telemetry_context_json": {"request_id": "request-id", "trace_headers": {}},
+                "executor_dispatch_id": "dispatch-id",
+            }
+        )
+
+    assert captured_context == {"benchmark_id": "benchmark-id", "request_id": "request-id"}
+
+
+def test_main_forwards_executor_payload(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    observability: tuple[Mock, Mock],
+) -> None:
     payload = {
         "start_benchmark_request_json": {"benchmark": "test-benchmark"},
         "benchmark_id_str": "benchmark-id",
@@ -73,6 +121,9 @@ def test_main_forwards_executor_payload(tmp_path: Path, monkeypatch: MonkeyPatch
 
     executor_entrypoint.main()
 
+    configure, flush = observability
+    configure.assert_called_once_with("valkyrie-executor", environment=ENVIRONMENT)
+    flush.assert_called_once_with()
     process_benchmark.assert_awaited_once_with(
         start_benchmark_request_json=payload["start_benchmark_request_json"],
         benchmark_id_str=payload["benchmark_id_str"],
@@ -82,7 +133,11 @@ def test_main_forwards_executor_payload(tmp_path: Path, monkeypatch: MonkeyPatch
     )
 
 
-def test_main_forwards_managed_execution_payload(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+def test_main_forwards_managed_execution_payload(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    observability: tuple[Mock, Mock],
+) -> None:
     payload = {
         "execution_context_json": {"benchmark_id": "benchmark-id"},
         "executor_dispatch_id": "dispatch-id",
@@ -95,6 +150,9 @@ def test_main_forwards_managed_execution_payload(tmp_path: Path, monkeypatch: Mo
 
     executor_entrypoint.main()
 
+    configure, flush = observability
+    configure.assert_called_once_with("valkyrie-executor", environment=ENVIRONMENT)
+    flush.assert_called_once_with()
     process_benchmark.assert_awaited_once_with(
         start_benchmark_request_json=None,
         benchmark_id_str=None,
@@ -102,6 +160,48 @@ def test_main_forwards_managed_execution_payload(tmp_path: Path, monkeypatch: Mo
         execution_context_json=payload["execution_context_json"],
         executor_dispatch_id=payload["executor_dispatch_id"],
     )
+
+
+def test_executor_context_restores_run_and_trace_context(monkeypatch: MonkeyPatch) -> None:
+    parent_span = NonRecordingSpan(
+        SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1234567890ABCDEF,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+    )
+    extract = Mock(return_value=set_span_in_context(parent_span))
+    monkeypatch.setattr(executor_entrypoint, "extract", extract)
+    request_token = request_id_var.set("outer-request")
+    benchmark_token = benchmark_id_var.set("outer-benchmark")
+    task_token = task_id_var.set("outer-task")
+
+    try:
+        with executor_entrypoint._executor_context(  # pyright: ignore[reportPrivateUsage]
+            {
+                "execution_context_json": {"benchmark_id": "benchmark-id"},
+                "telemetry_context_json": {
+                    "request_id": "request-id",
+                    "trace_headers": {"sentry-trace": "trace-header", "baggage": "baggage-header"},
+                },
+            }
+        ):
+            assert request_id_var.get() == "request-id"
+            assert benchmark_id_var.get() == "benchmark-id"
+            assert task_id_var.get() == ""
+            assert trace.get_current_span().get_span_context() == parent_span.get_span_context()
+
+        assert request_id_var.get() == "outer-request"
+        assert benchmark_id_var.get() == "outer-benchmark"
+        assert task_id_var.get() == "outer-task"
+        assert not trace.get_current_span().get_span_context().is_valid
+    finally:
+        task_id_var.reset(task_token)
+        benchmark_id_var.reset(benchmark_token)
+        request_id_var.reset(request_token)
+
+    extract.assert_called_once_with({"sentry-trace": "trace-header", "baggage": "baggage-header"})
 
 
 @pytest.mark.parametrize("payload", [[], "not an object", 1, None])

--- a/services/tracker/tests/unit/executor/test_entrypoint.py
+++ b/services/tracker/tests/unit/executor/test_entrypoint.py
@@ -1,4 +1,7 @@
-"""Tests for the immutable executor PEX entrypoint."""
+"""Tests for the immutable executor PEX entrypoint.
+
+Run: uv run pytest tests/unit/executor/test_entrypoint.py
+"""
 
 import asyncio
 import json

--- a/services/tracker/tests/unit/logging/test_logging.py
+++ b/services/tracker/tests/unit/logging/test_logging.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, Mock
 from uuid import UUID
 
 import pytest
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from main import app
@@ -20,7 +21,7 @@ from tracker.logging import (
     request_id_var,
     task_id_var,
 )
-from tracker.api.dependencies import bind_benchmark_id
+from tracker.api.dependencies import TrackedBenchmarkId, bind_benchmark_id
 from tracker.middleware import LoggingContextMiddleware
 from tracker.types import AWSCredentials, HarnessConfig
 
@@ -144,16 +145,34 @@ class TestContextFilter:
             task_id_var.reset(task_token)
 
 
-def test_bind_benchmark_id_updates_logging_context_and_request_span(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_bind_benchmark_id_updates_logging_context_and_request_span(monkeypatch: pytest.MonkeyPatch) -> None:
     span = Mock()
     monkeypatch.setattr("tracker.api.dependencies.trace.get_current_span", lambda: span)
 
     benchmark_id = UUID("12345678-1234-5678-9234-567812345678")
-    result = bind_benchmark_id(benchmark_id)
+    result = await bind_benchmark_id(benchmark_id)
 
     assert result == benchmark_id
     assert benchmark_id_var.get() == str(benchmark_id)
     span.set_attribute.assert_called_once_with("benchmark_id", str(benchmark_id))
+
+
+async def test_bind_benchmark_id_survives_fastapi_dependency_resolution() -> None:
+    test_app = FastAPI()
+    observed_benchmark_ids: list[str] = []
+
+    async def endpoint(benchmark_id: TrackedBenchmarkId) -> dict[str, str]:
+        observed_benchmark_ids.append(benchmark_id_var.get())
+        return {"benchmark_id": str(benchmark_id)}
+
+    test_app.add_api_route("/runs/{benchmark_id}", endpoint)
+    benchmark_id = UUID("12345678-1234-5678-9234-567812345678")
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get(f"/runs/{benchmark_id}")
+
+    assert response.status_code == 200
+    assert observed_benchmark_ids == [str(benchmark_id)]
 
 
 class TestConfigureLogging:

--- a/services/tracker/tests/unit/logging/test_logging.py
+++ b/services/tracker/tests/unit/logging/test_logging.py
@@ -5,7 +5,8 @@ Run: uv run pytest tests/unit/logging/test_logging.py
 
 import json
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
+from uuid import UUID
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -19,6 +20,7 @@ from tracker.logging import (
     request_id_var,
     task_id_var,
 )
+from tracker.api.dependencies import bind_benchmark_id
 from tracker.middleware import LoggingContextMiddleware
 from tracker.types import AWSCredentials, HarnessConfig
 
@@ -140,6 +142,18 @@ class TestContextFilter:
             request_id_var.reset(request_token)
             benchmark_id_var.reset(benchmark_token)
             task_id_var.reset(task_token)
+
+
+def test_bind_benchmark_id_updates_logging_context_and_request_span(monkeypatch: pytest.MonkeyPatch) -> None:
+    span = Mock()
+    monkeypatch.setattr("tracker.api.dependencies.trace.get_current_span", lambda: span)
+
+    benchmark_id = UUID("12345678-1234-5678-9234-567812345678")
+    result = bind_benchmark_id(benchmark_id)
+
+    assert result == benchmark_id
+    assert benchmark_id_var.get() == str(benchmark_id)
+    span.set_attribute.assert_called_once_with("benchmark_id", str(benchmark_id))
 
 
 class TestConfigureLogging:

--- a/services/tracker/tests/unit/observability/test_observability.py
+++ b/services/tracker/tests/unit/observability/test_observability.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from opentelemetry.trace import StatusCode
@@ -403,4 +403,30 @@ def test_observability_span_failure_does_not_skip_wrapped_work(monkeypatch: pyte
         completed.append(True)
 
     assert completed == [True]
+    warning.assert_called_once()
+
+
+@pytest.mark.parametrize("work_error", [None, RuntimeError("work failed")], ids=["success", "error"])
+def test_observability_span_close_failure_preserves_work_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    work_error: RuntimeError | None,
+) -> None:
+    span_manager = MagicMock()
+    span_manager.__exit__.side_effect = RuntimeError("tracing unavailable")
+    monkeypatch.setattr(tracing_module.logfire, "span", Mock(return_value=span_manager))
+    warning = Mock()
+    monkeypatch.setattr(tracing_module.logger, "warning", warning)
+    completed: list[bool] = []
+
+    if work_error is None:
+        with tracing_module.observability_span("task.status_transition"):
+            completed.append(True)
+        assert completed == [True]
+    else:
+        with pytest.raises(RuntimeError, match="work failed") as exc_info:
+            with tracing_module.observability_span("task.status_transition"):
+                raise work_error
+        assert exc_info.value is work_error
+        assert completed == []
+
     warning.assert_called_once()

--- a/services/tracker/tests/unit/observability/test_observability.py
+++ b/services/tracker/tests/unit/observability/test_observability.py
@@ -20,10 +20,31 @@ import tracker.observability.metrics as metrics_module
 import tracker.observability.retry as retry_module
 import tracker.observability.sentry as sentry_module
 import tracker.observability.tracing as tracing_module
+import tracker.observability as observability_module
 
 
 def _run_orchestration() -> Any:
     return importlib.import_module("tracker.utils.run_orchestration")
+
+
+@pytest.mark.parametrize("failing_component", ["sentry", "tracing"])
+def test_observability_initialization_failure_does_not_escape(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_component: str,
+) -> None:
+    error = RuntimeError(f"{failing_component} unavailable")
+    initialize_sentry = Mock(side_effect=error if failing_component == "sentry" else None)
+    initialize_tracing = Mock(side_effect=error if failing_component == "tracing" else None)
+    warning = Mock()
+    monkeypatch.setattr(observability_module, "init_sentry", initialize_sentry)
+    monkeypatch.setattr(observability_module, "configure_tracing", initialize_tracing)
+    monkeypatch.setattr(observability_module.logger, "warning", warning)
+
+    observability_module.configure_observability("valkyrie-test", "production")
+
+    initialize_sentry.assert_called_once_with("valkyrie-test", environment="production")
+    initialize_tracing.assert_called_once_with("valkyrie-test", environment="production")
+    assert error in warning.call_args.args
 
 
 def test_invalid_queued_request_does_not_expose_aws_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -370,3 +391,16 @@ def test_handled_error_span_records_exception_and_error_status(monkeypatch: pyte
     span.record_exception.assert_called_once_with(error)
     status = span.set_status.call_args.args[0]
     assert status.status_code is StatusCode.ERROR
+
+
+def test_observability_span_failure_does_not_skip_wrapped_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tracing_module.logfire, "span", Mock(side_effect=RuntimeError("tracing unavailable")))
+    warning = Mock()
+    monkeypatch.setattr(tracing_module.logger, "warning", warning)
+    completed: list[bool] = []
+
+    with tracing_module.observability_span("task.status_transition"):
+        completed.append(True)
+
+    assert completed == [True]
+    warning.assert_called_once()

--- a/services/tracker/tests/unit/observability/test_observability.py
+++ b/services/tracker/tests/unit/observability/test_observability.py
@@ -17,6 +17,7 @@ from tenacity import RetryCallState, Retrying
 import tracker.observability.metrics as metrics_module
 import tracker.observability.retry as retry_module
 import tracker.observability.sentry as sentry_module
+import tracker.observability.tracing as tracing_module
 
 
 def _run_orchestration() -> Any:
@@ -312,3 +313,39 @@ def test_retry_callback_logs_attempt_and_emits_retry_metric(monkeypatch: pytest.
             "error_class": "TimeoutError",
         }
     ]
+
+
+def test_sentry_span_processor_drops_noisy_polling_subtrees(monkeypatch: pytest.MonkeyPatch) -> None:
+    delegate = Mock()
+    delegate.force_flush.return_value = True
+    monkeypatch.setattr(tracing_module, "SentrySpanProcessor", Mock(return_value=delegate))
+    processor = tracing_module._FilteredSentrySpanProcessor()  # pyright: ignore[reportPrivateUsage]
+
+    root_context = SimpleNamespace(span_id=1)
+    polling_context = SimpleNamespace(span_id=2)
+    polling_child_context = SimpleNamespace(span_id=3)
+    meaningful_context = SimpleNamespace(span_id=4)
+    root = SimpleNamespace(name="sandbox.exec", parent=None, get_span_context=lambda: root_context)
+    polling = SimpleNamespace(
+        name="AsyncProcess.exec",
+        parent=root_context,
+        get_span_context=lambda: polling_context,
+    )
+    polling_child = SimpleNamespace(
+        name="http.client",
+        parent=polling_context,
+        get_span_context=lambda: polling_child_context,
+    )
+    meaningful = SimpleNamespace(
+        name="upload_output",
+        parent=root_context,
+        get_span_context=lambda: meaningful_context,
+    )
+
+    for span in (root, polling, polling_child, meaningful):
+        processor.on_start(span)
+    for span in (polling_child, polling, meaningful, root):
+        processor.on_end(span)
+
+    assert [call.args[0] for call in delegate.on_start.call_args_list] == [root, meaningful]
+    assert [call.args[0] for call in delegate.on_end.call_args_list] == [meaningful, root]

--- a/services/tracker/tests/unit/observability/test_observability.py
+++ b/services/tracker/tests/unit/observability/test_observability.py
@@ -6,11 +6,13 @@ Run: uv run pytest tests/unit/observability/test_observability.py
 import importlib
 import logging
 from collections.abc import Mapping
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from opentelemetry.trace import StatusCode
 from sentry_sdk import metrics as sentry_metrics
 from tenacity import RetryCallState, Retrying
 
@@ -349,3 +351,22 @@ def test_sentry_span_processor_drops_noisy_polling_subtrees(monkeypatch: pytest.
 
     assert [call.args[0] for call in delegate.on_start.call_args_list] == [root, meaningful]
     assert [call.args[0] for call in delegate.on_end.call_args_list] == [meaningful, root]
+
+
+def test_handled_error_span_records_exception_and_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    span = Mock()
+    error = RuntimeError("handled failure")
+
+    @contextmanager
+    def span_context(*_args: object, **_kwargs: object) -> Any:
+        yield
+
+    monkeypatch.setattr(tracing_module.logfire, "span", span_context)
+    monkeypatch.setattr(tracing_module.trace, "get_current_span", Mock(return_value=span))
+
+    with tracing_module.error_span("task.error", error, benchmark_id="benchmark-123"):
+        pass
+
+    span.record_exception.assert_called_once_with(error)
+    status = span.set_status.call_args.args[0]
+    assert status.status_code is StatusCode.ERROR

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -109,12 +109,21 @@ class TestSentrySetup:
             },
         )
         monkeypatch.setattr(sentry_module, "get_current_span", lambda: span)
+        monkeypatch.setattr(
+            sentry_module,
+            "get_context_tags",
+            lambda: {"request_id": "request-123", "benchmark_id": "benchmark-123", "task_id": ""},
+        )
 
         result = _before_send_log()(log, {})
 
         assert result is log
         assert log["trace_id"] == trace_id
         assert log["span_id"] == span_id
+        assert log["attributes"] == {
+            "request_id": "request-123",
+            "benchmark_id": "benchmark-123",
+        }
 
     def test_init_sentry_logs_warning_when_initialization_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         warnings: list[tuple[str, tuple[object, ...]]] = []

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -141,3 +141,12 @@ class TestSentrySetup:
         assert warnings[0][0] == "Failed to initialize Sentry: %s: %s"
         assert warnings[0][1][:1] == ("RuntimeError",)
         assert str(warnings[0][1][1]) == "bad dsn"
+
+    def test_init_sentry_rejects_invalid_production_configuration(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+        monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
+
+        with pytest.raises(RuntimeError, match="Check the production DSN secret") as exc_info:
+            sentry_module.init_sentry("valkyrie-worker", environment="production")
+
+        assert exc_info.value.__cause__ is None

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -135,24 +135,18 @@ class TestSentrySetup:
         monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
         monkeypatch.setattr(sentry_module.logger, "warning", fake_warning)
 
-        sentry_module.init_sentry("valkyrie-worker", environment="test")
+        sentry_module.init_sentry("valkyrie-worker", environment="production")
 
         assert len(warnings) == 1
         assert warnings[0][0] == "Failed to initialize Sentry: %s: %s"
         assert warnings[0][1][:1] == ("RuntimeError",)
         assert str(warnings[0][1][1]) == "bad dsn"
 
-    def test_init_sentry_rejects_invalid_production_configuration(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
-        monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
-
-        with pytest.raises(RuntimeError, match="Check the production DSN secret") as exc_info:
-            sentry_module.init_sentry("valkyrie-worker", environment="production")
-
-        assert exc_info.value.__cause__ is None
-
-    def test_init_sentry_requires_production_dsn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_init_sentry_skips_missing_production_dsn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        init_mock = Mock()
         monkeypatch.delenv("SENTRY_DSN", raising=False)
+        monkeypatch.setattr(sentry_sdk, "init", init_mock)
 
-        with pytest.raises(RuntimeError, match="Check the production DSN secret"):
-            sentry_module.init_sentry("valkyrie-worker", environment="production")
+        sentry_module.init_sentry("valkyrie-worker", environment="production")
+
+        init_mock.assert_not_called()

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -150,3 +150,9 @@ class TestSentrySetup:
             sentry_module.init_sentry("valkyrie-worker", environment="production")
 
         assert exc_info.value.__cause__ is None
+
+    def test_init_sentry_requires_production_dsn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("SENTRY_DSN", raising=False)
+
+        with pytest.raises(RuntimeError, match="Check the production DSN secret"):
+            sentry_module.init_sentry("valkyrie-worker", environment="production")

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -8,7 +8,7 @@ import logging
 import tarfile
 from collections.abc import AsyncIterator
 from datetime import timezone
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -30,7 +30,7 @@ from taskiq.message import BrokerMessage, TaskiqMessage
 
 import main as main_module
 import services.executor_host.supervisor as executor_host  # pyright: ignore[reportMissingImports]
-from executor_protocol import SUPPORTED_PROTOCOL_VERSION
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION, ExecutorTelemetryContext
 from main import app, tracker_service_error_handler
 from tests.utils import TEST_ORG_ID, async_iterator
 from tracker.auth import RequestIdentity, get_current_org, get_current_starter
@@ -702,7 +702,10 @@ class TestTrackerAPI:
         telemetry_context = taskiq_message.kwargs["telemetry_context_json"]
         assert telemetry_context["request_id"]
         assert isinstance(telemetry_context["trace_headers"], dict)
-        child_telemetry_context = process_payload.telemetry_context
+        child_telemetry_context = cast(
+            ExecutorTelemetryContext,
+            process_payload.arguments["telemetry_context_json"],
+        )
         assert child_telemetry_context["request_id"] == telemetry_context["request_id"]
         assert child_telemetry_context["trace_headers"]
         if aws_managed:

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -664,6 +664,7 @@ class TestTrackerAPI:
             else {"start_benchmark_request_json", "benchmark_id_str", "verified_task_ids"}
         )
         assert set(taskiq_message.kwargs) == execution_kwargs | {
+            "telemetry_context_json",
             "executor_dispatch_id",
             "executor_release_id",
             "executor_artifact_uri",
@@ -698,15 +699,23 @@ class TestTrackerAPI:
         assert isinstance(process_payload, executor_host.ExecutorProcessPayload)
         assert process_payload.benchmark_id == str(benchmark.id)
         assert process_payload.verified_task_ids == ["task_0"]
+        telemetry_context = taskiq_message.kwargs["telemetry_context_json"]
+        assert telemetry_context["request_id"]
+        assert isinstance(telemetry_context["trace_headers"], dict)
+        child_telemetry_context = process_payload.telemetry_context
+        assert child_telemetry_context["request_id"] == telemetry_context["request_id"]
+        assert child_telemetry_context["trace_headers"]
         if aws_managed:
             assert process_payload.arguments == {
-                "execution_context_json": taskiq_message.kwargs["execution_context_json"]
+                "execution_context_json": taskiq_message.kwargs["execution_context_json"],
+                "telemetry_context_json": child_telemetry_context,
             }
         else:
             assert process_payload.arguments == {
                 "start_benchmark_request_json": request.model_dump(),
                 "benchmark_id_str": str(benchmark.id),
                 "verified_task_ids": ["task_0"],
+                "telemetry_context_json": child_telemetry_context,
             }
         host_dispatch = observed_host["dispatch"]
         assert isinstance(host_dispatch, executor_host.ArtifactDispatch)

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -327,6 +327,11 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
 
+    def create_log_group(_benchmark_id: str, runtime: AWSRuntime) -> str:
+        assert runtime is aws_runtime
+        calls.append("logs")
+        return "benchmark-log-group"
+
     def fetch_provider(_name: str, clients: object, _provider: str) -> SandboxProviderConfig:
         assert clients is aws_runtime.clients
         calls.append("provider-secret")
@@ -355,6 +360,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         return MagicMock()
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
+    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", resolve_agent_secrets)
@@ -373,7 +379,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
 
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.FINISHED
-    assert calls[:3] == ["provider-secret", "agent-secrets", "lambda-dry-run"]
+    assert calls[:4] == ["logs", "provider-secret", "agent-secrets", "lambda-dry-run"]
     assert calls.count("agent-secrets") >= 2
     assert calls[-2:] == ["s3-final-upload", "lambda-post-run"]
     finalized_span = next(attributes for name, attributes in spans if name == "run.finalized")
@@ -396,6 +402,10 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     calls: list[str] = []
     provider_config = cast(SandboxProviderConfig, MagicMock())
 
+    def create_log_group(*_args: Any, **_kwargs: Any) -> str:
+        calls.append("logs")
+        return "benchmark-log-group"
+
     def fetch_provider(*_args: Any, **_kwargs: Any) -> SandboxProviderConfig:
         calls.append("sandbox_provider_secret")
         return provider_config
@@ -411,6 +421,7 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     def dry_run(*_args: Any, **_kwargs: Any) -> None:
         calls.append("lambda")
 
+    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_aws_secret", fetch_webhook_secret)
@@ -419,10 +430,10 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     result = _preflight_managed_aws(execution, aws_runtime)
 
     assert result is provider_config
-    assert calls == ["sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
+    assert calls == ["logs", "sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
 
 
-async def test_required_managed_preflight_failure_happens_before_sandbox(
+async def test_managed_preflight_failure_happens_before_sandbox(
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,
     database_session: Session,
@@ -437,11 +448,11 @@ async def test_required_managed_preflight_failure_happens_before_sandbox(
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
 
-    def fail_provider_preflight(*_args: Any, **_kwargs: Any) -> SandboxProviderConfig:
-        raise RuntimeError("managed provider preflight failed")
+    def fail_log_preflight(*_args: Any, **_kwargs: Any) -> str:
+        raise RuntimeError("managed log preflight failed")
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fail_provider_preflight)
+    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", fail_log_preflight)
     monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
 
     await process_benchmark(
@@ -451,5 +462,5 @@ async def test_required_managed_preflight_failure_happens_before_sandbox(
 
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.ERROR
-    assert "managed provider preflight failed" in (benchmark.error_message or "")
+    assert "managed log preflight failed" in (benchmark.error_message or "")
     create_sandbox.assert_not_awaited()

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -1,3 +1,8 @@
+"""Tests for managed and access-key executor inputs.
+
+Run: uv run pytest tests/unit/test_managed_execution.py
+"""
+
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
@@ -278,11 +283,17 @@ async def test_ineligible_managed_execution_marks_run_error(
 ) -> None:
     request = _managed_request(contract)
     benchmark = _persist_benchmark(database_session, request, aws_managed=True)
+    spans: list[tuple[str, dict[str, Any]]] = []
 
     def reject_managed_runtime(_org_id: UUID) -> AWSRuntime:
         raise ManagedAWSEligibilityError("Managed AWS access is not available for this organization")
 
+    def record_span(name: str, **attributes: Any) -> MagicMock:
+        spans.append((name, attributes))
+        return MagicMock()
+
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", reject_managed_runtime)
+    monkeypatch.setattr("tracker.utils.run_orchestration.observability_span", record_span)
 
     await process_benchmark(
         execution_context_json=_execution_context(request, benchmark.id),
@@ -292,6 +303,9 @@ async def test_ineligible_managed_execution_marks_run_error(
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.ERROR
     assert "Managed AWS access is not available for this organization" in (benchmark.error_message or "")
+    finalized_span = next(attributes for name, attributes in spans if name == "run.finalized")
+    assert finalized_span["benchmark_id"] == str(benchmark.id)
+    assert finalized_span["status"] == "ERROR"
 
 
 async def test_managed_execution_completes_with_the_deployment_runtime(
@@ -307,15 +321,11 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     )
     benchmark = _persist_benchmark(database_session, request, aws_managed=True)
     calls: list[str] = []
+    spans: list[tuple[str, dict[str, Any]]] = []
     provider_config = cast(SandboxProviderConfig, MagicMock())
 
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
-
-    def create_log_group(_benchmark_id: str, runtime: AWSRuntime) -> str:
-        assert runtime is aws_runtime
-        calls.append("logs")
-        return "benchmark-log-group"
 
     def fetch_provider(_name: str, clients: object, _provider: str) -> SandboxProviderConfig:
         assert clients is aws_runtime.clients
@@ -340,14 +350,18 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         calls.append("lambda-post-run")
         return {}
 
+    def record_span(name: str, **attributes: Any) -> MagicMock:
+        spans.append((name, attributes))
+        return MagicMock()
+
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", dry_run)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", upload_results)
     monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke_post_run)
+    monkeypatch.setattr("tracker.utils.run_orchestration.observability_span", record_span)
 
     execution_context = _execution_context(request, benchmark.id)
     # A resume may change stored inputs while this job is queued; the queued job must still run.
@@ -359,9 +373,11 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
 
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.FINISHED
-    assert calls[:4] == ["logs", "provider-secret", "agent-secrets", "lambda-dry-run"]
+    assert calls[:3] == ["provider-secret", "agent-secrets", "lambda-dry-run"]
     assert calls.count("agent-secrets") >= 2
     assert calls[-2:] == ["s3-final-upload", "lambda-post-run"]
+    finalized_span = next(attributes for name, attributes in spans if name == "run.finalized")
+    assert finalized_span["status"] == "FINISHED"
 
 
 def test_managed_execution_preflight_checks_aws_dependencies_in_order(
@@ -380,10 +396,6 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     calls: list[str] = []
     provider_config = cast(SandboxProviderConfig, MagicMock())
 
-    def create_log_group(*_args: Any, **_kwargs: Any) -> str:
-        calls.append("logs")
-        return "benchmark-log-group"
-
     def fetch_provider(*_args: Any, **_kwargs: Any) -> SandboxProviderConfig:
         calls.append("sandbox_provider_secret")
         return provider_config
@@ -399,7 +411,6 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     def dry_run(*_args: Any, **_kwargs: Any) -> None:
         calls.append("lambda")
 
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_aws_secret", fetch_webhook_secret)
@@ -408,10 +419,10 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     result = _preflight_managed_aws(execution, aws_runtime)
 
     assert result is provider_config
-    assert calls == ["logs", "sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
+    assert calls == ["sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
 
 
-async def test_managed_preflight_failure_happens_before_sandbox(
+async def test_required_managed_preflight_failure_happens_before_sandbox(
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,
     database_session: Session,
@@ -426,11 +437,11 @@ async def test_managed_preflight_failure_happens_before_sandbox(
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
 
-    def fail_log_preflight(*_args: Any, **_kwargs: Any) -> str:
-        raise RuntimeError("managed log preflight failed")
+    def fail_provider_preflight(*_args: Any, **_kwargs: Any) -> SandboxProviderConfig:
+        raise RuntimeError("managed provider preflight failed")
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", fail_log_preflight)
+    monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fail_provider_preflight)
     monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
 
     await process_benchmark(
@@ -440,5 +451,5 @@ async def test_managed_preflight_failure_happens_before_sandbox(
 
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.ERROR
-    assert "managed log preflight failed" in (benchmark.error_message or "")
+    assert "managed provider preflight failed" in (benchmark.error_message or "")
     create_sandbox.assert_not_awaited()

--- a/services/tracker/tests/unit/test_taskiq_producers.py
+++ b/services/tracker/tests/unit/test_taskiq_producers.py
@@ -1,3 +1,8 @@
+"""Tests for Taskiq executor payload producers.
+
+Run: uv run pytest tests/unit/test_taskiq_producers.py
+"""
+
 import json
 from typing import Any
 from unittest.mock import AsyncMock

--- a/services/tracker/tests/unit/test_taskiq_producers.py
+++ b/services/tracker/tests/unit/test_taskiq_producers.py
@@ -29,6 +29,7 @@ from tracker.types import HarnessConfig, StartBenchmarkRequest
 client = TestClient(app)
 
 _DISPATCH_TASK_KWARGS = {
+    "telemetry_context_json",
     "executor_dispatch_id",
     "executor_release_id",
     "executor_artifact_uri",

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -357,6 +357,53 @@ class TestBenchmarkServiceFailures:
         assert cloudwatch_error in captured_errors
 
     @pytest.mark.usefixtures("process_benchmark_env")
+    @pytest.mark.parametrize("cancel_during_flush", [False, True])
+    async def test_cloudwatch_write_timeout_does_not_delay_task_completion(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+        cancel_during_flush: bool,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        write_started = threading.Event()
+        release_write = threading.Event()
+        write_completed = threading.Event()
+
+        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            raise httpx.ConnectTimeout("benchmark unavailable")
+
+        def _blocked_write(*_args: Any, **_kwargs: Any) -> None:
+            write_started.set()
+            release_write.wait()
+            write_completed.set()
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
+        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _blocked_write)
+        monkeypatch.setattr(utils_module, "_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS", 0.01)
+        process_task = asyncio.create_task(
+            run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+        )
+
+        try:
+            assert await asyncio.to_thread(write_started.wait, 1)
+
+            if cancel_during_flush:
+                process_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(process_task, timeout=1)
+            else:
+                result = await asyncio.wait_for(process_task, timeout=1)
+                assert result == {"task_0": None}
+            assert not write_completed.is_set()
+        finally:
+            release_write.set()
+
+    @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_benchmark_blocks_external_internal_custom_destination(
         self,
         contract: AgentContractRequest,

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -6,6 +6,7 @@ Run: uv run pytest tests/unit/utils/test_benchmark_service_failures.py
 import asyncio
 import time
 from typing import Any, Never
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -371,6 +372,8 @@ class TestBenchmarkServiceFailures:
             raise BenchmarkServiceError(html_error)
 
         monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
+        capture_exception = Mock()
+        monkeypatch.setattr(run_orchestration_module.sentry_sdk, "capture_exception", capture_exception)
         benchmark_row = fetch_benchmark_row(benchmark_id, database_session, TEST_ORG)
         authority_kwargs = executor_authority_kwargs(benchmark_row)
 
@@ -386,3 +389,5 @@ class TestBenchmarkServiceFailures:
             assert benchmark_row.status == BenchmarkStatus.ERROR
             assert benchmark_row.error_message is not None
             assert "Final score failed with status code 404" in benchmark_row.error_message
+        captured_error = capture_exception.call_args.args[0]
+        assert isinstance(captured_error, BenchmarkServiceError)

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -4,6 +4,7 @@ Run: uv run pytest tests/unit/utils/test_benchmark_service_failures.py
 """
 
 import asyncio
+import threading
 import time
 from typing import Any, Never
 from unittest.mock import Mock
@@ -199,6 +200,8 @@ class TestBenchmarkServiceFailures:
         expected_log = f"[ERROR] {expected_error}"
         logged_messages: list[str] = []
         expected_log_written = asyncio.Event()
+        log_write_started = asyncio.Event()
+        release_log_write = threading.Event()
         event_loop = asyncio.get_running_loop()
 
         async def _mock_install_agent_dependencies(*_args: Any, **_kwargs: Any) -> None:
@@ -215,6 +218,8 @@ class TestBenchmarkServiceFailures:
             raise AssertionError(f"unexpected command: {command}")
 
         def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
+            event_loop.call_soon_threadsafe(log_write_started.set)
+            assert release_log_write.wait(timeout=5)
             logged_messages.append(message)
             if expected_log in message:
                 event_loop.call_soon_threadsafe(expected_log_written.set)
@@ -229,10 +234,14 @@ class TestBenchmarkServiceFailures:
         monkeypatch.setattr(sandbox_module, "_exec", _mock_exec)
         monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
 
-        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
-        # Log writes are dispatched to an executor and never awaited, so the flush carrying the
-        # error can land after run_process_task returns. Wait for that flush, not just the first.
-        await asyncio.wait_for(expected_log_written.wait(), timeout=10)
+        task = asyncio.create_task(
+            run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+        )
+        await asyncio.wait_for(log_write_started.wait(), timeout=5)
+        assert not task.done()
+        release_log_write.set()
+        result = await task
+        assert expected_log_written.is_set()
 
         assert result == {"task_0": None}
 
@@ -315,6 +324,37 @@ class TestBenchmarkServiceFailures:
         assert task_row.status == TaskStatus.ERROR
         assert self._latest_task_error(database_session, task_row) == "ConnectTimeout"
         assert any("[ERROR] ConnectTimeout" in message for message in logged_messages)
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_cloudwatch_write_failure_is_captured_before_task_returns(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        cloudwatch_error = RuntimeError("cloudwatch unavailable")
+        capture_exception = Mock()
+
+        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            raise httpx.ConnectTimeout("benchmark unavailable")
+
+        def _fail_write(*_args: Any, **_kwargs: Any) -> None:
+            raise cloudwatch_error
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
+        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _fail_write)
+        monkeypatch.setattr(utils_module.sentry_sdk, "capture_exception", capture_exception)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        captured_errors = [call.args[0] for call in capture_exception.call_args_list]
+        assert cloudwatch_error in captured_errors
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_benchmark_blocks_external_internal_custom_destination(

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -4,7 +4,6 @@ Run: uv run pytest tests/unit/utils/test_benchmark_service_failures.py
 """
 
 import asyncio
-import threading
 import time
 from typing import Any, Never
 from unittest.mock import Mock
@@ -200,8 +199,6 @@ class TestBenchmarkServiceFailures:
         expected_log = f"[ERROR] {expected_error}"
         logged_messages: list[str] = []
         expected_log_written = asyncio.Event()
-        log_write_started = asyncio.Event()
-        release_log_write = threading.Event()
         event_loop = asyncio.get_running_loop()
 
         async def _mock_install_agent_dependencies(*_args: Any, **_kwargs: Any) -> None:
@@ -218,8 +215,6 @@ class TestBenchmarkServiceFailures:
             raise AssertionError(f"unexpected command: {command}")
 
         def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
-            event_loop.call_soon_threadsafe(log_write_started.set)
-            assert release_log_write.wait(timeout=5)
             logged_messages.append(message)
             if expected_log in message:
                 event_loop.call_soon_threadsafe(expected_log_written.set)
@@ -234,14 +229,10 @@ class TestBenchmarkServiceFailures:
         monkeypatch.setattr(sandbox_module, "_exec", _mock_exec)
         monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
 
-        task = asyncio.create_task(
-            run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
-        )
-        await asyncio.wait_for(log_write_started.wait(), timeout=5)
-        assert not task.done()
-        release_log_write.set()
-        result = await task
-        assert expected_log_written.is_set()
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+        # Log writes are dispatched to an executor and never awaited, so the flush carrying the
+        # error can land after run_process_task returns. Wait for that flush, not just the first.
+        await asyncio.wait_for(expected_log_written.wait(), timeout=10)
 
         assert result == {"task_0": None}
 
@@ -324,84 +315,6 @@ class TestBenchmarkServiceFailures:
         assert task_row.status == TaskStatus.ERROR
         assert self._latest_task_error(database_session, task_row) == "ConnectTimeout"
         assert any("[ERROR] ConnectTimeout" in message for message in logged_messages)
-
-    @pytest.mark.usefixtures("process_benchmark_env")
-    async def test_cloudwatch_write_failure_is_captured_before_task_returns(
-        self,
-        contract: AgentContractRequest,
-        database_session: Session,
-        monkeypatch: pytest.MonkeyPatch,
-        harness_config: HarnessConfig,
-        aws_runtime: AWSRuntime,
-    ) -> None:
-        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
-            contract, database_session, harness_config
-        )
-        cloudwatch_error = RuntimeError("cloudwatch unavailable")
-        capture_exception = Mock()
-
-        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            raise httpx.ConnectTimeout("benchmark unavailable")
-
-        def _fail_write(*_args: Any, **_kwargs: Any) -> None:
-            raise cloudwatch_error
-
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
-        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _fail_write)
-        monkeypatch.setattr(utils_module.sentry_sdk, "capture_exception", capture_exception)
-
-        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
-
-        assert result == {"task_0": None}
-        captured_errors = [call.args[0] for call in capture_exception.call_args_list]
-        assert cloudwatch_error in captured_errors
-
-    @pytest.mark.usefixtures("process_benchmark_env")
-    @pytest.mark.parametrize("cancel_during_flush", [False, True])
-    async def test_cloudwatch_write_timeout_does_not_delay_task_completion(
-        self,
-        contract: AgentContractRequest,
-        database_session: Session,
-        monkeypatch: pytest.MonkeyPatch,
-        harness_config: HarnessConfig,
-        aws_runtime: AWSRuntime,
-        cancel_during_flush: bool,
-    ) -> None:
-        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
-            contract, database_session, harness_config
-        )
-        write_started = threading.Event()
-        release_write = threading.Event()
-        write_completed = threading.Event()
-
-        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            raise httpx.ConnectTimeout("benchmark unavailable")
-
-        def _blocked_write(*_args: Any, **_kwargs: Any) -> None:
-            write_started.set()
-            release_write.wait()
-            write_completed.set()
-
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
-        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _blocked_write)
-        monkeypatch.setattr(utils_module, "_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS", 0.01)
-        process_task = asyncio.create_task(
-            run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
-        )
-
-        try:
-            assert await asyncio.to_thread(write_started.wait, 1)
-
-            if cancel_during_flush:
-                process_task.cancel()
-                with pytest.raises(asyncio.CancelledError):
-                    await asyncio.wait_for(process_task, timeout=1)
-            else:
-                result = await asyncio.wait_for(process_task, timeout=1)
-                assert result == {"task_0": None}
-            assert not write_completed.is_set()
-        finally:
-            release_write.set()
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_benchmark_blocks_external_internal_custom_destination(

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1033,7 +1033,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
@@ -1114,7 +1114,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
         benchmark_service = request.benchmark_service

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1038,7 +1038,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
@@ -1119,7 +1119,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
         benchmark_service = request.benchmark_service

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -5,7 +5,7 @@ Run: uv run pytest tests/unit/utils/test_run_state.py
 
 from datetime import datetime
 from typing import Any, Sequence
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
@@ -612,7 +612,7 @@ class TestRunState:
             return MockSpan(record)
 
         monkeypatch.setattr("tracker.utils.task_execution.logger.info", fake_info)
-        monkeypatch.setattr("tracker.utils.task_execution.logfire.span", fake_span)
+        monkeypatch.setattr("tracker.observability.tracing.logfire.span", fake_span)
 
         database_session.add(example_benchmark_object)
         database_session.commit()
@@ -700,6 +700,7 @@ class TestRunState:
         example_benchmark_object: Benchmark,
         database_session: Session,
         executor_authority: Any,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Tests the end to end flow when stopping and resuming a benchmark
 
@@ -708,6 +709,15 @@ class TestRunState:
             - Benchmark status is set to finished if all tasks are finished
             - Benchmark status is set to stopped if any tasks are stopped
         """
+
+        finalized_statuses: list[str] = []
+
+        def record_span(name: str, **attributes: Any) -> MagicMock:
+            if name == "run.finalized":
+                finalized_statuses.append(attributes["status"])
+            return MagicMock()
+
+        monkeypatch.setattr("tracker.utils.run_orchestration.observability_span", record_span)
 
         # Create benchmark
         benchmark_row = example_benchmark_object
@@ -757,6 +767,7 @@ class TestRunState:
         set_benchmark_final_status(benchmark_row, database_session, self._test_org, authority=authority)
         database_session.refresh(benchmark_row, attribute_names=["status"])
         assert benchmark_row.status == BenchmarkStatus.STOPPED
+        assert finalized_statuses == ["FINISHED", "STOPPED"]
 
 
 class TestFetchStartedByFilter:

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -3,11 +3,9 @@
 Run: uv run pytest tests/unit/utils/test_task_execution_retry.py
 """
 
-import asyncio
-import threading
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 from uuid import UUID
 
@@ -34,95 +32,6 @@ from tracker.exceptions import AgentRunFailedError, DependencySetupExhaustedErro
 from tracker.sandbox import DependencySetupMode
 from tracker.types import HarnessConfig
 from tracker.utils import task_execution as task_execution_module
-
-
-async def test_buffered_cloudwatch_write_exposes_failure(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fail_write(_stream_key: str, _message: str, _runtime: AWSRuntime) -> None:
-        raise RuntimeError("cloudwatch unavailable")
-
-    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", fail_write)
-    monkeypatch.setattr(task_execution_module, "_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS", 0)
-    queue = task_execution_module.asyncio.Queue[str]()
-    queue.put_nowait("task output")
-
-    write = task_execution_module.buffer_logs(
-        queue,
-        "benchmark-123:task-456",
-        cast(AWSRuntime, Mock(spec=AWSRuntime)),
-        force_flush=True,
-    )
-
-    assert write is not None
-    with pytest.raises(RuntimeError, match="cloudwatch unavailable"):
-        await write
-
-
-async def test_buffered_cloudwatch_write_retries_the_same_batch(monkeypatch: pytest.MonkeyPatch) -> None:
-    messages: list[str] = []
-
-    def transient_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
-        messages.append(message)
-        if len(messages) == 1:
-            raise RuntimeError("cloudwatch unavailable")
-
-    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", transient_write)
-    monkeypatch.setattr(task_execution_module, "_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS", 0)
-    queue = task_execution_module.asyncio.Queue[str]()
-    queue.put_nowait("task output")
-
-    write = task_execution_module.buffer_logs(
-        queue,
-        "benchmark-123:task-456",
-        cast(AWSRuntime, Mock(spec=AWSRuntime)),
-        force_flush=True,
-    )
-
-    assert write is not None
-    await write
-    assert messages == ["task output", "task output"]
-
-
-async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
-    first_started = threading.Event()
-    release_first = threading.Event()
-    messages: list[str] = []
-
-    def record_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
-        messages.append(message)
-        if message == "first":
-            first_started.set()
-            assert release_first.wait(timeout=2)
-
-    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", record_write)
-    runtime = cast(AWSRuntime, Mock(spec=AWSRuntime))
-
-    first_queue = task_execution_module.asyncio.Queue[str]()
-    first_queue.put_nowait("first")
-    first_write = task_execution_module.buffer_logs(
-        first_queue,
-        "benchmark-123:task-456",
-        runtime,
-        force_flush=True,
-    )
-    assert first_write is not None
-    assert await asyncio.to_thread(first_started.wait, 2)
-
-    second_queue = task_execution_module.asyncio.Queue[str]()
-    second_queue.put_nowait("second")
-    second_write = task_execution_module.buffer_logs(
-        second_queue,
-        "benchmark-123:task-456",
-        runtime,
-        force_flush=True,
-        previous_write=first_write,
-    )
-    assert second_write is not None
-    await asyncio.sleep(0.05)
-    assert messages == ["first"]
-
-    release_first.set()
-    await asyncio.gather(first_write, second_write)
-    assert messages == ["first", "second"]
 
 
 class TestTaskExecutionRetry:
@@ -234,7 +143,7 @@ class TestTaskExecutionRetry:
         is_run_agent_target = fail_target == "tracker.utils.task_execution.run_agent"
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(fail_target, _fails_first_run_agent if is_run_agent_target else _fails_first_other)
         if not is_run_agent_target:
@@ -298,7 +207,7 @@ class TestTaskExecutionRetry:
         )
         monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
 
         sandbox_entry_count = 0
         retrieve_task_call_count = 0
@@ -394,7 +303,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
         monkeypatch.setattr(task_execution_module, "create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(task_execution_module, "run_agent", _mock_run_agent)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
@@ -457,7 +366,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
@@ -496,7 +405,7 @@ class TestTaskExecutionRetry:
         capture_exception = Mock()
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
         monkeypatch.setattr(task_execution_module.sentry_sdk, "capture_exception", capture_exception)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _failed_policy_lookup)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _lost_grading_sandbox, raising=False)
@@ -586,7 +495,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr("tracker.utils.task_execution.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.task_execution.run_agent", _mock_run_agent)

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -5,7 +5,7 @@ Run: uv run pytest tests/unit/utils/test_task_execution_retry.py
 
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 from uuid import UUID
 
@@ -32,6 +32,26 @@ from tracker.exceptions import AgentRunFailedError, DependencySetupExhaustedErro
 from tracker.sandbox import DependencySetupMode
 from tracker.types import HarnessConfig
 from tracker.utils import task_execution as task_execution_module
+
+
+async def test_buffered_cloudwatch_write_exposes_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_write(_stream_key: str, _message: str, _runtime: AWSRuntime) -> None:
+        raise RuntimeError("cloudwatch unavailable")
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", fail_write)
+    queue = task_execution_module.asyncio.Queue[str]()
+    queue.put_nowait("task output")
+
+    write = task_execution_module.buffer_logs(
+        queue,
+        "benchmark-123:task-456",
+        cast(AWSRuntime, Mock(spec=AWSRuntime)),
+        force_flush=True,
+    )
+
+    assert write is not None
+    with pytest.raises(RuntimeError, match="cloudwatch unavailable"):
+        await write
 
 
 class TestTaskExecutionRetry:
@@ -143,7 +163,7 @@ class TestTaskExecutionRetry:
         is_run_agent_target = fail_target == "tracker.utils.task_execution.run_agent"
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(fail_target, _fails_first_run_agent if is_run_agent_target else _fails_first_other)
         if not is_run_agent_target:
@@ -207,7 +227,7 @@ class TestTaskExecutionRetry:
         )
         monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
 
         sandbox_entry_count = 0
         retrieve_task_call_count = 0
@@ -303,7 +323,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(task_execution_module, "create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(task_execution_module, "run_agent", _mock_run_agent)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
@@ -366,7 +386,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
@@ -404,7 +424,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _failed_policy_lookup)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _lost_grading_sandbox, raising=False)
 
@@ -491,7 +511,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr("tracker.utils.task_execution.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.task_execution.run_agent", _mock_run_agent)
@@ -526,6 +546,10 @@ class TestTaskExecutionRetry:
         ]
 
         event_names = [record["message"] for record in log_records]
+        stream_record = next(record for record in log_records if record["message"] == "Task output stream selected")
+        assert stream_record["benchmark_id"] == str(benchmark_id)
+        assert stream_record["task_id"] == "task_0"
+        assert str(benchmark_id) in stream_record["cloudwatch_log_url"]
         assert "agent.run.complete" in event_names
         assert "task.evaluation.start" in event_names
 

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -3,6 +3,8 @@
 Run: uv run pytest tests/unit/utils/test_task_execution_retry.py
 """
 
+import asyncio
+import threading
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any, cast
@@ -52,6 +54,49 @@ async def test_buffered_cloudwatch_write_exposes_failure(monkeypatch: pytest.Mon
     assert write is not None
     with pytest.raises(RuntimeError, match="cloudwatch unavailable"):
         await write
+
+
+async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+    messages: list[str] = []
+
+    def record_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
+        messages.append(message)
+        if message == "first":
+            first_started.set()
+            assert release_first.wait(timeout=2)
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", record_write)
+    runtime = cast(AWSRuntime, Mock(spec=AWSRuntime))
+
+    first_queue = task_execution_module.asyncio.Queue[str]()
+    first_queue.put_nowait("first")
+    first_write = task_execution_module.buffer_logs(
+        first_queue,
+        "benchmark-123:task-456",
+        runtime,
+        force_flush=True,
+    )
+    assert first_write is not None
+    assert await asyncio.to_thread(first_started.wait, 2)
+
+    second_queue = task_execution_module.asyncio.Queue[str]()
+    second_queue.put_nowait("second")
+    second_write = task_execution_module.buffer_logs(
+        second_queue,
+        "benchmark-123:task-456",
+        runtime,
+        force_flush=True,
+        previous_write=first_write,
+    )
+    assert second_write is not None
+    await asyncio.sleep(0.05)
+    assert messages == ["first"]
+
+    release_first.set()
+    await asyncio.gather(first_write, second_write)
+    assert messages == ["first", "second"]
 
 
 class TestTaskExecutionRetry:
@@ -422,9 +467,11 @@ class TestTaskExecutionRetry:
         async def _lost_grading_sandbox(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
             raise SandboxNotFoundError("grading sandbox was preempted")
 
+        capture_exception = Mock()
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
         monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
+        monkeypatch.setattr(task_execution_module.sentry_sdk, "capture_exception", capture_exception)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _failed_policy_lookup)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _lost_grading_sandbox, raising=False)
 
@@ -439,6 +486,8 @@ class TestTaskExecutionRetry:
             .order_by(desc(ErrorResult.created_at))
         ).one()
         assert error_message == "grading sandbox was preempted"
+        captured_error = capture_exception.call_args.args[0]
+        assert isinstance(captured_error, SandboxNotFoundError)
 
     async def test_process_task_spans_timed_status_transitions(
         self,

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -41,6 +41,7 @@ async def test_buffered_cloudwatch_write_exposes_failure(monkeypatch: pytest.Mon
         raise RuntimeError("cloudwatch unavailable")
 
     monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", fail_write)
+    monkeypatch.setattr(task_execution_module, "_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS", 0)
     queue = task_execution_module.asyncio.Queue[str]()
     queue.put_nowait("task output")
 
@@ -54,6 +55,31 @@ async def test_buffered_cloudwatch_write_exposes_failure(monkeypatch: pytest.Mon
     assert write is not None
     with pytest.raises(RuntimeError, match="cloudwatch unavailable"):
         await write
+
+
+async def test_buffered_cloudwatch_write_retries_the_same_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages: list[str] = []
+
+    def transient_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
+        messages.append(message)
+        if len(messages) == 1:
+            raise RuntimeError("cloudwatch unavailable")
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", transient_write)
+    monkeypatch.setattr(task_execution_module, "_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS", 0)
+    queue = task_execution_module.asyncio.Queue[str]()
+    queue.put_nowait("task output")
+
+    write = task_execution_module.buffer_logs(
+        queue,
+        "benchmark-123:task-456",
+        cast(AWSRuntime, Mock(spec=AWSRuntime)),
+        force_flush=True,
+    )
+
+    assert write is not None
+    await write
+    assert messages == ["task output", "task output"]
 
 
 async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -565,13 +591,16 @@ class TestTaskExecutionRetry:
         monkeypatch.setattr("tracker.utils.task_execution.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.task_execution.run_agent", _mock_run_agent)
         monkeypatch.setattr("tracker.utils.task_execution.logger.info", _mock_logger_info)
-        monkeypatch.setattr("tracker.utils.task_execution.logfire.span", _mock_span)
+        monkeypatch.setattr("tracker.observability.tracing.logfire.span", _mock_span)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
 
         await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 
         transition_records = [record for record in span_records if record["message"] == "task.status_transition"]
+        lifecycle_records = [
+            record for record in span_records if record["message"] in {"task.started", "task.completed"}
+        ]
 
         assert [(record["from_status"], record["to_status"]) for record in transition_records] == [
             (TaskStatus.PENDING.value, TaskStatus.BUILDING.value),
@@ -582,6 +611,9 @@ class TestTaskExecutionRetry:
         assert all(record["task_id"] == "task_0" for record in transition_records)
         assert all(record["benchmark_id"] == str(benchmark_id) for record in transition_records)
         assert all(record["entered"] and record["exited"] for record in transition_records)
+        assert [record["message"] for record in lifecycle_records] == ["task.started", "task.completed"]
+        assert all(record["task_id"] == "task_0" for record in lifecycle_records)
+        assert all(record["benchmark_id"] == str(benchmark_id) for record in lifecycle_records)
         assert not any(record["message"].startswith("task.status_transition") for record in log_records)
         assert run_agent_kwargs["benchmark_id"] == str(benchmark_id)
         assert create_sandbox_kwargs["labels"]["run-id"] == str(benchmark_id)

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -1,4 +1,7 @@
-"""Credential-free end-to-end smoke test for run telemetry correlation."""
+"""Credential-free end-to-end smoke test for run telemetry correlation.
+
+Run: uv run pytest tests/integration/observability/test_run_correlation.py
+"""
 
 from __future__ import annotations
 

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import gzip
 import json
 import logging
@@ -17,10 +18,12 @@ from typing import Any, cast
 
 import logfire
 import sentry_sdk
-from opentelemetry.propagate import inject
 from sentry_sdk.envelope import Envelope, Item
 
+from services.executor_host import supervisor as host_supervisor
 from services.executor_host import observability as host_observability
+from services.executor_host.supervisor import ExecutorProcessPayload
+from services.tracker import main as tracker_main
 from tracker.executor.entrypoint import _executor_context
 from tracker.logging import benchmark_id_var, configure_logging, request_id_var, task_id_var
 from tracker.observability import configure_observability, incr
@@ -111,9 +114,18 @@ def _run_tracker(dsn: str, context_path: str) -> None:
                 "valkyrie.observability.smoke",
                 tags={"operation": "run", "benchmark_id": _RUN_ID},
             )
-            trace_headers: dict[str, str] = {}
-            inject(trace_headers)
-            Path(context_path).write_text(json.dumps({"request_id": _REQUEST_ID, "trace_headers": trace_headers}))
+            payload = {
+                "start_benchmark_request_json": {},
+                "benchmark_id_str": _RUN_ID,
+                "verified_task_ids": [],
+                "telemetry_context_json": tracker_main._executor_telemetry_context(),  # pyright: ignore[reportPrivateUsage]
+                "executor_dispatch_id": _DISPATCH_ID,
+                "executor_release_id": _RELEASE_ID,
+                "executor_artifact_uri": "s3://artifacts/local-smoke.pex",
+                "executor_artifact_digest": "a" * 64,
+                "executor_protocol_version": "1",
+            }
+            Path(context_path).write_text(json.dumps(payload))
             _capture_test_error("valkyrie-tracker")
     finally:
         for token in reversed(tokens):
@@ -125,16 +137,23 @@ def _run_executor_host(dsn: str, input_path: str, output_path: str) -> None:
     _set_sentry_environment(dsn)
     os.environ["ENVIRONMENT"] = _ENVIRONMENT
     host_observability.configure_observability()
-    telemetry_context = cast(dict[str, Any], json.loads(Path(input_path).read_text()))
-    with host_observability.dispatch_observability_context(
-        _RUN_ID,
-        _DISPATCH_ID,
-        _RELEASE_ID,
-        telemetry_context,
-    ) as child_context:
+    payload = cast(dict[str, Any], json.loads(Path(input_path).read_text()))
+
+    async def capture_dispatch(
+        _executor_supervisor: object,
+        _store: object,
+        *,
+        executor_dispatch_id: str,
+        dispatch: object,
+        process_payload: ExecutorProcessPayload,
+    ) -> None:
+        del _executor_supervisor, _store, executor_dispatch_id, dispatch
         logging.getLogger("executor-host.observability.smoke").info("ExecutorHost dispatched observability smoke run")
-        Path(output_path).write_text(json.dumps(child_context))
+        Path(output_path).write_text(json.dumps(process_payload.arguments["telemetry_context_json"]))
         _capture_test_error("valkyrie-executor-host")
+
+    host_supervisor.run_executor_dispatch = capture_dispatch
+    asyncio.run(host_supervisor.launch_executor.original_func(**payload))
     _flush_telemetry()
 
 

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -1,4 +1,4 @@
-"""Credential-free end-to-end smoke test for run telemetry correlation.
+"""Credential-free cross-process transport smoke for run telemetry correlation.
 
 Run: uv run pytest tests/integration/observability/test_run_correlation.py
 """

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -1,0 +1,274 @@
+"""Credential-free end-to-end smoke test for run telemetry correlation."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import logging
+import multiprocessing
+import os
+import threading
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, cast
+
+import logfire
+import sentry_sdk
+from opentelemetry.propagate import inject
+from sentry_sdk.envelope import Envelope, Item
+
+from services.executor_host import observability as host_observability
+from tracker.executor.entrypoint import _executor_context
+from tracker.logging import benchmark_id_var, configure_logging, request_id_var, task_id_var
+from tracker.observability import configure_observability, incr
+
+_RUN_ID = "00000000-0000-4000-8000-000000000123"
+_REQUEST_ID = "observability-smoke-request"
+_DISPATCH_ID = "00000000-0000-4000-8000-000000000456"
+_RELEASE_ID = "local-smoke-release"
+_ENVIRONMENT = "local-smoke"
+
+
+class _EnvelopeServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _EnvelopeHandler)
+        self.envelopes: list[bytes] = []
+        self.envelopes_lock = threading.Lock()
+
+    def record(self, body: bytes) -> None:
+        with self.envelopes_lock:
+            self.envelopes.append(body)
+
+
+class _EnvelopeHandler(BaseHTTPRequestHandler):
+    server: _EnvelopeServer
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length)
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+        self.server.record(body)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, _format: str, *args: object) -> None:
+        del args
+
+
+@contextmanager
+def _local_sentry_receiver() -> Iterator[tuple[str, _EnvelopeServer]]:
+    server = _EnvelopeServer()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://public@{host}:{port}/1", server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _set_sentry_environment(dsn: str) -> None:
+    os.environ["SENTRY_DSN"] = dsn
+    os.environ["SENTRY_RELEASE"] = _RELEASE_ID
+    os.environ["LOG_LEVEL"] = "INFO"
+
+
+def _capture_test_error(service_name: str) -> None:
+    try:
+        raise RuntimeError(f"{service_name} observability smoke error")
+    except RuntimeError as error:
+        sentry_sdk.capture_exception(error)
+
+
+def _flush_telemetry() -> None:
+    logfire.force_flush(timeout_millis=5000)
+    sentry_sdk.flush(timeout=5)
+
+
+def _run_tracker(dsn: str, context_path: str) -> None:
+    _set_sentry_environment(dsn)
+    os.environ["ENVIRONMENT"] = "development"
+    configure_logging()
+    configure_observability("valkyrie-tracker", environment=_ENVIRONMENT)
+    logger = logging.getLogger("tracker.observability.smoke")
+    tokens = [
+        request_id_var.set(_REQUEST_ID),
+        benchmark_id_var.set(_RUN_ID),
+        task_id_var.set("tracker-task"),
+    ]
+    try:
+        with logfire.span("observability.smoke.tracker"):
+            logger.info("Tracker accepted observability smoke run")
+            incr(
+                "valkyrie.observability.smoke",
+                tags={"operation": "run", "benchmark_id": _RUN_ID},
+            )
+            trace_headers: dict[str, str] = {}
+            inject(trace_headers)
+            Path(context_path).write_text(json.dumps({"request_id": _REQUEST_ID, "trace_headers": trace_headers}))
+            _capture_test_error("valkyrie-tracker")
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+        _flush_telemetry()
+
+
+def _run_executor_host(dsn: str, input_path: str, output_path: str) -> None:
+    _set_sentry_environment(dsn)
+    os.environ["ENVIRONMENT"] = _ENVIRONMENT
+    host_observability.configure_observability()
+    telemetry_context = cast(dict[str, Any], json.loads(Path(input_path).read_text()))
+    with host_observability.dispatch_observability_context(
+        _RUN_ID,
+        _DISPATCH_ID,
+        _RELEASE_ID,
+        telemetry_context,
+    ) as child_context:
+        logging.getLogger("executor-host.observability.smoke").info("ExecutorHost dispatched observability smoke run")
+        Path(output_path).write_text(json.dumps(child_context))
+        _capture_test_error("valkyrie-executor-host")
+    _flush_telemetry()
+
+
+def _run_executor(dsn: str, context_path: str) -> None:
+    _set_sentry_environment(dsn)
+    os.environ["ENVIRONMENT"] = "development"
+    configure_logging()
+    configure_observability("valkyrie-executor", environment=_ENVIRONMENT)
+    telemetry_context = cast(dict[str, Any], json.loads(Path(context_path).read_text()))
+    with _executor_context(
+        {
+            "benchmark_id_str": _RUN_ID,
+            "telemetry_context_json": telemetry_context,
+        }
+    ):
+        with logfire.span("observability.smoke.executor"):
+            logging.getLogger("tracker.executor.observability.smoke").info("Executor processed observability smoke run")
+            _capture_test_error("valkyrie-executor")
+    _flush_telemetry()
+
+
+def _run_process(target: Any, *args: str) -> None:
+    process = multiprocessing.get_context("spawn").Process(target=target, args=args)
+    process.start()
+    process.join(timeout=20)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        raise AssertionError(f"{target.__name__} did not finish")
+    assert process.exitcode == 0
+
+
+def _items(server: _EnvelopeServer) -> list[Item]:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        with server.envelopes_lock:
+            if server.envelopes:
+                bodies = list(server.envelopes)
+                break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("The local Sentry receiver did not receive any envelopes")
+    return [item for body in bodies for item in Envelope.deserialize(body).items]
+
+
+def _json_payload(item: Item) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(item.get_bytes()))
+
+
+def _log_entries(items: list[Item]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for item in items:
+        if item.type != "log":
+            continue
+        payload = _json_payload(item)
+        raw_entries = payload.get("items", [payload])
+        if isinstance(raw_entries, list):
+            entries.extend(cast(list[dict[str, Any]], raw_entries))
+    return entries
+
+
+def _metric_entries(items: list[Item]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for item in items:
+        if item.type != "trace_metric":
+            continue
+        payload = _json_payload(item)
+        raw_entries = payload.get("items", [payload])
+        if isinstance(raw_entries, list):
+            entries.extend(cast(list[dict[str, Any]], raw_entries))
+    return entries
+
+
+def _attribute_value(entry: Mapping[str, Any], key: str) -> object | None:
+    attributes = entry.get("attributes")
+    if not isinstance(attributes, Mapping):
+        return None
+    value = cast(Mapping[str, Any], attributes).get(key)
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value).get("value")
+    return value
+
+
+def _breadcrumbs(event: Mapping[str, Any]) -> list[dict[str, Any]]:
+    breadcrumbs = event.get("breadcrumbs", {})
+    if not isinstance(breadcrumbs, Mapping):
+        return []
+    values = cast(Mapping[str, Any], breadcrumbs).get("values", [])
+    return cast(list[dict[str, Any]], values) if isinstance(values, list) else []
+
+
+def test_run_id_correlates_logs_errors_and_traces_across_processes(tmp_path: Path) -> None:
+    tracker_context = tmp_path / "tracker-context.json"
+    executor_context = tmp_path / "executor-context.json"
+
+    with _local_sentry_receiver() as (dsn, server):
+        _run_process(_run_tracker, dsn, str(tracker_context))
+        _run_process(_run_executor_host, dsn, str(tracker_context), str(executor_context))
+        _run_process(_run_executor, dsn, str(executor_context))
+        items = _items(server)
+
+    events = [event for item in items if (event := item.get_event()) is not None]
+    transactions = [event for item in items if (event := item.get_transaction_event()) is not None]
+    logs = _log_entries(items)
+    metrics = _metric_entries(items)
+
+    assert {event["server_name"] for event in events} == {
+        "valkyrie-tracker",
+        "valkyrie-executor-host",
+        "valkyrie-executor",
+    }
+    assert all(event["tags"]["benchmark_id"] == _RUN_ID for event in events)
+    assert all(event["environment"] == _ENVIRONMENT for event in events)
+    assert all(event["release"] == _RELEASE_ID for event in events)
+    assert all(
+        any(breadcrumb.get("message", "").endswith("observability smoke run") for breadcrumb in _breadcrumbs(event))
+        for event in events
+    )
+
+    correlated_logs = [entry for entry in logs if _attribute_value(entry, "benchmark_id") == _RUN_ID]
+    assert len(correlated_logs) >= 3
+    assert {_attribute_value(entry, "server.address") for entry in correlated_logs} == {
+        "valkyrie-tracker",
+        "valkyrie-executor-host",
+        "valkyrie-executor",
+    }
+
+    assert len(transactions) >= 3
+    event_trace_ids = [cast(str, event["contexts"]["trace"]["trace_id"]) for event in events]
+    transaction_trace_ids = [cast(str, transaction["contexts"]["trace"]["trace_id"]) for transaction in transactions]
+    log_trace_ids = [cast(str, entry["trace_id"]) for entry in correlated_logs]
+    assert len(metrics) == 1
+    assert metrics[0]["name"] == "valkyrie.observability.smoke"
+    assert _attribute_value(metrics[0], "operation") == "run"
+    assert _attribute_value(metrics[0], "benchmark_id") is None
+    metric_trace_ids = [cast(str, metric["trace_id"]) for metric in metrics]
+    assert len(set([*event_trace_ids, *transaction_trace_ids, *log_trace_ids, *metric_trace_ids])) == 1

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -26,7 +26,7 @@ from services.executor_host.supervisor import ExecutorProcessPayload
 from services.tracker import main as tracker_main
 from tracker.executor.entrypoint import _executor_context
 from tracker.logging import benchmark_id_var, configure_logging, request_id_var, task_id_var
-from tracker.observability import configure_observability, incr
+from tracker.observability import configure_observability, error_span, incr
 
 _RUN_ID = "00000000-0000-4000-8000-000000000123"
 _REQUEST_ID = "observability-smoke-request"
@@ -84,11 +84,15 @@ def _set_sentry_environment(dsn: str) -> None:
     os.environ["LOG_LEVEL"] = "INFO"
 
 
-def _capture_test_error(service_name: str) -> None:
+def _capture_test_error(service_name: str, *, span_name: str | None = None) -> None:
     try:
         raise RuntimeError(f"{service_name} observability smoke error")
     except RuntimeError as error:
-        sentry_sdk.capture_exception(error)
+        if span_name is None:
+            sentry_sdk.capture_exception(error)
+            return
+        with error_span(span_name, error, benchmark_id=_RUN_ID):
+            sentry_sdk.capture_exception(error)
 
 
 def _flush_telemetry() -> None:
@@ -126,7 +130,7 @@ def _run_tracker(dsn: str, context_path: str) -> None:
                 "executor_protocol_version": "1",
             }
             Path(context_path).write_text(json.dumps(payload))
-            _capture_test_error("valkyrie-tracker")
+            _capture_test_error("valkyrie-tracker", span_name="run.error")
     finally:
         for token in reversed(tokens):
             token.var.reset(token)
@@ -282,6 +286,15 @@ def test_run_id_correlates_logs_errors_and_traces_across_processes(tmp_path: Pat
     }
 
     assert len(transactions) >= 3
+    tracker_error_spans = [
+        span
+        for transaction in transactions
+        if transaction.get("transaction") == "observability.smoke.tracker"
+        for span in transaction.get("spans", [])
+        if span.get("op") == "run.error"
+    ]
+    assert len(tracker_error_spans) == 1
+    assert tracker_error_spans[0]["status"] == "internal_error"
     event_trace_ids = [cast(str, event["contexts"]["trace"]["trace_id"]) for event in events]
     transaction_trace_ids = [cast(str, transaction["contexts"]["trace"]["trace_id"]) for transaction in transactions]
     log_trace_ids = [cast(str, entry["trace_id"]) for entry in correlated_logs]

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+import sentry_sdk
+
+from services.executor_host import observability
+
+
+def test_dispatch_context_correlates_cloudwatch_logs_and_child_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sentry_sdk, "get_traceparent", lambda: "sentry-child-trace")
+    monkeypatch.setattr(sentry_sdk, "get_baggage", lambda: "sentry-child-baggage")
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.addFilter(observability._ContextFilter())  # pyright: ignore[reportPrivateUsage]
+    handler.setFormatter(observability._JsonFormatter())  # pyright: ignore[reportPrivateUsage]
+    logger = logging.Logger("executor-host-test")
+    logger.addHandler(handler)
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        {
+            "request_id": "request-abc",
+            "trace_headers": {
+                "traceparent": "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+                "tracestate": "vendor=value",
+            },
+        },
+    ) as child_context:
+        logger.info("Launching executor")
+
+    record = json.loads(output.getvalue())
+    assert record == {
+        "timestamp": record["timestamp"],
+        "level": "INFO",
+        "logger": "executor-host-test",
+        "message": "Launching executor",
+        "request_id": "request-abc",
+        "benchmark_id": "benchmark-123",
+        "executor_dispatch_id": "dispatch-456",
+        "executor_release_id": "release-789",
+    }
+    assert child_context == {
+        "request_id": "request-abc",
+        "trace_headers": {
+            "sentry-trace": "sentry-child-trace",
+            "baggage": "sentry-child-baggage",
+        },
+    }

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -1,3 +1,8 @@
+"""Tests for ExecutorHost structured logging and Sentry correlation.
+
+Run: uv run pytest tests/unit/executor_host/test_observability.py
+"""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -3,11 +3,23 @@ from __future__ import annotations
 import io
 import json
 import logging
+from unittest.mock import Mock
 
 import pytest
 import sentry_sdk
 
 from services.executor_host import observability
+
+
+def test_invalid_production_sentry_configuration_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
+
+    with pytest.raises(RuntimeError, match="Check the production DSN secret") as exc_info:
+        observability.configure_observability()
+
+    assert exc_info.value.__cause__ is None
 
 
 def test_dispatch_context_correlates_cloudwatch_logs_and_child_trace(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -100,3 +100,29 @@ def test_dispatch_context_correlates_cloudwatch_logs_and_child_trace(monkeypatch
             "baggage": "sentry-child-baggage",
         },
     }
+
+
+def test_dispatch_error_logs_before_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+    span = Mock()
+
+    @contextmanager
+    def record_transaction(_transaction: object) -> Generator[Mock, None, None]:
+        yield span
+
+    def record_log(*_args: object, **_kwargs: object) -> None:
+        events.append("logged")
+
+    def record_capture(_error: BaseException) -> None:
+        events.append("captured")
+
+    monkeypatch.setattr(sentry_sdk, "continue_trace", Mock(return_value=Mock()))
+    monkeypatch.setattr(sentry_sdk, "start_transaction", record_transaction)
+    monkeypatch.setattr(observability.logger, "error", record_log)
+    monkeypatch.setattr(sentry_sdk, "capture_exception", record_capture)
+    error = RuntimeError("executor failed")
+
+    observability.capture_dispatch_error(error, {"request_id": "request-abc", "trace_headers": {}})
+
+    span.set_status.assert_called_once_with(observability.SPANSTATUS.INTERNAL_ERROR)
+    assert events == ["logged", "captured"]

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock
 import pytest
 import sentry_sdk
 
+from executor_protocol import ExecutorTelemetryContext
 from services.executor_host import observability
 
 
@@ -44,23 +45,82 @@ def test_dispatch_transaction_finishes_before_executor_work(monkeypatch: pytest.
     assert events == ["transaction-started", "transaction-finished", "executor-running"]
 
 
-def test_invalid_production_sentry_configuration_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_dispatch_acceptance_telemetry_failure_preserves_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    telemetry_context: ExecutorTelemetryContext = {
+        "request_id": "request-abc",
+        "trace_headers": {"traceparent": "parent-trace"},
+    }
+    monkeypatch.setattr(sentry_sdk, "continue_trace", Mock(side_effect=RuntimeError("sentry unavailable")))
+    monkeypatch.setattr(observability.logger, "warning", Mock())
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        telemetry_context,
+    ) as child_context:
+        assert observability.benchmark_id_var.get() == "benchmark-123"
+
+    assert child_context == telemetry_context
+
+
+def test_dispatch_scope_is_released_when_tag_binding_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    scope = Mock()
+    scope.set_tags.side_effect = RuntimeError("sentry unavailable")
+    scope_manager = Mock()
+    scope_manager.__enter__ = Mock(return_value=scope)
+    scope_manager.__exit__ = Mock(return_value=False)
+    monkeypatch.setattr(sentry_sdk, "new_scope", Mock(return_value=scope_manager))
+    monkeypatch.setattr(observability.logger, "warning", Mock())
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        {"request_id": "request-abc", "trace_headers": {}},
+    ):
+        pass
+
+    scope_manager.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_terminal_sentry_failure_does_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    telemetry_context: ExecutorTelemetryContext = {"request_id": "request-abc", "trace_headers": {}}
+    monkeypatch.setattr(sentry_sdk, "new_scope", Mock(side_effect=RuntimeError("sentry unavailable")))
+    monkeypatch.setattr(observability.logger, "info", Mock())
+    monkeypatch.setattr(observability.logger, "error", Mock())
+    warning = Mock()
+    monkeypatch.setattr(observability.logger, "warning", warning)
+
+    observability.record_dispatch_completion(telemetry_context)
+    observability.record_dispatch_cancellation(telemetry_context)
+    observability.capture_dispatch_error(RuntimeError("dispatch failed"), telemetry_context)
+
+    assert warning.call_count == 3
+
+
+def test_invalid_production_sentry_configuration_logs_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = RuntimeError("bad dsn")
+    warning = Mock()
     monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
     monkeypatch.setenv("ENVIRONMENT", "production")
-    monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
+    monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=error))
+    monkeypatch.setattr(observability.logger, "warning", warning)
 
-    with pytest.raises(RuntimeError, match="Check the production DSN secret") as exc_info:
-        observability.configure_observability()
+    observability.configure_observability()
 
-    assert exc_info.value.__cause__ is None
+    warning.assert_called_once_with("Failed to initialize Sentry: %s: %s", "RuntimeError", error)
 
 
-def test_missing_production_sentry_configuration_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_missing_production_sentry_configuration_skips_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    init_mock = Mock()
     monkeypatch.delenv("SENTRY_DSN", raising=False)
     monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(sentry_sdk, "init", init_mock)
 
-    with pytest.raises(RuntimeError, match="Check the production DSN secret"):
-        observability.configure_observability()
+    observability.configure_observability()
+
+    init_mock.assert_not_called()
 
 
 def test_dispatch_context_correlates_cloudwatch_logs_and_child_trace(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -22,6 +22,14 @@ def test_invalid_production_sentry_configuration_fails_startup(monkeypatch: pyte
     assert exc_info.value.__cause__ is None
 
 
+def test_missing_production_sentry_configuration_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+
+    with pytest.raises(RuntimeError, match="Check the production DSN secret"):
+        observability.configure_observability()
+
+
 def test_dispatch_context_correlates_cloudwatch_logs_and_child_trace(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sentry_sdk, "get_traceparent", lambda: "sentry-child-trace")
     monkeypatch.setattr(sentry_sdk, "get_baggage", lambda: "sentry-child-baggage")

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
 import io
 import json
 import logging
@@ -9,6 +11,32 @@ import pytest
 import sentry_sdk
 
 from services.executor_host import observability
+
+
+def test_dispatch_transaction_finishes_before_executor_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+    transaction = Mock()
+
+    @contextmanager
+    def record_transaction(_transaction: object) -> Generator[Mock, None, None]:
+        events.append("transaction-started")
+        yield transaction
+        events.append("transaction-finished")
+
+    monkeypatch.setattr(sentry_sdk, "continue_trace", Mock(return_value=transaction))
+    monkeypatch.setattr(sentry_sdk, "start_transaction", record_transaction)
+    monkeypatch.setattr(sentry_sdk, "get_traceparent", lambda: "child-trace")
+    monkeypatch.setattr(sentry_sdk, "get_baggage", lambda: None)
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        {"request_id": "request-abc", "trace_headers": {}},
+    ):
+        events.append("executor-running")
+
+    assert events == ["transaction-started", "transaction-finished", "executor-running"]
 
 
 def test_invalid_production_sentry_configuration_fails_startup(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -629,6 +629,44 @@ async def test_broker_payload_dispatch_id_reaches_dispatch_owner(
     assert captured["executor_dispatch_id"] == "dispatch-1"
 
 
+@pytest.mark.asyncio
+async def test_launch_executor_records_cancellation_before_context_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def cancel_dispatch(*_args: object, **_kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    cancellation_context: dict[str, object] = {}
+
+    def record_cancellation(telemetry_context: object) -> None:
+        cancellation_context.update(
+            {
+                "telemetry_context": telemetry_context,
+                "benchmark_id": host_observability.benchmark_id_var.get(),
+                "dispatch_id": host_observability.dispatch_id_var.get(),
+            }
+        )
+
+    monkeypatch.setattr(supervisor_module, "run_executor_dispatch", cancel_dispatch)
+    monkeypatch.setattr(supervisor_module, "record_dispatch_cancellation", record_cancellation)
+
+    with pytest.raises(asyncio.CancelledError):
+        await supervisor_module.launch_executor.original_func(
+            start_benchmark_request_json={},
+            benchmark_id_str="benchmark-1",
+            verified_task_ids=[],
+            executor_dispatch_id="dispatch-1",
+            executor_release_id="release-v2",
+            executor_artifact_uri="s3://artifacts/executors/v2.pex",
+            executor_artifact_digest="0" * 64,
+            executor_protocol_version="1",
+        )
+
+    assert cancellation_context["benchmark_id"] == "benchmark-1"
+    assert cancellation_context["dispatch_id"] == "dispatch-1"
+    assert host_observability.benchmark_id_var.get() == ""
+
+
 async def test_stream_message_is_deleted_only_after_successful_ack(monkeypatch: pytest.MonkeyPatch) -> None:
     commands: list[tuple[object, ...]] = []
     monkeypatch.setattr(

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -10,6 +10,7 @@ from collections.abc import Awaitable, Callable
 from functools import partial
 from pathlib import Path
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 
@@ -581,6 +582,8 @@ async def test_launch_executor_rejects_invalid_dispatch_id_without_side_effects(
     monkeypatch.setattr(supervisor, "run", unexpected_run)
     monkeypatch.setattr(supervisor_module, "supervisor", supervisor)
     monkeypatch.setattr(supervisor_module, "dispatch_store", store)
+    capture_exception = Mock()
+    monkeypatch.setattr(supervisor_module.sentry_sdk, "capture_exception", capture_exception)
 
     with pytest.raises(ValueError, match="executor_dispatch_id is required"):
         await supervisor_module.launch_executor.original_func(
@@ -597,6 +600,7 @@ async def test_launch_executor_rejects_invalid_dispatch_id_without_side_effects(
     assert store.claimed == []
     assert store.finished == []
     assert s3_client.calls == []
+    capture_exception.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -1,3 +1,8 @@
+"""Tests for ExecutorHost dispatch supervision.
+
+Run: uv run pytest tests/unit/executor_host/test_supervisor.py
+"""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -14,6 +14,7 @@ from unittest.mock import Mock
 
 import pytest
 
+import services.executor_host.observability as host_observability
 import services.executor_host.supervisor as supervisor_module
 from services.executor_host.supervisor import (  # pyright: ignore[reportMissingImports]
     ArtifactDispatch,
@@ -583,7 +584,7 @@ async def test_launch_executor_rejects_invalid_dispatch_id_without_side_effects(
     monkeypatch.setattr(supervisor_module, "supervisor", supervisor)
     monkeypatch.setattr(supervisor_module, "dispatch_store", store)
     capture_exception = Mock()
-    monkeypatch.setattr(supervisor_module.sentry_sdk, "capture_exception", capture_exception)
+    monkeypatch.setattr(host_observability.sentry_sdk, "capture_exception", capture_exception)
 
     with pytest.raises(ValueError, match="executor_dispatch_id is required"):
         await supervisor_module.launch_executor.original_func(

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -183,7 +183,10 @@ def test_managed_process_payload_is_normalized_once() -> None:
 
     assert payload.benchmark_id == "benchmark-1"
     assert payload.verified_task_ids == ["task-1"]
-    assert payload.arguments == {"execution_context_json": context}
+    assert payload.arguments == {
+        "execution_context_json": context,
+        "telemetry_context_json": {"request_id": "", "trace_headers": {}},
+    }
 
 
 def test_process_payload_rejects_mixed_execution_shapes() -> None:
@@ -433,7 +436,7 @@ async def test_run_forwards_dispatch_authority_to_executor(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    script = b"""import json, os, sys\nfrom pathlib import Path\npayload = json.loads(Path(sys.argv[1]).read_text())\nPath(os.environ[\"EXECUTOR_TEST_MARKER\"]).write_text(json.dumps(payload))\n"""
+    script = b"""import json, os, sys\nfrom pathlib import Path\npayload = json.loads(Path(sys.argv[1]).read_text())\nresult = {\"payload\": payload, \"sentry_release\": os.environ.get(\"SENTRY_RELEASE\")}\nPath(os.environ[\"EXECUTOR_TEST_MARKER\"]).write_text(json.dumps(result))\n"""
     digest = hashlib.sha256(script).hexdigest()
     marker = tmp_path / "marker.json"
     monkeypatch.setenv("EXECUTOR_TEST_MARKER", str(marker))
@@ -452,10 +455,12 @@ async def test_run_forwards_dispatch_authority_to_executor(
         result = json.loads(marker.read_text())
     except (OSError, JSONDecodeError) as error:
         raise AssertionError(f"executor marker was not valid JSON: {error}") from error
-    payload = result
+    payload = result["payload"]
     assert payload["benchmark_id_str"] == "benchmark-1"
     assert payload["verified_task_ids"] == ["task-1"]
     assert payload["executor_dispatch_id"] == "dispatch-1"
+    assert payload["telemetry_context_json"] == {"request_id": "", "trace_headers": {}}
+    assert result["sentry_release"] == "release-v2"
     assert store.authority_checks
     assert store.finished == [store.authority]
     assert (


### PR DESCRIPTION
## Human Description

### Why

Make sure that a run is traced end-to-end by run ID.

---

Once a run ID exists, Valkyrie carries it across the Tracker, Taskiq queue, ExecutorHost, immutable executor, and task execution path. Run-bound service logs include the benchmark ID in CloudWatch and Sentry. Errors and bounded trace segments use the same ID and distributed trace, so an operator can move between a run's logs, failures, and performance data without reconstructing the execution path manually.

Raw agent and task output remains in its existing CloudWatch run log group and task-attempt stream. A correlated Sentry log contains the exact CloudWatch URL. Aggregate metrics omit run and task IDs to avoid creating one metric series per execution; operators can find a run by ID in logs, errors, and spans, then use the shared trace to inspect its metrics.

```mermaid
flowchart LR
    API[Tracker API] --> Queue[Taskiq queue]
    Queue --> Host[ExecutorHost]
    Host --> Executor[Immutable executor]
    Executor --> Sandbox[Task sandbox]

    API -. structured logs<br/>run ID .-> ServiceLogs[CloudWatch service logs]
    Host -. structured logs<br/>run ID .-> ServiceLogs
    Executor -. structured logs<br/>run and task ID .-> ServiceLogs

    API -. logs, errors, spans<br/>run ID and trace .-> Sentry[Sentry]
    Host -. logs, errors, spans<br/>run ID and trace .-> Sentry
    Executor -. logs, errors, spans<br/>run and task ID, trace .-> Sentry

    Sandbox -. raw agent and task output .-> RunLogs[CloudWatch run log group<br/>task-attempt stream]
    Executor -. exact CloudWatch URL<br/>run and task ID .-> Sentry
```

## What changed

- Propagate request and trace context through queue messages, executor dispatches, and executor payloads. Older queued payloads remain valid and continue without distributed trace context.
- Bind the benchmark ID to run-addressed Tracker requests and to ExecutorHost and executor processing. Bind the task ID while each task runs.
- Add those identifiers to structured service logs written to CloudWatch and Sentry, and to Sentry errors and bounded spans.
- Emit a correlated Sentry log with the exact existing CloudWatch task-attempt stream URL without changing task-output delivery.
- Publish handled terminal run and task failures to Sentry using the producer, operation, error type, and cause already preserved with the database failure record. Attach the structured error log to the issue as a breadcrumb.
- Replace multi-hour run transactions with bounded run, task, dispatch, retry, status, cancellation, completion, and error segments. Emit `run.finalized` only after the corresponding terminal status is durably stored.
- Filter low-level sandbox polling spans and avoid duplicate Sentry trace export while preserving W3C and Sentry propagation headers.
- Require the account-local Sentry DSN secret for dev and production deployments. Missing or malformed runtime Sentry configuration logs a warning and does not prevent Tracker, ExecutorHost, or executor startup.
- Tag Tracker, ExecutorHost, and immutable executor telemetry with releases that follow each artifact's deployment lifecycle.
- Add a credential-free cross-process transport smoke that receives real Sentry envelopes locally and verifies correlation across the Tracker, ExecutorHost, and executor process types.

## How to review

Start with `tracker/observability` and the logging context, then follow `ExecutorTelemetryContext` from the Tracker queue producer through `services/executor_host` into the executor entrypoint. The task-output change in `tracker/utils/task_execution.py` only emits the correlated CloudWatch locator. Metrics are trace-linked and intentionally cannot be filtered directly by run ID because that would create one metric series per run.

## Testing

- `93053b28` — Ran one successful Swebench task locally against the hosted benchmark service and Daytona using the seeded no-model-cost test agent. The agent completed, evaluation completed, final scoring returned 200, and the test passed in 77.59 seconds. [Sentry logs for benchmark ID `9c209c40-12aa-4975-8d01-732c6e2b2160`](https://vals-ai.sentry.io/explore/logs/?logsQuery=benchmark_id%3A9c209c40-12aa-4975-8d01-732c6e2b2160&project=4511220450131968&logsFields=timestamp&logsFields=message&logsFields=server.address&logsFields=benchmark_id&logsFields=task_id&logsFields=trace&mode=samples&logsSortBys=-timestamp&statsPeriod=24h) show task-output selection, agent completion, and evaluation start on one trace. The sandbox-create metric carries that trace. [CloudWatch readback](https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/benchmarks$252F9c209c40-12aa-4975-8d01-732c6e2b2160/log-events/astropy__astropy-12907_65987daf150f0) contains setup, agent installation and execution, and evaluation output. The sandbox and temporary agent artifacts were deleted.
- `93053b28` — Sent the cross-process observability smoke from a local workstation to the real `vals-ai/valkyrie` Sentry project using the dev account DSN. The smoke deliberately captured one test exception per process to verify error correlation; it did not fail a benchmark. A query for benchmark ID `1e10ac67-57bf-4a5a-8c91-8ac6c493faff` returned one correlated log and error from each of Tracker, ExecutorHost, and executor. All three services shared [one five-span trace](https://vals-ai.sentry.io/explore/traces/trace/01a02139a344f1ff1b8b5fe2736403c2), and the smoke metric was attached to that trace.
- Not yet tested through the deployed API → Taskiq → ExecutorHost → executor path. The direct live orchestration fixture bypasses that distributed handoff, so it does not prove deployed multi-service spans or complete context binding. After dev deployment, the first check is a one-task CLI run followed by run-ID queries across Sentry logs, errors, and spans and a readback of the linked CloudWatch stream.

Design: architectural
