### PR TITLE
change: enable managed aws execution in prod

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -167,6 +167,8 @@ jobs:
       contents: read
       id-token: write
     env:
+      AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_REGION: us-east-1
       PRODUCTION_ACCOUNT_ID: "613431292675"
 
@@ -571,6 +573,8 @@ jobs:
       contents: read
       id-token: write
     env:
+      AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_REGION: us-east-1
       EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod/executor-release/launch-config
       PRODUCTION_ACCOUNT_ID: "613431292675"

--- a/infra/README.md
+++ b/infra/README.md
@@ -33,29 +33,34 @@ Environment with the `AWS_REGION=us-east-1` variable and the `DEV_ACCOUNT_ID`,
 `AWS_DEPLOY_ROLE_ARN`, `DESCOPE_PROJECT_ID`, and
 `DESCOPE_MANAGEMENT_KEY_SECRET_NAME` secrets (the last one names an
 account-local Secrets Manager secret holding the Descope management key).
-Managed AWS execution also requires these dev Environment secrets:
+Managed AWS execution also requires these secrets in each enabled stage's
+protected GitHub Environment. The `dev` and `prod` environments hold their own
+values:
 
 - `AWS_DEPLOYMENT_ROLE_ORG_IDS` -- comma-separated organization UUIDs allowed
   to submit managed runs
 - `AWS_TRACKER_SECRET_NAME_PREFIXES` -- comma-separated Secrets Manager name
   prefixes the Tracker may resolve for benchmark-service authentication
 
-The dev ExecutorHost task role can read every Secrets Manager secret in the dev
-account and Region. Production and release-test do not receive this access.
+The dev and production ExecutorHost task roles can read every Secrets Manager
+secret in their own account and Region. Release-test does not receive this
+access.
 
 To enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the
 name of an account-local Secrets Manager secret containing the DSN. Production
 requires `SENTRY_DSN_SECRET_NAME`, and `DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
 whenever `AUTH_REQUIRED` is `true`. The dev Environment holds every dev
 deployment input as an Environment secret except `AWS_REGION`, which stays a
-variable. The production jobs read repository-level secrets; the
-`SANDBOX_CLEANUP_ENABLED` and `SANDBOX_CLEANUP_PROVIDER` toggles stay
-variables.
+variable. Production reads its managed AWS inventory from the `prod`
+Environment and retains the existing repository-level deployment secrets. The
+`SANDBOX_CLEANUP_ENABLED` and `SANDBOX_CLEANUP_PROVIDER` toggles stay variables.
 
-Before production executor activation, configure the protected `prod` GitHub
-Environment used by both production deploy jobs. Both AWS accounts must already
-have the account-owned `token.actions.githubusercontent.com` OIDC provider with
-the `sts.amazonaws.com` audience. The stacks import that provider and create
+Before production activation, configure the protected `prod` GitHub
+Environment with `AWS_DEPLOYMENT_ROLE_ORG_IDS` and
+`AWS_TRACKER_SECRET_NAME_PREFIXES`. Both production deploy jobs use that
+Environment. Both AWS accounts must already have the account-owned
+`token.actions.githubusercontent.com` OIDC provider with the
+`sts.amazonaws.com` audience. The stacks import that provider and create
 separate environment-bound executor release roles; they do not create a fallback
 provider.
 
@@ -111,12 +116,15 @@ export AWS_DEPLOYMENT_ROLE_ORG_IDS="00000000-0000-0000-0000-000000000001"
 export AWS_TRACKER_SECRET_NAME_PREFIXES="benchmark-services/"
 ```
 
-   In GitHub, the corresponding values are under **Settings → Environments →
-   dev → Environment secrets**. GitHub does not reveal stored secret values, so
-   an administrator must obtain the approved values from the deployment owner.
+   Use the target stage's values. Production also requires its existing
+   production deployment inputs, including `SENTRY_DSN_SECRET_NAME`. In GitHub,
+   the managed AWS values are under **Settings → Environments → dev or prod →
+   Environment secrets**. GitHub does not reveal stored secret values, so an
+   administrator must obtain the approved values from the deployment owner.
 
