### PR TITLE
fix: clarify legacy s3 access denial #patch

### DIFF
--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -60,6 +60,7 @@ from tracker.aws.s3 import (
     download_many_from_s3,
     get_benchmark_contract_s3_key,
     get_contract_s3_key,
+    is_s3_access_denied,
     list_s3_objects,
     s3_object_exists,
 )
@@ -95,7 +96,7 @@ from tracker.database.session import check_database_connection, get_session
 from tracker.docent_analysis import (
     analyze_event_stream,
 )
-from tracker.exceptions import TrackerServiceError
+from tracker.exceptions import S3Error, TrackerServiceError
 from executor_protocol import EXECUTOR_TASK_NAME, ExecutorTelemetryContext, executor_task_signature
 from tracker.logging import configure_logging, get_logger, request_id_var
 from tracker.executor.release_control import MaintenanceModeError, ReleaseControlError, lock_executor_admission
@@ -1447,7 +1448,18 @@ async def fetch_run_outputs(
 
     # Peek a single key so an empty result still returns 404 before the stream starts.
     keys = _output_keys(benchmark_prefix, task_ids, aws_runtime, benchmark_id)
-    first_key = await anext(keys, None)
+    try:
+        first_key = await anext(keys, None)
+    except S3Error as exc:
+        if not run_context.benchmark.aws_managed and is_s3_access_denied(exc):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "The AWS credentials supplied for this run cannot access its S3 bucket. "
+                    "Check the run's AWS configuration and permissions, then try again."
+                ),
+            ) from exc
+        raise
     if first_key is None:
         raise HTTPException(status_code=404, detail=f"No outputs found for run '{benchmark_id}'")
 

--- a/services/tracker/src/tracker/aws/s3.py
+++ b/services/tracker/src/tracker/aws/s3.py
@@ -48,6 +48,14 @@ def get_agent_result_s3_key(benchmark_id: str, task_id: str, output_name: str) -
     return f"{S3_BENCHMARKS_PREFIX}/{benchmark_id}/{task_id}/{output_name}"
 
 
+def is_s3_access_denied(error: S3Error) -> bool:
+    """Return whether an S3 operation failed because AWS denied access."""
+    cause = error.__cause__
+    if not isinstance(cause, ClientError):
+        return False
+    return cause.response.get("Error", {}).get("Code") in {"AccessDenied", "AccessDeniedException"}
+
+
 def handle_s3_error(message: str) -> Callable[[Callable[_P, Awaitable[_R]]], Callable[_P, Coroutine[Any, Any, _R]]]:
     """Wrap AWS errors raised by an async S3 helper as S3Error."""
 

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -20,6 +20,7 @@ from benchmark_service.client import (
     BenchmarkServiceUnauthenticatedError,
 )
 from benchmark_service.schemas import FinalScoreResponse, VerifyTaskIdsResponse
+from botocore.exceptions import ClientError
 from dateutil.parser import isoparse
 from descope.descope_client import DescopeClient
 from fastapi import HTTPException
@@ -56,7 +57,7 @@ from tracker.database.models import (
     TaskStatus,
 )
 from tracker.config import STABLE_QUEUE_NAME
-from tracker.exceptions import TrackerServiceError
+from tracker.exceptions import S3Error, TrackerServiceError
 from tracker.types import (
     BenchmarkTableRow,
     FetchBenchmarksRequest,
@@ -2226,6 +2227,60 @@ class TestTrackerAPI:
 
         assert response.status_code == 404
         assert response.json() == {"detail": f"No outputs found for run '{example_benchmark_object.id}'"}
+
+    @pytest.mark.parametrize(
+        ("aws_managed", "expected_status", "expected_detail"),
+        [
+            pytest.param(
+                False,
+                403,
+                (
+                    "The AWS credentials supplied for this run cannot access its S3 bucket. "
+                    "Check the run's AWS configuration and permissions, then try again."
+                ),
+                id="access-key",
+            ),
+            pytest.param(True, 500, "Tracker service operation failed", id="managed"),
+        ],
+    )
+    async def test_fetch_run_outputs_classifies_s3_access_denied_by_aws_mode(
+        self,
+        monkeypatch: MonkeyPatch,
+        database_session: Session,
+        example_benchmark_object: Benchmark,
+        harness_headers: dict[str, str],
+        aws_managed: bool,
+        expected_status: int,
+        expected_detail: str,
+    ) -> None:
+        example_benchmark_object.aws_managed = aws_managed
+        database_session.add(example_benchmark_object)
+        database_session.commit()
+
+        if aws_managed:
+            monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_ROLE_ORG_IDS", str(TEST_ORG_ID))
+            monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_REGION", "deployment-region")
+            monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_S3_BUCKET", "deployment-bucket")
+            monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_LOG_GROUP", "deployment-log-group")
+            monkeypatch.setattr("tracker.config.AWS_DEPLOYMENT_LOG_RETENTION_DAYS", "30")
+
+        async def _denied_list_s3_objects(*_args: Any, **_kwargs: Any) -> AsyncIterator[str]:
+            client_error = ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "ListObjectsV2",
+            )
+            raise S3Error("Failed to list objects from S3") from client_error
+            yield
+
+        monkeypatch.setattr("main.list_s3_objects", _denied_list_s3_objects)
+
+        response = client.get(
+            f"/fetch-run-outputs/{example_benchmark_object.id}",
+            headers={} if aws_managed else harness_headers,
+        )
+
+        assert response.status_code == expected_status
+        assert response.json() == {"detail": expected_detail}
 
     async def test_benchmark_service_unauthenticated_error_returns(
         self,


### PR DESCRIPTION
## Human Description

### Why

<!-- Add the human-authored reason before requesting review. -->

---

When caller-provided AWS credentials cannot list a run S3 bucket, Tracker currently reports a generic server failure. Access-key output downloads now return a clear `403` that identifies the AWS configuration or permission problem. Managed-role denials remain server errors so production IAM failures still alert.

## Testing

Not yet live-tested.

Design: not architectural (refines one existing access-key error response without changing AWS authority selection)