### PR TITLE
chore(deps): relock root uv.lock for create-benchmark-service v0.31.2

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.31.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.1#426a51f81b1a6d19d3a66fe0aa3d24c1aa3b18c5" }
+version = "0.31.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2#fd4103a727288408b83f23536da6107f2b20287d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
#737 bumped the cbs pin in `services/tracker/pyproject.toml` but the root workspace lock still pinned `v0.31.1`, so `uv lock --check` at the repo root (required check `lockfile (.) / validate`) fails on `dev`, and `package` / `executor-build` fail for the same reason. This relocks the root `uv.lock` only.

## Changes
- `uv.lock`: `create-benchmark-service` `v0.31.1` (426a51f8) → `v0.31.2` (fd4103a7); no other packages change.

## Related Issues
Follow-up to #737, unblocks #736 (prod deploy).

## Type of Change
- [x] Docs / config

## Testing
Ran locally with uv 0.11.26 (matching CI): `uv lock` then `uv lock --check` at the repo root and in `services/tracker` — both clean. No runtime path to visually verify; this is a lockfile-only change.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/8ae1f1aee1014b75bb93056a3d87402b
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/738" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->