-   **Done when** -- All five variables print as non-empty when checked locally;
-   do not print their values into shared logs.
+   **Done when** -- The target account and every stage-required deployment
+   variable are non-empty when checked locally; do not print their values into
+   shared logs.
 
 2. Plan the intended scope.
 
@@ -127,13 +135,18 @@ export AWS_TRACKER_SECRET_NAME_PREFIXES="benchmark-services/"
 
 make plan STAGE=dev SCOPE=all AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
+
+make plan STAGE=prod SCOPE=all AWS_REGION=us-east-1 \
+  PROFILE=vals-prod-admin
 ```
 
    Console alternative: run **Actions → Deploy to AWS → Run workflow** on
-   `dev`, choose `plan`, and select the intended scope.
+   `dev`, choose `plan`, and select the intended scope. Production plans are
+   CLI-only because the manual workflow deliberately accepts only the `dev`
+   branch.
 
-   **Done when** -- The plan targets the expected dev account and contains only
-   the intended stack changes.
+   **Done when** -- The plan targets the expected account and contains only the
+   intended stack changes.
 
 3. Deploy the approved scope only when break-glass access is authorized.
 
@@ -144,6 +157,9 @@ make plan STAGE=dev SCOPE=all AWS_REGION=us-east-1 \
 
 make deploy STAGE=dev SCOPE=shared AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
+
+make deploy STAGE=prod SCOPE=shared AWS_REGION=us-east-1 \
+  PROFILE=vals-prod-admin
 ```
 
    This step is CLI-only because the manual GitHub workflow intentionally does

--- a/infra/README.md
+++ b/infra/README.md
@@ -42,9 +42,8 @@ values:
 - `AWS_TRACKER_SECRET_NAME_PREFIXES` -- comma-separated Secrets Manager name
   prefixes the Tracker may resolve for benchmark-service authentication
 
-The dev and production ExecutorHost task roles can read every Secrets Manager
-secret in their own account and Region. Release-test does not receive this
-access.
+The ExecutorHost task roles can read every Secrets Manager secret in their own
+account and Region. Release-test does not receive this access.
 
 To enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the
 name of an account-local Secrets Manager secret containing the DSN. Production

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -53,7 +53,7 @@ class ManagedAWSRuntimeConfig:
 
         for org_id in self.deployment_role_org_ids:
             try:
-                parsed_org_id = UUID(org_id)
+                parsed_org_id = UUID(org_id.strip())
             except ValueError:
                 raise ValueError(f"deployment_role_org_ids contains an invalid UUID: {org_id!r}") from None
             if org_id != str(parsed_org_id):

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -53,9 +53,11 @@ class ManagedAWSRuntimeConfig:
 
         for org_id in self.deployment_role_org_ids:
             try:
-                UUID(org_id.strip())
+                parsed_org_id = UUID(org_id)
             except ValueError:
                 raise ValueError(f"deployment_role_org_ids contains an invalid UUID: {org_id!r}") from None
