### PR TITLE
feat(tracker): support repeatable completion lambdas

### DIFF
--- a/docs/LAMBDA_USAGE.md
+++ b/docs/LAMBDA_USAGE.md
@@ -7,7 +7,7 @@ valkyrie run start \
   --agent agents/claude_code \
   --benchmark swebench \
   --lambda my-post-benchmark-handler \
-  --lambda vals-format-lambda
+  --lambda my-result-archiver
 ```
 
 Each lambda is invoked once after all tasks finish and results are uploaded, in the order given. A lambda that fails (uncaught exception or `statusCode >= 400`) does not stop the remaining ones; the failure is logged and reported, and the first one is re-raised once every lambda has been attempted. The run status is already terminal by this point, so a failing lambda does not change it.
@@ -31,7 +31,7 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the pers
   "task_ids": ["astropy__astropy-12907"],
   "slice_str": null,
   "lambda_function": "my-post-benchmark-handler",
-  "lambda_functions": ["my-post-benchmark-handler", "vals-format-lambda"],
+  "lambda_functions": ["my-post-benchmark-handler", "my-result-archiver"],
   "benchmark_id": "e532551e-d51b-4912-983d-47695bd24174",
   "benchmark_name": "swebench"
 }

--- a/docs/LAMBDA_USAGE.md
+++ b/docs/LAMBDA_USAGE.md
@@ -6,10 +6,11 @@ The `--lambda` flag on `run start` lets you invoke AWS Lambda functions after a 
 valkyrie run start \
   --agent agents/claude_code \
   --benchmark swebench \
-  --lambda my-post-benchmark-handler
+  --lambda my-post-benchmark-handler \
+  --lambda vals-format-lambda
 ```
 
-Each lambda is invoked once after all tasks finish and results are uploaded. If a lambda fails (uncaught exception or `statusCode >= 400`), the run will be marked as `ERROR`.
+Each lambda is invoked once after all tasks finish and results are uploaded, in the order given. A lambda that fails (uncaught exception or `statusCode >= 400`) does not stop the remaining ones; the failure is logged and reported, and the first one is re-raised once every lambda has been attempted. The run status is already terminal by this point, so a failing lambda does not change it.
 
 ## Payload
 
@@ -29,7 +30,8 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the pers
   "concurrency": 5,
   "task_ids": ["astropy__astropy-12907"],
   "slice_str": null,
-  "lambda_functions": ["my-post-benchmark-handler"],
+  "lambda_function": "my-post-benchmark-handler",
+  "lambda_functions": ["my-post-benchmark-handler", "vals-format-lambda"],
   "benchmark_id": "e532551e-d51b-4912-983d-47695bd24174",
   "benchmark_name": "swebench"
 }
@@ -41,7 +43,8 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the pers
 | `concurrency` | int | Concurrency level |
 | `task_ids` | list or null | Task IDs that were run (null = all) |
 | `slice_str` | string or null | Dataset slice if provided |
-| `lambda_functions` | list | Names of the lambdas invoked at completion |
+| `lambda_function` | string | Name of the lambda receiving this payload |
+| `lambda_functions` | list | Every lambda invoked at completion, in configured order |
 | `benchmark_id` | string | UUID of the completed run |
 | `benchmark_name` | string | Persisted name of the completed benchmark |
 

--- a/docs/LAMBDA_USAGE.md
+++ b/docs/LAMBDA_USAGE.md
@@ -1,6 +1,6 @@
 # Lambda Usage
 
-The `--lambda` flag on `run start` lets you invoke an AWS Lambda function after a run completes.
+The `--lambda` flag on `run start` lets you invoke AWS Lambda functions after a run completes, and may be repeated.
 
 ```bash
 valkyrie run start \
@@ -9,7 +9,7 @@ valkyrie run start \
   --lambda my-post-benchmark-handler
 ```
 
-The lambda is invoked once after all tasks finish and results are uploaded. If the lambda fails (uncaught exception or `statusCode >= 400`), the run will be marked as `ERROR`.
+Each lambda is invoked once after all tasks finish and results are uploaded. If a lambda fails (uncaught exception or `statusCode >= 400`), the run will be marked as `ERROR`.
 
 ## Payload
 
@@ -29,7 +29,7 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the pers
   "concurrency": 5,
   "task_ids": ["astropy__astropy-12907"],
   "slice_str": null,
-  "lambda_function": "my-post-benchmark-handler",
+  "lambda_functions": ["my-post-benchmark-handler"],
   "benchmark_id": "e532551e-d51b-4912-983d-47695bd24174",
   "benchmark_name": "swebench"
 }
@@ -41,7 +41,7 @@ The tracker invokes your lambda with the full `BenchmarkArguments` plus the pers
 | `concurrency` | int | Concurrency level |
 | `task_ids` | list or null | Task IDs that were run (null = all) |
 | `slice_str` | string or null | Dataset slice if provided |
-| `lambda_function` | string | Name of this lambda function |
+| `lambda_functions` | list | Names of the lambdas invoked at completion |
 | `benchmark_id` | string | UUID of the completed run |
 | `benchmark_name` | string | Persisted name of the completed benchmark |
 

--- a/packages/valkyrie-sdk/pyproject.toml
+++ b/packages/valkyrie-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "valkyrie-sdk"
-version = "0.2.9"
+version = "0.2.10"
 description = "Async Python SDK for managing Valkyrie benchmark runs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/models/runs.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/models/runs.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID, uuid4
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 from valkyrie.sdk.models._base import ResponseModel, serialize_utc
 from valkyrie.sdk.models.agents import AgentContractRequest
