### PR TITLE
feat(cli): forward -H headers on run resume/retry

### DIFF
--- a/src/valkyrie/cli/run/resume.py
+++ b/src/valkyrie/cli/run/resume.py
@@ -55,6 +55,15 @@ from valkyrie.cli.tracker_client import TrackerService
     help="Secret as ENV_VAR aws_secret_name (e.g., -s ANTHROPIC_API_KEY YourAnthropicKeySecret)",
 )
 @click.option(
+    "--header",
+    "-H",
+    "headers",
+    multiple=True,
+    nargs=2,
+    type=(str, str),
+    help="Custom header for benchmark service requests (e.g., -H Authorization my-credential)",
+)
+@click.option(
     "--update-agent",
     "-u",
     is_flag=True,
@@ -88,6 +97,7 @@ def resume(
     task_ids: str | None,
     task_ids_file: str | None,
     secrets: tuple[tuple[str, str]],
+    headers: tuple[tuple[str, str], ...],
     update_agent: bool,
     from_scratch: bool,
     benchmark_url: str | None,
@@ -108,7 +118,7 @@ def resume(
     try:
         with TrackerService() as tracker:
             benchmark_info = tracker.fetch_benchmark(run_id)
-            service_headers = benchmark_service_headers(benchmark_info.benchmark_name)
+            service_headers = benchmark_service_headers(benchmark_info.benchmark_name, headers)
 
             if update_agent:
                 metadata = tracker.fetch_benchmark_metadata(run_id)

--- a/tests/unit/cli/run/test_resume.py
+++ b/tests/unit/cli/run/test_resume.py
@@ -61,10 +61,14 @@ def test_resume_forwards_custom_headers(
     """Send `-H` headers to the tracker so custom benchmark services authenticate."""
     run_id = UUID("123e4567-e89b-12d3-a456-426614174000")
     monkeypatch.setattr(resume_module, "TrackerService", MockTrackerService)
+
+    def no_configured_auth(_benchmark_name: str) -> str | None:
+        return None
+
     monkeypatch.setattr(
         service_headers_module.TrackerService,
         "get_benchmark_auth",
-        staticmethod(lambda _name: None),
+        staticmethod(no_configured_auth),
     )
 
     result = cli_runner.invoke(

--- a/tests/unit/cli/run/test_resume.py
+++ b/tests/unit/cli/run/test_resume.py
@@ -1,0 +1,78 @@
+"""Tests for resuming and retrying runs.
+
+Run: uv run pytest tests/unit/cli/run/test_resume.py
+
+Covers benchmark service header forwarding for custom services.
+"""
+
+from importlib import import_module
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+from tracker.database.models import RetryMode
+from tracker.types import FetchBenchmarkResponse, RetryOrResumeBenchmarkResponse
+
+from tests.unit.cli.factories import make_fetch_response
+
+resume_module = import_module("valkyrie.cli.run.resume")
+service_headers_module = import_module("valkyrie.cli.service_headers")
+
+
+class MockTrackerService:
+    """Record retry/resume requests made by the CLI command."""
+
+    calls: list[dict[str, object]] = []
+
+    def __enter__(self) -> "MockTrackerService":
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def fetch_benchmark(self, benchmark_id: UUID) -> FetchBenchmarkResponse:
+        return make_fetch_response(benchmark_id)
+
+    def retry_or_resume_benchmark(
+        self,
+        benchmark_id: UUID,
+        retry: bool,
+        retry_mode: RetryMode,
+        concurrency: int | None,
+        task_ids: list[str],
+        service_headers: dict[str, str] | None = None,
+        secrets: dict[str, str] | None = None,
+        benchmark_url: str | None = None,
+    ) -> RetryOrResumeBenchmarkResponse:
+        self.calls.append({"benchmark_id": benchmark_id, "service_headers": service_headers})
+        return RetryOrResumeBenchmarkResponse(status="success")
+
+
+@pytest.fixture(autouse=True)
+def reset_calls() -> None:
+    """Reset recorded requests so each test is isolated."""
+    MockTrackerService.calls = []
+
+
+def test_resume_forwards_custom_headers(
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Send `-H` headers to the tracker so custom benchmark services authenticate."""
+    run_id = UUID("123e4567-e89b-12d3-a456-426614174000")
+    monkeypatch.setattr(resume_module, "TrackerService", MockTrackerService)
+    monkeypatch.setattr(
+        service_headers_module.TrackerService,
+        "get_benchmark_auth",
+        staticmethod(lambda _name: None),
+    )
+
+    result = cli_runner.invoke(
+        resume_module.resume,
+        [str(run_id), "-H", "x-descope-api-key", "secret-value"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert MockTrackerService.calls == [
+        {"benchmark_id": run_id, "service_headers": {"x-descope-api-key": "secret-value"}}
+    ]


### PR DESCRIPTION
## Summary
`valk run start` accepts `-H/--header` for benchmark service auth, but `run resume` / `run retry` did not, and the tracker does not persist a run's `service_headers` (`managed_start_benchmark_request(service_headers=...)` takes only what the caller passes). So any run against a custom benchmark service that authenticates with a non-`Authorization` header — e.g. srebench, which only accepts `x-descope-api-key` — could be started but never resumed or retried:

```
$ valk run retry <run-id> --task-ids-file ids.txt
Error: Failed to start run: Benchmark service authentication failed
```

The config-based path (`benchmark_auth` → `Authorization`) can't cover this, since the header name is fixed.

## Changes
- `run resume` / `run retry`: add `-H/--header` (same signature/help as `run start`) and pass it through `benchmark_service_headers(...)` into `retry_or_resume_benchmark`.
- Unit test asserting the headers reach the tracker call; it fails without the flag.

## Related Issues
n/a

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested

Live: retried 4 sandbox-setup-failed tasks on the in-flight srebench melon run `f8e9e4a5-1544-44ed-82b0-656d3e156724` from this branch:

```
$ uv run valk run retry f8e9e4a5-1544-44ed-82b0-656d3e156724 \
    --task-ids-file /tmp/docker_retry.txt -H x-descope-api-key "$VALKYRIE_API_KEY"
✓ Run retried successfully!
```

`valk run fetch` then showed `ERROR` 28 → 24 with the four tasks back in `PENDING`. The same command on `dev` fails with `Benchmark service authentication failed`.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed


Link to Devin session: https://app.devin.ai/sessions/e80cfc88068f4a42a713f58595832ad4
Open in Devin Desktop: https://app.devin.ai/desktop/session/e80cfc88068f4a42a713f58595832ad4?variant=devin
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->