### PR TITLE
fix(cli): defer managed agent resolution to Tracker

### DIFF
--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -369,9 +369,6 @@ def start(
                     kwargs={key: str(value) for key, value in agent_config.kwargs.items()},
                 )
         elif managed_execution:
-            # Tracker must rebuild hosted contracts from the frozen S3 bundle
-            # before their model and variant can be marked trusted. Sending a
-            # caller-expanded run command would correctly clear attestation.
             contract = AgentContractRequest(
                 name=agent,
                 model=agent_config.model,

--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import click
 from tracker.agent.contract import get_contract
 from tracker.agent.schemas import AgentConfig
+from tracker.database.models import AgentContractRequest
 from tracker.types import StartBenchmarkResponse
 
 from valkyrie.cli.exceptions import BundlerError, ContractValidationError, TrackerServiceError
@@ -345,6 +346,7 @@ def start(
 
         config_kwargs["kwargs"] = {key: value for key, value in kwargs}
         agent_config = AgentConfig(**config_kwargs)
+        managed_execution = not TrackerService.parse_config_keys()
 
         agent_path = Path(agent)
 
@@ -360,6 +362,21 @@ def start(
             )
             contract = get_contract(contract_file, agent_config)
             asyncio.run(push_agent(contract.name, agent_path))
+            if managed_execution:
+                contract = AgentContractRequest(
+                    name=contract.name,
+                    model=agent_config.model,
+                    kwargs={key: str(value) for key, value in agent_config.kwargs.items()},
+                )
+        elif managed_execution:
+            # Tracker must rebuild hosted contracts from the frozen S3 bundle
+            # before their model and variant can be marked trusted. Sending a
+            # caller-expanded run command would correctly clear attestation.
+            contract = AgentContractRequest(
+                name=agent,
+                model=agent_config.model,
+                kwargs={key: str(value) for key, value in agent_config.kwargs.items()},
+            )
         else:
             contract = asyncio.run(get_contract_from_s3(agent, agent_config))
             contract.name = agent

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -283,6 +283,54 @@ class TestCountedStarts:
             kwargs={"variant": "max"},
         )
 
+    def test_managed_local_start_uploads_then_sends_name_only_contract(
+        self,
+        start_testbed: StartTestbed,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        local_agent = tmp_path / "local-agent"
+        local_agent.mkdir()
+        (local_agent / "contract.yaml").write_text(
+            "name: local-agent\n",
+            encoding="utf-8",
+        )
+        get_contract = MagicMock(
+            return_value=AgentContractRequest(
+                name="local-agent",
+                install_cmd="echo install",
+                run_cmd="echo run",
+            )
+        )
+        push_agent = AsyncMock()
+        monkeypatch.setattr(start_module, "get_contract", get_contract)
+        monkeypatch.setattr(start_module, "push_agent", push_agent)
+        start_testbed.tracker_factory.parse_config_keys.return_value = {}
+
+        result = start_testbed.cli_runner.invoke(
+            start_command,
+            [
+                "--agent",
+                str(local_agent),
+                "--benchmark",
+                "swebench",
+                "--model",
+                "anthropic/claude-opus-5",
+                "-k",
+                "variant",
+                "max",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        push_agent.assert_awaited_once_with("local-agent", local_agent)
+        contract = start_testbed.tracker.start_benchmark.call_args.args[0]
+        assert contract == AgentContractRequest(
+            name="local-agent",
+            model="anthropic/claude-opus-5",
+            kwargs={"variant": "max"},
+        )
+
     def test_invalid_options_precede_side_effects(self, start_testbed: StartTestbed) -> None:
         """
         Reject invalid start options before resolving configuration or agents.

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -57,6 +57,7 @@ class StartTestbed:
         self.tracker.__enter__.return_value = self.tracker
         self.tracker_factory = MagicMock(return_value=self.tracker)
         self.tracker_factory.validate_sandbox_provider.return_value = ("daytona", "DaytonaSecrets")
+        self.tracker_factory.parse_config_keys.return_value = {"AWS_ACCESS_KEY_ID": "key"}
         self.tracker_factory.get_webhook_secret.return_value = None
         self.resolve_remote = AsyncMock(
             return_value=AgentContractRequest(name="remote-agent", install_cmd="echo install", run_cmd="echo run")
@@ -264,6 +265,23 @@ class TestCountedStarts:
         get_contract.assert_called_once()
         push_agent.assert_awaited_once_with("local-agent", local_agent)
         assert start_testbed.tracker.start_benchmark.call_count == 2
+
+    def test_managed_start_defers_contract_resolution_to_tracker(
+        self,
+        start_testbed: StartTestbed,
+    ) -> None:
+        start_testbed.tracker_factory.parse_config_keys.return_value = {}
+
+        result = start_testbed.invoke(["--model", "anthropic/claude-opus-5", "-k", "variant", "max"])
+
+        assert result.exit_code == 0, result.output
+        start_testbed.resolve_remote.assert_not_awaited()
+        contract = start_testbed.tracker.start_benchmark.call_args.args[0]
+        assert contract == AgentContractRequest(
+            name="remote-agent",
+            model="anthropic/claude-opus-5",
+            kwargs={"variant": "max"},
+        )
 
     def test_invalid_options_precede_side_effects(self, start_testbed: StartTestbed) -> None:
         """

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -117,6 +117,10 @@ class MockTrackerService:
         self.require_config_values.append(require_config)
 
     @staticmethod
+    def parse_config_keys() -> dict[str, str]:
+        return {"AWS_ACCESS_KEY_ID": "key"}
+
+    @staticmethod
     def benchmark_service_health(
         name: str,
         url: str,


### PR DESCRIPTION
## Summary

- send name-only agent contracts for managed Tracker execution
- let Tracker resolve the frozen Agent Registry bundle and attest model/variant
- preserve existing client-side resolution for static-key deployments

## Live reproduction

After benchmark-services-registry #749 deployed and `opencode_thinking` was republished, dev run `5b823ebf-c493-4786-8806-acb6886d7a10` reached KSP but failed closed with `hosted KSP setup requires tracker-owned VALKYRIE_AGENT_MODEL and VALKYRIE_AGENT_VARIANT`. The CLI had expanded the contract before submitting it, causing Tracker to correctly clear caller-provided attestation instead of resolving the frozen bundle itself.

## Validation

- 215 CLI tests passed in the sandbox
- loopback subprocess test passed separately
- focused start/tracker slice: 130 passed
- Ruff check and format check passed
- basedpyright: 0 errors, 0 warnings
- git diff --check passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/728" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->