### PR TITLE
fix: harden cloudwatch task log delivery

### DIFF
--- a/services/tracker/src/tracker/aws/clients.py
+++ b/services/tracker/src/tracker/aws/clients.py
@@ -15,6 +15,12 @@ if TYPE_CHECKING:
     from tracker.types import AWSCredentials
 
 _HIGH_CONCURRENCY_CLIENT_CONFIG = Config(max_pool_connections=200)
+_CLOUDWATCH_LOGS_CLIENT_CONFIG = Config(
+    max_pool_connections=200,
+    connect_timeout=5,
+    read_timeout=5,
+    retries={"mode": "standard", "total_max_attempts": 2},
+)
 _S3_CLIENT_CONFIG = Config(max_pool_connections=200, retries={"mode": "standard"})
 _DEFAULT_CHAIN_MAXIMUM_PRESIGN_TTL_SECONDS = 3600
 
@@ -46,7 +52,7 @@ class AWSClientProvider(ABC):
     def cloudwatch_logs_client(self) -> Any:
         return _boto3_client(
             "logs",
-            config=_HIGH_CONCURRENCY_CLIENT_CONFIG,
+            config=_CLOUDWATCH_LOGS_CLIENT_CONFIG,
             **self._client_kwargs(),
         )
 

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -12,6 +12,8 @@ from tracker.aws.runtime import AWSResources, AWSRuntime
 from tracker.exceptions import CloudWatchError
 
 _created_streams: set[str] = set()
+_created_log_groups: set[str] = set()
+_MAX_LOG_EVENT_MESSAGE_BYTES = 1_048_576 - 26
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
 
