### PR TITLE
Allow managed model gateway secrets

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -129,6 +129,7 @@ configure_logging()
 configure_observability("valkyrie-tracker", environment=ENVIRONMENT)
 
 logger = get_logger(__name__)
+MANAGED_SECRET_KEYS = {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"}
 
 
 def _operation_id(route: APIRoute) -> str:
@@ -318,7 +319,8 @@ async def start_benchmark(
     else:
         if run_starter.user_id is None:
             raise HTTPException(status_code=400, detail="The personal API key must be linked to a user")
-        if body.contract.secrets or body.service_auth_secret_name or body.webhook_secret_name:
+        has_secret_refs = set(body.contract.secrets) - MANAGED_SECRET_KEYS
+        if has_secret_refs or body.service_auth_secret_name or body.webhook_secret_name:
             raise HTTPException(status_code=400, detail="Managed runtime does not accept AWS secret references")
         if body.custom_benchmark_service:
             raise HTTPException(status_code=400, detail="Managed runtime does not accept custom benchmark services")
@@ -351,7 +353,7 @@ async def start_benchmark(
 
     if not request.contract.install_cmd and not request.contract.run_cmd:
         request = request.model_copy(update={"contract": await _resolve_contract_from_s3(request)})
-    if not isinstance(runtime, LegacyRuntime) and request.contract.secrets:
+    if not isinstance(runtime, LegacyRuntime) and set(request.contract.secrets) - MANAGED_SECRET_KEYS:
         raise HTTPException(status_code=400, detail="Managed runtime does not accept AWS secret references")
 
     logger.info(f"Starting benchmark run - contract: {request.contract.name}, benchmark: {request.benchmark_name}")

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -59,6 +59,7 @@ from tracker.utils.resources import fetch_benchmark_row, fetch_task_row
 logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
+MANAGED_SECRET_KEYS = {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"}
 
 
 class TrackedTaskStatus(str, Enum):
@@ -408,7 +409,7 @@ async def process_task(
             identity["email"] = benchmark_started_by_email
 
         if isinstance(harness_config.aws, TaskRoleAWSConfig):
-            if start_benchmark_request.contract.secrets:
+            if set(start_benchmark_request.contract.secrets) - MANAGED_SECRET_KEYS:
                 raise TrackerServiceError("Managed runtime does not accept AWS secret references")
             if benchmark_started_by_id is None:
                 raise TrackerServiceError("Managed run is missing its starter identity")

--- a/services/tracker/tests/unit/test_fastapi_server.py
+++ b/services/tracker/tests/unit/test_fastapi_server.py
@@ -212,6 +212,14 @@ class TestFastapiServer:
         monkeypatch.setattr("main.copy_agent_to_benchmark", copy_agent)
         monkeypatch.setattr("main.process_benchmark.kicker", lambda: _MockKicker())
 
+        contract = contract.model_copy(
+            update={
+                "secrets": {
+                    "MODEL_GATEWAY_URL": "devModelGatewayClientConfig",
+                    "MODEL_GATEWAY_API_KEY": "devModelGatewayClientConfig",
+                }
+            }
+        )
         response = client.post(
             "/start-benchmark",
             json={

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -49,6 +49,7 @@ _REQUIRED_CONFIG_KEYS = {
     "AWS_DEFAULT_REGION",
     "S3_BUCKET",
 }
+_MANAGED_SECRET_KEYS = {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"}
 _PROVIDER_SETUP_COMMAND = "valkyrie config provider set <provider> <secret-name>"
 
 
@@ -459,7 +460,7 @@ class TrackerService:
             TrackerServiceError: If start run fails
         """
         try:
-            if self._api_key and (contract.secrets or webhook_secret_name):
+            if self._api_key and ((set(contract.secrets) - _MANAGED_SECRET_KEYS) or webhook_secret_name):
                 raise TrackerServiceError("Hosted mode does not accept AWS secret references")
 
             provider_name, provider_secret_name = self.resolve_sandbox_provider(provider)

--- a/tests/unit/test_tracker_client.py
+++ b/tests/unit/test_tracker_client.py
@@ -105,7 +105,15 @@ def test_hosted_start_uses_managed_payload_and_legacy_headers_only_for_existing_
 
     tracker = TrackerService(base_url="http://tracker")
     tracker.start_benchmark(
-        contract=AgentContractRequest(name="agent", install_cmd="echo install", run_cmd="echo run"),
+        contract=AgentContractRequest(
+            name="agent",
+            install_cmd="echo install",
+            run_cmd="echo run",
+            secrets={
+                "MODEL_GATEWAY_URL": "devModelGatewayClientConfig",
+                "MODEL_GATEWAY_API_KEY": "devModelGatewayClientConfig",
+            },
+        ),
         benchmark_name="swebench",
         concurrency=1,
         ignore_custom_services=False,


### PR DESCRIPTION
Allow managed runs to accept contracts that declare only MODEL_GATEWAY_URL and MODEL_GATEWAY_API_KEY.\n\nManaged runtime still rejects arbitrary AWS secret references. The tracker ignores these model gateway secret refs and injects signed managed gateway values instead.\n\nValidation:\n- uv run --project /home/ec2-user/worktrees/valkyrie-managed-runtime --no-sync ruff check src/valkyrie/cli/tracker_client.py services/tracker/main.py services/tracker/src/tracker/utils/task_execution.py services/tracker/tests/unit/test_fastapi_server.py tests/unit/test_tracker_client.py\n- uv run --project /home/ec2-user/worktrees/valkyrie-managed-runtime --no-sync pytest -q services/tracker/tests/unit/test_fastapi_server.py services/tracker/tests/unit/test_process_task_env.py tests/unit/test_tracker_client.py
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/727" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->