### PR TITLE
#patch: Prod deploy 08/31/2026

### DIFF
--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -17,6 +17,16 @@ _KMS_KEY_ARN_PATTERN = re.compile(r"arn:[^:]+:kms:[^:]+:[0-9]{12}:key/[A-Za-z0-9
 _OFFLINE_SYNTH_ORG_ID = "00000000-0000-0000-0000-000000000001"
 _OFFLINE_SYNTH_SECRET_PREFIX = "offline-synth"
 
+_TRACKER_ANALYZER_LAMBDA_PATTERNS = ("analysis-*",)
+_EXECUTOR_OUTPUT_LAMBDA_PATTERNS = (
+    "vals-format-lambda",
+    "harvey-legal-agent-final-view-lambda",
+    "programbench-final-view-lambda",
+    "snap-final-view-lambda",
+    "swebench-final-view-lambda",
+    "terminalbench-final-view-lambda",
+)
+
 
 @dataclass(frozen=True)
 class ServiceConfig:
@@ -108,7 +118,8 @@ PROD_CONFIG = StageConfig(
         benchmark_log_retention_days=365,
         submissions_enabled=True,
         executor_all_secret_access=True,
-        executor_lambda_function_name_patterns=("vals-format-lambda",),
+        tracker_lambda_function_name_patterns=_TRACKER_ANALYZER_LAMBDA_PATTERNS,
+        executor_lambda_function_name_patterns=_EXECUTOR_OUTPUT_LAMBDA_PATTERNS,
     ),
 )
 
@@ -128,7 +139,8 @@ DEV_CONFIG = StageConfig(
         benchmark_log_retention_days=7,
         submissions_enabled=True,
         executor_all_secret_access=True,
-        executor_lambda_function_name_patterns=("vals-format-lambda",),
+        tracker_lambda_function_name_patterns=_TRACKER_ANALYZER_LAMBDA_PATTERNS,
+        executor_lambda_function_name_patterns=_EXECUTOR_OUTPUT_LAMBDA_PATTERNS,
     ),
 )
 

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -10,7 +10,7 @@ from aws_cdk import assertions, aws_s3
 
 from runtime_iam import create_executor_task_role, create_tracker_task_role
 from stage import DEV, PROD, RELEASE_TEST, Stage
-from stage_config import ManagedAWSRuntimeConfig
+from stage_config import DEV_CONFIG, PROD_CONFIG, ManagedAWSRuntimeConfig
 from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
@@ -144,7 +144,13 @@ class RuntimeIamTest(unittest.TestCase):
                 tracker_template,
                 "ValkyrieTrackerTaskRole-dev",
                 "TrackerTaskRoleArn",
-                expected_actions | {"s3:DeleteObject", "s3:DeleteObjectVersion", "secretsmanager:GetSecretValue"},
+                expected_actions
+                | {
+                    "s3:DeleteObject",
+                    "s3:DeleteObjectVersion",
+                    "secretsmanager:GetSecretValue",
+                    "lambda:InvokeFunction",
+                },
             ),
             (
                 executor_template,
@@ -265,11 +271,23 @@ class RuntimeIamTest(unittest.TestCase):
                         for statement in statements
                         if _statement_actions(statement) == {"lambda:InvokeFunction"}
                     )
-                    self.assertEqual(lambda_statement["Resource"], _lambda_function_resource("vals-format-lambda"))
+                    self.assertEqual(
+                        lambda_statement["Resource"],
+                        [
+                            _lambda_function_resource(pattern)
+                            for pattern in DEV_CONFIG.managed_aws.executor_lambda_function_name_patterns
+                        ],
+                    )
                 else:
                     secret_resources = json.dumps(secret_statement["Resource"])
                     self.assertIn("secretsmanager", secret_resources)
                     self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
+                    lambda_statement = next(
+                        statement
+                        for statement in statements
+                        if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                    )
+                    self.assertEqual(lambda_statement["Resource"], _lambda_function_resource("analysis-*"))
 
     def test_prod_managed_runtime_uses_prod_inventory_and_task_roles(self) -> None:
         with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=True):
@@ -319,16 +337,20 @@ class RuntimeIamTest(unittest.TestCase):
                     self.assertEqual(len(lambda_statements), 1)
                     self.assertEqual(
                         lambda_statements[0]["Resource"],
-                        _lambda_function_resource("vals-format-lambda"),
+                        [
+                            _lambda_function_resource(pattern)
+                            for pattern in PROD_CONFIG.managed_aws.executor_lambda_function_name_patterns
+                        ],
                     )
                 else:
                     self.assertIn(f"secret:{TEST_TRACKER_SECRET_NAME_PREFIX}*", secret_resources)
-                    self.assertFalse(
-                        any(
-                            _statement_actions(statement) == {"lambda:InvokeFunction"}
-                            for statement in _role_policy_statements(template, role_logical_id)
-                        )
-                    )
+                    lambda_statements = [
+                        statement
+                        for statement in _role_policy_statements(template, role_logical_id)
+                        if _statement_actions(statement) == {"lambda:InvokeFunction"}
+                    ]
+                    self.assertEqual(len(lambda_statements), 1)
+                    self.assertEqual(lambda_statements[0]["Resource"], _lambda_function_resource("analysis-*"))
 
     def test_release_test_managed_runtime_remains_closed(self) -> None:
         with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.31.2" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.32.0" }
 tracker = { path = "../tracker" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.31.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2#fd4103a727288408b83f23536da6107f2b20287d" }
+version = "0.32.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.31.2" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.32.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.31.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2#fd4103a727288408b83f23536da6107f2b20287d" }
+version = "0.32.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -800,9 +800,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
     { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
     { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
-    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
     { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
     { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
     { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
@@ -2118,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.31.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2#fd4103a727288408b83f23536da6107f2b20287d" }
+version = "0.32.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.31.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
Grant tracker analyzer and executor final-view lambda invoke permissions, bump create-benchmark-service to v0.32.0

## Commits
- chore(deps): bump create-benchmark-service to v0.32.0 (#743) (bbf6155f) by Braden Wicker
- feat(infra): grant tracker analyzer and executor final-view lambda invoke (#740) (e4100e2b) by Braden Wicker

Link to Devin session: https://app.devin.ai/sessions/6fbe3516ea0a4bc6bca98a617e66fee0
Open in Devin Desktop: https://app.devin.ai/desktop/session/6fbe3516ea0a4bc6bca98a617e66fee0?variant=devin
Requested by: @BradenBug