@@ -26,6 +28,19 @@ def _sanitize_log_stream_name(task_id: str) -> str:
     forbidden characters so logging degrades gracefully instead of failing.
     """
     return re.sub(r"[:*]", "_", task_id)
+
+
+def _split_log_message(message: str) -> list[str]:
+    encoded = message.encode("utf-8")
+    chunks: list[str] = []
+    start = 0
+    while start < len(encoded):
+        end = min(start + _MAX_LOG_EVENT_MESSAGE_BYTES, len(encoded))
+        while end < len(encoded) and encoded[end] & 0b1100_0000 == 0b1000_0000:
+            end -= 1
+        chunks.append(encoded[start:end].decode("utf-8"))
+        start = end
+    return chunks
 
 
 def handle_cloudwatch_error(message: str) -> Callable[[Callable[_P, _R]], Callable[_P, _R]]:
@@ -119,6 +134,10 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
     log_group_name = f"{runtime.resources.log_group}/{benchmark_id}"
     stream_name = _sanitize_log_stream_name(task_id)
 
+    if benchmark_id not in _created_log_groups:
+        create_benchmark_log_group(benchmark_id, runtime)
+        _created_log_groups.add(benchmark_id)
+
     if stream_key not in _created_streams:
         try:
             client.create_log_stream(logGroupName=log_group_name, logStreamName=stream_name)  # pyright: ignore[reportUnknownMemberType]
@@ -129,11 +148,12 @@ def write_benchmark_log_event(stream_key: str, message: str, runtime: AWSRuntime
             raise CloudWatchError(f"Failed to create log stream '{stream_name}': {e}") from e
         _created_streams.add(stream_key)
 
-    try:
-        client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group_name,
-            logStreamName=stream_name,
-            logEvents=[{"timestamp": int(time.time() * 1000), "message": message}],
-        )
-    except (ClientError, BotoCoreError) as e:
-        raise CloudWatchError(f"Failed to put log event: {e}") from e
+    for chunk in _split_log_message(message):
+        try:
+            client.put_log_events(  # pyright: ignore[reportUnknownMemberType]
+                logGroupName=log_group_name,
+                logStreamName=stream_name,
+                logEvents=[{"timestamp": int(time.time() * 1000), "message": chunk}],
+            )
+        except (ClientError, BotoCoreError) as e:
+            raise CloudWatchError(f"Failed to put log event: {e}") from e

--- a/services/tracker/src/tracker/aws/cloudwatch_logs.py
+++ b/services/tracker/src/tracker/aws/cloudwatch_logs.py
@@ -99,13 +99,14 @@ def create_benchmark_log_group(benchmark_id: str, runtime: AWSRuntime) -> str:
 
     try:
         client.create_log_group(logGroupName=log_group_name)  # pyright: ignore[reportUnknownMemberType]
-        client.put_retention_policy(  # pyright: ignore[reportUnknownMemberType]
-            logGroupName=log_group_name,
-            retentionInDays=runtime.resources.log_retention_days,
-        )
     except ClientError as e:
         if e.response.get("Error", {}).get("Code") != "ResourceAlreadyExistsException":
             raise
+
+    client.put_retention_policy(  # pyright: ignore[reportUnknownMemberType]
+        logGroupName=log_group_name,
+        retentionInDays=runtime.resources.log_retention_days,
+    )
 
     return log_group_name
 

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -17,7 +17,6 @@ from pydantic import ValidationError
 from sqlmodel import Session, col, desc, func, select
 
 from tracker._lambda import dry_run_lambda, invoke_lambda
-from tracker.aws.cloudwatch_logs import create_benchmark_log_group
 from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import fetch_aws_secret, resolve_secrets
@@ -395,7 +394,6 @@ def _preflight_managed_aws(
     runtime: AWSRuntime,
 ) -> SandboxProviderConfig:
     """Verify executor-owned AWS access before starting sandbox work."""
-    create_benchmark_log_group(str(execution.benchmark_id), runtime)
     request = execution.request
     provider_secret_name = request.sandbox_provider_secret_name
     if provider_secret_name is None:
@@ -510,9 +508,6 @@ async def process_benchmark(
                 clients=aws_runtime.clients,
                 intervals=start_benchmark_request.webhook_intervals,
             )
-
-        if not execution.aws_managed:
-            create_benchmark_log_group(str(benchmark_id), aws_runtime)
 
         # Create tasks inside of the database for each task id
         with Session(bind=engine) as session:

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -68,6 +68,9 @@ logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
 _SANDBOX_RETRY_DELAY_SECONDS: float = 2
+_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS: float = 10
+_CLOUDWATCH_LOG_WRITE_ATTEMPTS: int = 3
+_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS: float = 0.25
 
 
 @dataclass
@@ -390,12 +393,13 @@ def buffer_logs(
     stream_key: str,
     aws_runtime: AWSRuntime,
     force_flush: bool = False,
-) -> None:
+    previous_write: asyncio.Future[None] | None = None,
+) -> asyncio.Future[None] | None:
     """
     Buffers the logs in the queue and waits till they are full before streaming them to CloudWatch.
     """
     if not log_queue.full() and not force_flush:
-        return
+        return None
 
     messages: list[str] = []
     while not log_queue.empty():
@@ -403,7 +407,20 @@ def buffer_logs(
 
     message = "".join(messages)
     loop = asyncio.get_running_loop()
-    loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+
+    async def write_in_order() -> None:
+        if previous_write is not None:
+            await asyncio.gather(previous_write, return_exceptions=True)
+        for attempt in range(1, _CLOUDWATCH_LOG_WRITE_ATTEMPTS + 1):
+            try:
+                await loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+                return
+            except Exception:
+                if attempt == _CLOUDWATCH_LOG_WRITE_ATTEMPTS:
+                    raise
+                await asyncio.sleep(_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS)
+
+    return asyncio.create_task(write_in_order())
 
 
 def save_eval_resume_state(
@@ -619,6 +636,7 @@ async def _process_task_attempt(
     task_stream_name = f"{task_id}_{stream_suffix}"
     stream_key: str = f"{benchmark_id}:{task_stream_name}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
+    latest_log_write: asyncio.Future[None] | None = None
 
     logger.info(
         "Task output stream selected",
@@ -635,12 +653,45 @@ async def _process_task_attempt(
 
     last_log_time: float = time.monotonic()
 
+    def schedule_log_flush(*, force: bool = False) -> None:
+        nonlocal latest_log_write
+        write = buffer_logs(
+            log_queue,
+            stream_key,
+            aws_runtime,
+            force_flush=force,
+            previous_write=latest_log_write,
+        )
+        if write is None:
+            return
+        latest_log_write = write
+
+        def handle_completion(completed: asyncio.Future[None]) -> None:
+            try:
+                completed.result()
+            except asyncio.CancelledError:
+                return
+            except Exception as error:
+                with error_span(
+                    "task.output_write.error",
+                    error,
+                    benchmark_id=str(benchmark_id),
+                    task_id=task_id,
+                ):
+                    logger.exception(
+                        "Failed to write task output to CloudWatch",
+                        extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
+                    )
+                    capture_exception(error)
+
+        write.add_done_callback(handle_completion)
+
     # Collects the logs and dumps them when the queue is full
     def log_output(data: str) -> None:
         nonlocal last_log_time
         last_log_time = time.monotonic()
         log_queue.put_nowait(data)
-        buffer_logs(log_queue, stream_key, aws_runtime)
+        schedule_log_flush()
 
     # Auto flush if process takes a while to produce next log
     # If a process pauses without producing anymore logs, the logs we have collected get stuck
@@ -648,7 +699,7 @@ async def _process_task_attempt(
         while True:
             await asyncio.sleep(1)
             if not log_queue.empty() and time.monotonic() - last_log_time >= 10:
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                schedule_log_flush(force=True)
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
@@ -881,7 +932,7 @@ async def _process_task_attempt(
                 recovery_attempt.mark_replacement_ready()
 
                 # Force flush the logs if anything has been buffered
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                schedule_log_flush(force=True)
 
                 # Compute the S3 key for the agent's output archive
                 agent_output_s3_key = None
@@ -961,7 +1012,7 @@ async def _process_task_attempt(
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
-                buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+                schedule_log_flush(force=True)
 
                 # Save the evaluation result to the database with the task row
                 # Record the termination reason if the agent did not exit cleanly (timeout / OS kill)
@@ -1116,7 +1167,17 @@ async def _process_task_attempt(
         flush_task.cancel()
         with suppress(asyncio.CancelledError):
             await flush_task
-        buffer_logs(log_queue, stream_key, aws_runtime, force_flush=True)
+        schedule_log_flush(force=True)
+        if latest_log_write is not None:
+            try:
+                await asyncio.wait_for(latest_log_write, timeout=_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logger.warning(
+                    "Timed out waiting for task output to flush to CloudWatch",
+                    extra={"benchmark_id": str(benchmark_id), "task_id": task_id},
+                )
+            except Exception:
+                pass
 
 
 def commit_task_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -6,6 +6,7 @@ import time
 import traceback
 from asyncio import Semaphore
 from collections.abc import Coroutine
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime
@@ -71,6 +72,7 @@ _SANDBOX_RETRY_DELAY_SECONDS: float = 2
 _CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS: float = 10
 _CLOUDWATCH_LOG_WRITE_ATTEMPTS: int = 3
 _CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS: float = 0.25
+_CLOUDWATCH_LOG_EXECUTOR = ThreadPoolExecutor(thread_name_prefix="cloudwatch-task-output")
 
 
 @dataclass
@@ -413,7 +415,13 @@ def buffer_logs(
             await asyncio.gather(previous_write, return_exceptions=True)
         for attempt in range(1, _CLOUDWATCH_LOG_WRITE_ATTEMPTS + 1):
             try:
-                await loop.run_in_executor(None, write_benchmark_log_event, stream_key, message, aws_runtime)
+                await loop.run_in_executor(
+                    _CLOUDWATCH_LOG_EXECUTOR,
+                    write_benchmark_log_event,
+                    stream_key,
+                    message,
+                    aws_runtime,
+                )
                 return
             except Exception:
                 if attempt == _CLOUDWATCH_LOG_WRITE_ATTEMPTS:

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -8,6 +8,7 @@ from asyncio import Semaphore
 from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
+from contextvars import copy_context
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -415,8 +416,10 @@ def buffer_logs(
             await asyncio.gather(previous_write, return_exceptions=True)
         for attempt in range(1, _CLOUDWATCH_LOG_WRITE_ATTEMPTS + 1):
             try:
+                write_context = copy_context()
                 await loop.run_in_executor(
                     _CLOUDWATCH_LOG_EXECUTOR,
+                    write_context.run,
                     write_benchmark_log_event,
                     stream_key,
                     message,

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -254,9 +254,6 @@ class TestRunFinalization:
         async def skip_cloud_operation(*_args: Any, **_kwargs: Any) -> None:
             return None
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -308,7 +305,6 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[scored_task.task_id], final_score=0.25, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(BenchmarkServiceClient, "verify_task_ids", verify_retry_task)
@@ -391,9 +387,6 @@ class TestRunFinalization:
             upload_calls += 1
             return None
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -421,7 +414,6 @@ class TestRunFinalization:
             await both_monitors_arrived.wait()
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", skip_cloud_operation)
         monkeypatch.setattr(TaskMonitor, "track_tasks", synchronized_track_tasks)
@@ -536,9 +528,6 @@ class TestRunFinalization:
             side_effects["notification"]["calls"] += 1
             side_effects["notification"]["lock_held"] = assert_lock_held(benchmark.id)
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -550,7 +539,6 @@ class TestRunFinalization:
             return FinalScoreResponse(tasks_evaluated=[task.task_id], final_score=1.0, metadata={})
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
         monkeypatch.setattr(run_orchestration_module, "upload_final_view", assert_upload_lock_held)
         monkeypatch.setattr(run_orchestration_module, "invoke_lambda", assert_lambda_lock_held)
@@ -638,9 +626,6 @@ class TestRunFinalization:
             benchmarks.append((benchmark, expected_summary))
         postgres_session.commit()
 
-        def skip_log_group(*_args: Any, **_kwargs: Any) -> str:
-            return "test-log-group"
-
         def provider_config(*_args: Any, **_kwargs: Any) -> DaytonaProviderConfig:
             return DaytonaProviderConfig(
                 DAYTONA_API_KEY="test-key",
@@ -650,7 +635,6 @@ class TestRunFinalization:
 
         monkeypatch.setattr(run_orchestration_module, "engine", postgres_engine)
 
-        monkeypatch.setattr(run_orchestration_module, "create_benchmark_log_group", skip_log_group)
         monkeypatch.setattr(run_orchestration_module, "fetch_sandbox_provider_config", provider_config)
 
         for benchmark, expected_summary in benchmarks:

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -184,6 +184,19 @@ class TestS3ClientRetry:
 class TestCloudWatchClient:
     """CloudWatch exception translation at the client boundary."""
 
+    def test_uses_short_failure_timeouts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        boto_client_factory = MagicMock()
+        monkeypatch.setattr(aws_clients.boto3, "client", boto_client_factory)
+        provider = DefaultChainAWSClientProvider(region="us-east-1")
+
+        provider.cloudwatch_logs_client()
+
+        config = boto_client_factory.call_args.kwargs["config"]
+        assert config.connect_timeout == 5
+        assert config.read_timeout == 5
+        assert config.retries["total_max_attempts"] == 2
+        assert config.retries["mode"] == "standard"
+
     def test_cloudwatch_error_with_client(self) -> None:
         """Test that ClientError is caught buy the decorator"""
         client_error = ClientError({"Error": {"Code": "404", "Message": "Not found"}}, "CreateLogStream")
@@ -256,6 +269,7 @@ class TestWriteBenchmarkLogEvent:
         client_provider = MagicMock(spec=AWSClientProvider)
         client_provider.cloudwatch_logs_client.return_value = client
         monkeypatch.setattr(cloudwatch_logs, "_created_streams", set[str]())
+        monkeypatch.setattr(cloudwatch_logs, "_created_log_groups", set[str]())
         runtime = AWSRuntime(
             resources=_AWS_RESOURCES,
             clients=cast(AWSClientProvider, client_provider),
@@ -264,14 +278,28 @@ class TestWriteBenchmarkLogEvent:
 
     def test_creates_stream_and_puts_event_with_sanitized_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
         client, runtime = self._runtime_with_mock_client(monkeypatch)
+        create_log_group = MagicMock()
+        monkeypatch.setattr(cloudwatch_logs, "create_benchmark_log_group", create_log_group)
 
         # stream_key splits on the first ':' -> task_id keeps its own ':'
         write_benchmark_log_event("bench123:provider/model:fast", "hello", runtime)
 
+        create_log_group.assert_called_once_with("bench123", runtime)
         client.create_log_stream.assert_called_once_with(
             logGroupName="/valkyrie/worker/bench123", logStreamName="provider/model_fast"
         )
         assert client.put_log_events.call_args.kwargs["logStreamName"] == "provider/model_fast"
+
+    def test_splits_oversized_utf8_messages_without_losing_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, runtime = self._runtime_with_mock_client(monkeypatch)
+        message = "a" * 1_048_540 + "🙂" * 20
+
+        write_benchmark_log_event("bench123:task-1", message, runtime)
+
+        written = [call.kwargs["logEvents"][0]["message"] for call in client.put_log_events.call_args_list]
+        assert len(written) == 2
+        assert "".join(written) == message
+        assert all(len(chunk.encode("utf-8")) <= 1_048_550 for chunk in written)
 
     def test_create_stream_botocore_error_reports_sanitized_name(
         self,
@@ -285,3 +313,16 @@ class TestWriteBenchmarkLogEvent:
 
         assert "provider/model_fast" in str(exc_info.value)
         client.put_log_events.assert_not_called()
+
+    def test_log_group_failure_prevents_only_the_background_write(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client, runtime = self._runtime_with_mock_client(monkeypatch)
+        monkeypatch.setattr(
+            cloudwatch_logs,
+            "create_benchmark_log_group",
+            MagicMock(side_effect=CloudWatchError("Failed to create log group")),
+        )
+
+        with pytest.raises(CloudWatchError, match="Failed to create log group"):
+            write_benchmark_log_event("bench123:task-1", "hello", runtime)
+
+        client.create_log_stream.assert_not_called()

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -18,6 +18,7 @@ from tracker.aws.clients import (
     ExplicitCredentialsAWSClientProvider,
 )
 from tracker.aws.cloudwatch_logs import (
+    create_benchmark_log_group,
     get_benchmark_log_url,
     handle_cloudwatch_error,
     write_benchmark_log_event,
@@ -259,6 +260,27 @@ class TestGetBenchmarkLogUrl:
     def test_no_task_id_omits_log_events(self) -> None:
         url = get_benchmark_log_url("bench123", _AWS_RESOURCES)
         assert "log-events" not in url
+
+
+class TestCreateBenchmarkLogGroup:
+    """CloudWatch benchmark log group setup."""
+
+    def test_applies_retention_when_another_writer_created_the_group(self) -> None:
+        client = MagicMock()
+        client.create_log_group.side_effect = ClientError(
+            {"Error": {"Code": "ResourceAlreadyExistsException", "Message": "Already exists"}},
+            "CreateLogGroup",
+        )
+        client_provider = MagicMock(spec=AWSClientProvider)
+        client_provider.cloudwatch_logs_client.return_value = client
+        runtime = AWSRuntime(resources=_AWS_RESOURCES, clients=cast(AWSClientProvider, client_provider))
+
+        create_benchmark_log_group("bench123", runtime)
+
+        client.put_retention_policy.assert_called_once_with(
+            logGroupName="/valkyrie/worker/bench123",
+            retentionInDays=30,
+        )
 
 
 class TestWriteBenchmarkLogEvent:

--- a/services/tracker/tests/unit/conftest.py
+++ b/services/tracker/tests/unit/conftest.py
@@ -179,7 +179,6 @@ def mock_cloudwatch(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.aws.cloudwatch_logs.write_benchmark_log_event", _mock_write_benchmark_log_event)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", _mock_create_benchmark_log_group)
     monkeypatch.setattr("tracker.utils.task_execution.write_benchmark_log_event", _mock_write_benchmark_log_event)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", _mock_upload_final_view)
     monkeypatch.setattr("tracker.aws.secrets.fetch_aws_secret", _mock_fetch_aws_secret)

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -327,11 +327,6 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
 
-    def create_log_group(_benchmark_id: str, runtime: AWSRuntime) -> str:
-        assert runtime is aws_runtime
-        calls.append("logs")
-        return "benchmark-log-group"
-
     def fetch_provider(_name: str, clients: object, _provider: str) -> SandboxProviderConfig:
         assert clients is aws_runtime.clients
         calls.append("provider-secret")
@@ -360,7 +355,6 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         return MagicMock()
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", resolve_agent_secrets)
@@ -379,7 +373,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
 
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.FINISHED
-    assert calls[:4] == ["logs", "provider-secret", "agent-secrets", "lambda-dry-run"]
+    assert calls[:3] == ["provider-secret", "agent-secrets", "lambda-dry-run"]
     assert calls.count("agent-secrets") >= 2
     assert calls[-2:] == ["s3-final-upload", "lambda-post-run"]
     finalized_span = next(attributes for name, attributes in spans if name == "run.finalized")
@@ -402,10 +396,6 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     calls: list[str] = []
     provider_config = cast(SandboxProviderConfig, MagicMock())
 
-    def create_log_group(*_args: Any, **_kwargs: Any) -> str:
-        calls.append("logs")
-        return "benchmark-log-group"
-
     def fetch_provider(*_args: Any, **_kwargs: Any) -> SandboxProviderConfig:
         calls.append("sandbox_provider_secret")
         return provider_config
@@ -421,7 +411,6 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     def dry_run(*_args: Any, **_kwargs: Any) -> None:
         calls.append("lambda")
 
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
     monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_aws_secret", fetch_webhook_secret)
@@ -430,10 +419,10 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     result = _preflight_managed_aws(execution, aws_runtime)
 
     assert result is provider_config
-    assert calls == ["logs", "sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
+    assert calls == ["sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
 
 
-async def test_managed_preflight_failure_happens_before_sandbox(
+async def test_required_managed_preflight_failure_happens_before_sandbox(
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,
     database_session: Session,
@@ -448,11 +437,11 @@ async def test_managed_preflight_failure_happens_before_sandbox(
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
         return aws_runtime
 
-    def fail_log_preflight(*_args: Any, **_kwargs: Any) -> str:
-        raise RuntimeError("managed log preflight failed")
+    def fail_provider_preflight(*_args: Any, **_kwargs: Any) -> SandboxProviderConfig:
+        raise RuntimeError("managed provider preflight failed")
 
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", fail_log_preflight)
+    monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fail_provider_preflight)
     monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
 
     await process_benchmark(
@@ -462,5 +451,5 @@ async def test_managed_preflight_failure_happens_before_sandbox(
 
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.ERROR
-    assert "managed log preflight failed" in (benchmark.error_message or "")
+    assert "managed provider preflight failed" in (benchmark.error_message or "")
     create_sandbox.assert_not_awaited()

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -326,7 +326,7 @@ class TestBenchmarkServiceFailures:
         assert any("[ERROR] ConnectTimeout" in message for message in logged_messages)
 
     @pytest.mark.usefixtures("process_benchmark_env")
-    async def test_cloudwatch_write_failure_is_captured_before_task_returns(
+    async def test_cloudwatch_write_failure_does_not_change_successful_task_result(
         self,
         contract: AgentContractRequest,
         database_session: Session,
@@ -340,19 +340,17 @@ class TestBenchmarkServiceFailures:
         cloudwatch_error = RuntimeError("cloudwatch unavailable")
         capture_exception = Mock()
 
-        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
-            raise httpx.ConnectTimeout("benchmark unavailable")
-
         def _fail_write(*_args: Any, **_kwargs: Any) -> None:
             raise cloudwatch_error
 
-        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
         monkeypatch.setattr(utils_module, "write_benchmark_log_event", _fail_write)
         monkeypatch.setattr(utils_module.sentry_sdk, "capture_exception", capture_exception)
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 
-        assert result == {"task_0": None}
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
         captured_errors = [call.args[0] for call in capture_exception.call_args_list]
         assert cloudwatch_error in captured_errors
 

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -4,6 +4,7 @@ Run: uv run pytest tests/unit/utils/test_benchmark_service_failures.py
 """
 
 import asyncio