@@ -68,7 +68,7 @@ class StartBenchmarkRequest(BaseModel):
     label: str | None = None
     task_ids: list[str] | None = None
     slice_str: str | None = None
-    lambda_function: str | None = None
+    lambda_functions: list[str] = Field(default_factory=list)
     dataset: str | None = None
     harness_config: HarnessConfig | None = None
     custom_benchmark_service: str | None = None
@@ -205,14 +205,29 @@ class FetchBenchmarksResponse(ResponseModel):
 class BenchmarkArguments(ResponseModel):
     """Arguments retained with a completed run."""
 
+    model_config = ResponseModel.model_config | ConfigDict(populate_by_name=True)
+
     contract: AgentContractRequest
     concurrency: int
     task_ids: list[str] | None = None
     slice_str: str | None = None
-    lambda_function: str | None = None
+    lambda_functions: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("lambda_functions", "lambda_function"),
+    )
     dataset: str | None = None
     sandbox_provider: str = "daytona"
     sandbox_provider_secret_name: str | None = None
+
+    @field_validator("lambda_functions", mode="before")
+    @classmethod
+    def widen_single_lambda(cls, value: Any) -> Any:
+        """Read the single completion lambda retained by runs started before this field was a list."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return value
 
 
 class FetchBenchmarkMetadataResponse(ResponseModel):

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/resources/runs.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/resources/runs.py
@@ -48,7 +48,7 @@ class RunsResource:
         slice_str: str | None = None,
         dataset: str | None = None,
         label: str | None = None,
-        lambda_function: str | None = None,
+        lambda_functions: Sequence[str] | None = None,
         provider: str | None = None,
         agent_kwargs: Mapping[str, str] | None = None,
         secrets: Mapping[str, str] | None = None,
@@ -82,7 +82,7 @@ class RunsResource:
             slice_str=slice_str,
             dataset=dataset,
             label=label,
-            lambda_function=lambda_function,
+            lambda_functions=list(lambda_functions or []),
             harness_config=access_key_harness_config,
             custom_benchmark_service=(
                 None if ignore_custom_services else self._sdk.config.custom_benchmark_services.get(benchmark)

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -5,7 +5,15 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, SerializerFunctionWrapHandler, field_serializer, field_validator, model_serializer
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    Field as PydanticField,
+    SerializerFunctionWrapHandler,
+    field_serializer,
+    field_validator,
+    model_serializer,
+)
 from sqlalchemy import Boolean, Connection, Dialect, Index, event, text
 from sqlalchemy.orm import Mapped, Mapper
 from sqlmodel import (
@@ -183,16 +191,29 @@ class AgentContractRequest(BaseModel):
 
 
 class BenchmarkArguments(BaseModel):
-    model_config = {"extra": "forbid"}
+    model_config = {"extra": "forbid", "populate_by_name": True}
 
     contract: AgentContractRequest
     concurrency: int
     task_ids: list[str] | None = None
     slice_str: str | None = None
-    lambda_function: str | None = None
+    lambda_functions: list[str] = PydanticField(
+        default_factory=list,
+        validation_alias=AliasChoices("lambda_functions", "lambda_function"),
+    )
     dataset: str | None = None
     sandbox_provider: str = "daytona"
     sandbox_provider_secret_name: str | None = None
+
+    @field_validator("lambda_functions", mode="before")
+    @classmethod
+    def widen_single_lambda(cls, value: Any) -> Any:
+        """Read the single completion lambda persisted by runs started before this field was a list."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return value
 
 
 class FinalEvaluation(SQLModel, table=True):
@@ -381,7 +402,7 @@ class Benchmark(SQLModel, table=True):
             concurrency=self.arguments.concurrency,
             task_ids=self.arguments.task_ids,
             slice_str=self.arguments.slice_str,
-            lambda_function=self.arguments.lambda_function,
+            lambda_functions=self.arguments.lambda_functions,
             dataset=self.arguments.dataset,
             harness_config=harness_config,
             sandbox_provider=self.arguments.sandbox_provider,
@@ -406,7 +427,7 @@ class Benchmark(SQLModel, table=True):
             label=self.label,
             task_ids=self.arguments.task_ids,
             slice_str=self.arguments.slice_str,
