### PR TITLE
fix: explain historical run recovery

### DIFF
--- a/services/tracker/src/tracker/aws/resolver.py
+++ b/services/tracker/src/tracker/aws/resolver.py
@@ -259,11 +259,7 @@ def resolve_run_aws_runtime_and_access_key_config(
     if not header_inspection.present:
         raise HTTPException(
             status_code=400,
-            detail=(
-                "This run was started with access-key AWS and requires its legacy AWS configuration. "
-                "Use the Dashboard Legacy recovery control or an approved recovery agent. "
-                "Do not add static AWS credentials to your managed config."
-            ),
+            detail="This run was started with access-key AWS and requires its legacy AWS configuration.",
         )
     if header_inspection.config is None:
         assert header_inspection.first_missing_key is not None

--- a/services/tracker/src/tracker/aws/resolver.py
+++ b/services/tracker/src/tracker/aws/resolver.py
@@ -254,7 +254,22 @@ def resolve_run_aws_runtime_and_access_key_config(
     """Resolve AWS authority and retain any access-key harness configuration."""
     if aws_managed:
         return AWSRuntimeResolution(_http_deployment_runtime(org_id), None)
-    harness_config = fetch_harness_config(request)
+
+    header_inspection = inspect_harness_headers(request)
+    if not header_inspection.present:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This run was started with access-key AWS and requires its legacy AWS configuration. "
+                "Use the Dashboard Legacy recovery control or an approved recovery agent. "
+                "Do not add static AWS credentials to your managed config."
+            ),
+        )
+    if header_inspection.config is None:
+        assert header_inspection.first_missing_key is not None
+        _raise_missing_header(header_inspection.first_missing_key)
+
+    harness_config = header_inspection.config
     return AWSRuntimeResolution(AWSRuntime.from_harness_config(harness_config), harness_config)
 
 

--- a/services/tracker/tests/unit/test_aws_runtime_resolver.py
+++ b/services/tracker/tests/unit/test_aws_runtime_resolver.py
@@ -175,6 +175,18 @@ def test_run_runtime_uses_stored_mode(
     assert isinstance(runtime.clients, expected_provider)
 
 
+def test_access_key_run_reports_incomplete_legacy_config() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        resolve_run_aws_runtime(
+            _request({"x-harness-aws-access-key-id": "partial-access-key"}),
+            aws_managed=False,
+            org_id=_ORG_ID,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail == "Missing harness config header 'x-harness-aws-secret-access-key'"
+
+
 def test_managed_run_ignores_partial_access_key_headers(monkeypatch: pytest.MonkeyPatch) -> None:
     _configure_managed_runtime(monkeypatch)
 

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -2301,16 +2301,21 @@ class TestTrackerAPI:
         # None of the three cases should have reached Sentry
         assert captured == []
 
-    def test_fetch_benchmark_returns_400_when_harness_headers_missing(
+    def test_fetch_access_key_run_without_headers_explains_legacy_recovery(
         self,
         database_session: Session,
         example_benchmark_object: Benchmark,
     ) -> None:
-        """Missing X-Harness-* headers should return 400, not 500 KeyError."""
         database_session.add(example_benchmark_object)
         database_session.commit()
 
         response = client.get("/fetch-benchmark", params={"benchmark_id": str(example_benchmark_object.id)})
 
         assert response.status_code == 400
-        assert "Missing harness config header" in response.json()["detail"]
+        assert response.json() == {
+            "detail": (
+                "This run was started with access-key AWS and requires its legacy AWS configuration. "
+                "Use the Dashboard Legacy recovery control or an approved recovery agent. "
+                "Do not add static AWS credentials to your managed config."
+            )
+        }

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -2313,9 +2313,5 @@ class TestTrackerAPI:
 
         assert response.status_code == 400
         assert response.json() == {
-            "detail": (
-                "This run was started with access-key AWS and requires its legacy AWS configuration. "
-                "Use the Dashboard Legacy recovery control or an approved recovery agent. "
-                "Do not add static AWS credentials to your managed config."
-            )
+            "detail": "This run was started with access-key AWS and requires its legacy AWS configuration."
         }


### PR DESCRIPTION
## Human Description

### Why

Raise a more descriptive error when a user with a managed config tries to interact with an access key run

---

Access-key runs currently report a missing HTTP header when a managed configuration performs an AWS-backed operation. The error now explains that the run requires its legacy AWS configuration. Partially supplied legacy configurations continue to identify the specific missing header.

## Testing

Not yet live-tested.

Design: not architectural (changes an existing error response without changing AWS execution behavior)