+import threading
 import time
 from typing import Any, Never
 from unittest.mock import Mock
@@ -199,6 +200,8 @@ class TestBenchmarkServiceFailures:
         expected_log = f"[ERROR] {expected_error}"
         logged_messages: list[str] = []
         expected_log_written = asyncio.Event()
+        log_write_started = asyncio.Event()
+        release_log_write = threading.Event()
         event_loop = asyncio.get_running_loop()
 
         async def _mock_install_agent_dependencies(*_args: Any, **_kwargs: Any) -> None:
@@ -215,6 +218,8 @@ class TestBenchmarkServiceFailures:
             raise AssertionError(f"unexpected command: {command}")
 
         def _mock_write_benchmark_log_event(_stream_key: str, message: str, *_args: Any, **_kwargs: Any) -> None:
+            event_loop.call_soon_threadsafe(log_write_started.set)
+            assert release_log_write.wait(timeout=5)
             logged_messages.append(message)
             if expected_log in message:
                 event_loop.call_soon_threadsafe(expected_log_written.set)
@@ -229,10 +234,14 @@ class TestBenchmarkServiceFailures:
         monkeypatch.setattr(sandbox_module, "_exec", _mock_exec)
         monkeypatch.setattr(utils_module, "write_benchmark_log_event", _mock_write_benchmark_log_event)
 