+            if org_id != str(parsed_org_id):
+                raise ValueError(f"deployment_role_org_ids must contain canonical UUIDs: {org_id!r}")
 
         for field_name, prefixes in (
             ("tracker_secret_name_prefixes", self.tracker_secret_name_prefixes),
@@ -104,6 +106,8 @@ PROD_CONFIG = StageConfig(
     managed_aws=ManagedAWSRuntimeConfig(
         benchmark_log_group_prefix="/valkyrie/benchmarks",
         benchmark_log_retention_days=365,
+        submissions_enabled=True,
+        executor_all_secret_access=True,
     ),
 )
 
@@ -154,7 +158,7 @@ def config_for(stage: Stage) -> StageConfig:
     except KeyError:
         raise ValueError(f"unknown stage {stage.name!r}; expected {PROD!r}, {DEV!r}, or 'release-test'") from None
 
-    if stage.name != DEV:
+    if stage.name not in {DEV, PROD}:
         return config
 
     deployment_role_org_ids = _csv_environment("AWS_DEPLOYMENT_ROLE_ORG_IDS")
@@ -164,9 +168,9 @@ def config_for(stage: Stage) -> StageConfig:
         tracker_secret_name_prefixes = tracker_secret_name_prefixes or (_OFFLINE_SYNTH_SECRET_PREFIX,)
     if config.managed_aws.submissions_enabled:
         if not deployment_role_org_ids:
-            raise ValueError("Development deployments require AWS_DEPLOYMENT_ROLE_ORG_IDS.")
+            raise ValueError(f"{stage.name} deployments require AWS_DEPLOYMENT_ROLE_ORG_IDS.")
         if not tracker_secret_name_prefixes:
-            raise ValueError("Development deployments require AWS_TRACKER_SECRET_NAME_PREFIXES.")
+            raise ValueError(f"{stage.name} deployments require AWS_TRACKER_SECRET_NAME_PREFIXES.")
     return replace(
         config,
         managed_aws=replace(

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -25,6 +25,15 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("core_maintenance_required != 'true'", production_core)
         self.assertIn("database_maintenance_required != 'true'", production_core)
         self.assertIn("SCOPE=core", production_core)
+        self.assertIn(
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
+            production_core,
+        )
+        self.assertIn(
+            "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
+            production_core,
+        )
+        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", production_core)
         self.assertNotIn("services/executor_artifact/build.py", production_core)
         self.assertNotIn("executor_release/main.py", production_core)
         self.assertNotIn("maintenance-operation", production_core)
@@ -115,6 +124,15 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", dev_executor)
         self.assertIn("needs: [classify-deployment, deploy-production-core]", prod_executor)
         self.assertIn("environment: prod", prod_executor)
+        self.assertIn(
+            "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
+            prod_executor,
+        )
+        self.assertIn(
+            "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
+            prod_executor,
+        )
+        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", prod_executor)
         self.assertNotIn("production-executor-approval", workflow)
         self.assertNotIn("production-release", workflow)
         self.assertEqual(

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -51,7 +51,11 @@ TEST_DEV_ENV = {
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
 }
-TEST_PROD_ENV = {"SENTRY_DSN_SECRET_NAME": "example/sentry-dsn"}
+TEST_PROD_ENV = {
+    "AWS_DEPLOYMENT_ROLE_ORG_IDS": TEST_MANAGED_ORG_ID,
+    "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
+    "SENTRY_DSN_SECRET_NAME": "example/sentry-dsn",
+}
 TEST_RELEASE_TEST_ENV = {
     "DESCOPE_PROJECT_ID": "release-test",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
@@ -128,18 +132,20 @@ def _monitoring_template(stage_name: str = PROD) -> assertions.Template:
         engine="redis",
         num_cache_nodes=1,
     )
-    monitoring = MonitoringStack(
-        app,
-        "MonitoringStack",
-        stage=stage,
-        cluster=cluster,
-        tracker_service=tracker_service,
-        load_balancer=load_balancer,
-        target_group=target_group,
-        database=database,
-        redis_cluster=redis_cluster,
-        env=cdk.Environment(account="123456789012", region="us-west-2"),
-    )
+    stage_environment = TEST_DEV_ENV if stage_name == DEV else TEST_PROD_ENV
+    with mock.patch.dict(os.environ, stage_environment, clear=False):
+        monitoring = MonitoringStack(
+            app,
+            "MonitoringStack",
+            stage=stage,
+            cluster=cluster,
+            tracker_service=tracker_service,
+            load_balancer=load_balancer,
+            target_group=target_group,
+            database=database,
+            redis_cluster=redis_cluster,
+            env=cdk.Environment(account="123456789012", region="us-west-2"),
+        )
 
     return assertions.Template.from_stack(monitoring)
 
@@ -223,26 +229,29 @@ def service_templates(
 
 
 class MonitoringStackTest(unittest.TestCase):
-    def test_dev_managed_runtime_requires_deployment_authority(self) -> None:
-        for variable in (
-            "AWS_DEPLOYMENT_ROLE_ORG_IDS",
-            "AWS_TRACKER_SECRET_NAME_PREFIXES",
-        ):
-            with self.subTest(variable=variable):
-                environment = dict(TEST_DEV_ENV)
-                environment.pop(variable)
-                with mock.patch.dict(os.environ, environment, clear=True):
-                    with self.assertRaisesRegex(ValueError, variable):
-                        config_for(Stage(DEV))
+    def test_hosted_managed_runtime_requires_deployment_authority(self) -> None:
+        for stage_name, stage_environment in ((DEV, TEST_DEV_ENV), (PROD, TEST_PROD_ENV)):
+            for variable in (
+                "AWS_DEPLOYMENT_ROLE_ORG_IDS",
+                "AWS_TRACKER_SECRET_NAME_PREFIXES",
+            ):
+                with self.subTest(stage=stage_name, variable=variable):
+                    environment = dict(stage_environment)
+                    environment.pop(variable)
+                    with mock.patch.dict(os.environ, environment, clear=True):
+                        with self.assertRaisesRegex(ValueError, variable):
+                            config_for(Stage(stage_name))
 
     def test_offline_synth_uses_safe_managed_runtime_placeholders(self) -> None:
-        with mock.patch.dict(os.environ, {"DESCOPE_PROJECT_ID": "offline-synth"}, clear=True):
-            managed_aws = config_for(Stage(DEV)).managed_aws
+        for stage_name in (DEV, PROD):
+            with self.subTest(stage=stage_name):
+                with mock.patch.dict(os.environ, {"DESCOPE_PROJECT_ID": "offline-synth"}, clear=True):
+                    managed_aws = config_for(Stage(stage_name)).managed_aws
 
-        self.assertEqual(managed_aws.deployment_role_org_ids, (TEST_MANAGED_ORG_ID,))
-        self.assertEqual(managed_aws.tracker_secret_name_prefixes, ("offline-synth",))
-        self.assertEqual(managed_aws.executor_secret_name_prefixes, ())
-        self.assertTrue(managed_aws.executor_all_secret_access)
+                self.assertEqual(managed_aws.deployment_role_org_ids, (TEST_MANAGED_ORG_ID,))
+                self.assertEqual(managed_aws.tracker_secret_name_prefixes, ("offline-synth",))
+                self.assertEqual(managed_aws.executor_secret_name_prefixes, ())
+                self.assertTrue(managed_aws.executor_all_secret_access)
 
     def test_dev_stack_ids_are_valk_scoped(self) -> None:
         self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -9,13 +9,14 @@ import aws_cdk as cdk
 from aws_cdk import assertions, aws_s3
 
 from runtime_iam import create_executor_task_role, create_tracker_task_role
-from stage import DEV, RELEASE_TEST, Stage
+from stage import DEV, PROD, RELEASE_TEST, Stage
 from stage_config import ManagedAWSRuntimeConfig
 from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
     TEST_DEV_ENV,
     TEST_MANAGED_ORG_ID,
+    TEST_PROD_ENV,
     TEST_RELEASE_TEST_ENV,
     TEST_TRACKER_SECRET_NAME_PREFIX,
     JsonObject,
@@ -67,6 +68,7 @@ class RuntimeIamTest(unittest.TestCase):
             ("benchmark_log_retention_days", 0),
             ("benchmark_log_retention_days", -1),
             ("deployment_role_org_ids", ("not-a-uuid",)),
+            ("deployment_role_org_ids", ("AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA",)),
             ("tracker_secret_name_prefixes", ("",)),
             ("tracker_secret_name_prefixes", ("*",)),
             ("tracker_secret_name_prefixes", ("valkyrie/*",)),
@@ -247,6 +249,49 @@ class RuntimeIamTest(unittest.TestCase):
                 else:
                     secret_resources = json.dumps(secret_statement["Resource"])
                     self.assertIn("secretsmanager", secret_resources)
+                    self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
+
+    def test_prod_managed_runtime_uses_prod_inventory_and_task_roles(self) -> None:
+        with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=True):
+            tracker_template, executor_template, _ = service_templates(PROD)
+
+        expected_environment = assertions.Match.array_with(
+            [
+                {"Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS", "Value": TEST_MANAGED_ORG_ID},
+                {"Name": "AWS_DEPLOYMENT_REGION", "Value": TEST_AWS_REGION},
+                assertions.Match.object_like({"Name": "AWS_DEPLOYMENT_S3_BUCKET"}),
+                {"Name": "AWS_DEPLOYMENT_LOG_GROUP", "Value": "/valkyrie/benchmarks"},
+                {"Name": "AWS_DEPLOYMENT_LOG_RETENTION_DAYS", "Value": "365"},
+                {"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "true"},
+            ]
+        )
+
+        for template, role_name in (
+            (tracker_template, "ValkyrieTrackerTaskRole"),
+            (executor_template, "ValkyrieExecutorTaskRole"),
+        ):
+            with self.subTest(role=role_name):
+                role_logical_id, _ = _named_role(template, role_name)
+                template.has_resource_properties(
+                    "AWS::ECS::TaskDefinition",
+                    {
+                        "TaskRoleArn": {"Fn::GetAtt": [role_logical_id, "Arn"]},
+                        "ContainerDefinitions": assertions.Match.array_with(
+                            [assertions.Match.object_like({"Environment": expected_environment})]
+                        ),
+                    },
+                )
+
+                secret_statement = next(
+                    statement
+                    for statement in _role_policy_statements(template, role_logical_id)
+                    if _statement_actions(statement) == {"secretsmanager:GetSecretValue"}
+                )
+                secret_resources = json.dumps(secret_statement["Resource"])
+                if role_name.startswith("ValkyrieExecutor"):
+                    self.assertIn("secret:*", secret_resources)
+                    self.assertNotIn(TEST_TRACKER_SECRET_NAME_PREFIX, secret_resources)
+                else:
                     self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
 
     def test_release_test_managed_runtime_remains_closed(self) -> None:


### PR DESCRIPTION
## Human Description

### Why

This launches the managed mode feature in prod.

---

Production deployments now enable the existing managed AWS execution path for explicitly allowlisted organizations. Tracker and ExecutorHost receive the production AWS resource configuration and task-role permissions together, while missing deployment inventories stop the deployment before it can partially activate the feature.

## What changed

- Enable managed AWS submissions in production for organizations listed in the production GitHub Environment.
- Give Tracker access only to configured Secrets Manager name prefixes. Give ExecutorHost access to secrets in its production account and Region so managed runs can resolve their declared dependencies.
- Require canonical organization UUIDs and fail deployment when the production organization or Tracker secret inventories are missing.
- Pass the production inventories to both deployment jobs and document the production configuration.

## How to review

- Start with `infra/stage_config.py` for the production gate and fail-closed inventory handling.
- Review `infra/runtime_iam.py` with `infra/tests/test_runtime_iam.py` for the Tracker and ExecutorHost permission boundary.
- Review `.github/workflows/deploy.yaml` for the production-environment secret wiring. The repository classifier treats this as coordinated maintenance and redeploys Tracker and ExecutorHost before reopening admission.

## Testing

Tested in Dev, but not yet live-tested in Pord. After deployment, start and complete one managed one-task production run, then stop and resume it while checking S3 artifacts, CloudWatch logs, and provider-secret access. Run one explicit access-key control on the same deployment.

Design: not architectural (activates the existing managed AWS execution path in production)
