### PR TITLE
#minor: Prod deploy 08/21/2026

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@ services/*
 !services/executor_host/
 services/executor_host/*
 !services/executor_host/Dockerfile
+!services/executor_host/__init__.py
+!services/executor_host/observability.py
 !services/executor_host/requirements.txt
 !services/executor_host/supervisor.py
 !services/tracker/

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -216,6 +216,7 @@ jobs:
           DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
         working-directory: infra
         run: >-
           make deploy
@@ -255,6 +256,7 @@ jobs:
       PRODUCTION_ACCOUNT_ID: "613431292675"
       SCOPE: ${{ github.event_name == 'push' && 'core' || inputs.scope }}
       SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+      SENTRY_RELEASE: ${{ github.sha }}
 
     steps:
       - name: Validate dev configuration
@@ -270,6 +272,10 @@ jobs:
           fi
           if [[ "$OPERATION" != "credentials-only" && -z "$DESCOPE_MANAGEMENT_KEY_SECRET_NAME" ]]; then
             echo "::error::The dev Environment must define DESCOPE_MANAGEMENT_KEY_SECRET_NAME before planning or deploying."
+            exit 1
+          fi
+          if [[ "$OPERATION" != "credentials-only" && -z "$SENTRY_DSN_SECRET_NAME" ]]; then
+            echo "::error::The dev Environment must define SENTRY_DSN_SECRET_NAME before planning or deploying."
             exit 1
           fi
           if [[ "$OPERATION" != "credentials-only" && ( -z "$AWS_DEPLOYMENT_ROLE_ORG_IDS" || -z "$AWS_TRACKER_SECRET_NAME_PREFIXES" ) ]]; then
@@ -709,6 +715,7 @@ jobs:
           DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
           DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
         working-directory: infra
         run: make deploy STAGE=prod SCOPE=core AWS_REGION="$AWS_REGION"
 

--- a/.github/workflows/executor-build.yaml
+++ b/.github/workflows/executor-build.yaml
@@ -12,6 +12,7 @@ on:
       - "services/executor_artifact/**"
       - "services/executor_host/**"
       - "services/tracker/**"
+      - "tests/integration/observability/**"
       - "tests/unit/executor_host/**"
   # Runs on every PR so the required check is always reported; the guard below
   # skips the (slow) build when the PR does not touch executor-related paths.
@@ -44,7 +45,7 @@ jobs:
             echo "Could not compute the PR diff; running the build to be safe."
             echo "relevant=true" >> "$GITHUB_OUTPUT"; exit 0
           fi
-          if printf '%s\n' "$changed" | grep -qE '^(\.dockerignore|\.github/workflows/(executor-build|deploy)\.yaml|infra/(executor_stack|tracker_stack)\.py|services/(executor_artifact|executor_host|tracker)/|tests/unit/executor_host/)'; then
+          if printf '%s\n' "$changed" | grep -qE '^(\.dockerignore|\.github/workflows/(executor-build|deploy)\.yaml|infra/(executor_stack|tracker_stack)\.py|services/(executor_artifact|executor_host|tracker)/|tests/(integration/observability|unit/executor_host)/)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"
           else
             echo "No executor-related changes; skipping build."
@@ -87,9 +88,9 @@ jobs:
         if: steps.rel.outputs.relevant == 'true'
         run: uv sync --frozen
 
-      - name: Run executor support unit tests
+      - name: Run executor support tests
         if: steps.rel.outputs.relevant == 'true'
-        run: uv run pytest tests/unit/executor_host services/executor_artifact/tests
+        run: uv run pytest tests/unit/executor_host tests/integration/observability services/executor_artifact/tests
 
       - name: Build and inspect immutable executor PEX
         if: steps.rel.outputs.relevant == 'true'

--- a/infra/README.md
+++ b/infra/README.md
@@ -45,14 +45,17 @@ values:
 The ExecutorHost task roles can read every Secrets Manager secret in their own
 account and Region. Release-test does not receive this access.
 
-To enable Sentry in dev, also set the `SENTRY_DSN_SECRET_NAME` secret to the
-name of an account-local Secrets Manager secret containing the DSN. Production
-requires `SENTRY_DSN_SECRET_NAME`, and `DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
+Dev and production require `SENTRY_DSN_SECRET_NAME` to name an account-local
+Secrets Manager secret containing the DSN. Production also requires
+`DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
 whenever `AUTH_REQUIRED` is `true`. The dev Environment holds every dev
 deployment input as an Environment secret except `AWS_REGION`, which stays a
 variable. Production reads its managed AWS inventory from the `prod`
 Environment and retains the existing repository-level deployment secrets. The
 `SANDBOX_CLEANUP_ENABLED` and `SANDBOX_CLEANUP_PROVIDER` toggles stay variables.
+The Sentry DSN is injected into both Tracker and ExecutorHost. The host
+propagates each run's trace and request context into its immutable executor
+artifact.
 
 Before production activation, configure the protected `prod` GitHub
 Environment with `AWS_DEPLOYMENT_ROLE_ORG_IDS` and

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -23,7 +23,7 @@ from aws_cdk import (
     aws_sqs,
     aws_ssm,
 )
-from aws_cdk.aws_ecr_assets import Platform
+from aws_cdk.aws_ecr_assets import DockerImageAsset, Platform
 from constants import (
     DOCKER_ASSET_EXCLUDES,
     EXECUTOR_HOST_LOG_GROUP_NAME,
@@ -108,14 +108,19 @@ class ExecutorStack(Stack):
                     "Release-test ExecutorStack requires an executor-host repository and immutable image tag"
                 )
             executor_host_image = aws_ecs.ContainerImage.from_ecr_repository(executor_host_repository, image_tag)
+            executor_host_release = image_tag
         else:
-            executor_host_image = aws_ecs.ContainerImage.from_asset(
-                "..",
+            executor_host_asset = DockerImageAsset(
+                self,
+                "ExecutorHostImageAsset",
+                directory="..",
                 file="services/executor_host/Dockerfile",
                 platform=Platform.LINUX_ARM64,
                 exclude=list(DOCKER_ASSET_EXCLUDES),
                 ignore_mode=cdk.IgnoreMode.DOCKER,
             )
+            executor_host_image = aws_ecs.ContainerImage.from_docker_image_asset(executor_host_asset)
+            executor_host_release = executor_host_asset.asset_hash
 
         benchmark_service_url = benchmark_service_base_url(stage)
         bucket = aws_s3.Bucket.from_bucket_name(self, "ManagedRuntimeBucket", bucket_name)
@@ -140,6 +145,19 @@ class ExecutorStack(Stack):
             "DB_USERNAME": aws_ecs.Secret.from_secrets_manager(db_credentials_secret, field="username"),
             "DB_PASSWORD": aws_ecs.Secret.from_secrets_manager(db_credentials_secret, field="password"),
         }
+
+        sentry_secret_name = os.environ.get("SENTRY_DSN_SECRET_NAME", "")
+        if not stage.is_release_test and not sentry_secret_name:
+            raise ValueError("Dev and production deployments require SENTRY_DSN_SECRET_NAME.")
+
+        sentry_secrets: dict[str, aws_ecs.Secret] = {}
+        if sentry_secret_name:
+            sentry_secret = aws_secretsmanager.Secret.from_secret_name_v2(
+                self,
+                "ExecutorSentryDsnSecret",
+                sentry_secret_name,
+            )
+            sentry_secrets["SENTRY_DSN"] = aws_ecs.Secret.from_secrets_manager(sentry_secret)
 
         aws_logs.LogGroup(
             self,
@@ -180,8 +198,9 @@ class ExecutorStack(Stack):
                 "STABLE_QUEUE_NAME": "valkyrie-stable",
                 "EXECUTOR_RELEASE_BUCKET": self.executor_release_bucket.bucket_name,
                 "EXECUTOR_RELEASE_PREFIX": EXECUTOR_RELEASE_PREFIX,
+                "SENTRY_RELEASE": f"executor-host@{executor_host_release}",
             },
-            secrets=db_secrets,
+            secrets={**db_secrets, **sentry_secrets},
             stop_timeout=Duration.seconds(WORKER_STOP_TIMEOUT_SECONDS),
         )
         self.executor_task_role.add_to_policy(

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -108,6 +108,7 @@ PROD_CONFIG = StageConfig(
         benchmark_log_retention_days=365,
         submissions_enabled=True,
         executor_all_secret_access=True,
+        executor_lambda_function_name_patterns=("vals-format-lambda",),
     ),
 )
 
@@ -127,6 +128,7 @@ DEV_CONFIG = StageConfig(
         benchmark_log_retention_days=7,
         submissions_enabled=True,
         executor_all_secret_access=True,
+        executor_lambda_function_name_patterns=("vals-format-lambda",),
     ),
 )
 

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -1,4 +1,7 @@
-"""Tests for deployment workflow contracts."""
+"""Tests for deployment workflow contracts.
+
+Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_deploy_workflow.py
+"""
 
 import unittest
 from pathlib import Path
@@ -387,7 +390,13 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn('"services/tracker/**"', workflow)
         self.assertIn('".dockerignore"', workflow)
         self.assertIn("PYTHONPATH=services/tracker/src python services/executor_artifact/build.py", workflow)
-        self.assertIn("uv run pytest tests/unit/executor_host services/executor_artifact/tests", workflow)
+        self.assertIn("uv run pytest", workflow)
+        for test_path in (
+            "tests/unit/executor_host",
+            "tests/integration/observability",
+            "services/executor_artifact/tests",
+        ):
+            self.assertIn(test_path, workflow)
         self.assertIn(
             "docker build --platform linux/arm64 -t valkyrie-tracker:ci services/tracker",
             workflow,

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -1,4 +1,7 @@
-"""Tests for the development account infrastructure boundary."""
+"""Tests for the development account infrastructure boundary.
+
+Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_dev_account.py
+"""
 
 import json
 import os
@@ -62,11 +65,13 @@ DEV_TRACKER_CONTRACT_PARAMETERS = {
 }
 EXECUTOR_CONTRACT_PARAMETERS = {executor_release_launch_parameter(DEV)}
 DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
+SENTRY_DSN_SECRET_NAME = "example/sentry-dsn"
 DEV_AUTH_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": "00000000-0000-0000-0000-000000000001",
     "AWS_TRACKER_SECRET_NAME_PREFIXES": "test-tracker-secret",
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
+    "SENTRY_DSN_SECRET_NAME": SENTRY_DSN_SECRET_NAME,
 }
 
 
@@ -87,36 +92,37 @@ def dev_shared_stack() -> tuple[cdk.App, SharedStack]:
 
 
 def dev_service_templates() -> tuple[assertions.Template, assertions.Template]:
-    app, shared = dev_shared_stack()
-    stage = Stage(DEV)
-    tracker = TrackerStack(
-        app,
-        stage.stack_id("TrackerStack"),
-        stage=stage,
-        vpc=shared.vpc,
-        cluster=shared.cluster,
-        namespace=shared.namespace,
-        hosted_zone=shared.hosted_zone,
-        bucket_name=shared.bucket_name,
-        redis_url=shared.redis_url,
-        redis_security_group=shared.redis_security_group,
-        env=TEST_ENV,
-    )
-    executor = ExecutorStack(
-        app,
-        stage.stack_id("WorkerStack"),
-        stage=stage,
-        vpc=shared.vpc,
-        cluster=shared.cluster,
-        namespace=shared.namespace,
-        redis_url=shared.redis_url,
-        bucket_name=shared.bucket_name,
-        database=tracker.database,
-        db_credentials=tracker.db_credentials,
-        tracker_service=tracker.tracker_fargate_service,
-        tracker_image=tracker.tracker_image,
-        env=TEST_ENV,
-    )
+    with mock.patch.dict(os.environ, {"SENTRY_DSN_SECRET_NAME": SENTRY_DSN_SECRET_NAME}, clear=False):
+        app, shared = dev_shared_stack()
+        stage = Stage(DEV)
+        tracker = TrackerStack(
+            app,
+            stage.stack_id("TrackerStack"),
+            stage=stage,
+            vpc=shared.vpc,
+            cluster=shared.cluster,
+            namespace=shared.namespace,
+            hosted_zone=shared.hosted_zone,
+            bucket_name=shared.bucket_name,
+            redis_url=shared.redis_url,
+            redis_security_group=shared.redis_security_group,
+            env=TEST_ENV,
+        )
+        executor = ExecutorStack(
+            app,
+            stage.stack_id("WorkerStack"),
+            stage=stage,
+            vpc=shared.vpc,
+            cluster=shared.cluster,
+            namespace=shared.namespace,
+            redis_url=shared.redis_url,
+            bucket_name=shared.bucket_name,
+            database=tracker.database,
+            db_credentials=tracker.db_credentials,
+            tracker_service=tracker.tracker_fargate_service,
+            tracker_image=tracker.tracker_image,
+            env=TEST_ENV,
+        )
     return assertions.Template.from_stack(tracker), assertions.Template.from_stack(executor)
 
 
@@ -236,7 +242,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         self.assertNotIn("agents/*", json.dumps(delete_statements[0]["Resource"]))
         self.assertIn(DESCOPE_MANAGEMENT_KEY_SECRET_NAME, rendered)
         self.assertNotIn("/vals/dev/descope/project-id", rendered)
-        self.assertNotIn("SENTRY_DSN", rendered)
+        self.assertIn("SENTRY_DSN", rendered)
         self.assertNotIn("/valkyrie/dev/dns/tracker/certificate-arn", rendered)
         certificates = tracker_template.find_resources("AWS::CertificateManager::Certificate")
         self.assertEqual(len(certificates), 1)

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -1,3 +1,8 @@
+"""Tests for the monitoring stack.
+
+Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_monitoring_stack.py
+"""
+
 import json
 import os
 import unittest
@@ -43,6 +48,7 @@ TEST_DEPLOYMENT_SLACK_ENV = {
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV: "CDEPLOYCHANNEL",
 }
 TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
+TEST_SENTRY_DSN_SECRET_NAME = "example/sentry-dsn"
 TEST_MANAGED_ORG_ID = "00000000-0000-0000-0000-000000000001"
 TEST_TRACKER_SECRET_NAME_PREFIX = "test-tracker-secret"
 TEST_DEV_ENV = {
@@ -50,11 +56,12 @@ TEST_DEV_ENV = {
     "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
     "DESCOPE_PROJECT_ID": "dev-project",
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
+    "SENTRY_DSN_SECRET_NAME": TEST_SENTRY_DSN_SECRET_NAME,
 }
 TEST_PROD_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": TEST_MANAGED_ORG_ID,
     "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
-    "SENTRY_DSN_SECRET_NAME": "example/sentry-dsn",
+    "SENTRY_DSN_SECRET_NAME": TEST_SENTRY_DSN_SECRET_NAME,
 }
 TEST_RELEASE_TEST_ENV = {
     "DESCOPE_PROJECT_ID": "release-test",
@@ -816,21 +823,42 @@ class MonitoringStackTest(unittest.TestCase):
                 },
             )
 
-    def test_dev_sentry_secret_is_optional(self) -> None:
-        with mock.patch.dict(os.environ, TEST_DEV_ENV, clear=True):
-            tracker_template, executor_template, _ = service_templates(DEV)
+    def test_deployed_stages_require_sentry_secret(self) -> None:
+        for stage, environment in ((DEV, TEST_DEV_ENV), (PROD, TEST_PROD_ENV)):
+            environment_without_sentry = {
+                key: value for key, value in environment.items() if key != "SENTRY_DSN_SECRET_NAME"
+            }
+            with self.subTest(stage=stage), mock.patch.dict(os.environ, environment_without_sentry, clear=True):
+                with self.assertRaisesRegex(ValueError, "require SENTRY_DSN_SECRET_NAME"):
+                    service_templates(stage)
 
-        self.assertNotIn("SENTRY_DSN", str(tracker_template.to_json()))
-        self.assertNotIn("SENTRY_DSN", str(executor_template.to_json()))
-
+    def test_dev_sentry_secret_is_injected(self) -> None:
         custom_sentry_secret_name = "custom/dev-sentry-dsn"
         sentry_environment = {
             **TEST_DEV_ENV,
             "SENTRY_DSN_SECRET_NAME": custom_sentry_secret_name,
+            "SENTRY_RELEASE": "deployment-sha",
         }
         with mock.patch.dict(os.environ, sentry_environment, clear=True):
             tracker_template, executor_template, _ = service_templates(DEV)
 
+        for template in (tracker_template, executor_template):
+            template.has_resource_properties(
+                "AWS::ECS::TaskDefinition",
+                {
+                    "ContainerDefinitions": assertions.Match.array_with(
+                        [
+                            assertions.Match.object_like(
+                                {
+                                    "Secrets": assertions.Match.array_with(
+                                        [assertions.Match.object_like({"Name": "SENTRY_DSN"})]
+                                    ),
+                                }
+                            )
+                        ]
+                    )
+                },
+            )
         tracker_template.has_resource_properties(
             "AWS::ECS::TaskDefinition",
             {
@@ -838,8 +866,35 @@ class MonitoringStackTest(unittest.TestCase):
                     [
                         assertions.Match.object_like(
                             {
-                                "Secrets": assertions.Match.array_with(
-                                    [assertions.Match.object_like({"Name": "SENTRY_DSN"})]
+                                "Environment": assertions.Match.array_with(
+                                    [
+                                        assertions.Match.object_like(
+                                            {"Name": "SENTRY_RELEASE", "Value": "deployment-sha"}
+                                        )
+                                    ]
+                                )
+                            }
+                        )
+                    ]
+                )
+            },
+        )
+        executor_template.has_resource_properties(
+            "AWS::ECS::TaskDefinition",
+            {
+                "ContainerDefinitions": assertions.Match.array_with(
+                    [
+                        assertions.Match.object_like(
+                            {
+                                "Environment": assertions.Match.array_with(
+                                    [
+                                        assertions.Match.object_like(
+                                            {
+                                                "Name": "SENTRY_RELEASE",
+                                                "Value": assertions.Match.string_like_regexp("executor-host@.+"),
+                                            }
+                                        )
+                                    ]
                                 )
                             }
                         )
@@ -849,14 +904,14 @@ class MonitoringStackTest(unittest.TestCase):
         )
         sentry_value_from = [
             secret["ValueFrom"]
-            for task_definition in tracker_template.find_resources("AWS::ECS::TaskDefinition").values()
+            for template in (tracker_template, executor_template)
+            for task_definition in template.find_resources("AWS::ECS::TaskDefinition").values()
             for container in task_definition["Properties"]["ContainerDefinitions"]
             for secret in container.get("Secrets", [])
             if secret["Name"] == "SENTRY_DSN"
         ]
-        self.assertEqual(len(sentry_value_from), 1)
-        self.assertIn(custom_sentry_secret_name, str(sentry_value_from[0]))
-        self.assertNotIn("SENTRY_DSN", str(executor_template.to_json()))
+        self.assertEqual(len(sentry_value_from), 2)
+        self.assertTrue(all(custom_sentry_secret_name in str(value) for value in sentry_value_from))
 
 
 if __name__ == "__main__":

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -57,6 +57,19 @@ def _statement_actions(statement: JsonObject) -> set[str]:
     return set(actions) if isinstance(actions, list) else {actions}
 
 
+def _lambda_function_resource(function_name: str) -> JsonObject:
+    return {
+        "Fn::Join": [
+            "",
+            [
+                "arn:",
+                {"Ref": "AWS::Partition"},
+                f":lambda:{TEST_AWS_REGION}:{TEST_AWS_ACCOUNT}:function:{function_name}",
+            ],
+        ]
+    }
+
+
 class RuntimeIamTest(unittest.TestCase):
     def test_managed_runtime_rejects_invalid_authority_configuration(self) -> None:
         config = ManagedAWSRuntimeConfig(
@@ -146,6 +159,7 @@ class RuntimeIamTest(unittest.TestCase):
                     "logs:CreateLogStream",
                     "logs:PutLogEvents",
                     "ecs:UpdateTaskProtection",
+                    "lambda:InvokeFunction",
                 },
             ),
         ):
@@ -246,6 +260,12 @@ class RuntimeIamTest(unittest.TestCase):
                     )
                     self.assertIn("/valkyrie/benchmarks-dev/*", json.dumps(log_statement["Resource"]))
                     self.assertNotIn(":log-stream:", json.dumps(log_statement["Resource"]))
+                    lambda_statement = next(
+                        statement
+                        for statement in statements
+                        if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                    )
+                    self.assertEqual(lambda_statement["Resource"], _lambda_function_resource("vals-format-lambda"))
                 else:
                     secret_resources = json.dumps(secret_statement["Resource"])
                     self.assertIn("secretsmanager", secret_resources)
@@ -291,8 +311,24 @@ class RuntimeIamTest(unittest.TestCase):
                 if role_name.startswith("ValkyrieExecutor"):
                     self.assertIn("secret:*", secret_resources)
                     self.assertNotIn(TEST_TRACKER_SECRET_NAME_PREFIX, secret_resources)
+                    lambda_statements = [
+                        statement
+                        for statement in _role_policy_statements(template, role_logical_id)
+                        if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                    ]
+                    self.assertEqual(len(lambda_statements), 1)
+                    self.assertEqual(
+                        lambda_statements[0]["Resource"],
+                        _lambda_function_resource("vals-format-lambda"),
+                    )
                 else:
                     self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
+                    self.assertFalse(
+                        any(
+                            _statement_actions(statement) == {"lambda:InvokeFunction"}
+                            for statement in _role_policy_statements(template, role_logical_id)
+                        )
+                    )
 
     def test_release_test_managed_runtime_remains_closed(self) -> None:
         with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -160,8 +160,8 @@ class TrackerStack(Stack):
         }
 
         sentry_secret_name = os.environ.get("SENTRY_DSN_SECRET_NAME", "")
-        if stage.is_prod and not sentry_secret_name:
-            raise ValueError("Production deployments require SENTRY_DSN_SECRET_NAME.")
+        if not stage.is_release_test and not sentry_secret_name:
+            raise ValueError("Dev and production deployments require SENTRY_DSN_SECRET_NAME.")
 
         sentry_secrets: dict[str, aws_ecs.Secret] = {}
         if sentry_secret_name:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ venvPath="."
 venv=".venv"
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
+extraPaths = ["services/tracker/src"]
 
 reportExplicitAny = false
 reportAny = false
@@ -77,7 +78,7 @@ packages = ["src/valkyrie"]
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]
-pythonpath = ["."]
+pythonpath = [".", "services/tracker/src"]
 
 # Async test configuration
 asyncio_mode = "auto"

--- a/services/executor_host/Dockerfile
+++ b/services/executor_host/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 COPY services/executor_host/requirements.txt ./
 RUN pip install --no-cache-dir --require-hashes -r requirements.txt
 
-COPY services/executor_host/supervisor.py ./
+COPY services/executor_host/__init__.py services/executor_host/observability.py services/executor_host/supervisor.py ./services/executor_host/
 COPY services/tracker/src/executor_protocol.py ./
 RUN useradd --create-home --uid 10001 executor \
     && mkdir -p /var/cache/valkyrie-executors \
@@ -17,4 +17,4 @@ ENV STABLE_QUEUE_NAME=valkyrie-stable
 
 USER executor
 
-CMD ["python", "-m", "taskiq", "worker", "--workers", "1", "--no-configure-logging", "supervisor:broker", "supervisor"]
+CMD ["python", "-m", "taskiq", "worker", "--workers", "1", "--no-configure-logging", "services.executor_host.supervisor:broker", "services.executor_host.supervisor"]

--- a/services/executor_host/observability.py
+++ b/services/executor_host/observability.py
@@ -1,0 +1,240 @@
+"""Structured logging and Sentry correlation for the stable executor host."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import os
+import sys
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Generator
+
+import sentry_sdk
+from sentry_sdk.consts import SPANSTATUS
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from executor_protocol import ExecutorTelemetryContext
+
+request_id_var = contextvars.ContextVar("request_id", default="")
+benchmark_id_var = contextvars.ContextVar("benchmark_id", default="")
+dispatch_id_var = contextvars.ContextVar("executor_dispatch_id", default="")
+release_id_var = contextvars.ContextVar("executor_release_id", default="")
+logger = logging.getLogger(__name__)
+
+
+def _context_fields() -> dict[str, str]:
+    return {
+        "request_id": request_id_var.get(),
+        "benchmark_id": benchmark_id_var.get(),
+        "executor_dispatch_id": dispatch_id_var.get(),
+        "executor_release_id": release_id_var.get(),
+    }
+
+
+class _ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        for key, value in _context_fields().items():
+            if not getattr(record, key, None):
+                setattr(record, key, value)
+        return True
+
+
+class _JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+            **{key: getattr(record, key, "") for key in _context_fields()},
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, default=str)
+
+
+def configure_observability() -> None:
+    """Configure CloudWatch JSON logs and Sentry for the host process."""
+    handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(_ContextFilter())
+    handler.setFormatter(_JsonFormatter())
+    root_logger = logging.getLogger()
+    root_logger.handlers = [handler]
+    root_logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+    dsn = os.environ.get("SENTRY_DSN", "")
+    if not dsn:
+        return
+    try:
+        sentry_sdk.init(
+            dsn=dsn,
+            environment=os.environ.get("ENVIRONMENT", "development"),
+            release=os.environ.get("SENTRY_RELEASE") or None,
+            server_name="valkyrie-executor-host",
+            enable_logs=True,
+            send_default_pii=False,
+            traces_sample_rate=1.0,
+            integrations=[
+                LoggingIntegration(
+                    level=logging.INFO,
+                    event_level=None,
+                    sentry_logs_level=logging.INFO,
+                )
+            ],
+        )
+    except Exception as error:
+        logger.warning(
+            "Failed to initialize Sentry: %s: %s",
+            type(error).__name__,
+            error,
+        )
+
+
+@contextmanager
+def dispatch_observability_context(
+    benchmark_id: str,
+    dispatch_id: str,
+    release_id: str,
+    telemetry_context: ExecutorTelemetryContext,
+) -> Generator[ExecutorTelemetryContext, None, None]:
+    """Bind one dispatch and create the child executor trace context."""
+    tokens = [
+        request_id_var.set(telemetry_context["request_id"]),
+        benchmark_id_var.set(benchmark_id),
+        dispatch_id_var.set(dispatch_id),
+        release_id_var.set(release_id),
+    ]
+    try:
+        with _dispatch_sentry_scope():
+            child_context = _accepted_telemetry_context(telemetry_context)
+            yield child_context
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+
+
+@contextmanager
+def _dispatch_sentry_scope() -> Generator[None, None, None]:
+    scope_manager = None
+    scope_entered = False
+    try:
+        scope_manager = sentry_sdk.new_scope()
+        scope = scope_manager.__enter__()
+        scope_entered = True
+        scope.set_tags({key: value for key, value in _context_fields().items() if value})
+    except Exception as error:
+        logger.warning("Failed to bind executor dispatch telemetry: %s: %s", type(error).__name__, error)
+
+    try:
+        yield
+    except BaseException as error:
+        if scope_manager is not None and scope_entered:
+            try:
+                scope_manager.__exit__(type(error), error, error.__traceback__)
+            except Exception as telemetry_error:
+                logger.warning(
+                    "Failed to release executor dispatch telemetry: %s: %s",
+                    type(telemetry_error).__name__,
+                    telemetry_error,
+                )
+        raise
+    else:
+        if scope_manager is not None and scope_entered:
+            try:
+                scope_manager.__exit__(None, None, None)
+            except Exception as error:
+                logger.warning("Failed to release executor dispatch telemetry: %s: %s", type(error).__name__, error)
+
+
+def _accepted_telemetry_context(telemetry_context: ExecutorTelemetryContext) -> ExecutorTelemetryContext:
+    try:
+        transaction = sentry_sdk.continue_trace(
+            telemetry_context["trace_headers"],
+            op="queue.process",
+            name="executor_host.dispatch.accepted",
+        )
+        with sentry_sdk.start_transaction(transaction):
+            trace_headers = dict(telemetry_context["trace_headers"])
+            if sentry_trace := sentry_sdk.get_traceparent():
+                trace_headers.pop("traceparent", None)
+                trace_headers.pop("tracestate", None)
+                trace_headers["sentry-trace"] = sentry_trace
+            if baggage := sentry_sdk.get_baggage():
+                trace_headers["baggage"] = baggage
+            child_context: ExecutorTelemetryContext = {
+                "request_id": telemetry_context["request_id"],
+                "trace_headers": trace_headers,
+            }
+        return child_context
+    except Exception as error:
+        logger.warning(
+            "Failed to record executor dispatch acceptance: %s: %s",
+            type(error).__name__,
+            error,
+        )
+        return {
+            "request_id": telemetry_context["request_id"],
+            "trace_headers": dict(telemetry_context["trace_headers"]),
+        }
+
+
+def _record_terminal_transaction(
+    telemetry_context: ExecutorTelemetryContext,
+    *,
+    name: str,
+    status: str | None = None,
+    error: BaseException | None = None,
+) -> None:
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_tags({key: value for key, value in _context_fields().items() if value})
+            transaction = sentry_sdk.continue_trace(
+                telemetry_context["trace_headers"],
+                op="queue.process",
+                name=name,
+            )
+            with sentry_sdk.start_transaction(transaction) as span:
+                if status is not None:
+                    span.set_status(status)
+                if error is not None:
+                    sentry_sdk.capture_exception(error)
+    except Exception as telemetry_error:
+        logger.warning(
+            "Failed to record executor dispatch telemetry: %s: %s",
+            type(telemetry_error).__name__,
+            telemetry_error,
+        )
+
+
+def record_dispatch_completion(telemetry_context: ExecutorTelemetryContext) -> None:
+    """Record the terminal host signal without holding a transaction across execution."""
+    _record_terminal_transaction(
+        telemetry_context,
+        name="executor_host.dispatch.completed",
+    )
+
+
+def record_dispatch_cancellation(telemetry_context: ExecutorTelemetryContext) -> None:
+    """Record a cancelled host dispatch without creating an error issue."""
+    logger.info("Executor dispatch cancelled")
+    _record_terminal_transaction(
+        telemetry_context,
+        name="executor_host.dispatch.cancelled",
+        status=SPANSTATUS.CANCELLED,
+    )
+
+
+def capture_dispatch_error(error: BaseException, telemetry_context: ExecutorTelemetryContext) -> None:
+    """Capture a host dispatch error on a bounded trace segment."""
+    logger.error(
+        "Executor dispatch failed",
+        exc_info=(type(error), error, error.__traceback__),
+    )
+    _record_terminal_transaction(
+        telemetry_context,
+        name="executor_host.dispatch.failed",
+        status=SPANSTATUS.INTERNAL_ERROR,
+        error=error,
+    )

--- a/services/executor_host/pyproject.toml
+++ b/services/executor_host/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = "==3.12.*"
 dependencies = [
   "boto3==1.43.0",
   "psycopg2-binary==2.9.11",
+  "sentry-sdk==2.58.0",
   "taskiq==0.12.1",
   "taskiq-redis==1.2.2",
 ]

--- a/services/executor_host/requirements.txt
+++ b/services/executor_host/requirements.txt
@@ -51,6 +51,10 @@ botocore==1.43.51 \
     # via
     #   boto3
     #   s3transfer
+certifi==2026.7.22 \
+    --hash=sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775 \
+    --hash=sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55
+    # via sentry-sdk
 frozenlist==1.8.0 \
     --hash=sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d \
     --hash=sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b \
@@ -196,6 +200,10 @@ s3transfer==0.17.1 \
     --hash=sha256:042dd5e3b1b512355e35a23f0223e426b7042e80b97830ea2680ddce327fc45e \
     --hash=sha256:5b9827d1044159bbb01b86ef8902760ea39281927f5de31de75e1d657177bf4c
     # via boto3
+sentry-sdk==2.58.0 \
+    --hash=sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e \
+    --hash=sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f
+    # via valkyrie-executor-host
 six==1.17.0 \
     --hash=sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274 \
     --hash=sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81
@@ -231,7 +239,9 @@ typing-inspection==0.4.2 \
 urllib3==2.7.0 \
     --hash=sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c \
     --hash=sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
-    # via botocore
+    # via
+    #   botocore
+    #   sentry-sdk
 yarl==1.24.5 \
     --hash=sha256:3363fcc96e665878946ad7a106b9a13eac0541766a690ef287c0232ac768b6ec \
     --hash=sha256:377fe3732edbaf78ee74efdf2c9f49f6e99f20e7f9d2649fda3eb4badd77d76e \

--- a/services/executor_host/supervisor.py
+++ b/services/executor_host/supervisor.py
@@ -20,6 +20,7 @@ import boto3
 import psycopg2  # pyright: ignore[reportMissingModuleSource]
 from psycopg2.extensions import connection as PostgresConnection  # pyright: ignore[reportMissingModuleSource]
 from redis.asyncio import Redis
+from taskiq import TaskiqEvents
 from taskiq_redis import RedisStreamBroker
 from executor_protocol import (
     DEFAULT_EXECUTOR_RELEASE_PREFIX,
@@ -27,8 +28,18 @@ from executor_protocol import (
     EXECUTOR_TASK_NAME,
     SUPPORTED_PROTOCOL_VERSIONS,
     ExecutorPayload,
+    ExecutorTelemetryContext,
+    executor_payload_benchmark_id,
+    normalize_executor_telemetry_context,
     validate_executor_artifact_uri,
     validate_executor_digest,
+)
+from services.executor_host.observability import (
+    capture_dispatch_error,
+    configure_observability,
+    dispatch_observability_context,
+    record_dispatch_cancellation,
+    record_dispatch_completion,
 )
 
 logger = logging.getLogger(__name__)
@@ -170,7 +181,12 @@ class ExecutorProcessPayload:
     arguments: dict[str, object]
 
     @classmethod
-    def from_payload(cls, payload: Mapping[str, object]) -> ExecutorProcessPayload:
+    def from_payload(
+        cls,
+        payload: Mapping[str, object],
+        *,
+        telemetry_context: ExecutorTelemetryContext,
+    ) -> ExecutorProcessPayload:
         execution_context = payload.get("execution_context_json")
         access_key_values = (
             payload.get("start_benchmark_request_json"),
@@ -196,6 +212,7 @@ class ExecutorProcessPayload:
                 "benchmark_id_str": benchmark_id,
                 "verified_task_ids": raw_task_ids,
             }
+        arguments["telemetry_context_json"] = telemetry_context
         if not isinstance(benchmark_id, str) or not benchmark_id:
             raise ValueError("Executor payload has no valid benchmark ID")
         verified_task_ids = (
@@ -206,6 +223,11 @@ class ExecutorProcessPayload:
             verified_task_ids=verified_task_ids,
             arguments=arguments,
         )
+
+
+def _payload_string(payload: Mapping[str, object], key: str) -> str:
+    value = payload.get(key)
+    return str(value) if value else ""
 
 
 class ExecutorDispatchStore(Protocol):
@@ -578,6 +600,7 @@ class ExecutorSupervisor:
                 str(artifact_path),
                 str(payload_path),
                 start_new_session=True,
+                env={**os.environ, "SENTRY_RELEASE": dispatch.release_id},
             )
             try:
                 return_code = await self._wait_with_authority(process, is_current)
@@ -672,6 +695,13 @@ broker = DeleteAfterAckRedisStreamBroker(
     consumer_group_name=QUEUE_NAME,
     idle_timeout=86400000,
 )
+
+
+@broker.on_event(TaskiqEvents.WORKER_STARTUP)
+async def _init_worker_observability(*_args: object, **_kwargs: object) -> None:  # pyright: ignore[reportUnusedFunction]
+    configure_observability()
+
+
 supervisor = ExecutorSupervisor(CACHE_DIR)
 dispatch_store = PostgresExecutorDispatchStore.from_environment()
 
@@ -762,13 +792,30 @@ async def run_executor_dispatch(
 @broker.task(EXECUTOR_TASK_NAME)
 async def launch_executor(**payload: Unpack[ExecutorPayload]) -> None:
     raw_payload: dict[str, object] = dict(payload)
-    dispatch_id = _required_string(raw_payload, "executor_dispatch_id")
-    dispatch = ArtifactDispatch.from_payload(raw_payload)
-    process_payload = ExecutorProcessPayload.from_payload(raw_payload)
-    await run_executor_dispatch(
-        supervisor,
-        dispatch_store,
-        executor_dispatch_id=dispatch_id,
-        dispatch=dispatch,
-        process_payload=process_payload,
-    )
+    with dispatch_observability_context(
+        executor_payload_benchmark_id(raw_payload),
+        _payload_string(raw_payload, "executor_dispatch_id"),
+        _payload_string(raw_payload, "executor_release_id"),
+        normalize_executor_telemetry_context(raw_payload.get("telemetry_context_json")),
+    ) as child_telemetry_context:
+        try:
+            dispatch_id = _required_string(raw_payload, "executor_dispatch_id")
+            dispatch = ArtifactDispatch.from_payload(raw_payload)
+            process_payload = ExecutorProcessPayload.from_payload(
+                raw_payload,
+                telemetry_context=child_telemetry_context,
+            )
+            await run_executor_dispatch(
+                supervisor,
+                dispatch_store,
+                executor_dispatch_id=dispatch_id,
+                dispatch=dispatch,
+                process_payload=process_payload,
+            )
+            record_dispatch_completion(child_telemetry_context)
+        except asyncio.CancelledError:
+            record_dispatch_cancellation(child_telemetry_context)
+            raise
+        except BaseException as error:
+            capture_dispatch_error(error, child_telemetry_context)
+            raise

--- a/services/executor_host/uv.lock
+++ b/services/executor_host/uv.lock
@@ -120,6 +120,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -340,6 +349,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -425,6 +447,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "boto3" },
     { name = "psycopg2-binary" },
+    { name = "sentry-sdk" },
     { name = "taskiq" },
     { name = "taskiq-redis" },
 ]
@@ -433,6 +456,7 @@ dependencies = [
 requires-dist = [
     { name = "boto3", specifier = "==1.43.0" },
     { name = "psycopg2-binary", specifier = "==2.9.11" },
+    { name = "sentry-sdk", specifier = "==2.58.0" },
     { name = "taskiq", specifier = "==0.12.1" },
     { name = "taskiq-redis", specifier = "==1.2.2" },
 ]

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -5,7 +5,7 @@ import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Annotated, Any, cast
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 import httpx
@@ -24,6 +24,7 @@ from sqlmodel import Session, col, select
 from tracker.api.agents import router as agents_router
 from tracker.api.benchmark_services import router as benchmark_services_router
 from tracker.api.benchmarks_status import router as benchmarks_status_router
+from tracker.api.dependencies import TrackedBenchmarkId, bind_benchmark_id
 from tracker.api.dependencies import RunAWSDependency
 from tracker.api.filter_options import router as filter_options_router
 from tracker.api.single_benchmark import router as single_benchmark_router
@@ -95,8 +96,8 @@ from tracker.docent_analysis import (
     analyze_event_stream,
 )
 from tracker.exceptions import TrackerServiceError
-from executor_protocol import EXECUTOR_TASK_NAME, executor_task_signature
-from tracker.logging import benchmark_id_var, configure_logging, get_logger, request_id_var
+from executor_protocol import EXECUTOR_TASK_NAME, ExecutorTelemetryContext, executor_task_signature
+from tracker.logging import configure_logging, get_logger, request_id_var
 from tracker.executor.release_control import MaintenanceModeError, ReleaseControlError, lock_executor_admission
 from tracker.executor.release_retirement import AutomaticReleaseRetirement
 from tracker.middleware import RequestContextMiddleware
@@ -192,20 +193,14 @@ class HealthCheckFilter(logging.Filter):
 logging.getLogger("uvicorn.access").addFilter(HealthCheckFilter())
 
 
-def bind_benchmark_id(benchmark_id: UUID) -> UUID:
-    """Dependency that binds benchmark_id to the logging context."""
-    benchmark_id_var.set(str(benchmark_id))
-    return benchmark_id
-
-
-TrackedBenchmarkId = Annotated[UUID, Depends(bind_benchmark_id)]
-
-
-def _taskiq_labels() -> dict[str, str]:
-    """Labels attached to a kicked task: current request id + injected OTel trace context."""
-    trace_context: dict[str, str] = {}
-    inject(trace_context)
-    return {"request_id": request_id_var.get(), **trace_context}
+def _executor_telemetry_context() -> ExecutorTelemetryContext:
+    """Capture request and distributed trace context for the executor process."""
+    trace_headers: dict[str, str] = {}
+    inject(trace_headers)
+    return {
+        "request_id": request_id_var.get(),
+        "trace_headers": trace_headers,
+    }
 
 
 def _process_benchmark_kwargs(
@@ -236,19 +231,17 @@ async def _enqueue_executor_dispatch(
     payload: dict[str, Any],
     verified_task_ids: list[str],
 ) -> None:
+    telemetry_context = _executor_telemetry_context()
     for attempt in range(3):
         try:
-            await (
-                process_benchmark.kicker()
-                .with_labels(**_taskiq_labels())
-                .kiq(
-                    **payload,
-                    executor_dispatch_id=str(dispatch.id),
-                    executor_release_id=dispatch.executor_release_id,
-                    executor_artifact_uri=dispatch.executor_artifact_uri,
-                    executor_artifact_digest=dispatch.executor_artifact_digest,
-                    executor_protocol_version=dispatch.executor_protocol_version,
-                )
+            await process_benchmark.kicker().kiq(
+                **payload,
+                telemetry_context_json=telemetry_context,
+                executor_dispatch_id=str(dispatch.id),
+                executor_release_id=dispatch.executor_release_id,
+                executor_artifact_uri=dispatch.executor_artifact_uri,
+                executor_artifact_digest=dispatch.executor_artifact_digest,
+                executor_protocol_version=dispatch.executor_protocol_version,
             )
             return
         except Exception as exc:
@@ -632,7 +625,7 @@ async def start_benchmark(
             raise HTTPException(status_code=503, detail=str(exc)) from exc
         raise TrackerServiceError("Failed to admit benchmark execution") from exc
 
-    benchmark_id_var.set(str(benchmark_row.id))
+    await bind_benchmark_id(benchmark_row.id)
 
     if run_starter.access_key_id is not None and run_starter.email is None:
         logger.warning(

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -77,7 +77,7 @@ venvPath = "."
 venv = ".venv"
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
-extraPaths = ["../.."]
+extraPaths = ["src", "../.."]
 
 reportExplicitAny = false
 reportAny = false
@@ -89,7 +89,7 @@ exclude = ["src/tracker/database/migrations/versions"]
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]
 asyncio_mode = "auto"
-pythonpath = [".", "../.."]
+pythonpath = [".", "src", "../.."]
 env = ["BROKER_ENVIRONMENT=testing"]
 [tool.coverage.run]
 source = ["src/tracker", "main"]

--- a/services/tracker/src/executor_protocol.py
+++ b/services/tracker/src/executor_protocol.py
@@ -1,7 +1,8 @@
 """Shared Tracker-to-ExecutorHost wire contract."""
 
+from collections.abc import Mapping
 from enum import Enum
-from typing import Any, NotRequired, TypedDict, Unpack
+from typing import Any, NotRequired, TypedDict, Unpack, cast
 from urllib.parse import urlparse
 
 EXECUTOR_TASK_NAME = "tracker.utils:process_benchmark"
@@ -19,6 +20,11 @@ class ExecutorDispatchStatus(str, Enum):
     FAILED = "FAILED"
 
 
+class ExecutorTelemetryContext(TypedDict):
+    request_id: str
+    trace_headers: dict[str, str]
+
+
 class ExecutorPayload(TypedDict):
     # Exactly one execution shape is set: access-key runs carry the first three
     # fields; managed runs carry only execution_context_json. Dispatch fields
@@ -27,6 +33,7 @@ class ExecutorPayload(TypedDict):
     benchmark_id_str: NotRequired[str | None]
     verified_task_ids: NotRequired[list[str] | None]
     execution_context_json: NotRequired[dict[str, Any] | None]
+    telemetry_context_json: NotRequired[ExecutorTelemetryContext | None]
     executor_dispatch_id: str
     executor_release_id: str
     executor_artifact_uri: str
@@ -37,6 +44,39 @@ class ExecutorPayload(TypedDict):
 async def executor_task_signature(**_payload: Unpack[ExecutorPayload]) -> None:
     """Provide the producer's typed Taskiq signature; this body never executes."""
     raise RuntimeError("Executor task signatures cannot execute in Tracker")
+
+
+def executor_payload_benchmark_id(payload: Mapping[str, object]) -> str:
+    """Return the benchmark ID from either supported executor payload shape."""
+    benchmark_id = payload.get("benchmark_id_str")
+    if benchmark_id:
+        return str(benchmark_id)
+
+    execution_context = payload.get("execution_context_json")
+    if isinstance(execution_context, Mapping):
+        benchmark_id = cast(Mapping[object, object], execution_context).get("benchmark_id")
+
+    return str(benchmark_id) if benchmark_id else ""
+
+
+def normalize_executor_telemetry_context(value: object) -> ExecutorTelemetryContext:
+    """Normalize optional telemetry fields at the executor wire boundary."""
+    if not isinstance(value, Mapping):
+        return {"request_id": "", "trace_headers": {}}
+
+    telemetry_context = cast(Mapping[object, object], value)
+    request_id = telemetry_context.get("request_id")
+    raw_trace_headers = telemetry_context.get("trace_headers")
+    trace_headers = (
+        {str(key): str(header) for key, header in cast(Mapping[object, object], raw_trace_headers).items()}
+        if isinstance(raw_trace_headers, Mapping)
+        else {}
+    )
+
+    return {
+        "request_id": str(request_id) if request_id else "",
+        "trace_headers": trace_headers,
+    }
 
 
 def validate_executor_digest(digest: str) -> str:

--- a/services/tracker/src/tracker/api/dependencies.py
+++ b/services/tracker/src/tracker/api/dependencies.py
@@ -5,6 +5,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends, Request
+from opentelemetry import trace
 from sqlmodel import Session
 
 from tracker.auth import get_current_org
@@ -13,6 +14,18 @@ from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import Benchmark, Org
 from tracker.database.scoping import get_scoped
 from tracker.database.session import get_session
+from tracker.logging import benchmark_id_var
+
+
+async def bind_benchmark_id(benchmark_id: UUID) -> UUID:
+    """Bind a route's run identifier to logs, errors, and the active request span."""
+    value = str(benchmark_id)
+    benchmark_id_var.set(value)
+    trace.get_current_span().set_attribute("benchmark_id", value)
+    return benchmark_id
+
+
+TrackedBenchmarkId = Annotated[UUID, Depends(bind_benchmark_id)]
 
 
 def get_agent_library_aws_runtime(
@@ -32,7 +45,7 @@ class RunAWSContext:
 
 
 def get_run_aws_context(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     request: Request,
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),

--- a/services/tracker/src/tracker/api/single_benchmark.py
+++ b/services/tracker/src/tracker/api/single_benchmark.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 from typing import Literal
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import case
 from sqlmodel import Session, col, desc, func, select
 
 from tracker.api.parsing import parse_csv
+from tracker.api.dependencies import TrackedBenchmarkId
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.resolver import resolve_run_metadata_aws_runtime
@@ -46,7 +45,7 @@ _STATUS_SORT_PRIORITY = case(
 
 @router.get("/{benchmark_id}", response_model=SingleBenchmarkResponse)
 def get_single_benchmark(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     request: Request,
     org: Org = Depends(get_current_org),
     session: Session = Depends(get_session),
@@ -103,7 +102,7 @@ def get_single_benchmark(
 
 @router.get("/{benchmark_id}/tasks", response_model=TasksResponse)
 def get_benchmark_tasks(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     status: str = Query(default=""),
     task_id_search: str | None = None,
     sort: Literal["task_id", "started_at", "duration", "status"] = Query(default="started_at"),

--- a/services/tracker/src/tracker/api/single_task.py
+++ b/services/tracker/src/tracker/api/single_task.py
@@ -8,7 +8,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel import Session, col, desc, select
 
-from tracker.api.dependencies import RunAWSDependency
+from tracker.api.dependencies import RunAWSDependency, TrackedBenchmarkId
 from tracker.auth import get_current_org
 from tracker.aws.cloudwatch_logs import get_benchmark_log_url
 from tracker.aws.s3 import S3_BENCHMARKS_PREFIX, create_presigned_url, s3_object_exists
@@ -85,7 +85,7 @@ def _fetch_result_objects(session: Session, task: Task, org: Org) -> tuple[Evalu
     response_model=SingleTaskResponse,
 )
 def get_single_task(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     task_id: str,
     org: Org = Depends(get_current_org),
     session: Session = Depends(get_session),
@@ -114,7 +114,7 @@ def get_single_task(
     response_model=TaskArtifactsResponse,
 )
 async def get_task_artifacts(
-    benchmark_id: UUID,
+    benchmark_id: TrackedBenchmarkId,
     task_id: str,
     run_context: RunAWSDependency,
     org: Org = Depends(get_current_org),

--- a/services/tracker/src/tracker/executor/entrypoint.py
+++ b/services/tracker/src/tracker/executor/entrypoint.py
@@ -5,32 +5,84 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import logging
 import signal
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Generator, Mapping, cast
 
-from executor_protocol import SUPPORTED_PROTOCOL_VERSION
+import logfire
+import sentry_sdk
+from opentelemetry.context import attach, detach
+from opentelemetry.propagate import extract
+
+from executor_protocol import (
+    SUPPORTED_PROTOCOL_VERSION,
+    executor_payload_benchmark_id,
+    normalize_executor_telemetry_context,
+)
+from tracker.config import ENVIRONMENT
+from tracker.logging import benchmark_id_var, request_id_var, task_id_var
+from tracker.observability import configure_observability
+from tracker.observability.sentry import capture_exception
 from tracker.utils.run_orchestration import process_benchmark
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def _executor_context(payload: Mapping[str, object]) -> Generator[None, None, None]:
+    telemetry_context = normalize_executor_telemetry_context(payload.get("telemetry_context_json"))
+
+    context_tokens = [
+        request_id_var.set(telemetry_context["request_id"]),
+        benchmark_id_var.set(executor_payload_benchmark_id(payload)),
+        task_id_var.set(""),
+    ]
+    trace_headers = telemetry_context["trace_headers"]
+    otel_token = attach(extract(trace_headers)) if trace_headers else None
+    try:
+        yield
+    finally:
+        if otel_token is not None:
+            detach(otel_token)
+        for token in reversed(context_tokens):
+            token.var.reset(token)
 
 
 async def _run_executor(payload: dict[str, Any]) -> None:
-    task = asyncio.create_task(
-        process_benchmark(
-            start_benchmark_request_json=payload.get("start_benchmark_request_json"),
-            benchmark_id_str=payload.get("benchmark_id_str"),
-            verified_task_ids=payload.get("verified_task_ids"),
-            execution_context_json=payload.get("execution_context_json"),
-            executor_dispatch_id=payload["executor_dispatch_id"],
+    with _executor_context(payload):
+        task = asyncio.create_task(
+            process_benchmark(
+                start_benchmark_request_json=payload.get("start_benchmark_request_json"),
+                benchmark_id_str=payload.get("benchmark_id_str"),
+                verified_task_ids=payload.get("verified_task_ids"),
+                execution_context_json=payload.get("execution_context_json"),
+                executor_dispatch_id=payload["executor_dispatch_id"],
+            )
         )
-    )
-    loop = asyncio.get_running_loop()
-    loop.add_signal_handler(signal.SIGTERM, task.cancel)
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGTERM, task.cancel)
+        try:
+            await task
+        except asyncio.CancelledError:
+            return
+        except Exception as error:
+            capture_exception(error)
+            raise
+        finally:
+            loop.remove_signal_handler(signal.SIGTERM)
+
+
+def _flush_observability() -> None:
     try:
-        await task
-    except asyncio.CancelledError:
-        return
-    finally:
-        loop.remove_signal_handler(signal.SIGTERM)
+        logfire.force_flush(timeout_millis=3000)
+    except Exception as error:
+        logger.warning("Failed to flush executor traces: %s: %s", type(error).__name__, error)
+    try:
+        sentry_sdk.flush(timeout=3)
+    except Exception as error:
+        logger.warning("Failed to flush executor Sentry events: %s: %s", type(error).__name__, error)
 
 
 def main() -> None:
@@ -48,7 +100,11 @@ def main() -> None:
     if not isinstance(decoded, dict):
         raise SystemExit("Invalid executor payload: expected object")
     payload = cast(dict[str, Any], decoded)
-    asyncio.run(_run_executor(payload))
+    configure_observability("valkyrie-executor", environment=ENVIRONMENT)
+    try:
+        asyncio.run(_run_executor(payload))
+    finally:
+        _flush_observability()
 
 
 if __name__ == "__main__":

--- a/services/tracker/src/tracker/middleware/logging_context.py
+++ b/services/tracker/src/tracker/middleware/logging_context.py
@@ -1,19 +1,11 @@
 """Taskiq middleware that sets logging context vars for executor jobs."""
 
-from typing import Any, cast
+from typing import Any
 
 from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
 
+from executor_protocol import executor_payload_benchmark_id
 from tracker.logging import benchmark_id_var, request_id_var, task_id_var
-
-
-def _benchmark_id_from_message(message: TaskiqMessage) -> str:
-    benchmark_id = message.kwargs.get("benchmark_id_str")
-    if not benchmark_id:
-        execution_context = message.kwargs.get("execution_context_json")
-        if isinstance(execution_context, dict):
-            benchmark_id = cast(dict[str, Any], execution_context).get("benchmark_id")
-    return str(benchmark_id) if benchmark_id else ""
 
 
 class LoggingContextMiddleware(TaskiqMiddleware):
@@ -24,7 +16,7 @@ class LoggingContextMiddleware(TaskiqMiddleware):
         benchmark_id_var.set("")
         task_id_var.set("")
 
-        benchmark_id = _benchmark_id_from_message(message)
+        benchmark_id = executor_payload_benchmark_id(message.kwargs)
         if benchmark_id:
             benchmark_id_var.set(benchmark_id)
 

--- a/services/tracker/src/tracker/observability/__init__.py
+++ b/services/tracker/src/tracker/observability/__init__.py
@@ -1,17 +1,27 @@
 """Observability setup and runtime helpers for the tracker service."""
 
+import logging
 import time
 
 from tracker.observability.metrics import distribution, gauge, incr
 from tracker.observability.retry import retry_callback
 from tracker.observability.sentry import init_sentry, set_sandbox_context
-from tracker.observability.tracing import configure_tracing
+from tracker.observability.tracing import configure_tracing, error_span
+
+logger = logging.getLogger(__name__)
 
 
 def configure_observability(service_name: str, environment: str) -> None:
     """Configure Sentry first, then OTel/Logfire tracing for this process."""
-    init_sentry(service_name, environment=environment)
-    configure_tracing(service_name, environment=environment)
+    try:
+        init_sentry(service_name, environment=environment)
+    except Exception as error:
+        logger.warning("Failed to initialize Sentry: %s: %s", type(error).__name__, error)
+
+    try:
+        configure_tracing(service_name, environment=environment)
+    except Exception as error:
+        logger.warning("Failed to initialize tracing: %s: %s", type(error).__name__, error)
 
 
 def elapsed_ms(start: float) -> float:
@@ -24,6 +34,7 @@ __all__ = [
     "configure_tracing",
     "distribution",
     "elapsed_ms",
+    "error_span",
     "gauge",
     "incr",
     "init_sentry",

--- a/services/tracker/src/tracker/observability/metrics.py
+++ b/services/tracker/src/tracker/observability/metrics.py
@@ -11,9 +11,12 @@ logger = logging.getLogger(__name__)
 # High-cardinality diagnostic fields belong in logs, spans, or Sentry context,
 # not metric attributes where they create one time series per task/session/etc.
 _BANNED_TAG_KEYS = {
+    "benchmark_id",
     "command",
     "error_message",
+    "org_id",
     "request_id",
+    "run_id",
     "sandbox_id",
     "session_id",
     "task_id",

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -44,12 +44,16 @@ def _apply_current_otel_trace_context(telemetry: dict[str, Any]) -> None:
 
 
 def _before_send_log(log: Log, _hint: Hint) -> Log | None:
+    attributes = log.setdefault("attributes", {})
+    for key, value in get_context_tags().items():
+        if value:
+            attributes[key] = value
     _apply_current_otel_trace_context(cast(dict[str, Any], log))
     return log
 
 
 def init_sentry(service_name: str, environment: str) -> None:
-    """Initialize Sentry SDK. No-op if SENTRY_DSN is not set.
+    """Initialize Sentry SDK when configured.
 
     Args:
         service_name: Identifies the process in Sentry (e.g. "valkyrie-tracker").
@@ -73,10 +77,10 @@ def init_sentry(service_name: str, environment: str) -> None:
             before_send=_before_send,
             before_send_log=_before_send_log,
             integrations=[
-                # level=None / event_level=None: spans carry context and we capture_exception explicitly,
-                # so we only want LoggingIntegration for shipping log records to Sentry Logs.
+                # INFO records become both searchable logs and breadcrumbs. Explicit exception
+                # capture owns issue creation so an error log cannot create a duplicate issue.
                 LoggingIntegration(
-                    level=None,
+                    level=logging.INFO,
                     event_level=None,
                     sentry_logs_level=logging.INFO,
                 ),
@@ -93,8 +97,15 @@ def init_sentry(service_name: str, environment: str) -> None:
             ],
         )
     except Exception as e:
-        # A malformed SENTRY_DSN or invalid integration shouldn't crash service startup.
         logger.warning("Failed to initialize Sentry: %s: %s", type(e).__name__, e)
+
+
+def capture_exception(error: BaseException) -> None:
+    """Capture an exception without allowing Sentry failures to escape."""
+    try:
+        sentry_sdk.capture_exception(error)
+    except Exception as telemetry_error:
+        logger.warning("Failed to capture exception: %s: %s", type(telemetry_error).__name__, telemetry_error)
 
 
 def set_sandbox_context(sandbox: Any, *, image: str | None = None) -> None:

--- a/services/tracker/src/tracker/observability/tracing.py
+++ b/services/tracker/src/tracker/observability/tracing.py
@@ -1,20 +1,78 @@
 """Tracing configuration: OTel instrumentation (via logfire) with Sentry as the backend."""
 
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
 import logfire
+from opentelemetry import trace
 from opentelemetry.baggage.propagation import W3CBaggagePropagator
 from opentelemetry.context import Context
 from opentelemetry.propagate import set_global_textmap
 from opentelemetry.propagators.composite import CompositePropagator
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
+from opentelemetry.trace import Status, StatusCode
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from sentry_sdk.integrations.opentelemetry import SentryPropagator, SentrySpanProcessor
-from sentry_sdk.integrations.opentelemetry import span_processor as _sentry_span_processor
 
 from tracker.logging.context import get_context_tags
+from tracker.logging.logger import get_logger
 
-# SentrySpanProcessor drops spans from its in-memory map after 10 minutes by default, which
-# silently loses long-running parents like process_benchmark / process_task. Bump to 4 hours.
-_sentry_span_processor.SPAN_MAX_TIME_OPEN_MINUTES = 240
+logger = get_logger(__name__)
+
+_EXCLUDED_SPAN_NAMES = frozenset(
+    {
+        "AsyncProcess.exec",
+        "AsyncSandbox.refresh_data",
+    }
+)
+
+
+@contextmanager
+def observability_span(name: str, **attributes: Any) -> Generator[None, None, None]:
+    """Create a span without allowing telemetry failures to escape."""
+    span_manager = None
+    span_entered = False
+    try:
+        span_manager = logfire.span(name, **attributes)
+        span_manager.__enter__()
+        span_entered = True
+    except Exception as error:
+        logger.warning("Failed to start observability span %s: %s: %s", name, type(error).__name__, error)
+
+    try:
+        yield
+    except BaseException as error:
+        if span_manager is not None and span_entered:
+            try:
+                span_manager.__exit__(type(error), error, error.__traceback__)
+            except Exception as telemetry_error:
+                logger.warning(
+                    "Failed to finish observability span %s: %s: %s",
+                    name,
+                    type(telemetry_error).__name__,
+                    telemetry_error,
+                )
+        raise
+    else:
+        if span_manager is not None and span_entered:
+            try:
+                span_manager.__exit__(None, None, None)
+            except Exception as error:
+                logger.warning("Failed to finish observability span %s: %s: %s", name, type(error).__name__, error)
+
+
+@contextmanager
+def error_span(name: str, exc: BaseException, **attributes: Any) -> Generator[None, None, None]:
+    """Create a bounded error span for a handled exception."""
+    with observability_span(name, **attributes):
+        span = trace.get_current_span()
+        try:
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR))
+        except Exception as error:
+            logger.warning("Failed to annotate observability span %s: %s: %s", name, type(error).__name__, error)
+        yield
 
 
 class _ContextVarSpanProcessor(SpanProcessor):
@@ -36,6 +94,35 @@ class _ContextVarSpanProcessor(SpanProcessor):
         return True
 
 
+class _FilteredSentrySpanProcessor(SpanProcessor):
+    """Drop low-level polling span subtrees before exporting them to Sentry."""
+
+    def __init__(self) -> None:
+        self._delegate = SentrySpanProcessor()
+        self._excluded_span_ids: set[int] = set()
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        parent_span_id = span.parent.span_id if span.parent is not None else None
+        span_id = span.get_span_context().span_id
+        if span.name in _EXCLUDED_SPAN_NAMES or parent_span_id in self._excluded_span_ids:
+            self._excluded_span_ids.add(span_id)
+            return
+        self._delegate.on_start(span, parent_context)
+
+    def on_end(self, span: ReadableSpan) -> None:
+        span_id = span.get_span_context().span_id
+        if span_id in self._excluded_span_ids:
+            self._excluded_span_ids.discard(span_id)
+            return
+        self._delegate.on_end(span)
+
+    def shutdown(self) -> None:
+        self._delegate.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self._delegate.force_flush(timeout_millis)
+
+
 def configure_tracing(service_name: str, environment: str) -> None:
     """Configure OTel tracing. Call after init_sentry() and before any instrument_*() hooks."""
     logfire.configure(
@@ -46,7 +133,7 @@ def configure_tracing(service_name: str, environment: str) -> None:
         distributed_tracing=True,
         # configure_logging() owns stdout.
         console=False,
-        additional_span_processors=[_ContextVarSpanProcessor(), SentrySpanProcessor()],
+        additional_span_processors=[_ContextVarSpanProcessor(), _FilteredSentrySpanProcessor()],
     )
     # Composite: inject both W3C traceparent/tracestate (for non-Sentry peers like Daytona /
     # benchmark_service) and Sentry's sentry-trace/baggage. Extract honors whichever headers arrive.

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -9,12 +9,10 @@ from dataclasses import dataclass
 from typing import Any, Sequence, cast
 from uuid import UUID
 
-import logfire
 import sentry_sdk
 from benchmark_service import SandboxProviderConfig
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
 from botocore.config import Config
-from opentelemetry import trace
 from pydantic import ValidationError
 from sqlmodel import Session, col, desc, func, select
 
@@ -41,6 +39,9 @@ from tracker.executor.execution_authority import ExecutionAuthority, lock_execut
 from executor_protocol import EXECUTOR_TASK_NAME
 from tracker.logging import get_logger
 from tracker.notifications import NotificationContext, SlackNotifier
+from tracker.observability import error_span
+from tracker.observability.sentry import capture_exception
+from tracker.observability.tracing import observability_span
 from tracker.outbound_security import validate_custom_service_destination
 from tracker.types import (
     FinalViewResponse,
@@ -64,6 +65,47 @@ _SANDBOX_CREATION_CAP: int = 10
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
 # Limit non-idempotent completion callbacks to one attempt and a 60-second read.
 _COMPLETION_CALLBACK_CONFIG = Config(read_timeout=60, retries={"total_max_attempts": 1})
+
+
+def _capture_run_error(
+    exc: BaseException,
+    benchmark_id: UUID,
+    *,
+    producer: str,
+    operation: str,
+    cause_code: str | None = None,
+) -> None:
+    with error_span(
+        "run.error",
+        exc,
+        benchmark_id=str(benchmark_id),
+        producer=producer,
+        operation=operation,
+        error_type=type(exc).__name__,
+        cause_code=cause_code or "",
+    ):
+        logger.error(
+            "Run execution failed",
+            exc_info=(type(exc), exc, exc.__traceback__),
+            extra={
+                "benchmark_id": str(benchmark_id),
+                "producer": producer,
+                "operation": operation,
+                "error_type": type(exc).__name__,
+                "cause_code": cause_code or "",
+            },
+        )
+        capture_exception(exc)
+
+
+def _record_run_finalized(benchmark_id: UUID, status: BenchmarkStatus, authority: ExecutionAuthority) -> None:
+    with observability_span(
+        "run.finalized",
+        benchmark_id=str(benchmark_id),
+        status=status.value,
+        executor_dispatch_id=str(authority.dispatch_id),
+    ):
+        pass
 
 
 def set_benchmark_final_status(
@@ -115,6 +157,7 @@ def set_benchmark_final_status(
     benchmark_row.error_message = None
     session.add(benchmark_row)
     session.commit()
+    _record_run_finalized(benchmark_row.id, benchmark_status, authority)
 
 
 def create_task_rows(
@@ -382,7 +425,6 @@ async def hold_dispatch_authority(
 
 # Keep the Tracker producer and ExecutorHost on one stable Taskiq wire name.
 @broker.task(EXECUTOR_TASK_NAME)
-@logfire.instrument("process_benchmark", extract_args=("benchmark_id_str", "verified_task_ids"))
 async def process_benchmark(
     start_benchmark_request_json: dict[str, Any] | None = None,
     benchmark_id_str: str | None = None,
@@ -425,15 +467,15 @@ async def process_benchmark(
 
         sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
         sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
-        trace.get_current_span().set_attributes(
-            {
-                "benchmark_id": str(benchmark_id),
-                "benchmark_name": start_benchmark_request.benchmark_name,
-                "agent_name": start_benchmark_request.contract.name,
-                "task_count": len(verified_task_ids),
-                "executor_dispatch_id": executor_dispatch_id,
-            }
-        )
+        with observability_span(
+            "run.started",
+            benchmark_id=str(benchmark_id),
+            benchmark_name=start_benchmark_request.benchmark_name,
+            agent_name=start_benchmark_request.contract.name,
+            task_count=len(verified_task_ids),
+            executor_dispatch_id=executor_dispatch_id,
+        ):
+            pass
 
         if execution.aws_managed != benchmark_row.aws_managed:
             queued_mode = "managed" if execution.aws_managed else "access-key"
@@ -608,7 +650,13 @@ async def process_benchmark(
     except ExecutionAuthorityRevoked:
         finalization_deferred = True
     except BenchmarkServiceUnauthenticatedError as e:
-        logfire.warn("process_benchmark failed due to benchmark service auth error")
+        _capture_run_error(
+            e,
+            benchmark_id,
+            producer="benchmark_service",
+            operation="authenticate",
+            cause_code="authentication_failed",
+        )
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"
@@ -625,6 +673,12 @@ async def process_benchmark(
                 task_ids=verified_task_ids,
             )
     except BenchmarkServiceError as e:
+        _capture_run_error(
+            e,
+            benchmark_id,
+            producer="benchmark_service",
+            operation="process_benchmark",
+        )
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = str(e)
@@ -639,8 +693,7 @@ async def process_benchmark(
                 task_ids=verified_task_ids,
             )
     except Exception as e:
-        logfire.exception("process_benchmark failed")
-        sentry_sdk.capture_exception(e)
+        _capture_run_error(e, benchmark_id, producer="tracker", operation="process_benchmark")
         with Session(bind=engine) as session:
             benchmark_row = fetch_benchmark_row(benchmark_id, session, org)
             error_message = f"{str(e)}\n{traceback.format_exc()}"
@@ -718,6 +771,8 @@ def commit_benchmark_error(
         cause_code=cause_code,
     )
     session.commit()
+    if committed and benchmark_row.status == BenchmarkStatus.ERROR:
+        _record_run_finalized(benchmark_row.id, BenchmarkStatus.ERROR, authority)
     return committed
 
 
@@ -783,4 +838,6 @@ def catch_errors_during_cleanup(
         error_type="UndetectedExecutorExit",
     )
     session.commit()
+    if committed and benchmark_row.status == BenchmarkStatus.ERROR:
+        _record_run_finalized(benchmark_id, BenchmarkStatus.ERROR, authority)
     return committed

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import socket
 import time
 import traceback
 from asyncio import Semaphore
@@ -22,7 +23,7 @@ from benchmark_service import (
     SandboxProviderConfig,
     SandboxRecoveryAttempt,
 )
-from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceStreamError
 from opentelemetry import trace
 from pydantic import ValidationError
 from sqlmodel import Session, col, select, update
@@ -36,6 +37,7 @@ from tracker.aws.s3 import (
 from tracker.aws.secrets import resolve_secrets
 from tracker.config import ENVIRONMENT
 from tracker.database.models import (
+    AgentCausedExitReason,
     AgentContractRequest,
     BenchmarkStatus,
     ErrorResult,
@@ -68,6 +70,18 @@ logger = get_logger(__name__)
 
 _PTY_TASK_RETRY_LIMIT: int = 1
 _SANDBOX_RETRY_DELAY_SECONDS: float = 2
+
+
+class BenchmarkServiceWebSocketDNSResolutionError(BenchmarkServiceError):
+    """A benchmark-service WebSocket could not resolve its destination host."""
+
+
+async def _run_benchmark_service_websocket(operation: Coroutine[Any, Any, Any]) -> Any:
+    """Translate DNS failures from benchmark-service WebSocket calls at the boundary."""
+    try:
+        return await operation
+    except socket.gaierror as exc:
+        raise BenchmarkServiceWebSocketDNSResolutionError(_exception_message(exc)) from exc
 
 
 @dataclass
@@ -637,7 +651,15 @@ async def _process_task_attempt(
 
     flush_task = asyncio.create_task(auto_flush_logs())
 
+    evaluation_resume_state = task_row.eval_resume_state
+    sandbox_id_for_recovery: str | None = None
+    exit_reason: AgentCausedExitReason | None = None
+    evaluation_start_time: float | None = None
+    start_sandbox_run_time: float | None = None
+
     def on_eval_resume_state(state: dict[str, Any]) -> None:
+        nonlocal evaluation_resume_state
+        evaluation_resume_state = state
         save_eval_resume_state(task_row.id, org, state, expected_started_at=attempt_started_at, authority=authority)
 
     def execution_is_current() -> bool:
@@ -678,6 +700,90 @@ async def _process_task_attempt(
             )
         return {task_id: None}
 
+    async def recover_evaluation_stream_failure(error_message: str) -> dict[str, dict[str, Any] | None] | None:
+        """Resume an interrupted evaluation when the service has persisted continuation state."""
+        nonlocal last_log_time
+        if evaluation_resume_state is None:
+            return None
+        if task_is_stopped():
+            return {task_id: None}
+
+        recovery_message = f"{error_message}; resuming evaluation from durable benchmark state"
+        logger.warning(recovery_message)
+        log_output(f"\n[WARN] {recovery_message}\n")
+        resume_eval_start_time = time.perf_counter()
+        try:
+            last_log_time = time.monotonic()
+            evaluation_result = await _run_benchmark_service_websocket(
+                benchmark_service.resume_evaluation(
+                    task_row.task_id,
+                    eval_resume_state=evaluation_resume_state,
+                    on_message=log_output,
+                    on_eval_resume_state=on_eval_resume_state,
+                    dataset=start_benchmark_request.dataset,
+                    sandbox_provider=sandbox_provider_config,
+                )
+            )
+        except BenchmarkServiceWebSocketDNSResolutionError as resume_error:
+            if task_is_stopped():
+                return {task_id: None}
+            terminal_error = (
+                f"{recovery_message}; WebSocket DNS resolution failed during resume: {_exception_message(resume_error)}"
+            )
+            logger.warning(terminal_error)
+            log_output(f"\n[ERROR] {terminal_error}")
+            return commit_terminal_error(
+                resume_error,
+                terminal_error,
+                producer="benchmark_service",
+                operation="websocket_connect",
+                cause_code="websocket_dns_resolution",
+            )
+        except Exception as resume_error:
+            if task_is_stopped():
+                return {task_id: None}
+            terminal_error = f"{recovery_message}; resume failed: {_exception_message(resume_error)}"
+            logger.warning(terminal_error)
+            log_output(f"\n[ERROR] {terminal_error}")
+            return commit_terminal_error(
+                resume_error,
+                terminal_error,
+                producer="benchmark_service",
+                operation="resume_evaluation",
+            )
+
+        finished_at = time.perf_counter()
+        evaluation_run_duration = finished_at - (evaluation_start_time or resume_eval_start_time)
+        sandbox_run_duration = finished_at - start_sandbox_run_time if start_sandbox_run_time is not None else None
+        evaluation_result_value = cast(dict[str, Any], evaluation_result)
+        evaluation_result_row = EvaluationResult(
+            org_id=org.id,
+            task=task_row.id,
+            instance_id=sandbox_id_for_recovery,
+            result=evaluation_result_value,
+            agent_caused_exit_reason=exit_reason,
+        )
+        with Session(bind=engine) as task_session:
+            task_session.add(evaluation_result_row)
+            task_in_session = fetch_task_row(task_row.id, task_session, org)
+            if task_in_session.task_breakdown:
+                existing_breakdown = task_session.get(TaskBreakdown, task_in_session.task_breakdown)
+                assert existing_breakdown is not None
+                existing_breakdown.evaluation_run_duration = evaluation_run_duration
+                if sandbox_run_duration is not None:
+                    existing_breakdown.sandbox_run_duration = sandbox_run_duration
+            if not commit_task_status_transition(
+                task_row.id,
+                task_session,
+                org,
+                TaskStatus.FINISHED,
+                expected_started_at=attempt_started_at,
+                authority=authority,
+            ):
+                return {task_id: None}
+
+        return {task_id: evaluation_result_value}
+
     try:
         if task_row.status == TaskStatus.EVALUATING and task_row.eval_resume_state is not None:
             try:
@@ -685,13 +791,15 @@ async def _process_task_attempt(
                 resume_eval_start_time = time.perf_counter()
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
-                evaluation_result = await benchmark_service.resume_evaluation(
-                    task_row.task_id,
-                    eval_resume_state=task_row.eval_resume_state,
-                    on_message=log_output,
-                    on_eval_resume_state=on_eval_resume_state,
-                    dataset=start_benchmark_request.dataset,
-                    sandbox_provider=sandbox_provider_config,
+                evaluation_result = await _run_benchmark_service_websocket(
+                    benchmark_service.resume_evaluation(
+                        task_row.task_id,
+                        eval_resume_state=task_row.eval_resume_state,
+                        on_message=log_output,
+                        on_eval_resume_state=on_eval_resume_state,
+                        dataset=start_benchmark_request.dataset,
+                        sandbox_provider=sandbox_provider_config,
+                    )
                 )
                 resume_eval_duration = time.perf_counter() - resume_eval_start_time
                 evaluation_result_row = EvaluationResult(
@@ -806,6 +914,7 @@ async def _process_task_attempt(
             volumes=task_data.volumes,
             creation_semaphore=creation_semaphore,
         ) as sandbox:
+            sandbox_id_for_recovery = sandbox.id
             task_breakdown.sandbox_build_duration = time.perf_counter() - start_sandbox_build_time
             start_sandbox_run_time = time.perf_counter()
 
@@ -831,12 +940,14 @@ async def _process_task_attempt(
 
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
-                _ = await benchmark_service.setup_task(
-                    task_row.task_id,
-                    sandbox.id,
-                    on_message=log_output,
-                    dataset=start_benchmark_request.dataset,
-                    sandbox_provider=sandbox_provider_config,
+                _ = await _run_benchmark_service_websocket(
+                    benchmark_service.setup_task(
+                        task_row.task_id,
+                        sandbox.id,
+                        on_message=log_output,
+                        dataset=start_benchmark_request.dataset,
+                        sandbox_provider=sandbox_provider_config,
+                    )
                 )
                 # The benchmark has now had an opportunity to persist the
                 # outage metadata in its restored volume. A later loss is a
@@ -911,16 +1022,19 @@ async def _process_task_attempt(
                 logger.info(f"Evaluating agent {start_benchmark_request.contract.name} in sandbox {sandbox.name}")
                 # Reset timer to keep the last received message from the benchmarks service accurate
                 last_log_time = time.monotonic()
-                evaluation_result = await benchmark_service.evaluate_instance(
-                    task_row.task_id,
-                    sandbox.id,
-                    on_message=log_output,
-                    on_eval_resume_state=on_eval_resume_state,
-                    dataset=start_benchmark_request.dataset,
-                    sandbox_provider=sandbox_provider_config,
+                evaluation_result = await _run_benchmark_service_websocket(
+                    benchmark_service.evaluate_instance(
+                        task_row.task_id,
+                        sandbox.id,
+                        on_message=log_output,
+                        on_eval_resume_state=on_eval_resume_state,
+                        dataset=start_benchmark_request.dataset,
+                        sandbox_provider=sandbox_provider_config,
+                    )
                 )
                 task_breakdown.evaluation_run_duration = time.perf_counter() - evaluation_start_time
 
+                assert start_sandbox_run_time is not None
                 task_breakdown.sandbox_run_duration = time.perf_counter() - start_sandbox_run_time
 
                 # Force flush the logs, maybe redundant since we have the one in finally:
@@ -1009,6 +1123,20 @@ async def _process_task_attempt(
             producer="output_artifact",
             operation="upload_output_artifacts",
         )
+    except BenchmarkServiceWebSocketDNSResolutionError as e:
+        if task_is_stopped():
+            return {task_id: None}
+        error_message = f"Benchmark service WebSocket connection failed during DNS resolution: {_exception_message(e)}"
+        logger.warning(error_message)
+        log_output(f"\n[ERROR] {error_message}")
+
+        return commit_terminal_error(
+            e,
+            error_message,
+            producer="benchmark_service",
+            operation="websocket_connect",
+            cause_code="websocket_dns_resolution",
+        )
     except ConnectionClosedError as e:
         if task_is_stopped():
             return {task_id: None}
@@ -1016,6 +1144,26 @@ async def _process_task_attempt(
         error_message = (
             f"Benchmark service WebSocket disconnected: {e}; last application message received {seconds}s ago"
         )
+        recovered = await recover_evaluation_stream_failure(error_message)
+        if recovered is not None:
+            return recovered
+        logger.warning(error_message)
+        log_output(f"\n[ERROR] {error_message}")
+
+        return commit_terminal_error(
+            e,
+            error_message,
+            producer="benchmark_service",
+            operation="websocket",
+            cause_code="websocket_connection_closed",
+        )
+    except BenchmarkServiceStreamError as e:
+        if task_is_stopped():
+            return {task_id: None}
+        error_message = f"Benchmark service WebSocket stream failed: {_exception_message(e)}"
+        recovered = await recover_evaluation_stream_failure(error_message)
+        if recovered is not None:
+            return recovered
         logger.warning(error_message)
         log_output(f"\n[ERROR] {error_message}")
 

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -24,12 +24,11 @@ from benchmark_service import (
     SandboxRecoveryAttempt,
 )
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceStreamError
-from opentelemetry import trace
 from pydantic import ValidationError
 from sqlmodel import Session, col, select, update
 from websockets.exceptions import ConnectionClosedError, InvalidStatus
 
-from tracker.aws.cloudwatch_logs import write_benchmark_log_event
+from tracker.aws.cloudwatch_logs import get_benchmark_log_url, write_benchmark_log_event
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.s3 import (
     get_agent_result_s3_key,
@@ -58,7 +57,9 @@ from tracker.exceptions import (
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
 from tracker.logging import get_logger, task_id_var
 from tracker.notifications import NotificationContext, SlackNotifier
-from tracker.observability import elapsed_ms, incr
+from tracker.observability import elapsed_ms, error_span, incr
+from tracker.observability.sentry import capture_exception
+from tracker.observability.tracing import observability_span
 from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.types import (
     StartBenchmarkRequest,
@@ -160,17 +161,18 @@ def _observe_task_retry(attempt: SandboxRecoveryAttempt, exc: BaseException) -> 
     """Emit the retry telemetry the Tenacity before_sleep hook owned before recovery
     moved into the benchmark-service client."""
     error_class = type(exc).__name__
-    logger.warning(
-        "retry.before_sleep",
-        extra={
-            "metric": _TASK_RETRY_METRIC,
-            "fn": "_process_task_attempt",
-            "attempt": attempt.number,
-            "idle_for": _SANDBOX_RETRY_DELAY_SECONDS,
-            "error_class": error_class,
-        },
-    )
-    incr(f"{_TASK_RETRY_METRIC}.retry", tags={"error_class": error_class})
+    with observability_span("task.retry", attempt=attempt.number, error_class=error_class):
+        logger.warning(
+            "retry.before_sleep",
+            extra={
+                "metric": _TASK_RETRY_METRIC,
+                "fn": "_process_task_attempt",
+                "attempt": attempt.number,
+                "idle_for": _SANDBOX_RETRY_DELAY_SECONDS,
+                "error_class": error_class,
+            },
+        )
+        incr(f"{_TASK_RETRY_METRIC}.retry", tags={"error_class": error_class})
 
 
 class TrackedTaskStatus(str, Enum):
@@ -261,7 +263,7 @@ class TrackedTask:
             error_message = f"Task error was not handled: {_exception_message(e)}\n{traceback.format_exc()}"
             logger.error(error_message)
             logfire.exception("tracked_task_run failed")
-            sentry_sdk.capture_exception(e)
+            capture_exception(e)
             with Session(bind=engine) as session:
                 task = fetch_task_row(task_row.id, session, self._org)
                 commit_task_error(
@@ -478,7 +480,7 @@ def _commit_task_status(
     if error_message is not None:
         span_attributes["has_error_message"] = True
 
-    with logfire.span("task.status_transition", **span_attributes):  # pyright: ignore[reportArgumentType]
+    with observability_span("task.status_transition", **span_attributes):
         try:
             lock_execution_authority(session, authority)
         except ExecutionAuthorityRevoked:
@@ -524,7 +526,6 @@ def commit_task_status_transition(
     )
 
 
-@logfire.instrument("process_task", extract_args=("benchmark_id", "task_id"))
 async def process_task(
     task_row: Task,
     start_benchmark_request: StartBenchmarkRequest,
@@ -539,6 +540,15 @@ async def process_task(
 ) -> dict[str, dict[str, Any] | None]:
     """Process one task while retaining dependency recovery state across sandbox attempts."""
     dependency_setup_recovery = _DependencySetupRecoveryState()
+
+    with observability_span(
+        "task.started",
+        benchmark_id=str(benchmark_id),
+        task_id=task_id,
+        benchmark_name=start_benchmark_request.benchmark_name,
+        agent_name=start_benchmark_request.contract.name,
+    ):
+        pass
 
     async def run_attempt(
         recovery_attempt: SandboxRecoveryAttempt,
@@ -563,7 +573,7 @@ async def process_task(
         if isinstance(exc, SandboxSetupError):
             _record_failure_before_retry(task_row, authority, exc, attempt.number)
 
-    return await benchmark_service.run_with_sandbox_recovery(
+    result = await benchmark_service.run_with_sandbox_recovery(
         task_id=task_id,
         run_id=str(benchmark_id),
         operation=run_attempt,
@@ -573,6 +583,16 @@ async def process_task(
         retry_delay_s=_SANDBOX_RETRY_DELAY_SECONDS,
         on_retry=record_attempt_failure,
     )
+
+    if result.get(task_id) is not None:
+        with observability_span(
+            "task.completed",
+            benchmark_id=str(benchmark_id),
+            task_id=task_id,
+        ):
+            pass
+
+    return result
 
 
 async def _process_task_attempt(
@@ -598,14 +618,6 @@ async def _process_task_attempt(
     task_id_var.set(task_id)
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
-    trace.get_current_span().set_attributes(
-        {
-            "task_id": task_id,
-            "benchmark_id": str(benchmark_id),
-            "benchmark_name": start_benchmark_request.benchmark_name,
-            "agent_name": start_benchmark_request.contract.name,
-        }
-    )
 
     requested_attempt_started_at = task_row.started_at
     with Session(bind=engine) as task_session:
@@ -629,8 +641,22 @@ async def _process_task_attempt(
     # Setup logging infrastructure before try block so it's always available
     # Suffix is required to version control streams, never delete between retries
     stream_suffix = f"{int(task_row.started_at.timestamp() * 1_000_000):x}"
-    stream_key: str = f"{benchmark_id}:{task_id}_{stream_suffix}"
+    task_stream_name = f"{task_id}_{stream_suffix}"
+    stream_key: str = f"{benchmark_id}:{task_stream_name}"
     log_queue: asyncio.Queue[str] = asyncio.Queue(maxsize=20)
+
+    logger.info(
+        "Task output stream selected",
+        extra={
+            "benchmark_id": str(benchmark_id),
+            "task_id": task_id,
+            "cloudwatch_log_url": get_benchmark_log_url(
+                str(benchmark_id),
+                aws_runtime.resources,
+                task_stream_name,
+            ),
+        },
+    )
 
     last_log_time: float = time.monotonic()
 
@@ -685,6 +711,29 @@ async def _process_task_attempt(
         operation: str,
         cause_code: str | None = None,
     ) -> dict[str, dict[str, Any] | None]:
+        with error_span(
+            "task.error",
+            exc,
+            benchmark_id=str(benchmark_id),
+            task_id=task_id,
+            producer=producer,
+            operation=operation,
+            error_type=type(exc).__name__,
+            cause_code=cause_code or "",
+        ):
+            logger.error(
+                "Task execution failed",
+                exc_info=(type(exc), exc, exc.__traceback__),
+                extra={
+                    "benchmark_id": str(benchmark_id),
+                    "task_id": task_id,
+                    "producer": producer,
+                    "operation": operation,
+                    "error_type": type(exc).__name__,
+                    "cause_code": cause_code or "",
+                },
+            )
+            capture_exception(exc)
         with Session(bind=engine) as task_session:
             task = fetch_task_row(task_row.id, task_session, org)
             commit_task_error(
@@ -1095,21 +1144,14 @@ async def _process_task_attempt(
             raise
 
         error_message = _exception_message(e)
-        logger.error(error_message)
         log_output(f"\n[ERROR] {error_message}")
-        with Session(bind=engine) as task_session:
-            task = fetch_task_row(task_row.id, task_session, org)
-            commit_task_error(
-                task,
-                task_session,
-                error_message,
-                producer="sandbox_provider",
-                operation="sandbox_recovery",
-                error_type=type(e).__name__,
-                expected_started_at=attempt_started_at,
-                authority=authority,
-            )
-        return {task_id: None}
+
+        return commit_terminal_error(
+            e,
+            error_message,
+            producer="sandbox_provider",
+            operation="sandbox_recovery",
+        )
     except OutputArtifactError as e:
         if task_is_stopped():
             return {task_id: None}
@@ -1220,9 +1262,6 @@ async def _process_task_attempt(
             return {task_id: None}
         logfire.exception("process_task failed")
         error_message = _exception_message(e)
-        logger.error(error_message, exc_info=True)
-
-        sentry_sdk.capture_exception(e)
 
         # include the error message
         log_output(f"\n[ERROR] {error_message}")

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -1,6 +1,6 @@
-"""Run with `uv run pytest tests/integration/local/database/test_run_finalization.py`.
+"""Exercise run-finalization concurrency against disposable Postgres.
 
-Exercise run-finalization concurrency against disposable Postgres.
+Run: uv run pytest tests/integration/local/database/test_run_finalization.py
 """
 
 import asyncio

--- a/services/tracker/tests/unit/aws/test_clients.py
+++ b/services/tracker/tests/unit/aws/test_clients.py
@@ -240,8 +240,7 @@ class TestGetBenchmarkLogUrl:
 
     def test_sanitizes_task_id_in_url(self) -> None:
         url = get_benchmark_log_url("bench123", _AWS_RESOURCES, task_id="provider/model:fast")
-        # task id is sanitized before being url-quoted into the log-events path
-        assert "model_fast" in url
+        assert "provider%2Fmodel_fast" in url
         assert "model:fast" not in url
 
     def test_no_task_id_omits_log_events(self) -> None:

--- a/services/tracker/tests/unit/executor/test_entrypoint.py
+++ b/services/tracker/tests/unit/executor/test_entrypoint.py
@@ -1,17 +1,35 @@
-"""Tests for the immutable executor PEX entrypoint."""
+"""Tests for the immutable executor PEX entrypoint.
+
+Run: uv run pytest tests/unit/executor/test_entrypoint.py
+"""
 
 import asyncio
 import json
 import signal
 import sys
-from pathlib import Path
 from collections.abc import Callable
-from unittest.mock import AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
 
 import pytest
+import sentry_sdk
+from opentelemetry import trace
+from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from opentelemetry.trace.propagation import set_span_in_context
 from pytest import MonkeyPatch
 
+from tracker.config import ENVIRONMENT
 from tracker.executor import entrypoint as executor_entrypoint
+from tracker.logging import benchmark_id_var, request_id_var, task_id_var
+
+
+@pytest.fixture(autouse=True)
+def observability(monkeypatch: MonkeyPatch) -> tuple[Mock, Mock]:
+    configure = Mock()
+    flush = Mock()
+    monkeypatch.setattr(executor_entrypoint, "configure_observability", configure)
+    monkeypatch.setattr(executor_entrypoint, "_flush_observability", flush)
+    return configure, flush
 
 
 @pytest.mark.asyncio
@@ -58,7 +76,40 @@ async def test_sigterm_cancels_executor_and_awaits_cleanup(monkeypatch: MonkeyPa
     assert cleaned_up.is_set()
 
 
-def test_main_forwards_executor_payload(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_unhandled_executor_error_is_captured_with_run_context(monkeypatch: MonkeyPatch) -> None:
+    error = RuntimeError("executor failed")
+
+    async def process_benchmark(**_payload: object) -> None:
+        raise error
+
+    captured_context: dict[str, str] = {}
+
+    def capture_exception(captured_error: BaseException) -> None:
+        assert captured_error is error
+        captured_context["benchmark_id"] = benchmark_id_var.get()
+        captured_context["request_id"] = request_id_var.get()
+
+    monkeypatch.setattr(executor_entrypoint, "process_benchmark", process_benchmark)
+    monkeypatch.setattr(sentry_sdk, "capture_exception", capture_exception)
+
+    with pytest.raises(RuntimeError, match="executor failed"):
+        await executor_entrypoint._run_executor(  # pyright: ignore[reportPrivateUsage]
+            {
+                "benchmark_id_str": "benchmark-id",
+                "telemetry_context_json": {"request_id": "request-id", "trace_headers": {}},
+                "executor_dispatch_id": "dispatch-id",
+            }
+        )
+
+    assert captured_context == {"benchmark_id": "benchmark-id", "request_id": "request-id"}
+
+
+def test_main_forwards_executor_payload(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    observability: tuple[Mock, Mock],
+) -> None:
     payload = {
         "start_benchmark_request_json": {"benchmark": "test-benchmark"},
         "benchmark_id_str": "benchmark-id",
@@ -73,6 +124,9 @@ def test_main_forwards_executor_payload(tmp_path: Path, monkeypatch: MonkeyPatch
 
     executor_entrypoint.main()
 
+    configure, flush = observability
+    configure.assert_called_once_with("valkyrie-executor", environment=ENVIRONMENT)
+    flush.assert_called_once_with()
     process_benchmark.assert_awaited_once_with(
         start_benchmark_request_json=payload["start_benchmark_request_json"],
         benchmark_id_str=payload["benchmark_id_str"],
@@ -82,7 +136,11 @@ def test_main_forwards_executor_payload(tmp_path: Path, monkeypatch: MonkeyPatch
     )
 
 
-def test_main_forwards_managed_execution_payload(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+def test_main_forwards_managed_execution_payload(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+    observability: tuple[Mock, Mock],
+) -> None:
     payload = {
         "execution_context_json": {"benchmark_id": "benchmark-id"},
         "executor_dispatch_id": "dispatch-id",
@@ -95,6 +153,9 @@ def test_main_forwards_managed_execution_payload(tmp_path: Path, monkeypatch: Mo
 
     executor_entrypoint.main()
 
+    configure, flush = observability
+    configure.assert_called_once_with("valkyrie-executor", environment=ENVIRONMENT)
+    flush.assert_called_once_with()
     process_benchmark.assert_awaited_once_with(
         start_benchmark_request_json=None,
         benchmark_id_str=None,
@@ -102,6 +163,48 @@ def test_main_forwards_managed_execution_payload(tmp_path: Path, monkeypatch: Mo
         execution_context_json=payload["execution_context_json"],
         executor_dispatch_id=payload["executor_dispatch_id"],
     )
+
+
+def test_executor_context_restores_run_and_trace_context(monkeypatch: MonkeyPatch) -> None:
+    parent_span = NonRecordingSpan(
+        SpanContext(
+            trace_id=0x1234567890ABCDEF1234567890ABCDEF,
+            span_id=0x1234567890ABCDEF,
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+    )
+    extract = Mock(return_value=set_span_in_context(parent_span))
+    monkeypatch.setattr(executor_entrypoint, "extract", extract)
+    request_token = request_id_var.set("outer-request")
+    benchmark_token = benchmark_id_var.set("outer-benchmark")
+    task_token = task_id_var.set("outer-task")
+
+    try:
+        with executor_entrypoint._executor_context(  # pyright: ignore[reportPrivateUsage]
+            {
+                "execution_context_json": {"benchmark_id": "benchmark-id"},
+                "telemetry_context_json": {
+                    "request_id": "request-id",
+                    "trace_headers": {"sentry-trace": "trace-header", "baggage": "baggage-header"},
+                },
+            }
+        ):
+            assert request_id_var.get() == "request-id"
+            assert benchmark_id_var.get() == "benchmark-id"
+            assert task_id_var.get() == ""
+            assert trace.get_current_span().get_span_context() == parent_span.get_span_context()
+
+        assert request_id_var.get() == "outer-request"
+        assert benchmark_id_var.get() == "outer-benchmark"
+        assert task_id_var.get() == "outer-task"
+        assert not trace.get_current_span().get_span_context().is_valid
+    finally:
+        task_id_var.reset(task_token)
+        benchmark_id_var.reset(benchmark_token)
+        request_id_var.reset(request_token)
+
+    extract.assert_called_once_with({"sentry-trace": "trace-header", "baggage": "baggage-header"})
 
 
 @pytest.mark.parametrize("payload", [[], "not an object", 1, None])

--- a/services/tracker/tests/unit/logging/test_logging.py
+++ b/services/tracker/tests/unit/logging/test_logging.py
@@ -5,9 +5,11 @@ Run: uv run pytest tests/unit/logging/test_logging.py
 
 import json
 import logging
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
+from uuid import UUID
 
 import pytest
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from main import app
@@ -19,6 +21,7 @@ from tracker.logging import (
     request_id_var,
     task_id_var,
 )
+from tracker.api.dependencies import TrackedBenchmarkId, bind_benchmark_id
 from tracker.middleware import LoggingContextMiddleware
 from tracker.types import AWSCredentials, HarnessConfig
 
@@ -140,6 +143,36 @@ class TestContextFilter:
             request_id_var.reset(request_token)
             benchmark_id_var.reset(benchmark_token)
             task_id_var.reset(task_token)
+
+
+async def test_bind_benchmark_id_updates_logging_context_and_request_span(monkeypatch: pytest.MonkeyPatch) -> None:
+    span = Mock()
+    monkeypatch.setattr("tracker.api.dependencies.trace.get_current_span", lambda: span)
+
+    benchmark_id = UUID("12345678-1234-5678-9234-567812345678")
+    result = await bind_benchmark_id(benchmark_id)
+
+    assert result == benchmark_id
+    assert benchmark_id_var.get() == str(benchmark_id)
+    span.set_attribute.assert_called_once_with("benchmark_id", str(benchmark_id))
+
+
+async def test_bind_benchmark_id_survives_fastapi_dependency_resolution() -> None:
+    test_app = FastAPI()
+    observed_benchmark_ids: list[str] = []
+
+    async def endpoint(benchmark_id: TrackedBenchmarkId) -> dict[str, str]:
+        observed_benchmark_ids.append(benchmark_id_var.get())
+        return {"benchmark_id": str(benchmark_id)}
+
+    test_app.add_api_route("/runs/{benchmark_id}", endpoint)
+    benchmark_id = UUID("12345678-1234-5678-9234-567812345678")
+
+    async with AsyncClient(transport=ASGITransport(app=test_app), base_url="http://test") as client:
+        response = await client.get(f"/runs/{benchmark_id}")
+
+    assert response.status_code == 200
+    assert observed_benchmark_ids == [str(benchmark_id)]
 
 
 class TestConfigureLogging:

--- a/services/tracker/tests/unit/observability/test_observability.py
+++ b/services/tracker/tests/unit/observability/test_observability.py
@@ -6,21 +6,45 @@ Run: uv run pytest tests/unit/observability/test_observability.py
 import importlib
 import logging
 from collections.abc import Mapping
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
+from opentelemetry.trace import StatusCode
 from sentry_sdk import metrics as sentry_metrics
 from tenacity import RetryCallState, Retrying
 
 import tracker.observability.metrics as metrics_module
 import tracker.observability.retry as retry_module
 import tracker.observability.sentry as sentry_module
+import tracker.observability.tracing as tracing_module
+import tracker.observability as observability_module
 
 
 def _run_orchestration() -> Any:
     return importlib.import_module("tracker.utils.run_orchestration")
+
+
+@pytest.mark.parametrize("failing_component", ["sentry", "tracing"])
+def test_observability_initialization_failure_does_not_escape(
+    monkeypatch: pytest.MonkeyPatch,
+    failing_component: str,
+) -> None:
+    error = RuntimeError(f"{failing_component} unavailable")
+    initialize_sentry = Mock(side_effect=error if failing_component == "sentry" else None)
+    initialize_tracing = Mock(side_effect=error if failing_component == "tracing" else None)
+    warning = Mock()
+    monkeypatch.setattr(observability_module, "init_sentry", initialize_sentry)
+    monkeypatch.setattr(observability_module, "configure_tracing", initialize_tracing)
+    monkeypatch.setattr(observability_module.logger, "warning", warning)
+
+    observability_module.configure_observability("valkyrie-test", "production")
+
+    initialize_sentry.assert_called_once_with("valkyrie-test", environment="production")
+    initialize_tracing.assert_called_once_with("valkyrie-test", environment="production")
+    assert error in warning.call_args.args
 
 
 def test_invalid_queued_request_does_not_expose_aws_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -312,3 +336,97 @@ def test_retry_callback_logs_attempt_and_emits_retry_metric(monkeypatch: pytest.
             "error_class": "TimeoutError",
         }
     ]
+
+
+def test_sentry_span_processor_drops_noisy_polling_subtrees(monkeypatch: pytest.MonkeyPatch) -> None:
+    delegate = Mock()
+    delegate.force_flush.return_value = True
+    monkeypatch.setattr(tracing_module, "SentrySpanProcessor", Mock(return_value=delegate))
+    processor = tracing_module._FilteredSentrySpanProcessor()  # pyright: ignore[reportPrivateUsage]
+
+    root_context = SimpleNamespace(span_id=1)
+    polling_context = SimpleNamespace(span_id=2)
+    polling_child_context = SimpleNamespace(span_id=3)
+    meaningful_context = SimpleNamespace(span_id=4)
+    root = SimpleNamespace(name="sandbox.exec", parent=None, get_span_context=lambda: root_context)
+    polling = SimpleNamespace(
+        name="AsyncProcess.exec",
+        parent=root_context,
+        get_span_context=lambda: polling_context,
+    )
+    polling_child = SimpleNamespace(
+        name="http.client",
+        parent=polling_context,
+        get_span_context=lambda: polling_child_context,
+    )
+    meaningful = SimpleNamespace(
+        name="upload_output",
+        parent=root_context,
+        get_span_context=lambda: meaningful_context,
+    )
+
+    for span in (root, polling, polling_child, meaningful):
+        processor.on_start(span)
+    for span in (polling_child, polling, meaningful, root):
+        processor.on_end(span)
+
+    assert [call.args[0] for call in delegate.on_start.call_args_list] == [root, meaningful]
+    assert [call.args[0] for call in delegate.on_end.call_args_list] == [meaningful, root]
+
+
+def test_handled_error_span_records_exception_and_error_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    span = Mock()
+    error = RuntimeError("handled failure")
+
+    @contextmanager
+    def span_context(*_args: object, **_kwargs: object) -> Any:
+        yield
+
+    monkeypatch.setattr(tracing_module.logfire, "span", span_context)
+    monkeypatch.setattr(tracing_module.trace, "get_current_span", Mock(return_value=span))
+
+    with tracing_module.error_span("task.error", error, benchmark_id="benchmark-123"):
+        pass
+
+    span.record_exception.assert_called_once_with(error)
+    status = span.set_status.call_args.args[0]
+    assert status.status_code is StatusCode.ERROR
+
+
+def test_observability_span_failure_does_not_skip_wrapped_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tracing_module.logfire, "span", Mock(side_effect=RuntimeError("tracing unavailable")))
+    warning = Mock()
+    monkeypatch.setattr(tracing_module.logger, "warning", warning)
+    completed: list[bool] = []
+
+    with tracing_module.observability_span("task.status_transition"):
+        completed.append(True)
+
+    assert completed == [True]
+    warning.assert_called_once()
+
+
+@pytest.mark.parametrize("work_error", [None, RuntimeError("work failed")], ids=["success", "error"])
+def test_observability_span_close_failure_preserves_work_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+    work_error: RuntimeError | None,
+) -> None:
+    span_manager = MagicMock()
+    span_manager.__exit__.side_effect = RuntimeError("tracing unavailable")
+    monkeypatch.setattr(tracing_module.logfire, "span", Mock(return_value=span_manager))
+    warning = Mock()
+    monkeypatch.setattr(tracing_module.logger, "warning", warning)
+    completed: list[bool] = []
+
+    if work_error is None:
+        with tracing_module.observability_span("task.status_transition"):
+            completed.append(True)
+        assert completed == [True]
+    else:
+        with pytest.raises(RuntimeError, match="work failed") as exc_info:
+            with tracing_module.observability_span("task.status_transition"):
+                raise work_error
+        assert exc_info.value is work_error
+        assert completed == []
+
+    warning.assert_called_once()

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -109,12 +109,21 @@ class TestSentrySetup:
             },
         )
         monkeypatch.setattr(sentry_module, "get_current_span", lambda: span)
+        monkeypatch.setattr(
+            sentry_module,
+            "get_context_tags",
+            lambda: {"request_id": "request-123", "benchmark_id": "benchmark-123", "task_id": ""},
+        )
 
         result = _before_send_log()(log, {})
 
         assert result is log
         assert log["trace_id"] == trace_id
         assert log["span_id"] == span_id
+        assert log["attributes"] == {
+            "request_id": "request-123",
+            "benchmark_id": "benchmark-123",
+        }
 
     def test_init_sentry_logs_warning_when_initialization_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         warnings: list[tuple[str, tuple[object, ...]]] = []
@@ -126,9 +135,18 @@ class TestSentrySetup:
         monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=RuntimeError("bad dsn")))
         monkeypatch.setattr(sentry_module.logger, "warning", fake_warning)
 
-        sentry_module.init_sentry("valkyrie-worker", environment="test")
+        sentry_module.init_sentry("valkyrie-worker", environment="production")
 
         assert len(warnings) == 1
         assert warnings[0][0] == "Failed to initialize Sentry: %s: %s"
         assert warnings[0][1][:1] == ("RuntimeError",)
         assert str(warnings[0][1][1]) == "bad dsn"
+
+    def test_init_sentry_skips_missing_production_dsn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        init_mock = Mock()
+        monkeypatch.delenv("SENTRY_DSN", raising=False)
+        monkeypatch.setattr(sentry_sdk, "init", init_mock)
+
+        sentry_module.init_sentry("valkyrie-worker", environment="production")
+
+        init_mock.assert_not_called()

--- a/services/tracker/tests/unit/test_main.py
+++ b/services/tracker/tests/unit/test_main.py
@@ -8,7 +8,7 @@ import logging
 import tarfile
 from collections.abc import AsyncIterator
 from datetime import timezone
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
@@ -30,7 +30,7 @@ from taskiq.message import BrokerMessage, TaskiqMessage
 
 import main as main_module
 import services.executor_host.supervisor as executor_host  # pyright: ignore[reportMissingImports]
-from executor_protocol import SUPPORTED_PROTOCOL_VERSION
+from executor_protocol import SUPPORTED_PROTOCOL_VERSION, ExecutorTelemetryContext
 from main import app, tracker_service_error_handler
 from tests.utils import TEST_ORG_ID, async_iterator
 from tracker.auth import RequestIdentity, get_current_org, get_current_starter
@@ -664,6 +664,7 @@ class TestTrackerAPI:
             else {"start_benchmark_request_json", "benchmark_id_str", "verified_task_ids"}
         )
         assert set(taskiq_message.kwargs) == execution_kwargs | {
+            "telemetry_context_json",
             "executor_dispatch_id",
             "executor_release_id",
             "executor_artifact_uri",
@@ -698,15 +699,26 @@ class TestTrackerAPI:
         assert isinstance(process_payload, executor_host.ExecutorProcessPayload)
         assert process_payload.benchmark_id == str(benchmark.id)
         assert process_payload.verified_task_ids == ["task_0"]
+        telemetry_context = taskiq_message.kwargs["telemetry_context_json"]
+        assert telemetry_context["request_id"]
+        assert isinstance(telemetry_context["trace_headers"], dict)
+        child_telemetry_context = cast(
+            ExecutorTelemetryContext,
+            process_payload.arguments["telemetry_context_json"],
+        )
+        assert child_telemetry_context["request_id"] == telemetry_context["request_id"]
+        assert child_telemetry_context["trace_headers"]
         if aws_managed:
             assert process_payload.arguments == {
-                "execution_context_json": taskiq_message.kwargs["execution_context_json"]
+                "execution_context_json": taskiq_message.kwargs["execution_context_json"],
+                "telemetry_context_json": child_telemetry_context,
             }
         else:
             assert process_payload.arguments == {
                 "start_benchmark_request_json": request.model_dump(),
                 "benchmark_id_str": str(benchmark.id),
                 "verified_task_ids": ["task_0"],
+                "telemetry_context_json": child_telemetry_context,
             }
         host_dispatch = observed_host["dispatch"]
         assert isinstance(host_dispatch, executor_host.ArtifactDispatch)
@@ -723,9 +735,6 @@ class TestTrackerAPI:
         harness_config: HarnessConfig,
     ) -> None:
         class FailingKicker:
-            def with_labels(self, **_labels: str) -> "FailingKicker":
-                return self
-
             async def kiq(self, **_kwargs: Any) -> None:
                 raise RuntimeError("redis unavailable")
 

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -1,3 +1,8 @@
+"""Tests for managed and access-key executor inputs.
+
+Run: uv run pytest tests/unit/test_managed_execution.py
+"""
+
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
@@ -278,11 +283,17 @@ async def test_ineligible_managed_execution_marks_run_error(
 ) -> None:
     request = _managed_request(contract)
     benchmark = _persist_benchmark(database_session, request, aws_managed=True)
+    spans: list[tuple[str, dict[str, Any]]] = []
 
     def reject_managed_runtime(_org_id: UUID) -> AWSRuntime:
         raise ManagedAWSEligibilityError("Managed AWS access is not available for this organization")
 
+    def record_span(name: str, **attributes: Any) -> MagicMock:
+        spans.append((name, attributes))
+        return MagicMock()
+
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", reject_managed_runtime)
+    monkeypatch.setattr("tracker.utils.run_orchestration.observability_span", record_span)
 
     await process_benchmark(
         execution_context_json=_execution_context(request, benchmark.id),
@@ -292,6 +303,9 @@ async def test_ineligible_managed_execution_marks_run_error(
     database_session.refresh(benchmark)
     assert benchmark.status == BenchmarkStatus.ERROR
     assert "Managed AWS access is not available for this organization" in (benchmark.error_message or "")
+    finalized_span = next(attributes for name, attributes in spans if name == "run.finalized")
+    assert finalized_span["benchmark_id"] == str(benchmark.id)
+    assert finalized_span["status"] == "ERROR"
 
 
 async def test_managed_execution_completes_with_the_deployment_runtime(
@@ -307,6 +321,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     )
     benchmark = _persist_benchmark(database_session, request, aws_managed=True)
     calls: list[str] = []
+    spans: list[tuple[str, dict[str, Any]]] = []
     provider_config = cast(SandboxProviderConfig, MagicMock())
 
     def deployment_runtime(_org_id: UUID) -> AWSRuntime:
@@ -340,6 +355,10 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         calls.append("lambda-post-run")
         return {}
 
+    def record_span(name: str, **attributes: Any) -> MagicMock:
+        spans.append((name, attributes))
+        return MagicMock()
+
     monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
     monkeypatch.setattr("tracker.utils.run_orchestration.create_benchmark_log_group", create_log_group)
     monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
@@ -348,6 +367,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", dry_run)
     monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", upload_results)
     monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke_post_run)
+    monkeypatch.setattr("tracker.utils.run_orchestration.observability_span", record_span)
 
     execution_context = _execution_context(request, benchmark.id)
     # A resume may change stored inputs while this job is queued; the queued job must still run.
@@ -362,6 +382,8 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     assert calls[:4] == ["logs", "provider-secret", "agent-secrets", "lambda-dry-run"]
     assert calls.count("agent-secrets") >= 2
     assert calls[-2:] == ["s3-final-upload", "lambda-post-run"]
+    finalized_span = next(attributes for name, attributes in spans if name == "run.finalized")
+    assert finalized_span["status"] == "FINISHED"
 
 
 def test_managed_execution_preflight_checks_aws_dependencies_in_order(

--- a/services/tracker/tests/unit/test_taskiq_producers.py
+++ b/services/tracker/tests/unit/test_taskiq_producers.py
@@ -1,3 +1,8 @@
+"""Tests for Taskiq executor payload producers.
+
+Run: uv run pytest tests/unit/test_taskiq_producers.py
+"""
+
 import json
 from typing import Any, cast
 from unittest.mock import AsyncMock
@@ -31,6 +36,7 @@ from tracker.types import HarnessConfig, StartBenchmarkRequest
 client = TestClient(app)
 
 _DISPATCH_TASK_KWARGS = {
+    "telemetry_context_json",
     "executor_dispatch_id",
     "executor_release_id",
     "executor_artifact_uri",
@@ -66,9 +72,6 @@ def _capture_task_payloads(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, An
     payloads: list[dict[str, Any]] = []
 
     class CapturingKicker:
-        def with_labels(self, **_kwargs: Any) -> "CapturingKicker":
-            return self
-
         async def kiq(self, **kwargs: Any) -> None:
             payloads.append(kwargs)
 

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -7,6 +7,7 @@ import asyncio
 import socket
 import time
 from typing import Any, Never
+from unittest.mock import Mock
 
 import httpx
 import pytest
@@ -779,6 +780,8 @@ class TestBenchmarkServiceFailures:
             raise BenchmarkServiceError(html_error)
 
         monkeypatch.setattr(BenchmarkServiceClient, "final_score", _mock_final_score)
+        capture_exception = Mock()
+        monkeypatch.setattr(run_orchestration_module.sentry_sdk, "capture_exception", capture_exception)
         benchmark_row = fetch_benchmark_row(benchmark_id, database_session, TEST_ORG)
         authority_kwargs = executor_authority_kwargs(benchmark_row)
 
@@ -794,3 +797,5 @@ class TestBenchmarkServiceFailures:
             assert benchmark_row.status == BenchmarkStatus.ERROR
             assert benchmark_row.error_message is not None
             assert "Final score failed with status code 404" in benchmark_row.error_message
+        captured_error = capture_exception.call_args.args[0]
+        assert isinstance(captured_error, BenchmarkServiceError)

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -4,13 +4,18 @@ Run: uv run pytest tests/unit/utils/test_benchmark_service_failures.py
 """
 
 import asyncio
+import socket
 import time
 from typing import Any, Never
 
 import httpx
 import pytest
 from benchmark_service import ExecResult
-from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
+from benchmark_service.client import (
+    BenchmarkServiceClient,
+    BenchmarkServiceError,
+    BenchmarkServiceStreamClosedError,
+)
 from benchmark_service.schemas import RetrieveTaskResponse
 from sqlmodel import Session, desc, select
 from websockets.datastructures import Headers
@@ -23,7 +28,16 @@ import tracker.utils.run_orchestration as run_orchestration_module
 import tracker.utils.task_execution as utils_module
 from tests.unit.utils.task_execution_support import TEST_ORG, create_task_environment, run_process_task
 from tracker.aws.runtime import AWSRuntime
-from tracker.database.models import AgentContractRequest, BenchmarkStatus, ErrorResult, Task, TaskStatus
+from tracker.database.models import (
+    AgentContractRequest,
+    AgentCausedExitReason,
+    BenchmarkStatus,
+    ErrorResult,
+    EvaluationResult,
+    Task,
+    TaskBreakdown,
+    TaskStatus,
+)
 from tracker.types import HarnessConfig
 from tracker.utils import (
     fetch_benchmark_row,
@@ -119,6 +133,400 @@ class TestBenchmarkServiceFailures:
         assert f"received {code}" in error_message
         assert reason in error_message
         assert "last application message received" in error_message
+
+    @pytest.mark.parametrize("stream_failure", ["wrapped", "raw"])
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_close_with_saved_state_resumes_evaluation(
+        self,
+        stream_failure: str,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        resume_calls = 0
+
+        async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
+            on_eval_resume_state(saved_state)
+            if stream_failure == "raw":
+                raise ConnectionClosedError(None, None)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        async def _mock_resume_evaluation(
+            *_args: Any, eval_resume_state: dict[str, Any], **_kwargs: Any
+        ) -> dict[str, Any]:
+            nonlocal resume_calls
+            resume_calls += 1
+            assert eval_resume_state == saved_state
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert resume_calls == 1
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+        evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+        assert evaluation.instance_id == "mock-sandbox-id"
+        assert not database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).first()
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_recovery_preserves_sandbox_metadata(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+
+        async def _mock_run_agent(*_args: Any, **_kwargs: Any) -> tuple[AgentCausedExitReason, float]:
+            return AgentCausedExitReason.TIMEOUT, 12.5
+
+        async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
+            on_eval_resume_state(saved_state)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        async def _mock_resume_evaluation(
+            *_args: Any, eval_resume_state: dict[str, Any], **_kwargs: Any
+        ) -> dict[str, Any]:
+            assert eval_resume_state == saved_state
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr(utils_module, "run_agent", _mock_run_agent)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        evaluation = database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+        assert evaluation.instance_id == "mock-sandbox-id"
+        assert evaluation.agent_caused_exit_reason == AgentCausedExitReason.TIMEOUT
+        database_session.refresh(task_row)
+        breakdown = database_session.get(TaskBreakdown, task_row.task_breakdown)
+        assert breakdown is not None
+        assert breakdown.evaluation_run_duration is not None
+        assert breakdown.evaluation_run_duration > 0
+        assert breakdown.sandbox_run_duration is not None
+        assert breakdown.sandbox_run_duration > 0
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_durable_resume_without_breakdown_can_recover(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        task_row.status = TaskStatus.EVALUATING
+        task_row.eval_resume_state = saved_state
+        database_session.commit()
+        resume_calls = 0
+
+        async def _mock_resume_evaluation(
+            *_args: Any, eval_resume_state: dict[str, Any], **_kwargs: Any
+        ) -> dict[str, Any]:
+            nonlocal resume_calls
+            resume_calls += 1
+            assert eval_resume_state == saved_state
+            if resume_calls == 1:
+                raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert resume_calls == 2
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+        assert task_row.task_breakdown is None
+        assert database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
+        assert not database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).first()
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_close_without_saved_state_produces_stream_error(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        error_message = self._latest_task_error(database_session, task_row)
+        assert "Benchmark service WebSocket stream failed" in error_message
+        assert "keepalive timeout" in error_message
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_resume_failure_produces_terminal_error(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+
+        async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
+            on_eval_resume_state(saved_state)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        async def _mock_resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise BenchmarkServiceError("resume endpoint unavailable")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        error_message = self._latest_task_error(database_session, task_row)
+        assert "resuming evaluation from durable benchmark state" in error_message
+        assert "resume failed: resume endpoint unavailable" in error_message
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_resume_stops_when_task_is_stopped_during_retry(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+
+        async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
+            on_eval_resume_state(saved_state)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        async def _mock_resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            with Session(bind=database_session.bind) as session:
+                stopped_task = session.get(Task, task_row.id)
+                assert stopped_task is not None
+                stopped_task.status = TaskStatus.STOPPED
+                session.commit()
+            raise BenchmarkServiceError("resume endpoint unavailable")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.STOPPED
+        assert not database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).first()
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_recovery_is_abandoned_if_task_stops_during_error_handling(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        original_exception_message = utils_module._exception_message
+
+        async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
+            on_eval_resume_state(saved_state)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        def _stop_task_before_recovery(error: BaseException) -> str:
+            with Session(bind=database_session.bind) as session:
+                stopped_task = session.get(Task, task_row.id)
+                assert stopped_task is not None
+                stopped_task.status = TaskStatus.STOPPED
+                session.commit()
+            return original_exception_message(error)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr(utils_module, "_exception_message", _stop_task_before_recovery)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.STOPPED
+        assert not database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).first()
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_stream_recovery_does_not_finish_a_stale_task(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+        commit_calls = 0
+        saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        original_commit_task_status_transition = utils_module.commit_task_status_transition
+
+        async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
+            on_eval_resume_state(saved_state)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        async def _mock_resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"status": "success", "score": 1.0}
+
+        def _reject_finish(*args: Any, **kwargs: Any) -> bool:
+            nonlocal commit_calls
+            commit_calls += 1
+            if commit_calls == 4:
+                return False
+            return original_commit_task_status_transition(*args, **kwargs)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+        monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
+        monkeypatch.setattr(utils_module, "commit_task_status_transition", _reject_finish)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        assert commit_calls == 4
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.EVALUATING
+
+    @pytest.mark.parametrize("failure", ["dns", "raw", "stream"])
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_preconnection_failure_ignores_stopped_task(
+        self,
+        failure: str,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> Never:
+            with Session(bind=database_session.bind) as session:
+                stopped_task = session.get(Task, task_row.id)
+                assert stopped_task is not None
+                stopped_task.status = TaskStatus.STOPPED
+                session.commit()
+            if failure == "dns":
+                raise socket.gaierror(-2, "Name or service not known")
+            if failure == "raw":
+                raise ConnectionClosedError(None, None)
+            raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.STOPPED
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_dns_failure_is_reported_as_preconnection_error(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise socket.gaierror(-2, "Name or service not known")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        error_message = self._latest_task_error(database_session, task_row)
+        assert "WebSocket connection failed during DNS resolution" in error_message
+        assert "Name or service not known" in error_message
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_retrieve_task_dns_failure_is_not_reported_as_websocket_error(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract, database_session, harness_config
+        )
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> Never:
+            raise socket.gaierror(-2, "unrelated DNS failure")
+
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        error_result = self._latest_task_error_result(database_session, task_row)
+        assert "unrelated DNS failure" in error_result.error_message
+        assert "WebSocket" not in error_result.error_message
+        assert error_result.producer == "tracker"
+        assert error_result.operation == "process_task"
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_validation_error_produces_human_readable_message(

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -5,7 +5,7 @@ Run: uv run pytest tests/unit/utils/test_run_state.py
 
 from datetime import datetime
 from typing import Any, Sequence
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
@@ -612,7 +612,7 @@ class TestRunState:
             return MockSpan(record)
 
         monkeypatch.setattr("tracker.utils.task_execution.logger.info", fake_info)
-        monkeypatch.setattr("tracker.utils.task_execution.logfire.span", fake_span)
+        monkeypatch.setattr("tracker.observability.tracing.logfire.span", fake_span)
 
         database_session.add(example_benchmark_object)
         database_session.commit()
@@ -700,6 +700,7 @@ class TestRunState:
         example_benchmark_object: Benchmark,
         database_session: Session,
         executor_authority: Any,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Tests the end to end flow when stopping and resuming a benchmark
 
@@ -708,6 +709,15 @@ class TestRunState:
             - Benchmark status is set to finished if all tasks are finished
             - Benchmark status is set to stopped if any tasks are stopped
         """
+
+        finalized_statuses: list[str] = []
+
+        def record_span(name: str, **attributes: Any) -> MagicMock:
+            if name == "run.finalized":
+                finalized_statuses.append(attributes["status"])
+            return MagicMock()
+
+        monkeypatch.setattr("tracker.utils.run_orchestration.observability_span", record_span)
 
         # Create benchmark
         benchmark_row = example_benchmark_object
@@ -757,6 +767,7 @@ class TestRunState:
         set_benchmark_final_status(benchmark_row, database_session, self._test_org, authority=authority)
         database_session.refresh(benchmark_row, attribute_names=["status"])
         assert benchmark_row.status == BenchmarkStatus.STOPPED
+        assert finalized_statuses == ["FINISHED", "STOPPED"]
 
 
 class TestFetchStartedByFilter:

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -402,9 +402,11 @@ class TestTaskExecutionRetry:
         async def _lost_grading_sandbox(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
             raise SandboxNotFoundError("grading sandbox was preempted")
 
+        capture_exception = Mock()
         monkeypatch.setattr(task_execution_module, "engine", database_session.bind)
         monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
         monkeypatch.setattr(task_execution_module, "buffer_logs", Mock())
+        monkeypatch.setattr(task_execution_module.sentry_sdk, "capture_exception", capture_exception)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _failed_policy_lookup)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _lost_grading_sandbox, raising=False)
 
@@ -419,6 +421,8 @@ class TestTaskExecutionRetry:
             .order_by(desc(ErrorResult.created_at))
         ).one()
         assert error_message == "grading sandbox was preempted"
+        captured_error = capture_exception.call_args.args[0]
+        assert isinstance(captured_error, SandboxNotFoundError)
 
     async def test_process_task_spans_timed_status_transitions(
         self,
@@ -496,13 +500,16 @@ class TestTaskExecutionRetry:
         monkeypatch.setattr("tracker.utils.task_execution.upload_agent_artifacts", _mock_upload_agent_artifacts)
         monkeypatch.setattr("tracker.utils.task_execution.run_agent", _mock_run_agent)
         monkeypatch.setattr("tracker.utils.task_execution.logger.info", _mock_logger_info)
-        monkeypatch.setattr("tracker.utils.task_execution.logfire.span", _mock_span)
+        monkeypatch.setattr("tracker.observability.tracing.logfire.span", _mock_span)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
 
         await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 
         transition_records = [record for record in span_records if record["message"] == "task.status_transition"]
+        lifecycle_records = [
+            record for record in span_records if record["message"] in {"task.started", "task.completed"}
+        ]
 
         assert [(record["from_status"], record["to_status"]) for record in transition_records] == [
             (TaskStatus.PENDING.value, TaskStatus.BUILDING.value),
@@ -513,6 +520,9 @@ class TestTaskExecutionRetry:
         assert all(record["task_id"] == "task_0" for record in transition_records)
         assert all(record["benchmark_id"] == str(benchmark_id) for record in transition_records)
         assert all(record["entered"] and record["exited"] for record in transition_records)
+        assert [record["message"] for record in lifecycle_records] == ["task.started", "task.completed"]
+        assert all(record["task_id"] == "task_0" for record in lifecycle_records)
+        assert all(record["benchmark_id"] == str(benchmark_id) for record in lifecycle_records)
         assert not any(record["message"].startswith("task.status_transition") for record in log_records)
         assert run_agent_kwargs["benchmark_id"] == str(benchmark_id)
         assert create_sandbox_kwargs["labels"]["run-id"] == str(benchmark_id)
@@ -526,6 +536,10 @@ class TestTaskExecutionRetry:
         ]
 
         event_names = [record["message"] for record in log_records]
+        stream_record = next(record for record in log_records if record["message"] == "Task output stream selected")
+        assert stream_record["benchmark_id"] == str(benchmark_id)
+        assert stream_record["task_id"] == "task_0"
+        assert str(benchmark_id) in stream_record["cloudwatch_log_url"]
         assert "agent.run.complete" in event_names
         assert "task.evaluation.start" in event_names
 

--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -6,6 +6,7 @@ from uuid import UUID
 import click
 from tracker.agent.contract import get_contract
 from tracker.agent.schemas import AgentConfig
+from tracker.database.models import AgentContractRequest
 from tracker.types import StartBenchmarkResponse
 
 from valkyrie.cli.exceptions import BundlerError, ContractValidationError, TrackerServiceError
@@ -345,6 +346,7 @@ def start(
 
         config_kwargs["kwargs"] = {key: value for key, value in kwargs}
         agent_config = AgentConfig(**config_kwargs)
+        managed_execution = not TrackerService.parse_config_keys()
 
         agent_path = Path(agent)
 
@@ -360,6 +362,18 @@ def start(
             )
             contract = get_contract(contract_file, agent_config)
             asyncio.run(push_agent(contract.name, agent_path))
+            if managed_execution:
+                contract = AgentContractRequest(
+                    name=contract.name,
+                    model=agent_config.model,
+                    kwargs={key: str(value) for key, value in agent_config.kwargs.items()},
+                )
+        elif managed_execution:
+            contract = AgentContractRequest(
+                name=agent,
+                model=agent_config.model,
+                kwargs={key: str(value) for key, value in agent_config.kwargs.items()},
+            )
         else:
             contract = asyncio.run(get_contract_from_s3(agent, agent_config))
             contract.name = agent

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -1,0 +1,309 @@
+"""Credential-free cross-process transport smoke for run telemetry correlation.
+
+Run: uv run pytest tests/integration/observability/test_run_correlation.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import logging
+import multiprocessing
+import os
+import threading
+import time
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, cast
+
+import logfire
+import sentry_sdk
+from sentry_sdk.envelope import Envelope, Item
+
+from services.executor_host import supervisor as host_supervisor
+from services.executor_host import observability as host_observability
+from services.executor_host.supervisor import ExecutorProcessPayload
+from services.tracker import main as tracker_main
+from tracker.executor.entrypoint import _executor_context
+from tracker.logging import benchmark_id_var, configure_logging, request_id_var, task_id_var
+from tracker.observability import configure_observability, error_span, incr
+
+_RUN_ID = "00000000-0000-4000-8000-000000000123"
+_REQUEST_ID = "observability-smoke-request"
+_DISPATCH_ID = "00000000-0000-4000-8000-000000000456"
+_RELEASE_ID = "local-smoke-release"
+_ENVIRONMENT = "local-smoke"
+
+
+class _EnvelopeServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self) -> None:
+        super().__init__(("127.0.0.1", 0), _EnvelopeHandler)
+        self.envelopes: list[bytes] = []
+        self.envelopes_lock = threading.Lock()
+
+    def record(self, body: bytes) -> None:
+        with self.envelopes_lock:
+            self.envelopes.append(body)
+
+
+class _EnvelopeHandler(BaseHTTPRequestHandler):
+    server: _EnvelopeServer
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(content_length)
+        if self.headers.get("Content-Encoding") == "gzip":
+            body = gzip.decompress(body)
+        self.server.record(body)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, _format: str, *args: object) -> None:
+        del args
+
+
+@contextmanager
+def _local_sentry_receiver() -> Iterator[tuple[str, _EnvelopeServer]]:
+    server = _EnvelopeServer()
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = server.server_address
+    try:
+        yield f"http://public@{host}:{port}/1", server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _set_sentry_environment(dsn: str) -> None:
+    os.environ["SENTRY_DSN"] = dsn
+    os.environ["SENTRY_RELEASE"] = _RELEASE_ID
+    os.environ["LOG_LEVEL"] = "INFO"
+
+
+def _capture_test_error(service_name: str, *, span_name: str | None = None) -> None:
+    try:
+        raise RuntimeError(f"{service_name} observability smoke error")
+    except RuntimeError as error:
+        if span_name is None:
+            sentry_sdk.capture_exception(error)
+            return
+        with error_span(span_name, error, benchmark_id=_RUN_ID):
+            sentry_sdk.capture_exception(error)
+
+
+def _flush_telemetry() -> None:
+    logfire.force_flush(timeout_millis=5000)
+    sentry_sdk.flush(timeout=5)
+
+
+def _run_tracker(dsn: str, context_path: str) -> None:
+    _set_sentry_environment(dsn)
+    os.environ["ENVIRONMENT"] = "development"
+    configure_logging()
+    configure_observability("valkyrie-tracker", environment=_ENVIRONMENT)
+    logger = logging.getLogger("tracker.observability.smoke")
+    tokens = [
+        request_id_var.set(_REQUEST_ID),
+        benchmark_id_var.set(_RUN_ID),
+        task_id_var.set("tracker-task"),
+    ]
+    try:
+        with logfire.span("observability.smoke.tracker"):
+            logger.info("Tracker accepted observability smoke run")
+            incr(
+                "valkyrie.observability.smoke",
+                tags={"operation": "run", "benchmark_id": _RUN_ID},
+            )
+            payload = {
+                "start_benchmark_request_json": {},
+                "benchmark_id_str": _RUN_ID,
+                "verified_task_ids": [],
+                "telemetry_context_json": tracker_main._executor_telemetry_context(),  # pyright: ignore[reportPrivateUsage]
+                "executor_dispatch_id": _DISPATCH_ID,
+                "executor_release_id": _RELEASE_ID,
+                "executor_artifact_uri": "s3://artifacts/local-smoke.pex",
+                "executor_artifact_digest": "a" * 64,
+                "executor_protocol_version": "1",
+            }
+            Path(context_path).write_text(json.dumps(payload))
+            _capture_test_error("valkyrie-tracker", span_name="run.error")
+    finally:
+        for token in reversed(tokens):
+            token.var.reset(token)
+        _flush_telemetry()
+
+
+def _run_executor_host(dsn: str, input_path: str, output_path: str) -> None:
+    _set_sentry_environment(dsn)
+    os.environ["ENVIRONMENT"] = _ENVIRONMENT
+    host_observability.configure_observability()
+    payload = cast(dict[str, Any], json.loads(Path(input_path).read_text()))
+
+    async def capture_dispatch(
+        _executor_supervisor: object,
+        _store: object,
+        *,
+        executor_dispatch_id: str,
+        dispatch: object,
+        process_payload: ExecutorProcessPayload,
+    ) -> None:
+        del _executor_supervisor, _store, executor_dispatch_id, dispatch
+        logging.getLogger("executor-host.observability.smoke").info("ExecutorHost dispatched observability smoke run")
+        Path(output_path).write_text(json.dumps(process_payload.arguments["telemetry_context_json"]))
+        _capture_test_error("valkyrie-executor-host")
+
+    host_supervisor.run_executor_dispatch = capture_dispatch
+    asyncio.run(host_supervisor.launch_executor.original_func(**payload))
+    _flush_telemetry()
+
+
+def _run_executor(dsn: str, context_path: str) -> None:
+    _set_sentry_environment(dsn)
+    os.environ["ENVIRONMENT"] = "development"
+    configure_logging()
+    configure_observability("valkyrie-executor", environment=_ENVIRONMENT)
+    telemetry_context = cast(dict[str, Any], json.loads(Path(context_path).read_text()))
+    with _executor_context(
+        {
+            "benchmark_id_str": _RUN_ID,
+            "telemetry_context_json": telemetry_context,
+        }
+    ):
+        with logfire.span("observability.smoke.executor"):
+            logging.getLogger("tracker.executor.observability.smoke").info("Executor processed observability smoke run")
+            _capture_test_error("valkyrie-executor")
+    _flush_telemetry()
+
+
+def _run_process(target: Any, *args: str) -> None:
+    process = multiprocessing.get_context("spawn").Process(target=target, args=args)
+    process.start()
+    process.join(timeout=20)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=5)
+        raise AssertionError(f"{target.__name__} did not finish")
+    assert process.exitcode == 0
+
+
+def _items(server: _EnvelopeServer) -> list[Item]:
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        with server.envelopes_lock:
+            if server.envelopes:
+                bodies = list(server.envelopes)
+                break
+        time.sleep(0.05)
+    else:
+        raise AssertionError("The local Sentry receiver did not receive any envelopes")
+    return [item for body in bodies for item in Envelope.deserialize(body).items]
+
+
+def _json_payload(item: Item) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(item.get_bytes()))
+
+
+def _log_entries(items: list[Item]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for item in items:
+        if item.type != "log":
+            continue
+        payload = _json_payload(item)
+        raw_entries = payload.get("items", [payload])
+        if isinstance(raw_entries, list):
+            entries.extend(cast(list[dict[str, Any]], raw_entries))
+    return entries
+
+
+def _metric_entries(items: list[Item]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for item in items:
+        if item.type != "trace_metric":
+            continue
+        payload = _json_payload(item)
+        raw_entries = payload.get("items", [payload])
+        if isinstance(raw_entries, list):
+            entries.extend(cast(list[dict[str, Any]], raw_entries))
+    return entries
+
+
+def _attribute_value(entry: Mapping[str, Any], key: str) -> object | None:
+    attributes = entry.get("attributes")
+    if not isinstance(attributes, Mapping):
+        return None
+    value = cast(Mapping[str, Any], attributes).get(key)
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, Any], value).get("value")
+    return value
+
+
+def _breadcrumbs(event: Mapping[str, Any]) -> list[dict[str, Any]]:
+    breadcrumbs = event.get("breadcrumbs", {})
+    if not isinstance(breadcrumbs, Mapping):
+        return []
+    values = cast(Mapping[str, Any], breadcrumbs).get("values", [])
+    return cast(list[dict[str, Any]], values) if isinstance(values, list) else []
+
+
+def test_run_id_correlates_logs_errors_and_traces_across_processes(tmp_path: Path) -> None:
+    tracker_context = tmp_path / "tracker-context.json"
+    executor_context = tmp_path / "executor-context.json"
+
+    with _local_sentry_receiver() as (dsn, server):
+        _run_process(_run_tracker, dsn, str(tracker_context))
+        _run_process(_run_executor_host, dsn, str(tracker_context), str(executor_context))
+        _run_process(_run_executor, dsn, str(executor_context))
+        items = _items(server)
+
+    events = [event for item in items if (event := item.get_event()) is not None]
+    transactions = [event for item in items if (event := item.get_transaction_event()) is not None]
+    logs = _log_entries(items)
+    metrics = _metric_entries(items)
+
+    assert {event["server_name"] for event in events} == {
+        "valkyrie-tracker",
+        "valkyrie-executor-host",
+        "valkyrie-executor",
+    }
+    assert all(event["tags"]["benchmark_id"] == _RUN_ID for event in events)
+    assert all(event["environment"] == _ENVIRONMENT for event in events)
+    assert all(event["release"] == _RELEASE_ID for event in events)
+    assert all(
+        any(breadcrumb.get("message", "").endswith("observability smoke run") for breadcrumb in _breadcrumbs(event))
+        for event in events
+    )
+
+    correlated_logs = [entry for entry in logs if _attribute_value(entry, "benchmark_id") == _RUN_ID]
+    assert len(correlated_logs) >= 3
+    assert {_attribute_value(entry, "server.address") for entry in correlated_logs} == {
+        "valkyrie-tracker",
+        "valkyrie-executor-host",
+        "valkyrie-executor",
+    }
+
+    assert len(transactions) >= 3
+    tracker_error_spans = [
+        span
+        for transaction in transactions
+        if transaction.get("transaction") == "observability.smoke.tracker"
+        for span in transaction.get("spans", [])
+        if span.get("op") == "run.error"
+    ]
+    assert len(tracker_error_spans) == 1
+    assert tracker_error_spans[0]["status"] == "internal_error"
+    event_trace_ids = [cast(str, event["contexts"]["trace"]["trace_id"]) for event in events]
+    transaction_trace_ids = [cast(str, transaction["contexts"]["trace"]["trace_id"]) for transaction in transactions]
+    log_trace_ids = [cast(str, entry["trace_id"]) for entry in correlated_logs]
+    assert len(metrics) == 1
+    assert metrics[0]["name"] == "valkyrie.observability.smoke"
+    assert _attribute_value(metrics[0], "operation") == "run"
+    assert _attribute_value(metrics[0], "benchmark_id") is None
+    metric_trace_ids = [cast(str, metric["trace_id"]) for metric in metrics]
+    assert len(set([*event_trace_ids, *transaction_trace_ids, *log_trace_ids, *metric_trace_ids])) == 1

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -57,6 +57,7 @@ class StartTestbed:
         self.tracker.__enter__.return_value = self.tracker
         self.tracker_factory = MagicMock(return_value=self.tracker)
         self.tracker_factory.validate_sandbox_provider.return_value = ("daytona", "DaytonaSecrets")
+        self.tracker_factory.parse_config_keys.return_value = {"AWS_ACCESS_KEY_ID": "key"}
         self.tracker_factory.get_webhook_secret.return_value = None
         self.resolve_remote = AsyncMock(
             return_value=AgentContractRequest(name="remote-agent", install_cmd="echo install", run_cmd="echo run")
@@ -264,6 +265,71 @@ class TestCountedStarts:
         get_contract.assert_called_once()
         push_agent.assert_awaited_once_with("local-agent", local_agent)
         assert start_testbed.tracker.start_benchmark.call_count == 2
+
+    def test_managed_start_defers_contract_resolution_to_tracker(
+        self,
+        start_testbed: StartTestbed,
+    ) -> None:
+        start_testbed.tracker_factory.parse_config_keys.return_value = {}
+
+        result = start_testbed.invoke(["--model", "anthropic/claude-opus-5", "-k", "variant", "max"])
+
+        assert result.exit_code == 0, result.output
+        start_testbed.resolve_remote.assert_not_awaited()
+        contract = start_testbed.tracker.start_benchmark.call_args.args[0]
+        assert contract == AgentContractRequest(
+            name="remote-agent",
+            model="anthropic/claude-opus-5",
+            kwargs={"variant": "max"},
+        )
+
+    def test_managed_local_start_uploads_then_sends_name_only_contract(
+        self,
+        start_testbed: StartTestbed,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        local_agent = tmp_path / "local-agent"
+        local_agent.mkdir()
+        (local_agent / "contract.yaml").write_text(
+            "name: local-agent\n",
+            encoding="utf-8",
+        )
+        get_contract = MagicMock(
+            return_value=AgentContractRequest(
+                name="local-agent",
+                install_cmd="echo install",
+                run_cmd="echo run",
+            )
+        )
+        push_agent = AsyncMock()
+        monkeypatch.setattr(start_module, "get_contract", get_contract)
+        monkeypatch.setattr(start_module, "push_agent", push_agent)
+        start_testbed.tracker_factory.parse_config_keys.return_value = {}
+
+        result = start_testbed.cli_runner.invoke(
+            start_command,
+            [
+                "--agent",
+                str(local_agent),
+                "--benchmark",
+                "swebench",
+                "--model",
+                "anthropic/claude-opus-5",
+                "-k",
+                "variant",
+                "max",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        push_agent.assert_awaited_once_with("local-agent", local_agent)
+        contract = start_testbed.tracker.start_benchmark.call_args.args[0]
+        assert contract == AgentContractRequest(
+            name="local-agent",
+            model="anthropic/claude-opus-5",
+            kwargs={"variant": "max"},
+        )
 
     def test_invalid_options_precede_side_effects(self, start_testbed: StartTestbed) -> None:
         """

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -117,6 +117,10 @@ class MockTrackerService:
         self.require_config_values.append(require_config)
 
     @staticmethod
+    def parse_config_keys() -> dict[str, str]:
+        return {"AWS_ACCESS_KEY_ID": "key"}
+
+    @staticmethod
     def benchmark_service_health(
         name: str,
         url: str,

--- a/tests/unit/executor_host/test_observability.py
+++ b/tests/unit/executor_host/test_observability.py
@@ -1,0 +1,193 @@
+"""Tests for ExecutorHost structured logging and Sentry correlation.
+
+Run: uv run pytest tests/unit/executor_host/test_observability.py
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+import io
+import json
+import logging
+from unittest.mock import Mock
+
+import pytest
+import sentry_sdk
+
+from executor_protocol import ExecutorTelemetryContext
+from services.executor_host import observability
+
+
+def test_dispatch_transaction_finishes_before_executor_work(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+    transaction = Mock()
+
+    @contextmanager
+    def record_transaction(_transaction: object) -> Generator[Mock, None, None]:
+        events.append("transaction-started")
+        yield transaction
+        events.append("transaction-finished")
+
+    monkeypatch.setattr(sentry_sdk, "continue_trace", Mock(return_value=transaction))
+    monkeypatch.setattr(sentry_sdk, "start_transaction", record_transaction)
+    monkeypatch.setattr(sentry_sdk, "get_traceparent", lambda: "child-trace")
+    monkeypatch.setattr(sentry_sdk, "get_baggage", lambda: None)
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        {"request_id": "request-abc", "trace_headers": {}},
+    ):
+        events.append("executor-running")
+
+    assert events == ["transaction-started", "transaction-finished", "executor-running"]
+
+
+def test_dispatch_acceptance_telemetry_failure_preserves_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    telemetry_context: ExecutorTelemetryContext = {
+        "request_id": "request-abc",
+        "trace_headers": {"traceparent": "parent-trace"},
+    }
+    monkeypatch.setattr(sentry_sdk, "continue_trace", Mock(side_effect=RuntimeError("sentry unavailable")))
+    monkeypatch.setattr(observability.logger, "warning", Mock())
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        telemetry_context,
+    ) as child_context:
+        assert observability.benchmark_id_var.get() == "benchmark-123"
+
+    assert child_context == telemetry_context
+
+
+def test_dispatch_scope_is_released_when_tag_binding_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    scope = Mock()
+    scope.set_tags.side_effect = RuntimeError("sentry unavailable")
+    scope_manager = Mock()
+    scope_manager.__enter__ = Mock(return_value=scope)
+    scope_manager.__exit__ = Mock(return_value=False)
+    monkeypatch.setattr(sentry_sdk, "new_scope", Mock(return_value=scope_manager))
+    monkeypatch.setattr(observability.logger, "warning", Mock())
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        {"request_id": "request-abc", "trace_headers": {}},
+    ):
+        pass
+
+    scope_manager.__exit__.assert_called_once_with(None, None, None)
+
+
+def test_terminal_sentry_failure_does_not_escape(monkeypatch: pytest.MonkeyPatch) -> None:
+    telemetry_context: ExecutorTelemetryContext = {"request_id": "request-abc", "trace_headers": {}}
+    monkeypatch.setattr(sentry_sdk, "new_scope", Mock(side_effect=RuntimeError("sentry unavailable")))
+    monkeypatch.setattr(observability.logger, "info", Mock())
+    monkeypatch.setattr(observability.logger, "error", Mock())
+    warning = Mock()
+    monkeypatch.setattr(observability.logger, "warning", warning)
+
+    observability.record_dispatch_completion(telemetry_context)
+    observability.record_dispatch_cancellation(telemetry_context)
+    observability.capture_dispatch_error(RuntimeError("dispatch failed"), telemetry_context)
+
+    assert warning.call_count == 3
+
+
+def test_invalid_production_sentry_configuration_logs_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    error = RuntimeError("bad dsn")
+    warning = Mock()
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(sentry_sdk, "init", Mock(side_effect=error))
+    monkeypatch.setattr(observability.logger, "warning", warning)
+
+    observability.configure_observability()
+
+    warning.assert_called_once_with("Failed to initialize Sentry: %s: %s", "RuntimeError", error)
+
+
+def test_missing_production_sentry_configuration_skips_sentry(monkeypatch: pytest.MonkeyPatch) -> None:
+    init_mock = Mock()
+    monkeypatch.delenv("SENTRY_DSN", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setattr(sentry_sdk, "init", init_mock)
+
+    observability.configure_observability()
+
+    init_mock.assert_not_called()
+
+
+def test_dispatch_context_correlates_cloudwatch_logs_and_child_trace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sentry_sdk, "get_traceparent", lambda: "sentry-child-trace")
+    monkeypatch.setattr(sentry_sdk, "get_baggage", lambda: "sentry-child-baggage")
+    output = io.StringIO()
+    handler = logging.StreamHandler(output)
+    handler.addFilter(observability._ContextFilter())  # pyright: ignore[reportPrivateUsage]
+    handler.setFormatter(observability._JsonFormatter())  # pyright: ignore[reportPrivateUsage]
+    logger = logging.Logger("executor-host-test")
+    logger.addHandler(handler)
+
+    with observability.dispatch_observability_context(
+        "benchmark-123",
+        "dispatch-456",
+        "release-789",
+        {
+            "request_id": "request-abc",
+            "trace_headers": {
+                "traceparent": "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
+                "tracestate": "vendor=value",
+            },
+        },
+    ) as child_context:
+        logger.info("Launching executor")
+
+    record = json.loads(output.getvalue())
+    assert record == {
+        "timestamp": record["timestamp"],
+        "level": "INFO",
+        "logger": "executor-host-test",
+        "message": "Launching executor",
+        "request_id": "request-abc",
+        "benchmark_id": "benchmark-123",
+        "executor_dispatch_id": "dispatch-456",
+        "executor_release_id": "release-789",
+    }
+    assert child_context == {
+        "request_id": "request-abc",
+        "trace_headers": {
+            "sentry-trace": "sentry-child-trace",
+            "baggage": "sentry-child-baggage",
+        },
+    }
+
+
+def test_dispatch_error_logs_before_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    events: list[str] = []
+    span = Mock()
+
+    @contextmanager
+    def record_transaction(_transaction: object) -> Generator[Mock, None, None]:
+        yield span
+
+    def record_log(*_args: object, **_kwargs: object) -> None:
+        events.append("logged")
+
+    def record_capture(_error: BaseException) -> None:
+        events.append("captured")
+
+    monkeypatch.setattr(sentry_sdk, "continue_trace", Mock(return_value=Mock()))
+    monkeypatch.setattr(sentry_sdk, "start_transaction", record_transaction)
+    monkeypatch.setattr(observability.logger, "error", record_log)
+    monkeypatch.setattr(sentry_sdk, "capture_exception", record_capture)
+    error = RuntimeError("executor failed")
+
+    observability.capture_dispatch_error(error, {"request_id": "request-abc", "trace_headers": {}})
+
+    span.set_status.assert_called_once_with(observability.SPANSTATUS.INTERNAL_ERROR)
+    assert events == ["logged", "captured"]

--- a/tests/unit/executor_host/test_supervisor.py
+++ b/tests/unit/executor_host/test_supervisor.py
@@ -1,3 +1,8 @@
+"""Tests for ExecutorHost dispatch supervision.
+
+Run: uv run pytest tests/unit/executor_host/test_supervisor.py
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -10,9 +15,11 @@ from collections.abc import Awaitable, Callable
 from functools import partial
 from pathlib import Path
 from typing import cast
+from unittest.mock import Mock
 
 import pytest
 
+import services.executor_host.observability as host_observability
 import services.executor_host.supervisor as supervisor_module
 from services.executor_host.supervisor import (  # pyright: ignore[reportMissingImports]
     ArtifactDispatch,
@@ -25,7 +32,7 @@ from services.executor_host.supervisor import (  # pyright: ignore[reportMissing
     run_executor_dispatch,
     verify_file_digest,
 )
-from executor_protocol import validate_executor_artifact_uri
+from executor_protocol import ExecutorTelemetryContext, validate_executor_artifact_uri
 
 
 class FakeDispatchStore:
@@ -168,22 +175,33 @@ def _process_payload(
             "start_benchmark_request_json": request or {},
             "benchmark_id_str": benchmark_id,
             "verified_task_ids": task_ids or [],
-        }
+        },
+        telemetry_context={"request_id": "", "trace_headers": {}},
     )
 
 
-def test_managed_process_payload_is_normalized_once() -> None:
+def test_managed_process_payload_includes_child_telemetry_context() -> None:
     context: dict[str, object] = {
         "benchmark_id": "benchmark-1",
         "verified_task_ids": ["task-1"],
         "start_benchmark_request": {},
     }
+    telemetry_context: ExecutorTelemetryContext = {
+        "request_id": "request-1",
+        "trace_headers": {"sentry-trace": "trace-header"},
+    }
 
-    payload = ExecutorProcessPayload.from_payload({"execution_context_json": context})
+    payload = ExecutorProcessPayload.from_payload(
+        {"execution_context_json": context},
+        telemetry_context=telemetry_context,
+    )
 
     assert payload.benchmark_id == "benchmark-1"
     assert payload.verified_task_ids == ["task-1"]
-    assert payload.arguments == {"execution_context_json": context}
+    assert payload.arguments == {
+        "execution_context_json": context,
+        "telemetry_context_json": telemetry_context,
+    }
 
 
 def test_process_payload_rejects_mixed_execution_shapes() -> None:
@@ -195,7 +213,8 @@ def test_process_payload_rejects_mixed_execution_shapes() -> None:
                     "verified_task_ids": [],
                 },
                 "start_benchmark_request_json": {},
-            }
+            },
+            telemetry_context={"request_id": "", "trace_headers": {}},
         )
 
 
@@ -433,7 +452,7 @@ async def test_run_forwards_dispatch_authority_to_executor(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    script = b"""import json, os, sys\nfrom pathlib import Path\npayload = json.loads(Path(sys.argv[1]).read_text())\nPath(os.environ[\"EXECUTOR_TEST_MARKER\"]).write_text(json.dumps(payload))\n"""
+    script = b"""import json, os, sys\nfrom pathlib import Path\npayload = json.loads(Path(sys.argv[1]).read_text())\nresult = {\"payload\": payload, \"sentry_release\": os.environ.get(\"SENTRY_RELEASE\")}\nPath(os.environ[\"EXECUTOR_TEST_MARKER\"]).write_text(json.dumps(result))\n"""
     digest = hashlib.sha256(script).hexdigest()
     marker = tmp_path / "marker.json"
     monkeypatch.setenv("EXECUTOR_TEST_MARKER", str(marker))
@@ -452,10 +471,12 @@ async def test_run_forwards_dispatch_authority_to_executor(
         result = json.loads(marker.read_text())
     except (OSError, JSONDecodeError) as error:
         raise AssertionError(f"executor marker was not valid JSON: {error}") from error
-    payload = result
+    payload = result["payload"]
     assert payload["benchmark_id_str"] == "benchmark-1"
     assert payload["verified_task_ids"] == ["task-1"]
     assert payload["executor_dispatch_id"] == "dispatch-1"
+    assert payload["telemetry_context_json"] == {"request_id": "", "trace_headers": {}}
+    assert result["sentry_release"] == "release-v2"
     assert store.authority_checks
     assert store.finished == [store.authority]
     assert (
@@ -576,6 +597,8 @@ async def test_launch_executor_rejects_invalid_dispatch_id_without_side_effects(
     monkeypatch.setattr(supervisor, "run", unexpected_run)
     monkeypatch.setattr(supervisor_module, "supervisor", supervisor)
     monkeypatch.setattr(supervisor_module, "dispatch_store", store)
+    capture_exception = Mock()
+    monkeypatch.setattr(host_observability.sentry_sdk, "capture_exception", capture_exception)
 
     with pytest.raises(ValueError, match="executor_dispatch_id is required"):
         await supervisor_module.launch_executor.original_func(
@@ -592,6 +615,7 @@ async def test_launch_executor_rejects_invalid_dispatch_id_without_side_effects(
     assert store.claimed == []
     assert store.finished == []
     assert s3_client.calls == []
+    capture_exception.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -617,6 +641,44 @@ async def test_broker_payload_dispatch_id_reaches_dispatch_owner(
     )
 
     assert captured["executor_dispatch_id"] == "dispatch-1"
+
+
+@pytest.mark.asyncio
+async def test_launch_executor_records_cancellation_before_context_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def cancel_dispatch(*_args: object, **_kwargs: object) -> None:
+        raise asyncio.CancelledError
+
+    cancellation_context: dict[str, object] = {}
+
+    def record_cancellation(telemetry_context: object) -> None:
+        cancellation_context.update(
+            {
+                "telemetry_context": telemetry_context,
+                "benchmark_id": host_observability.benchmark_id_var.get(),
+                "dispatch_id": host_observability.dispatch_id_var.get(),
+            }
+        )
+
+    monkeypatch.setattr(supervisor_module, "run_executor_dispatch", cancel_dispatch)
+    monkeypatch.setattr(supervisor_module, "record_dispatch_cancellation", record_cancellation)
+
+    with pytest.raises(asyncio.CancelledError):
+        await supervisor_module.launch_executor.original_func(
+            start_benchmark_request_json={},
+            benchmark_id_str="benchmark-1",
+            verified_task_ids=[],
+            executor_dispatch_id="dispatch-1",
+            executor_release_id="release-v2",
+            executor_artifact_uri="s3://artifacts/executors/v2.pex",
+            executor_artifact_digest="0" * 64,
+            executor_protocol_version="1",
+        )
+
+    assert cancellation_context["benchmark_id"] == "benchmark-1"
+    assert cancellation_context["dispatch_id"] == "dispatch-1"
+    assert host_observability.benchmark_id_var.get() == ""
 
 
 async def test_stream_message_is_deleted_only_after_successful_ack(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Weekly prod deploy: end-to-end run telemetry correlation, tracker recovery for interrupted evaluation streams, and managed-format lambda invocation support.

## Changes
- feat: correlate run telemetry end to end ([#716](https://github.com/vals-ai/Valkyrie/pull/716))
- fix(tracker): resume interrupted evaluation streams ([#702](https://github.com/vals-ai/Valkyrie/pull/702))
- fix: allow managed format lambda invocation ([#729](https://github.com/vals-ai/Valkyrie/pull/729))

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [ ] Added/updated unit tests
- [x] Manually tested
- Each change was reviewed, CI-verified, and merged to `dev` individually; this PR promotes the current `dev` head to `prod` with no additional commits.

## Contributors
- @BradenBug
- @conjfrnk

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/1e92898483e94a6eb217085fd9eb9fce
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/732" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->