-        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
-        # Log writes are dispatched to an executor and never awaited, so the flush carrying the
-        # error can land after run_process_task returns. Wait for that flush, not just the first.
-        await asyncio.wait_for(expected_log_written.wait(), timeout=10)
+        task = asyncio.create_task(
+            run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+        )
+        await asyncio.wait_for(log_write_started.wait(), timeout=5)
+        assert not task.done()
+        release_log_write.set()
+        result = await task
+        assert expected_log_written.is_set()
 
         assert result == {"task_0": None}
 
@@ -315,6 +324,84 @@ class TestBenchmarkServiceFailures:
         assert task_row.status == TaskStatus.ERROR
         assert self._latest_task_error(database_session, task_row) == "ConnectTimeout"
         assert any("[ERROR] ConnectTimeout" in message for message in logged_messages)
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_cloudwatch_write_failure_is_captured_before_task_returns(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        cloudwatch_error = RuntimeError("cloudwatch unavailable")
+        capture_exception = Mock()
+
+        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            raise httpx.ConnectTimeout("benchmark unavailable")
+
+        def _fail_write(*_args: Any, **_kwargs: Any) -> None:
+            raise cloudwatch_error
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
+        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _fail_write)
+        monkeypatch.setattr(utils_module.sentry_sdk, "capture_exception", capture_exception)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        captured_errors = [call.args[0] for call in capture_exception.call_args_list]
+        assert cloudwatch_error in captured_errors
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    @pytest.mark.parametrize("cancel_during_flush", [False, True])
+    async def test_cloudwatch_write_timeout_does_not_delay_task_completion(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+        cancel_during_flush: bool,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        write_started = threading.Event()
+        release_write = threading.Event()
+        write_completed = threading.Event()
+
+        async def _mock_retrieve_task_timeout(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            raise httpx.ConnectTimeout("benchmark unavailable")
+
+        def _blocked_write(*_args: Any, **_kwargs: Any) -> None:
+            write_started.set()
+            release_write.wait()
+            write_completed.set()
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task_timeout)
+        monkeypatch.setattr(utils_module, "write_benchmark_log_event", _blocked_write)
+        monkeypatch.setattr(utils_module, "_CLOUDWATCH_LOG_FLUSH_TIMEOUT_SECONDS", 0.01)
+        process_task = asyncio.create_task(
+            run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+        )
+
+        try:
+            assert await asyncio.to_thread(write_started.wait, 1)
+
+            if cancel_during_flush:
+                process_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(process_task, timeout=1)
+            else:
+                result = await asyncio.wait_for(process_task, timeout=1)
+                assert result == {"task_0": None}
+            assert not write_completed.is_set()
+        finally:
+            release_write.set()
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_process_benchmark_blocks_external_internal_custom_destination(

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -1038,7 +1038,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", create_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
@@ -1119,7 +1119,7 @@ class TestRunRecovery:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
         benchmark_service = request.benchmark_service

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -3,9 +3,11 @@
 Run: uv run pytest tests/unit/utils/test_task_execution_retry.py
 """
 
+import asyncio
+import threading
 from collections.abc import AsyncGenerator, Generator
 from contextlib import asynccontextmanager, contextmanager
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
 from uuid import UUID
 
@@ -32,6 +34,95 @@ from tracker.exceptions import AgentRunFailedError, DependencySetupExhaustedErro
 from tracker.sandbox import DependencySetupMode
 from tracker.types import HarnessConfig
 from tracker.utils import task_execution as task_execution_module
+
+
+async def test_buffered_cloudwatch_write_exposes_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_write(_stream_key: str, _message: str, _runtime: AWSRuntime) -> None:
+        raise RuntimeError("cloudwatch unavailable")
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", fail_write)
+    monkeypatch.setattr(task_execution_module, "_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS", 0)
+    queue = task_execution_module.asyncio.Queue[str]()
+    queue.put_nowait("task output")
+
+    write = task_execution_module.buffer_logs(
+        queue,
+        "benchmark-123:task-456",
+        cast(AWSRuntime, Mock(spec=AWSRuntime)),
+        force_flush=True,
+    )
+
+    assert write is not None
+    with pytest.raises(RuntimeError, match="cloudwatch unavailable"):
+        await write
+
+
+async def test_buffered_cloudwatch_write_retries_the_same_batch(monkeypatch: pytest.MonkeyPatch) -> None:
+    messages: list[str] = []
+
+    def transient_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
+        messages.append(message)
+        if len(messages) == 1:
+            raise RuntimeError("cloudwatch unavailable")
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", transient_write)
+    monkeypatch.setattr(task_execution_module, "_CLOUDWATCH_LOG_WRITE_RETRY_DELAY_SECONDS", 0)
+    queue = task_execution_module.asyncio.Queue[str]()
+    queue.put_nowait("task output")
+
+    write = task_execution_module.buffer_logs(
+        queue,
+        "benchmark-123:task-456",
+        cast(AWSRuntime, Mock(spec=AWSRuntime)),
+        force_flush=True,
+    )
+
+    assert write is not None
+    await write
+    assert messages == ["task output", "task output"]
+
+
+async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
+    first_started = threading.Event()
+    release_first = threading.Event()
+    messages: list[str] = []
+
+    def record_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
+        messages.append(message)
+        if message == "first":
+            first_started.set()
+            assert release_first.wait(timeout=2)
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", record_write)
+    runtime = cast(AWSRuntime, Mock(spec=AWSRuntime))
+
+    first_queue = task_execution_module.asyncio.Queue[str]()
+    first_queue.put_nowait("first")
+    first_write = task_execution_module.buffer_logs(
+        first_queue,
+        "benchmark-123:task-456",
+        runtime,
+        force_flush=True,
+    )
+    assert first_write is not None
+    assert await asyncio.to_thread(first_started.wait, 2)
+
+    second_queue = task_execution_module.asyncio.Queue[str]()
+    second_queue.put_nowait("second")
+    second_write = task_execution_module.buffer_logs(
+        second_queue,
+        "benchmark-123:task-456",
+        runtime,
+        force_flush=True,
+        previous_write=first_write,
+    )
+    assert second_write is not None
+    await asyncio.sleep(0.05)
+    assert messages == ["first"]
+
+    release_first.set()
+    await asyncio.gather(first_write, second_write)
+    assert messages == ["first", "second"]
 
 
 class TestTaskExecutionRetry:
@@ -143,7 +234,7 @@ class TestTaskExecutionRetry:
         is_run_agent_target = fail_target == "tracker.utils.task_execution.run_agent"
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(fail_target, _fails_first_run_agent if is_run_agent_target else _fails_first_other)
         if not is_run_agent_target:
@@ -207,7 +298,7 @@ class TestTaskExecutionRetry:
         )
         monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
 
         sandbox_entry_count = 0
         retrieve_task_call_count = 0
@@ -303,7 +394,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(task_execution_module, "create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr(task_execution_module, "run_agent", _mock_run_agent)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
@@ -366,7 +457,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
 
@@ -405,7 +496,7 @@ class TestTaskExecutionRetry:
         capture_exception = Mock()
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module, "buffer_logs", Mock(return_value=None))
         monkeypatch.setattr(task_execution_module.sentry_sdk, "capture_exception", capture_exception)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _failed_policy_lookup)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _lost_grading_sandbox, raising=False)
@@ -495,7 +586,7 @@ class TestTaskExecutionRetry:
 
         monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
-        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock(return_value=None))
         monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
         monkeypatch.setattr("tracker.utils.task_execution.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.task_execution.run_agent", _mock_run_agent)

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -6,6 +6,7 @@ Run: uv run pytest tests/unit/utils/test_task_execution_retry.py
 import asyncio
 import threading
 from collections.abc import AsyncGenerator, Generator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock
@@ -82,9 +83,47 @@ async def test_buffered_cloudwatch_write_retries_the_same_batch(monkeypatch: pyt
     assert messages == ["task output", "task output"]
 
 
+async def test_buffered_cloudwatch_write_does_not_wait_for_default_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    default_worker_started = threading.Event()
+    release_default_worker = threading.Event()
+
+    def block_default_worker() -> None:
+        default_worker_started.set()
+        assert release_default_worker.wait(timeout=2)
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", Mock())
+    loop = asyncio.get_running_loop()
+    default_executor = ThreadPoolExecutor(max_workers=1)
+    loop.set_default_executor(default_executor)
+    blocked_work = loop.run_in_executor(None, block_default_worker)
+
+    try:
+        while not default_worker_started.is_set():
+            await asyncio.sleep(0)
+        queue = task_execution_module.asyncio.Queue[str]()
+        queue.put_nowait("task output")
+
+        write = task_execution_module.buffer_logs(
+            queue,
+            "benchmark-123:task-456",
+            cast(AWSRuntime, Mock(spec=AWSRuntime)),
+            force_flush=True,
+        )
+
+        assert write is not None
+        await asyncio.wait_for(write, timeout=0.5)
+    finally:
+        release_default_worker.set()
+        await blocked_work
+        default_executor.shutdown(wait=True)
+
+
 async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.MonkeyPatch) -> None:
     first_started = threading.Event()
     release_first = threading.Event()
+    second_waiting = asyncio.Event()
     messages: list[str] = []
 
     def record_write(_stream_key: str, message: str, _runtime: AWSRuntime) -> None:
@@ -107,6 +146,15 @@ async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.Monke
     assert first_write is not None
     assert await asyncio.to_thread(first_started.wait, 2)
 
+    original_gather = asyncio.gather
+
+    async def record_ordering_wait(*futures: Any, **kwargs: Any) -> Any:
+        if first_write in futures:
+            second_waiting.set()
+        return await original_gather(*futures, **kwargs)
+
+    monkeypatch.setattr(task_execution_module.asyncio, "gather", record_ordering_wait)
+
     second_queue = task_execution_module.asyncio.Queue[str]()
     second_queue.put_nowait("second")
     second_write = task_execution_module.buffer_logs(
@@ -117,11 +165,11 @@ async def test_buffered_cloudwatch_writes_stay_ordered(monkeypatch: pytest.Monke
         previous_write=first_write,
     )
     assert second_write is not None
-    await asyncio.sleep(0.05)
+    await asyncio.wait_for(second_waiting.wait(), timeout=1)
     assert messages == ["first"]
 
     release_first.set()
-    await asyncio.gather(first_write, second_write)
+    await original_gather(first_write, second_write)
     assert messages == ["first", "second"]
 
 

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -32,6 +32,7 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.exceptions import AgentRunFailedError, DependencySetupExhaustedError, SandboxSetupError
+from tracker.logging import benchmark_id_var
 from tracker.sandbox import DependencySetupMode
 from tracker.types import HarnessConfig
 from tracker.utils import task_execution as task_execution_module
@@ -88,12 +89,16 @@ async def test_buffered_cloudwatch_write_does_not_wait_for_default_executor(
 ) -> None:
     default_worker_started = threading.Event()
     release_default_worker = threading.Event()
+    observed_benchmark_ids: list[str] = []
 
     def block_default_worker() -> None:
         default_worker_started.set()
         assert release_default_worker.wait(timeout=2)
 
-    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", Mock())
+    def record_write_context(*_args: Any, **_kwargs: Any) -> None:
+        observed_benchmark_ids.append(benchmark_id_var.get())
+
+    monkeypatch.setattr(task_execution_module, "write_benchmark_log_event", record_write_context)
     loop = asyncio.get_running_loop()
     default_executor = ThreadPoolExecutor(max_workers=1)
     loop.set_default_executor(default_executor)
@@ -105,15 +110,20 @@ async def test_buffered_cloudwatch_write_does_not_wait_for_default_executor(
         queue = task_execution_module.asyncio.Queue[str]()
         queue.put_nowait("task output")
 
-        write = task_execution_module.buffer_logs(
-            queue,
-            "benchmark-123:task-456",
-            cast(AWSRuntime, Mock(spec=AWSRuntime)),
-            force_flush=True,
-        )
+        benchmark_id_token = benchmark_id_var.set("benchmark-123")
+        try:
+            write = task_execution_module.buffer_logs(
+                queue,
+                "benchmark-123:task-456",
+                cast(AWSRuntime, Mock(spec=AWSRuntime)),
+                force_flush=True,
+            )
+        finally:
+            benchmark_id_var.reset(benchmark_id_token)
 
         assert write is not None
         await asyncio.wait_for(write, timeout=0.5)
+        assert observed_benchmark_ids == ["benchmark-123"]
     finally:
         release_default_worker.set()
         await blocked_work


### PR DESCRIPTION
## Human Description

### Why

<!-- Author: explain why this change is needed. -->

---

Task and agent output is written to CloudWatch without changing the task result when logging fails. Each task attempt now has one ordered write chain. A failed batch retries before later output, oversized UTF-8 output is split within CloudWatch's event limit, and task shutdown waits for the latest write for at most ten seconds.

CloudWatch log-group creation moves into a dedicated background worker so an unavailable logging service cannot prevent a benchmark from starting or occupy Tracker's shared worker pool. Delivery remains best-effort. Each batch gets up to three attempts, but exhausted attempts or the final flush deadline can leave output missing. If CloudWatch accepts an event but the client times out, a retry can create a duplicate.

## Stack

- [#716](https://github.com/vals-ai/Valkyrie/pull/716)
- **[#720](https://github.com/vals-ai/Valkyrie/pull/720) ← this PR**

## What changed

- Create the run log group when the first task-output batch is written instead of during run startup.
- Apply the configured retention policy even when concurrent tasks race to create the same run log group.
- Split output on UTF-8 boundaries so each CloudWatch event stays below AWS's one-megabyte limit.
- Serialize batches per task attempt and retry the same failed batch up to three times before later output proceeds.
- Isolate CloudWatch calls from Tracker's shared worker pool, apply short client timeouts, and cap the final task-output flush at ten seconds.
- Record a correlated error log and Sentry error when a write exhausts its retries before the flush deadline. Record a correlated warning when the task stops waiting at the deadline.

## How to review

Start with `tracker/utils/task_execution.py`, where each task attempt owns its write chain, dedicated CloudWatch worker pool, and bounded final wait. Then review `tracker/aws/cloudwatch_logs.py` for lazy resource creation, retention, and byte-safe event splitting. The writer preserves order while it is active, but delivery is best-effort and not deduplicated.

```mermaid
flowchart LR
    Output[Agent and task output] --> Queue[Per-task buffer]
    Queue --> Writer[Dedicated ordered writer]
    Writer -->|retry same batch| Writer
    Writer --> CloudWatch[CloudWatch task-attempt stream]
    Writer -. failure signal .-> Sentry[Sentry error]
    Writer -. bounded final wait .-> Task[Task completion]
```

## Testing

Not yet live-tested

Design: architectural