-            lambda_function=self.arguments.lambda_function,
+            lambda_functions=self.arguments.lambda_functions,
             dataset=self.arguments.dataset,
             harness_config=None,
             sandbox_provider=self.arguments.sandbox_provider,

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -1,13 +1,14 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import PurePosixPath
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Annotated, Any
 from uuid import UUID, uuid4
 from zoneinfo import ZoneInfo
 
 from pydantic import (
     AliasChoices,
     BaseModel,
+    BeforeValidator,
     Field as PydanticField,
     SerializerFunctionWrapHandler,
     field_serializer,
@@ -190,6 +191,22 @@ class AgentContractRequest(BaseModel):
         return normalized_artifacts
 
 
+def _widen_single_lambda(value: Any) -> Any:
+    """Read the single completion lambda persisted or sent before this field was a list."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return value
+
+
+CompletionLambdas = Annotated[
+    list[str],
+    BeforeValidator(_widen_single_lambda),
+    PydanticField(validation_alias=AliasChoices("lambda_functions", "lambda_function")),
+]
+
+
 class BenchmarkArguments(BaseModel):
     model_config = {"extra": "forbid", "populate_by_name": True}
 
@@ -197,23 +214,10 @@ class BenchmarkArguments(BaseModel):
     concurrency: int
     task_ids: list[str] | None = None
     slice_str: str | None = None
-    lambda_functions: list[str] = PydanticField(
-        default_factory=list,
-        validation_alias=AliasChoices("lambda_functions", "lambda_function"),
-    )
+    lambda_functions: CompletionLambdas = PydanticField(default_factory=list)
     dataset: str | None = None
     sandbox_provider: str = "daytona"
     sandbox_provider_secret_name: str | None = None
-
-    @field_validator("lambda_functions", mode="before")
-    @classmethod
-    def widen_single_lambda(cls, value: Any) -> Any:
-        """Read the single completion lambda persisted by runs started before this field was a list."""
-        if value is None:
-            return []
-        if isinstance(value, str):
-            return [value]
-        return value
 
 
 class FinalEvaluation(SQLModel, table=True):

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -8,21 +8,14 @@ from typing import Any, Literal, cast
 from uuid import UUID
 
 from benchmark_service.client import BenchmarkServiceClient
-from pydantic import (
-    AliasChoices,
-    BaseModel,
-    ConfigDict,
-    Field,
-    field_serializer,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
 
 from tracker.config import create_benchmark_service_url
 from tracker.database.models import (
     AgentContractRequest,
     BenchmarkArguments,
     BenchmarkStatus,
+    CompletionLambdas,
     DocentReadingStatus,
     FinalEvaluation,
     TaskStatus,
@@ -73,10 +66,7 @@ class StartBenchmarkRequest(BaseModel):
     label: str | None = None
     task_ids: list[str] | None = None
     slice_str: str | None = None
-    lambda_functions: list[str] = Field(
-        default_factory=list,
-        validation_alias=AliasChoices("lambda_functions", "lambda_function"),
-    )
+    lambda_functions: CompletionLambdas = Field(default_factory=list)
     dataset: str | None = None
     harness_config: HarnessConfig | None = None
     custom_benchmark_service: str | None = None
@@ -87,16 +77,6 @@ class StartBenchmarkRequest(BaseModel):
     service_auth_secret_name: str | None = None
     webhook_secret_name: str | None = None
     webhook_intervals: list[int] | None = None
-
-    @field_validator("lambda_functions", mode="before")
-    @classmethod
-    def widen_single_lambda(cls, value: Any) -> Any:
-        """Accept the single completion lambda sent by clients from before this field was a list."""
-        if value is None:
-            return []
-        if isinstance(value, str):
-            return [value]
-        return value
 
     @field_validator("benchmark_name")
     @classmethod

--- a/services/tracker/src/tracker/types.py
+++ b/services/tracker/src/tracker/types.py
@@ -8,7 +8,15 @@ from typing import Any, Literal, cast
 from uuid import UUID
 
 from benchmark_service.client import BenchmarkServiceClient
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator, model_validator
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from tracker.config import create_benchmark_service_url
 from tracker.database.models import (
@@ -57,13 +65,18 @@ class HarnessConfig(BaseModel):
 
 
 class StartBenchmarkRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     contract: AgentContractRequest
     benchmark_name: str
     concurrency: int = 5
     label: str | None = None
     task_ids: list[str] | None = None
     slice_str: str | None = None
-    lambda_function: str | None = None
+    lambda_functions: list[str] = Field(
+        default_factory=list,
+        validation_alias=AliasChoices("lambda_functions", "lambda_function"),
+    )
     dataset: str | None = None
     harness_config: HarnessConfig | None = None
     custom_benchmark_service: str | None = None
@@ -74,6 +87,16 @@ class StartBenchmarkRequest(BaseModel):
     service_auth_secret_name: str | None = None
     webhook_secret_name: str | None = None
     webhook_intervals: list[int] | None = None
+
+    @field_validator("lambda_functions", mode="before")
+    @classmethod
+    def widen_single_lambda(cls, value: Any) -> Any:
+        """Accept the single completion lambda sent by clients from before this field was a list."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return value
 
     @field_validator("benchmark_name")
     @classmethod

--- a/services/tracker/src/tracker/utils/resources.py
+++ b/services/tracker/src/tracker/utils/resources.py
@@ -97,7 +97,7 @@ def start_benchmark_request_to_benchmark(
             concurrency=request.concurrency,
             task_ids=request.task_ids,
             slice_str=request.slice_str,
-            lambda_function=request.lambda_function,
+            lambda_functions=request.lambda_functions,
             dataset=request.dataset,
             sandbox_provider=request.sandbox_provider,
             sandbox_provider_secret_name=provider_secret_name,

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -665,6 +665,9 @@ async def process_benchmark(
                         logger.warning(f"Completion lambda '{lambda_function}' failed: {error}")
                         callback_failure = callback_failure or error
                 if callback_failure is not None:
+                    # Reported, but not reflected in the run: set_benchmark_final_status has already
+                    # committed the terminal status, so commit_benchmark_error rolls back on
+                    # require_in_progress and the run stays FINISHED.
                     raise callback_failure
 
     except ExecutionAuthorityRevoked:

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -35,7 +35,7 @@ from tracker.database.models import (
 )
 from tracker.database.session import engine
 from tracker.executor.dispatch_control import record_dispatch_failure, terminalize_active_dispatches
-from tracker.exceptions import ExecutionAuthorityRevoked, TrackerServiceError
+from tracker.exceptions import ExecutionAuthorityRevoked, LambdaError, TrackerServiceError
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
 from executor_protocol import EXECUTOR_TASK_NAME
 from tracker.logging import get_logger
@@ -647,14 +647,20 @@ async def process_benchmark(
 
         if lambda_payload is not None:
             async with hold_dispatch_authority(authority):
+                callback_failure: LambdaError | None = None
                 for lambda_function in lambda_functions:
-                    await asyncio.to_thread(
-                        invoke_lambda,
-                        aws_runtime.clients,
-                        lambda_function,
-                        lambda_payload,
-                        config=_COMPLETION_CALLBACK_CONFIG,
-                    )
+                    try:
+                        await asyncio.to_thread(
+                            invoke_lambda,
+                            aws_runtime.clients,
+                            lambda_function,
+                            lambda_payload,
+                            config=_COMPLETION_CALLBACK_CONFIG,
+                        )
+                    except LambdaError as error:
+                        callback_failure = callback_failure or error
+                if callback_failure is not None:
+                    raise callback_failure
 
     except ExecutionAuthorityRevoked:
         finalization_deferred = True

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -35,7 +35,7 @@ from tracker.database.models import (
 )
 from tracker.database.session import engine
 from tracker.executor.dispatch_control import record_dispatch_failure, terminalize_active_dispatches
-from tracker.exceptions import ExecutionAuthorityRevoked, LambdaError, TrackerServiceError
+from tracker.exceptions import ExecutionAuthorityRevoked, TrackerServiceError
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
 from executor_protocol import EXECUTOR_TASK_NAME
 from tracker.logging import get_logger
@@ -647,17 +647,22 @@ async def process_benchmark(
 
         if lambda_payload is not None:
             async with hold_dispatch_authority(authority):
-                callback_failure: LambdaError | None = None
+                callback_failure: Exception | None = None
                 for lambda_function in lambda_functions:
                     try:
                         await asyncio.to_thread(
                             invoke_lambda,
                             aws_runtime.clients,
                             lambda_function,
-                            lambda_payload,
+                            # `lambda_function` names the callback reading this payload, as it did
+                            # when a run could configure only one.
+                            {**lambda_payload, "lambda_function": lambda_function},
                             config=_COMPLETION_CALLBACK_CONFIG,
                         )
-                    except LambdaError as error:
+                    except Exception as error:
+                        # Every configured callback owns a distinct artifact, so one failure must not
+                        # skip the rest; the first failure is re-raised once all have been attempted.
+                        logger.warning(f"Completion lambda '{lambda_function}' failed: {error}")
                         callback_failure = callback_failure or error
                 if callback_failure is not None:
                     raise callback_failure

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -413,8 +413,8 @@ def _preflight_managed_aws(
     resolve_secrets(request.contract.secrets, secret_store)
     if request.webhook_secret_name and request.webhook_intervals:
         secret_store.get(request.webhook_secret_name)
-    if request.lambda_function:
-        dry_run_lambda(runtime.clients, request.lambda_function)
+    for lambda_function in request.lambda_functions:
+        dry_run_lambda(runtime.clients, lambda_function)
     return sandbox_provider_config
 
 
@@ -635,9 +635,9 @@ async def process_benchmark(
             set_benchmark_final_status(benchmark_row, session, org, authority=authority)
 
             final_view: FinalViewResponse = create_final_view(benchmark_row, session, org)
-            lambda_function = benchmark_row.arguments.lambda_function
+            lambda_functions = benchmark_row.arguments.lambda_functions
             lambda_payload: dict[str, Any] | None = None
-            if lambda_function:
+            if lambda_functions:
                 lambda_payload = benchmark_row.arguments.model_dump()
                 lambda_payload["benchmark_id"] = str(benchmark_id)
                 lambda_payload["benchmark_name"] = benchmark_row.name
@@ -645,15 +645,16 @@ async def process_benchmark(
         async with hold_dispatch_authority(authority) as (_, benchmark_row):
             await upload_final_view(benchmark_row, final_view, aws_runtime)
 
-        if lambda_function and lambda_payload is not None:
+        if lambda_payload is not None:
             async with hold_dispatch_authority(authority):
-                await asyncio.to_thread(
-                    invoke_lambda,
-                    aws_runtime.clients,
-                    lambda_function,
-                    lambda_payload,
-                    config=_COMPLETION_CALLBACK_CONFIG,
-                )
+                for lambda_function in lambda_functions:
+                    await asyncio.to_thread(
+                        invoke_lambda,
+                        aws_runtime.clients,
+                        lambda_function,
+                        lambda_payload,
+                        config=_COMPLETION_CALLBACK_CONFIG,
+                    )
 
     except ExecutionAuthorityRevoked:
         finalization_deferred = True

--- a/services/tracker/tests/integration/local/database/test_run_finalization.py
+++ b/services/tracker/tests/integration/local/database/test_run_finalization.py
@@ -497,7 +497,7 @@ class TestRunFinalization:
             webhook_intervals=[100],
         )
         authority_kwargs = executor_authority_kwargs(benchmark, dispatch_id=uuid4(), session=postgres_session)
-        benchmark.arguments = benchmark.arguments.model_copy(update={"lambda_function": "test-lambda"})
+        benchmark.arguments = benchmark.arguments.model_copy(update={"lambda_functions": ["test-lambda"]})
         postgres_session.add(benchmark)
         postgres_session.commit()
         side_effects: dict[str, dict[str, int | bool]] = {

--- a/services/tracker/tests/unit/database/test_models.py
+++ b/services/tracker/tests/unit/database/test_models.py
@@ -85,3 +85,27 @@ def test_create_benchmark_table_row_counts_stopped_tasks_as_finished(database_se
 
     assert row.total_tasks == 4
     assert row.finished_tasks == 3
+
+
+@pytest.mark.parametrize(
+    ("persisted", "expected"),
+    [
+        ({"lambda_function": "programbench-final-view-lambda"}, ["programbench-final-view-lambda"]),
+        ({"lambda_function": None}, []),
+        ({"lambda_functions": ["a", "b"]}, ["a", "b"]),
+        ({}, []),
+    ],
+)
+def test_benchmark_arguments_read_completion_lambdas_from_either_shape(
+    persisted: dict[str, object],
+    expected: list[str],
+) -> None:
+    arguments = BenchmarkArguments.model_validate(
+        {
+            "contract": {"name": "agent", "install_cmd": "echo install", "run_cmd": "echo run"},
+            "concurrency": 1,
+            **persisted,
+        }
+    )
+
+    assert arguments.lambda_functions == expected

--- a/services/tracker/tests/unit/database/test_models.py
+++ b/services/tracker/tests/unit/database/test_models.py
@@ -16,6 +16,7 @@ from tracker.database.models import (
     Task,
     TaskStatus,
 )
+from tracker.types import StartBenchmarkRequest
 
 
 def test_required_output_artifact_omits_default_from_serialized_contract() -> None:
@@ -88,7 +89,7 @@ def test_create_benchmark_table_row_counts_stopped_tasks_as_finished(database_se
 
 
 @pytest.mark.parametrize(
-    ("persisted", "expected"),
+    ("received", "expected"),
     [
         ({"lambda_function": "programbench-final-view-lambda"}, ["programbench-final-view-lambda"]),
         ({"lambda_function": None}, []),
@@ -96,16 +97,25 @@ def test_create_benchmark_table_row_counts_stopped_tasks_as_finished(database_se
         ({}, []),
     ],
 )
-def test_benchmark_arguments_read_completion_lambdas_from_either_shape(
-    persisted: dict[str, object],
+@pytest.mark.parametrize(
+    ("model", "required"),
+    [(BenchmarkArguments, {}), (StartBenchmarkRequest, {"benchmark_name": "swebench"})],
+    ids=["persisted", "inbound"],
+)
+def test_completion_lambdas_are_read_from_either_shape(
+    model: type[BenchmarkArguments | StartBenchmarkRequest],
+    required: dict[str, object],
+    received: dict[str, object],
     expected: list[str],
 ) -> None:
-    arguments = BenchmarkArguments.model_validate(
+    """Rows written before this field was a list still load, and so do requests from an older CLI or SDK."""
+    parsed = model.model_validate(
         {
             "contract": {"name": "agent", "install_cmd": "echo install", "run_cmd": "echo run"},
             "concurrency": 1,
-            **persisted,
+            **required,
+            **received,
         }
     )
 
-    assert arguments.lambda_functions == expected
+    assert parsed.lambda_functions == expected

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -3,12 +3,14 @@
 Run: uv run pytest tests/unit/test_managed_execution.py
 """
 
+from collections.abc import Callable
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
 
 import pytest
 from benchmark_service import SandboxProviderConfig
+from botocore.exceptions import ReadTimeoutError
 from sqlmodel import Session
 
 from tests.conftest import TEST_ORG_ID
@@ -467,6 +469,37 @@ async def test_managed_preflight_failure_happens_before_sandbox(
     create_sandbox.assert_not_awaited()
 
 
+def _patch_completion_lambda_run(
+    monkeypatch: pytest.MonkeyPatch,
+    aws_runtime: AWSRuntime,
+    *,
+    dry_run: Callable[[object, str], None],
+    invoke: Callable[..., dict[str, Any]],
+) -> None:
+    """Stub every managed-run dependency except the completion-lambda calls under test."""
+
+    def deployment_runtime(_org_id: UUID) -> AWSRuntime:
+        return aws_runtime
+
+    def create_log_group(_self: object, _benchmark_id: str, *, retention_days: int) -> None:
+        return None
+
+    def fetch_provider(_name: str, _secret_store: object, _provider: str) -> SandboxProviderConfig:
+        return cast(SandboxProviderConfig, MagicMock())
+
+    def resolve_agent_secrets(_secrets: object, _secret_store: object) -> dict[str, str]:
+        return {}
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
+    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", create_log_group)
+    monkeypatch.setattr("tracker.utils.run_orchestration.fetch_sandbox_provider_config", fetch_provider)
+    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", resolve_agent_secrets)
+    monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", resolve_agent_secrets)
+    monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", dry_run)
+    monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", AsyncMock())
+    monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke)
+
+
 async def test_managed_execution_invokes_every_configured_completion_lambda(
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,
@@ -482,9 +515,6 @@ async def test_managed_execution_invokes_every_configured_completion_lambda(
     dry_run_names: list[str] = []
     invocations: list[tuple[str, dict[str, Any]]] = []
 
-    def deployment_runtime(_org_id: UUID) -> AWSRuntime:
-        return aws_runtime
-
     def dry_run(_clients: object, function_name: str) -> None:
         dry_run_names.append(function_name)
 
@@ -497,17 +527,7 @@ async def test_managed_execution_invokes_every_configured_completion_lambda(
         invocations.append((function_name, payload))
         return {}
 
-    monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
-        lambda *_args, **_kwargs: cast(SandboxProviderConfig, MagicMock()),
-    )
-    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", lambda *_args, **_kwargs: {})
-    monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", lambda *_args, **_kwargs: {})
-    monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", dry_run)
-    monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", AsyncMock())
-    monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke_post_run)
+    _patch_completion_lambda_run(monkeypatch, aws_runtime, dry_run=dry_run, invoke=invoke_post_run)
 
     await process_benchmark(
         execution_context_json=_execution_context(request, benchmark.id),
@@ -519,12 +539,28 @@ async def test_managed_execution_invokes_every_configured_completion_lambda(
     assert dry_run_names == ["programbench-final-view-lambda", "vals-format-lambda"]
     assert [name for name, _ in invocations] == ["programbench-final-view-lambda", "vals-format-lambda"]
     payloads = [payload for _, payload in invocations]
+    # Each callback still receives the singular field naming itself, as it did before the list.
+    assert [payload.pop("lambda_function") for payload in payloads] == [
+        "programbench-final-view-lambda",
+        "vals-format-lambda",
+    ]
     assert payloads[0] == payloads[1]
+    assert payloads[0]["lambda_functions"] == ["programbench-final-view-lambda", "vals-format-lambda"]
     assert payloads[0]["benchmark_id"] == str(benchmark.id)
     assert payloads[0]["benchmark_name"] == benchmark.name
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        LambdaError("Lambda function 'programbench-final-view-lambda' returned status 500: {}"),
+        # invoke_lambda only wraps ClientError, so the 60s completion read timeout escapes as itself.
+        ReadTimeoutError(endpoint_url="https://lambda.us-east-1.amazonaws.com"),
+    ],
+    ids=["lambda_error", "read_timeout"],
+)
 async def test_managed_execution_invokes_later_completion_lambdas_after_a_failure(
+    failure: Exception,
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,
     database_session: Session,
@@ -538,8 +574,8 @@ async def test_managed_execution_invokes_later_completion_lambdas_after_a_failur
     benchmark = _persist_benchmark(database_session, request, aws_managed=True)
     invoked: list[str] = []
 
-    def deployment_runtime(_org_id: UUID) -> AWSRuntime:
-        return aws_runtime
+    def dry_run(_clients: object, _function_name: str) -> None:
+        return None
 
     def invoke_post_run(
         _clients: object,
@@ -549,20 +585,10 @@ async def test_managed_execution_invokes_later_completion_lambdas_after_a_failur
     ) -> dict[str, Any]:
         invoked.append(function_name)
         if function_name == "programbench-final-view-lambda":
-            raise LambdaError("Lambda function 'programbench-final-view-lambda' returned status 500: {}")
+            raise failure
         return {}
 
-    monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
-    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(
-        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
-        lambda *_args, **_kwargs: cast(SandboxProviderConfig, MagicMock()),
-    )
-    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", lambda *_args, **_kwargs: {})
-    monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", lambda *_args, **_kwargs: {})
-    monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", AsyncMock())
-    monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke_post_run)
+    _patch_completion_lambda_run(monkeypatch, aws_runtime, dry_run=dry_run, invoke=invoke_post_run)
 
     await process_benchmark(
         execution_context_json=_execution_context(request, benchmark.id),
@@ -570,3 +596,7 @@ async def test_managed_execution_invokes_later_completion_lambdas_after_a_failur
     )
 
     assert invoked == ["programbench-final-view-lambda", "vals-format-lambda"]
+    # The run is already FINISHED when callbacks run, so commit_benchmark_error cannot reopen it;
+    # a failing callback surfaces through the log and Sentry, not the run status.
+    database_session.refresh(benchmark)
+    assert benchmark.status == BenchmarkStatus.FINISHED

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -17,6 +17,7 @@ from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogSink
 from tracker.aws.resolver import ManagedAWSEligibilityError
 from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import AgentContractRequest, Benchmark, BenchmarkStatus, Org
+from tracker.exceptions import LambdaError
 from tracker.types import HarnessConfig, ManagedExecutionContext, StartBenchmarkRequest
 from tracker.utils import process_benchmark, start_benchmark_request_to_benchmark
 from tracker.utils.run_orchestration import (
@@ -521,3 +522,51 @@ async def test_managed_execution_invokes_every_configured_completion_lambda(
     assert payloads[0] == payloads[1]
     assert payloads[0]["benchmark_id"] == str(benchmark.id)
     assert payloads[0]["benchmark_name"] == benchmark.name
+
+
+async def test_managed_execution_invokes_later_completion_lambdas_after_a_failure(
+    contract: AgentContractRequest,
+    aws_runtime: AWSRuntime,
+    database_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    process_benchmark_env: None,
+    executor_authority_kwargs: Any,
+) -> None:
+    request = _managed_request(contract).model_copy(
+        update={"lambda_functions": ["programbench-final-view-lambda", "vals-format-lambda"]}
+    )
+    benchmark = _persist_benchmark(database_session, request, aws_managed=True)
+    invoked: list[str] = []
+
+    def deployment_runtime(_org_id: UUID) -> AWSRuntime:
+        return aws_runtime
+
+    def invoke_post_run(
+        _clients: object,
+        function_name: str,
+        _payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        invoked.append(function_name)
+        if function_name == "programbench-final-view-lambda":
+            raise LambdaError("Lambda function 'programbench-final-view-lambda' returned status 500: {}")
+        return {}
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
+    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
+        lambda *_args, **_kwargs: cast(SandboxProviderConfig, MagicMock()),
+    )
+    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", AsyncMock())
+    monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke_post_run)
+
+    await process_benchmark(
+        execution_context_json=_execution_context(request, benchmark.id),
+        **executor_authority_kwargs(benchmark),
+    )
+
+    assert invoked == ["programbench-final-view-lambda", "vals-format-lambda"]

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -318,7 +318,7 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
     executor_authority_kwargs: Any,
 ) -> None:
     request = _managed_request(contract.model_copy(update={"secrets": {"MODEL_API_KEY": "model-secret"}})).model_copy(
-        update={"lambda_function": "post-run-handler"}
+        update={"lambda_functions": ["post-run-handler"]}
     )
     benchmark = _persist_benchmark(database_session, request, aws_managed=True)
     calls: list[str] = []
@@ -395,7 +395,7 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
         update={
             "webhook_secret_name": "webhook-secret",
             "webhook_intervals": [10],
-            "lambda_function": "result-handler",
+            "lambda_functions": ["result-handler"],
         }
     )
     execution = _parse_queued_execution(None, None, None, _execution_context(request, uuid4()))
@@ -464,3 +464,60 @@ async def test_managed_preflight_failure_happens_before_sandbox(
     assert benchmark.status == BenchmarkStatus.ERROR
     assert "managed log preflight failed" in (benchmark.error_message or "")
     create_sandbox.assert_not_awaited()
+
+
+async def test_managed_execution_invokes_every_configured_completion_lambda(
+    contract: AgentContractRequest,
+    aws_runtime: AWSRuntime,
+    database_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    process_benchmark_env: None,
+    executor_authority_kwargs: Any,
+) -> None:
+    request = _managed_request(contract).model_copy(
+        update={"lambda_functions": ["programbench-final-view-lambda", "vals-format-lambda"]}
+    )
+    benchmark = _persist_benchmark(database_session, request, aws_managed=True)
+    dry_run_names: list[str] = []
+    invocations: list[tuple[str, dict[str, Any]]] = []
+
+    def deployment_runtime(_org_id: UUID) -> AWSRuntime:
+        return aws_runtime
+
+    def dry_run(_clients: object, function_name: str) -> None:
+        dry_run_names.append(function_name)
+
+    def invoke_post_run(
+        _clients: object,
+        function_name: str,
+        payload: dict[str, Any],
+        **_kwargs: Any,
+    ) -> dict[str, Any]:
+        invocations.append((function_name, payload))
+        return {}
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.deployment_aws_runtime", deployment_runtime)
+    monkeypatch.setattr(CloudWatchBenchmarkLogSink, "create_benchmark", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
+        lambda *_args, **_kwargs: cast(SandboxProviderConfig, MagicMock()),
+    )
+    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr("tracker.utils.task_execution.resolve_secrets", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr("tracker.utils.run_orchestration.dry_run_lambda", dry_run)
+    monkeypatch.setattr("tracker.utils.run_orchestration.upload_final_view", AsyncMock())
+    monkeypatch.setattr("tracker.utils.run_orchestration.invoke_lambda", invoke_post_run)
+
+    await process_benchmark(
+        execution_context_json=_execution_context(request, benchmark.id),
+        **executor_authority_kwargs(benchmark),
+    )
+
+    database_session.refresh(benchmark)
+    assert benchmark.status == BenchmarkStatus.FINISHED
+    assert dry_run_names == ["programbench-final-view-lambda", "vals-format-lambda"]
+    assert [name for name, _ in invocations] == ["programbench-final-view-lambda", "vals-format-lambda"]
+    payloads = [payload for _, payload in invocations]
+    assert payloads[0] == payloads[1]
+    assert payloads[0]["benchmark_id"] == str(benchmark.id)
+    assert payloads[0]["benchmark_name"] == benchmark.name

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -557,7 +557,7 @@ class TestRunRecovery:
             contract=contract,
             concurrency=2,
             task_ids=task_ids,
-            lambda_function="vals-format-lambda",
+            lambda_functions=["vals-format-lambda"],
             harness_config=harness_config,
         )
 

--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -187,11 +187,11 @@ def resolve_webhook_config(
 )
 @click.option(
     "--lambda",
-    "lambda_function",
+    "lambda_functions",
     type=str,
-    default=None,
+    multiple=True,
     required=False,
-    help="Lambda function to invoke at the end of the benchmark run",
+    help="Lambda function to invoke at the end of the benchmark run; repeatable",
 )
 @click.option(
     "--task-ids",
@@ -297,7 +297,7 @@ def start(
     model: str | None,
     benchmark: str,
     concurrency: int,
-    lambda_function: str | None,
+    lambda_functions: tuple[str, ...],
     task_ids: str | None,
     task_ids_file: str | None,
     slice_str: str | None,
@@ -396,7 +396,7 @@ def start(
                         formatted_task_ids,
                         slice_str,
                         label,
-                        lambda_function,
+                        list(lambda_functions),
                         dataset,
                         service_headers=service_headers or None,
                         provider=provider,

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -423,7 +423,7 @@ class TrackerService:
         task_ids: list[str] | None,
         slice_str: str | None,
         label: str | None = None,
-        lambda_function: str | None = None,
+        lambda_functions: list[str] | None = None,
         dataset: str | None = None,
         service_headers: dict[str, str] | None = None,
         provider: str | None = None,
@@ -440,7 +440,7 @@ class TrackerService:
             task_ids: Optional list of specific task IDs to run
             slice_str: Optional slice string for task selection
             label: Optional run label
-            lambda_function: Optional lambda function to invoke after benchmark
+            lambda_functions: Lambda functions to invoke after benchmark
 
         Returns:
             Run response with status, message, and results
@@ -462,7 +462,7 @@ class TrackerService:
                 label=label,
                 task_ids=task_ids,
                 slice_str=slice_str,
-                lambda_function=lambda_function,
+                lambda_functions=lambda_functions or [],
                 dataset=dataset,
                 harness_config=access_key_harness_config,
                 custom_benchmark_service=self.get_benchmark_service_url(benchmark_name)

--- a/tests/fixtures/sdk_api/results.json
+++ b/tests/fixtures/sdk_api/results.json
@@ -30,7 +30,7 @@
         "task-2"
       ],
       "slice_str": null,
-      "lambda_function": null,
+      "lambda_functions": [],
       "dataset": "default",
       "sandbox_provider": "modal",
       "sandbox_provider_secret_name": "ModalSecret"

--- a/tests/fixtures/sdk_api/start.json
+++ b/tests/fixtures/sdk_api/start.json
@@ -28,7 +28,7 @@
       "task-1"
     ],
     "slice_str": null,
-    "lambda_function": null,
+    "lambda_functions": [],
     "dataset": "default",
     "harness_config": {
       "aws": {

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -442,3 +442,20 @@ class TestCountedStarts:
             assert "valkyrie run status --ids" not in result.output
         else:
             assert "requested runs successfully started" not in result.output
+
+
+def test_repeated_lambda_options_all_reach_the_tracker(start_testbed: StartTestbed) -> None:
+    result = start_testbed.invoke(["--lambda", "programbench-final-view-lambda", "--lambda", "vals-format-lambda"])
+
+    assert result.exit_code == 0, result.output
+    assert start_testbed.tracker.start_benchmark.call_args.args[7] == [
+        "programbench-final-view-lambda",
+        "vals-format-lambda",
+    ]
+
+
+def test_start_without_lambda_options_sends_no_completion_lambdas(start_testbed: StartTestbed) -> None:
+    result = start_testbed.invoke([])
+
+    assert result.exit_code == 0, result.output
+    assert start_testbed.tracker.start_benchmark.call_args.args[7] == []

--- a/tests/unit/sdk/test_public_api.py
+++ b/tests/unit/sdk/test_public_api.py
@@ -63,7 +63,7 @@ EXPECTED_SIGNATURES = {
     ),
     RunsResource.start: (
         "self, agent, benchmark, *, model=None, concurrency=5, task_ids=None, slice_str=None, dataset=None, "
-        "label=None, lambda_function=None, provider=None, agent_kwargs=None, secrets=None, service_headers=None, "
+        "label=None, lambda_functions=None, provider=None, agent_kwargs=None, secrets=None, service_headers=None, "
         "webhook_intervals=None, ignore_custom_services=False"
     ),
     RunsResource.fetch: "self, run_id",

--- a/uv.lock
+++ b/uv.lock
@@ -2538,7 +2538,7 @@ dev = [
 
 [[package]]
 name = "valkyrie-sdk"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "packages/valkyrie-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

A run could configure only one completion lambda, so a benchmark with its own final-view lambda (programbench, swebench, snap, terminal-bench, harvey) could never also produce the shared `vals_format/vals_format.json` artifact that export and cost recalculation read — the artifact had to be produced later by hand-invoking `vals-format-lambda`. `--lambda` is now repeatable and tracker invokes every configured lambda with the same completion payload.

```diff
-lambda_function: str | None
+lambda_functions: list[str]
```

Persisted `BenchmarkArguments` and inbound requests still accept the singular `lambda_function` (alias + string widening), so runs started before this change reconstruct, recover and finalize unchanged. The completion payload also still carries `lambda_function`, now naming the callback receiving it, so deployed lambdas reading the documented singular field are unaffected. Preflight dry-runs every configured lambda; finalization builds the payload once and invokes each lambda synchronously after the final-view upload.

One callback failure must not cost another its artifact, so each invocation is isolated and the first failure is re-raised only once every lambda has been attempted. `invoke_lambda` wraps only `ClientError`, so this catches any exception — a read timeout on the 60s completion config arrives as `ReadTimeoutError` and would otherwise skip every later callback.

## Changes

- SDK: `runs.start(lambda_functions=[...])`; `StartBenchmarkRequest`/`BenchmarkArguments` carry a list.
- CLI: `--lambda` is `multiple=True`.
- Tracker: one shared `CompletionLambdas` annotated type carries the list, alias and widening for both the inbound request and the persisted arguments, so the two shapes cannot drift; preflight validates each lambda; finalization invokes each one.
- Docs: `docs/LAMBDA_USAGE.md` payload fields, repeatability, and callback failure semantics.

## Related Issues

Motivated by downstream benchmark configs that need a legacy final-view lambda and the shared `vals-format-lambda` on the same run; those consumers are tracked separately.

## Type of Change

- [x] New feature
- [x] Docs / config

## Testing

- [x] Added/updated unit tests
- [ ] Manually tested

Not live-tested: this path only runs inside a deployed tracker at run finalization, and I did not start a benchmark run. `test_managed_execution_invokes_every_configured_completion_lambda` covers both preflight dry-runs, both invocations, and a payload that differs only in `lambda_function`; `test_managed_execution_invokes_later_completion_lambdas_after_a_failure` covers a later callback still running after both a `LambdaError` and a `ReadTimeoutError`; legacy singular payloads are covered by the parameterized `BenchmarkArguments` cases.

Note on the docs correction: `docs/LAMBDA_USAGE.md` claimed a failing lambda marks the run `ERROR`. It does not, and did not before this PR — finalization commits the terminal status before invoking callbacks, so `commit_benchmark_error` hits `require_in_progress` and rolls back. A failing callback is logged and reported, but the run stays `FINISHED`.

Deliberately not changed here. The ordering predates this PR and applies to every run that configures any completion lambda, so flipping a run whose tasks all succeeded to `ERROR` would change retry, monitoring and status semantics repo-wide — too broad to ride along with repeatable lambdas. This PR makes the behaviour accurate instead of aspirational, in the docs, in a comment at the `raise`, and in a test that asserts `FINISHED`.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/43fd1e8242e44704bc575bedd476e654
Open in Devin Desktop: https://app.devin.ai/desktop/session/43fd1e8242e44704bc575bedd476e654?variant=devin
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/741" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->



