### PR TITLE
fix(infra): treat env-only executor host changes as rolling #patch

### DIFF
--- a/infra/classify_executor_template_change.py
+++ b/infra/classify_executor_template_change.py
@@ -10,7 +10,7 @@ _TASK_PATH_SUFFIX = "/ExecutorHostTaskDef/Resource"
 _SERVICE_PATH_SUFFIX = "/ExecutorHostService/Service"
 _TASK_TYPE = "AWS::ECS::TaskDefinition"
 _TASK_ROLLING_PROPERTIES = frozenset({"Cpu", "Memory"})
-_CONTAINER_ROLLING_KEYS = frozenset({"Environment"})
+_CONTAINER_ROLLING_PROPERTIES = frozenset({"Environment"})
 _SERVICE_TYPE = "AWS::ECS::Service"
 _SERVICE_REDEPLOY_PROPERTIES = frozenset(
     {
@@ -197,51 +197,41 @@ def _resource_identity_changed(base: _HostResource, head: _HostResource) -> bool
     return base.logical_id != head.logical_id or base.resource_type != head.resource_type
 
 
+def _changed_properties(base: Mapping[str, object], head: Mapping[str, object]) -> set[str]:
+    return {key for key in base.keys() | head.keys() if base.get(key) != head.get(key)}
+
+
 def _task_change_requires_maintenance(base: _HostResource, head: _HostResource) -> bool:
-    changed_properties = {
-        key
-        for key in base.properties.keys() | head.properties.keys()
-        if key != "Tags" and base.properties.get(key) != head.properties.get(key)
-    }
-    if "ContainerDefinitions" in changed_properties and _container_change_is_environment_only(
-        base.properties.get("ContainerDefinitions"),
-        head.properties.get("ContainerDefinitions"),
-    ):
-        changed_properties.discard("ContainerDefinitions")
-    return bool(changed_properties - _TASK_ROLLING_PROPERTIES)
+    changed_properties = _changed_properties(base.properties, head.properties) - _TASK_ROLLING_PROPERTIES - {"Tags"}
+    if changed_properties == {"ContainerDefinitions"}:
+        return not _containers_differ_only_in_environment(
+            base.properties.get("ContainerDefinitions"),
+            head.properties.get("ContainerDefinitions"),
+        )
+    return bool(changed_properties)
 
 
-def _container_change_is_environment_only(base: object, head: object) -> bool:
-    """Report whether the same containers differ only in plain environment variables."""
-    if not isinstance(base, list) or not isinstance(head, list):
-        return False
-    base_containers = cast(list[object], base)
-    head_containers = cast(list[object], head)
+def _containers_differ_only_in_environment(base: object, head: object) -> bool:
+    base_containers = _container_definitions(base, revision="base")
+    head_containers = _container_definitions(head, revision="head")
     if len(base_containers) != len(head_containers):
         return False
-    for raw_base_container, raw_head_container in zip(base_containers, head_containers):
-        if not isinstance(raw_base_container, Mapping) or not isinstance(raw_head_container, Mapping):
-            return False
-        base_container = cast(Mapping[str, object], raw_base_container)
-        head_container = cast(Mapping[str, object], raw_head_container)
-        if base_container.get("Name") != head_container.get("Name"):
-            return False
-        changed_keys = {
-            key
-            for key in base_container.keys() | head_container.keys()
-            if base_container.get(key) != head_container.get(key)
-        }
-        if changed_keys - _CONTAINER_ROLLING_KEYS:
-            return False
-    return True
+    return all(
+        not _changed_properties(base_container, head_container) - _CONTAINER_ROLLING_PROPERTIES
+        for base_container, head_container in zip(base_containers, head_containers)
+    )
+
+
+def _container_definitions(value: object, *, revision: str) -> list[Mapping[str, object]]:
+    if not isinstance(value, list) or not all(
+        isinstance(container, Mapping) for container in cast(list[object], value)
+    ):
+        raise TemplateClassificationError(f"{revision} ExecutorHost ContainerDefinitions must be a list of objects")
+    return cast(list[Mapping[str, object]], value)
 
 
 def _service_change_reasons(base: _HostResource, head: _HostResource) -> set[str]:
-    changed_properties = {
-        key
-        for key in base.properties.keys() | head.properties.keys()
-        if base.properties.get(key) != head.properties.get(key)
-    }
+    changed_properties = _changed_properties(base.properties, head.properties)
     reasons: set[str] = set()
     for property_name in changed_properties:
         if property_name in _SERVICE_REDEPLOY_PROPERTIES:

--- a/infra/classify_executor_template_change.py
+++ b/infra/classify_executor_template_change.py
@@ -205,15 +205,15 @@ def _task_change_requires_maintenance(base: _HostResource, head: _HostResource) 
     changed_properties = _changed_properties(base.properties, head.properties) - _TASK_ROLLING_PROPERTIES - {"Tags"}
     if changed_properties == {"ContainerDefinitions"}:
         return not _containers_differ_only_in_environment(
-            base.properties.get("ContainerDefinitions"),
-            head.properties.get("ContainerDefinitions"),
+            base.properties["ContainerDefinitions"],
+            head.properties["ContainerDefinitions"],
         )
     return bool(changed_properties)
 
 
 def _containers_differ_only_in_environment(base: object, head: object) -> bool:
-    base_containers = _container_definitions(base, revision="base")
-    head_containers = _container_definitions(head, revision="head")
+    base_containers = _container_definitions(base)
+    head_containers = _container_definitions(head)
     if len(base_containers) != len(head_containers):
         return False
     return all(
@@ -222,11 +222,11 @@ def _containers_differ_only_in_environment(base: object, head: object) -> bool:
     )
 
 
-def _container_definitions(value: object, *, revision: str) -> list[Mapping[str, object]]:
+def _container_definitions(value: object) -> list[Mapping[str, object]]:
     if not isinstance(value, list) or not all(
         isinstance(container, Mapping) for container in cast(list[object], value)
     ):
-        raise TemplateClassificationError(f"{revision} ExecutorHost ContainerDefinitions must be a list of objects")
+        raise TemplateClassificationError("ExecutorHost ContainerDefinitions must be a list of objects")
     return cast(list[Mapping[str, object]], value)
 
 

--- a/infra/classify_executor_template_change.py
+++ b/infra/classify_executor_template_change.py
@@ -10,6 +10,7 @@ _TASK_PATH_SUFFIX = "/ExecutorHostTaskDef/Resource"
 _SERVICE_PATH_SUFFIX = "/ExecutorHostService/Service"
 _TASK_TYPE = "AWS::ECS::TaskDefinition"
 _TASK_ROLLING_PROPERTIES = frozenset({"Cpu", "Memory"})
+_CONTAINER_ROLLING_KEYS = frozenset({"Environment"})
 _SERVICE_TYPE = "AWS::ECS::Service"
 _SERVICE_REDEPLOY_PROPERTIES = frozenset(
     {
@@ -202,7 +203,37 @@ def _task_change_requires_maintenance(base: _HostResource, head: _HostResource) 
         for key in base.properties.keys() | head.properties.keys()
         if key != "Tags" and base.properties.get(key) != head.properties.get(key)
     }
+    if "ContainerDefinitions" in changed_properties and _container_change_is_environment_only(
+        base.properties.get("ContainerDefinitions"),
+        head.properties.get("ContainerDefinitions"),
+    ):
+        changed_properties.discard("ContainerDefinitions")
     return bool(changed_properties - _TASK_ROLLING_PROPERTIES)
+
+
+def _container_change_is_environment_only(base: object, head: object) -> bool:
+    """Report whether the same containers differ only in plain environment variables."""
+    if not isinstance(base, list) or not isinstance(head, list):
+        return False
+    base_containers = cast(list[object], base)
+    head_containers = cast(list[object], head)
+    if len(base_containers) != len(head_containers):
+        return False
+    for raw_base_container, raw_head_container in zip(base_containers, head_containers):
+        if not isinstance(raw_base_container, Mapping) or not isinstance(raw_head_container, Mapping):
+            return False
+        base_container = cast(Mapping[str, object], raw_base_container)
+        head_container = cast(Mapping[str, object], raw_head_container)
+        if base_container.get("Name") != head_container.get("Name"):
+            return False
+        changed_keys = {
+            key
+            for key in base_container.keys() | head_container.keys()
+            if base_container.get(key) != head_container.get(key)
+        }
+        if changed_keys - _CONTAINER_ROLLING_KEYS:
+            return False
+    return True
 
 
 def _service_change_reasons(base: _HostResource, head: _HostResource) -> set[str]:

--- a/infra/tests/test_executor_template_classifier.py
+++ b/infra/tests/test_executor_template_classifier.py
@@ -30,7 +30,14 @@ def _template(
         resources[_TASK_ID] = {
             "Type": "AWS::ECS::TaskDefinition",
             "Properties": {
-                "ContainerDefinitions": [{"Name": "ExecutorHost", "Image": "image:base"}],
+                "ContainerDefinitions": [
+                    {
+                        "Name": "ExecutorHost",
+                        "Image": "image:base",
+                        "Environment": [{"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "false"}],
+                        "Secrets": [{"Name": "DATABASE_URL", "ValueFrom": "arn:secret:base"}],
+                    }
+                ],
                 "Cpu": "4096",
                 "Memory": "8192",
                 "NetworkMode": "awsvpc",
@@ -115,6 +122,54 @@ class ExecutorTemplateClassifierTest(unittest.TestCase):
         task_properties = _properties(head, _TASK_ID)
         task_properties["Cpu"] = "8192"
         task_properties["ContainerDefinitions"] = [{"Name": "ExecutorHost", "Image": "image:changed"}]
+
+        effect = self._classify(base, head)
+
+        self.assertTrue(effect.redeploy_required)
+        self.assertEqual(effect.reasons, ("executor-host-task-definition-changed",))
+
+    def test_container_environment_only_change_does_not_require_maintenance(self) -> None:
+        base = _template()
+        head = copy.deepcopy(base)
+        containers = _properties(head, _TASK_ID)["ContainerDefinitions"]
+        assert isinstance(containers, list)
+        container = cast(dict[str, object], containers[0])
+        container["Environment"] = [
+            {"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "true"},
+            {"Name": "AWS_DEPLOYMENT_ROLE_ORG_IDS", "Value": "org"},
+        ]
+
+        effect = self._classify(base, head)
+
+        self.assertFalse(effect.redeploy_required)
+        self.assertEqual(effect.reasons, ())
+
+    def test_container_change_beyond_environment_requires_maintenance(self) -> None:
+        for key, value in (
+            ("Image", "image:changed"),
+            ("Secrets", [{"Name": "DATABASE_URL", "ValueFrom": "arn:secret:changed"}]),
+            ("Name", "RenamedExecutorHost"),
+        ):
+            with self.subTest(key=key):
+                base = _template()
+                head = copy.deepcopy(base)
+                containers = _properties(head, _TASK_ID)["ContainerDefinitions"]
+                assert isinstance(containers, list)
+                container = cast(dict[str, object], containers[0])
+                container["Environment"] = [{"Name": "AWS_MANAGED_SUBMISSIONS_ENABLED", "Value": "true"}]
+                container[key] = value
+
+                effect = self._classify(base, head)
+
+                self.assertTrue(effect.redeploy_required)
+                self.assertEqual(effect.reasons, ("executor-host-task-definition-changed",))
+
+    def test_added_container_requires_maintenance(self) -> None:
+        base = _template()
+        head = copy.deepcopy(base)
+        containers = _properties(head, _TASK_ID)["ContainerDefinitions"]
+        assert isinstance(containers, list)
+        cast(list[object], containers).append({"Name": "Sidecar", "Image": "image:sidecar"})
 
         effect = self._classify(base, head)
 

--- a/infra/tests/test_executor_template_classifier.py
+++ b/infra/tests/test_executor_template_classifier.py
@@ -176,6 +176,16 @@ class ExecutorTemplateClassifierTest(unittest.TestCase):
         self.assertTrue(effect.redeploy_required)
         self.assertEqual(effect.reasons, ("executor-host-task-definition-changed",))
 
+    def test_malformed_container_definitions_are_rejected(self) -> None:
+        for containers in ("ExecutorHost", ["ExecutorHost"]):
+            with self.subTest(containers=containers):
+                base = _template()
+                head = copy.deepcopy(base)
+                _properties(head, _TASK_ID)["ContainerDefinitions"] = containers
+
+                with self.assertRaisesRegex(TemplateClassificationError, "ContainerDefinitions"):
+                    self._classify(base, head)
+
     def test_task_definition_tags_do_not_require_redeploy(self) -> None:
         base = _template()
         head = copy.deepcopy(base)


### PR DESCRIPTION
## Summary
`_task_change_requires_maintenance` only allowed `Cpu`/`Memory` (and `Tags`) to change without escalating to `maintenance-required`, so any ExecutorHost task-definition diff — including a single environment variable flip — forced the stop-the-world maintenance path (`begin_maintenance` stops in-progress benchmarks/tasks, fails dispatches, scales services to 0). This narrows that: if the ExecutorHost `ContainerDefinitions` diff is the same containers, same names/order, differing only in `Environment`, it is treated as rolling-safe. Everything else (image, command, secrets, mounts, ports, container add/remove/rename, other task-def properties, resource replacement/removal, service redeploy properties) still requires maintenance.

Motivating case: #721 (`dev` → `prod`) classifies as `maintenance-required` solely because `PROD_CONFIG` gains `submissions_enabled=True`, i.e. `AWS_MANAGED_SUBMISSIONS_ENABLED` false→true on the ExecutorHost container. That flag is read at submission time and has no effect on already-running work, and the host holds ECS task protection while an execution is active, so a rolling replacement drains rather than kills runs.

## Changes
- `infra/classify_executor_template_change.py`: add `_container_change_is_environment_only`; drop `ContainerDefinitions` from the maintenance-forcing set when the only per-container difference is `Environment`.
- `infra/tests/test_executor_template_classifier.py`: fixture container now carries `Environment` + `Secrets`; new cases for env-only (rolling), env+image / env+secrets / rename (maintenance), and added sidecar container (maintenance).

## Related Issues
Follow-up from #721 review discussion.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

No live validation: I did not `cdk synth` the `prod` base and `dev` head templates to diff the real ExecutorHost resources — the env-only conclusion for #721 is read from `stage_config.py`/`runtime_iam.py`, not from synthesized templates. Worth confirming with a synth diff before relying on it for the prod merge.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/99bd69a614e84623acaa59f6edcb9b11
Requested by: @BradenBug