### PR TITLE
chore(deps): bump create-benchmark-service to v0.31.2

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.31.1" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.31.2" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.31.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.1#426a51f81b1a6d19d3a66fe0aa3d24c1aa3b18c5" }
+version = "0.31.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2#fd4103a727288408b83f23536da6107f2b20287d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2118,7 +2118,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
The `cbs / validate` required check fails on `dev` (and therefore on the prod deploy PR #736) because it enforces that the pinned `create-benchmark-service` rev is the latest tag: installed `v0.31.1`, latest `v0.31.2`. This bumps the git pin and regenerates `services/tracker/uv.lock`.

## Changes
- `services/tracker/pyproject.toml`: `create-benchmark-service` rev `v0.31.1` → `v0.31.2`
- `services/tracker/uv.lock`: regenerated via `uv lock` (only the cbs entry changes)

## Related Issues
Unblocks #736 (prod deploy).

## Type of Change
- [x] Docs / config

## Testing
No live-path testing — dependency pin bump only; correctness is enforced by the `cbs / validate` check plus tracker CI on this PR.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/8ae1f1aee1014b75bb93056a3d87402b
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->