### PR TITLE
feat(infra): grant tracker analyzer and executor final-view lambda invoke #patch

### DIFF
--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -17,6 +17,16 @@ _KMS_KEY_ARN_PATTERN = re.compile(r"arn:[^:]+:kms:[^:]+:[0-9]{12}:key/[A-Za-z0-9
 _OFFLINE_SYNTH_ORG_ID = "00000000-0000-0000-0000-000000000001"
 _OFFLINE_SYNTH_SECRET_PREFIX = "offline-synth"
 
+_TRACKER_ANALYZER_LAMBDA_PATTERNS = ("analysis-*",)
+_EXECUTOR_OUTPUT_LAMBDA_PATTERNS = (
+    "vals-format-lambda",
+    "harvey-legal-agent-final-view-lambda",
+    "programbench-final-view-lambda",
+    "snap-final-view-lambda",
+    "swebench-final-view-lambda",
+    "terminalbench-final-view-lambda",
+)
+
 
 @dataclass(frozen=True)
 class ServiceConfig:
@@ -108,7 +118,8 @@ PROD_CONFIG = StageConfig(
         benchmark_log_retention_days=365,
         submissions_enabled=True,
         executor_all_secret_access=True,
-        executor_lambda_function_name_patterns=("vals-format-lambda",),
+        tracker_lambda_function_name_patterns=_TRACKER_ANALYZER_LAMBDA_PATTERNS,
+        executor_lambda_function_name_patterns=_EXECUTOR_OUTPUT_LAMBDA_PATTERNS,
     ),
 )
 
@@ -128,7 +139,8 @@ DEV_CONFIG = StageConfig(
         benchmark_log_retention_days=7,
         submissions_enabled=True,
         executor_all_secret_access=True,
-        executor_lambda_function_name_patterns=("vals-format-lambda",),
+        tracker_lambda_function_name_patterns=_TRACKER_ANALYZER_LAMBDA_PATTERNS,
+        executor_lambda_function_name_patterns=_EXECUTOR_OUTPUT_LAMBDA_PATTERNS,
     ),
 )
 

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -10,7 +10,7 @@ from aws_cdk import assertions, aws_s3
 
 from runtime_iam import create_executor_task_role, create_tracker_task_role
 from stage import DEV, PROD, RELEASE_TEST, Stage
-from stage_config import ManagedAWSRuntimeConfig
+from stage_config import DEV_CONFIG, PROD_CONFIG, ManagedAWSRuntimeConfig
 from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
@@ -144,7 +144,13 @@ class RuntimeIamTest(unittest.TestCase):
                 tracker_template,
                 "ValkyrieTrackerTaskRole-dev",
                 "TrackerTaskRoleArn",
-                expected_actions | {"s3:DeleteObject", "s3:DeleteObjectVersion", "secretsmanager:GetSecretValue"},
+                expected_actions
+                | {
+                    "s3:DeleteObject",
+                    "s3:DeleteObjectVersion",
+                    "secretsmanager:GetSecretValue",
+                    "lambda:InvokeFunction",
+                },
             ),
             (
                 executor_template,
@@ -265,11 +271,23 @@ class RuntimeIamTest(unittest.TestCase):
                         for statement in statements
                         if _statement_actions(statement) == {"lambda:InvokeFunction"}
                     )
-                    self.assertEqual(lambda_statement["Resource"], _lambda_function_resource("vals-format-lambda"))
+                    self.assertEqual(
+                        lambda_statement["Resource"],
+                        [
+                            _lambda_function_resource(pattern)
+                            for pattern in DEV_CONFIG.managed_aws.executor_lambda_function_name_patterns
+                        ],
+                    )
                 else:
                     secret_resources = json.dumps(secret_statement["Resource"])
                     self.assertIn("secretsmanager", secret_resources)
                     self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
+                    lambda_statement = next(
+                        statement
+                        for statement in statements
+                        if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                    )
+                    self.assertEqual(lambda_statement["Resource"], _lambda_function_resource("analysis-*"))
 
     def test_prod_managed_runtime_uses_prod_inventory_and_task_roles(self) -> None:
         with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=True):
@@ -319,16 +337,20 @@ class RuntimeIamTest(unittest.TestCase):
                     self.assertEqual(len(lambda_statements), 1)
                     self.assertEqual(
                         lambda_statements[0]["Resource"],
-                        _lambda_function_resource("vals-format-lambda"),
+                        [
+                            _lambda_function_resource(pattern)
+                            for pattern in PROD_CONFIG.managed_aws.executor_lambda_function_name_patterns
+                        ],
                     )
                 else:
                     self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
-                    self.assertFalse(
-                        any(
-                            _statement_actions(statement) == {"lambda:InvokeFunction"}
-                            for statement in _role_policy_statements(template, role_logical_id)
-                        )
-                    )
+                    lambda_statements = [
+                        statement
+                        for statement in _role_policy_statements(template, role_logical_id)
+                        if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                    ]
+                    self.assertEqual(len(lambda_statements), 1)
+                    self.assertEqual(lambda_statements[0]["Resource"], _lambda_function_resource("analysis-*"))
 
     def test_release_test_managed_runtime_remains_closed(self) -> None:
         with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):


### PR DESCRIPTION
## Summary
Records in CDK two `lambda:InvokeFunction` grants that were applied by hand to the live roles, so they survive the next deploy:

- `ValkyrieTrackerTaskRole` → `analysis-*` (Docent ingest lambdas: `analysis-terminus2`, `analysis-model-library`, ...), equivalent to the manual `AllowInvokeAnalyzerLambdas` policy.
- `ValkyrieExecutorTaskRole` → the per-benchmark final-view lambdas alongside the existing `vals-format-lambda`.

Both prod and dev configs get the same patterns; resources are still region/account-scoped by `stack.format_arn`, so dev grants only cover dev-account functions.

## Changes
- `infra/stage_config.py`: add `_TRACKER_ANALYZER_LAMBDA_PATTERNS` / `_EXECUTOR_OUTPUT_LAMBDA_PATTERNS` and wire them into `PROD_CONFIG` and `DEV_CONFIG`.
- `infra/tests/test_runtime_iam.py`: tracker role now expects a lambda statement scoped to `analysis-*`; executor role expects the full pattern list.

## Related Issues
Slack thread: https://valsai.slack.com/archives/C0ALMLKRS12/p1787878436940969?thread_ts=1787878436.940969&cid=C0ALMLKRS12

## Type of Change
- [x] Docs / config

## Testing
- [x] Added/updated unit tests
- [ ] Manually tested

No live AWS validation was run — the deployed effect should be confirmed with `make plan STAGE=prod` (and dev) before deploying; the expected diff is the two IAM policy statements above.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/469738174d7c4c4ebefb013ac8efc4e8
Open in Devin Desktop: https://app.devin.ai/desktop/session/469738174d7c4c4ebefb013ac8efc4e8?variant=devin
Requested by: @BradenBug