### PR TITLE
#minor: Prod deploy 09/02/2026

### DIFF
--- a/.github/scripts/synthesize-worker-templates.sh
+++ b/.github/scripts/synthesize-worker-templates.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# PR classification runs this helper from the trusted base revision while
-# synthesizing candidate source with synthetic account IDs and no AWS access.
+# PR classification runs this helper from a trusted branch revision while
+# synthesizing source revisions with synthetic account IDs and no AWS access.
 revision="${1:?revision is required}"
 target_branch="${2:?target branch is required}"
 label="${3:?label is required}"

--- a/.github/scripts/synthesize-worker-templates.sh
+++ b/.github/scripts/synthesize-worker-templates.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PR classification runs this helper from the trusted base revision while
+# synthesizing candidate source with synthetic account IDs and no AWS access.
+revision="${1:?revision is required}"
+target_branch="${2:?target branch is required}"
+label="${3:?label is required}"
+artifact_directory="${4:?artifact directory is required}"
+repository_directory="${5:-.}"
+
+source_directory="$RUNNER_TEMP/source-$label"
+mkdir -p "$source_directory" "$artifact_directory"
+: > "$artifact_directory/stack-ids.txt"
+if [[ ! "$revision" =~ ^0+$ ]]; then
+  git -C "$repository_directory" archive "$revision" | tar -x -C "$source_directory"
+fi
+
+has_bench_stage=false
+if [[ ! "$revision" =~ ^0+$ ]] && python3 -c \
+  'import ast, sys; from pathlib import Path; tree = ast.parse(Path(sys.argv[1]).read_text()); matches = [node for node in tree.body if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == "BENCH" for target in node.targets)]; raise SystemExit(len(matches) != 1 or not isinstance(matches[0].value, ast.Constant) or matches[0].value.value != "bench")' \
+  "$source_directory/infra/stage.py"; then
+  has_bench_stage=true
+fi
+
+production_account_id=222222222222
+if [[ "$has_bench_stage" == "true" ]]; then
+  production_account_id=333333333333
+fi
+
+case "$target_branch" in
+  dev)
+    targets=("dev:ValkDevWorkerStack:111111111111")
+    ;;
+  prod)
+    if [[ "$has_bench_stage" == "true" ]]; then
+      targets=(
+        "bench:WorkerStack:222222222222"
+        "prod:ValkProdWorkerStack:333333333333"
+      )
+    else
+      targets=(
+        "prod:WorkerStack:222222222222"
+        "unsupported:ValkProdWorkerStack:333333333333"
+      )
+    fi
+    ;;
+  *)
+    echo "::error::Unsupported deployment branch '$target_branch'."
+    exit 1
+    ;;
+esac
+
+for target in "${targets[@]}"; do
+  IFS=: read -r stage stack_id account_id <<< "$target"
+  printf '%s\n' "$stack_id" >> "$artifact_directory/stack-ids.txt"
+  template="$artifact_directory/$stack_id.template.json"
+  if [[ "$revision" =~ ^0+$ || "$stage" == "unsupported" ]]; then
+    printf '{"Resources": {}}\n' > "$template"
+    continue
+  fi
+
+  assembly="$RUNNER_TEMP/cdk-$label-$stage"
+  (
+    cd "$source_directory/infra"
+    BENCH_ACCOUNT_ID=222222222222 \
+    PRODUCTION_ACCOUNT_ID="$production_account_id" \
+    DEV_ACCOUNT_ID=111111111111 \
+    CDK_DEFAULT_ACCOUNT="$account_id" \
+    CDK_DEFAULT_REGION=us-east-1 \
+    AWS_REGION=us-east-1 \
+    STAGE="$stage" \
+    AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
+    AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
+    AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
+    BENCHMARK_CATALOG_URL=https://offline.invalid \
+    SENTRY_DSN_SECRET_NAME=offline-synth \
+    DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
+    DESCOPE_PROJECT_ID=offline-synth \
+    CDK_CONTEXT_JSON="{\"stage\":\"$stage\"}" \
+    CDK_OUTDIR="$assembly" \
+      uv run --frozen python app.py
+  )
+  cp "$assembly/$stack_id.template.json" "$template"
+done

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -71,68 +71,36 @@ jobs:
           HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          case "$GITHUB_REF_NAME" in
-            dev)
-              stage=dev
-              stack_id=ValkDevWorkerStack
-              account_id=111111111111
-              ;;
-            prod)
-              stage=prod
-              stack_id=WorkerStack
-              account_id=613431292675
-              ;;
-            *)
-              echo "::error::Unsupported deployment branch '$GITHUB_REF_NAME'."
-              exit 1
-              ;;
-          esac
           npm install -g aws-cdk@2.1132.0
-
-          synth_revision() {
-            local revision="$1"
-            local label="$2"
-            local source="$RUNNER_TEMP/source-$label"
-            local assembly="$RUNNER_TEMP/cdk-$label"
-            local artifact="$RUNNER_TEMP/worker-template-$label"
-            mkdir -p "$source" "$artifact"
-            if [[ "$revision" =~ ^0+$ ]]; then
-              printf '{"Resources": {}}\n' > "$artifact/WorkerStack.template.json"
-              return
-            fi
-            git archive "$revision" | tar -x -C "$source"
-            (
-              cd "$source/infra"
-              PRODUCTION_ACCOUNT_ID=613431292675 \
-              DEV_ACCOUNT_ID=111111111111 \
-              CDK_DEFAULT_ACCOUNT="$account_id" \
-              CDK_DEFAULT_REGION=us-east-1 \
-              AWS_REGION=us-east-1 \
-              STAGE="$stage" \
-              AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
-              AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
-              AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
-              SENTRY_DSN_SECRET_NAME=offline-synth \
-              DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
-              DESCOPE_PROJECT_ID=offline-synth \
-                uv run --frozen cdk synth "$stack_id" -c stage="$stage" --output "$assembly"
-            )
-            cp "$assembly/$stack_id.template.json" "$artifact/WorkerStack.template.json"
-          }
-
-          synth_revision "$BASE_SHA" base
-          synth_revision "$HEAD_SHA" head
-          echo "STACK_ID=$stack_id" >> "$GITHUB_ENV"
+          bash .github/scripts/synthesize-worker-templates.sh \
+            "$BASE_SHA" "$GITHUB_REF_NAME" base "$RUNNER_TEMP/worker-template-base"
+          bash .github/scripts/synthesize-worker-templates.sh \
+            "$HEAD_SHA" "$GITHUB_REF_NAME" head "$RUNNER_TEMP/worker-template-head"
+          mapfile -t stack_ids < "$RUNNER_TEMP/worker-template-head/stack-ids.txt"
+          echo "PRIMARY_STACK_ID=${stack_ids[0]}" >> "$GITHUB_ENV"
+          if [[ "${#stack_ids[@]}" -gt 1 ]]; then
+            echo "SECONDARY_STACK_ID=${stack_ids[1]}" >> "$GITHUB_ENV"
+          fi
 
       - name: Classify deployment
-        run: >-
-          python3 infra/classify_repository_change.py
-          --base-sha "${{ github.event.before }}"
-          --head-sha "$GITHUB_SHA"
-          --executor-base-template "$RUNNER_TEMP/worker-template-base/WorkerStack.template.json"
-          --executor-head-template "$RUNNER_TEMP/worker-template-head/WorkerStack.template.json"
-          --expected-stack-id "$STACK_ID"
-          --output maintenance-classification.json
+        run: |
+          set -euo pipefail
+          arguments=(
+            --base-sha "${{ github.event.before }}"
+            --head-sha "$GITHUB_SHA"
+            --executor-base-template "$RUNNER_TEMP/worker-template-base/$PRIMARY_STACK_ID.template.json"
+            --executor-head-template "$RUNNER_TEMP/worker-template-head/$PRIMARY_STACK_ID.template.json"
+            --expected-stack-id "$PRIMARY_STACK_ID"
+            --output maintenance-classification.json
+          )
+          if [[ -n "${SECONDARY_STACK_ID:-}" ]]; then
+            arguments+=(
+              --secondary-executor-base-template "$RUNNER_TEMP/worker-template-base/$SECONDARY_STACK_ID.template.json"
+              --secondary-executor-head-template "$RUNNER_TEMP/worker-template-head/$SECONDARY_STACK_ID.template.json"
+              --secondary-expected-stack-id "$SECONDARY_STACK_ID"
+            )
+          fi
+          python3 infra/classify_repository_change.py "${arguments[@]}"
 
       - name: Read classification
         id: result
@@ -152,17 +120,17 @@ jobs:
               print(f"{key}={str(result[key]).lower()}")
           PY
 
-  deploy-production-core:
+  deploy-prod-core:
     if: >-
       github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
       needs.classify-deployment.outputs.core_maintenance_required != 'true' &&
       needs.classify-deployment.outputs.database_maintenance_required != 'true'
     needs: classify-deployment
     concurrency:
-      group: valkyrie-prod-deploy
+      group: valkyrie-production-deploy
       cancel-in-progress: false
     runs-on: ubuntu-24.04-arm
-    environment: prod
+    environment: prod-external
     permissions:
       contents: read
       id-token: write
@@ -170,7 +138,10 @@ jobs:
       AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
       AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_REGION: us-east-1
-      PRODUCTION_ACCOUNT_ID: "613431292675"
+      AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}
+      BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
+      PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}
 
     steps:
       - name: Checkout code
@@ -178,10 +149,29 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate prod deployment inputs
+        run: |
+          set -euo pipefail
+          if [[ ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$PRODUCTION_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::The repository must define the bench and production account IDs as 12-digit Actions secrets."
+            exit 1
+          fi
+          if [[ "$PRODUCTION_ACCOUNT_ID" == "$BENCH_ACCOUNT_ID" ]]; then
+            echo "::error::PRODUCTION_ACCOUNT_ID must not be the bench AWS account."
+            exit 1
+          fi
+          if [[ -z "$AWS_DEPLOY_ROLE_ARN" ]]; then
+            echo "::error::The prod-external Environment must define AWS_DEPLOY_ROLE_ARN."
+            exit 1
+          fi
+          if [[ "$AWS_DEPLOY_ROLE_ARN" != "arn:aws:iam::${PRODUCTION_ACCOUNT_ID}:role/"* ]]; then
+            echo "::error::AWS_DEPLOY_ROLE_ARN must name a role in the approved prod account."
+            exit 1
+          fi
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
           allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
 
@@ -206,7 +196,333 @@ jobs:
           npm install -g aws-cdk@2.1132.0
           uv sync --frozen --python 3.12 --project infra
 
-      - name: Deploy production core stacks
+      - name: Deploy prod core stacks
+        env:
+          SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
+          VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
+          DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID: ${{ secrets.DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID }}
+          AUTH_REQUIRED: "true"
+          DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
+          DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
+          SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
+        working-directory: infra
+        run: >-
+          make deploy
+          STAGE=prod
+          SCOPE=core
+          AWS_REGION="$AWS_REGION"
+
+  executor-prod:
+    if: >-
+      always() && github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
+      needs.classify-deployment.result == 'success' &&
+      (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+       needs.classify-deployment.outputs.executor_release_required == 'true' ||
+       needs.classify-deployment.outputs.database_maintenance_required == 'true') &&
+      (needs.classify-deployment.outputs.core_maintenance_required == 'true' ||
+       needs.classify-deployment.outputs.database_maintenance_required == 'true' ||
+       needs.deploy-prod-core.result == 'success')
+    needs: [classify-deployment, deploy-prod-core]
+    concurrency:
+      group: valkyrie-production-deploy
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04-arm
+    environment: prod-external
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
+      AWS_REGION: us-east-1
+      AWS_DEPLOY_ROLE_ARN: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+      BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}
+      EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod/executor-release/launch-config
+      BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
+      PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}
+
+    steps:
+      - name: Verify current prod executor revision
+        id: freshness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          current_sha="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_REF_NAME" --jq .sha)"
+          if [[ "$current_sha" == "$GITHUB_SHA" ]]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping stale executor revision $GITHUB_SHA; current $GITHUB_REF_NAME is $current_sha."
+          fi
+
+      - name: Checkout code
+        if: steps.freshness.outputs.current == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Validate prod deployment inputs
+        id: validate
+        if: steps.freshness.outputs.current == 'true'
+        run: |
+          set -euo pipefail
+          if [[ ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$PRODUCTION_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::The repository must define the bench and production account IDs as 12-digit Actions secrets."
+            exit 1
+          fi
+          if [[ "$PRODUCTION_ACCOUNT_ID" == "$BENCH_ACCOUNT_ID" ]]; then
+            echo "::error::PRODUCTION_ACCOUNT_ID must not be the bench AWS account."
+            exit 1
+          fi
+          if [[ -z "$AWS_DEPLOY_ROLE_ARN" ]]; then
+            echo "::error::The prod-external Environment must define AWS_DEPLOY_ROLE_ARN."
+            exit 1
+          fi
+          if [[ "$AWS_DEPLOY_ROLE_ARN" != "arn:aws:iam::${PRODUCTION_ACCOUNT_ID}:role/"* ]]; then
+            echo "::error::AWS_DEPLOY_ROLE_ARN must name a role in the approved prod account."
+            exit 1
+          fi
+      - name: Setup Python
+        if: steps.freshness.outputs.current == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        if: steps.freshness.outputs.current == 'true'
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            infra/executor_release/uv.lock
+            infra/uv.lock
+            services/executor_artifact/uv.lock
+
+      - name: Build immutable executor artifact
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_release_required == 'true'
+        run: |
+          PYTHONPATH=services/tracker/src python services/executor_artifact/build.py \
+            --output-directory "$GITHUB_WORKSPACE/executor-release" \
+            --source-revision "$GITHUB_SHA"
+
+      - name: Configure prod release preflight credentials
+        if: steps.freshness.outputs.current == 'true'
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PRODUCTION_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-prod
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+          role-session-name: valkyrie-prod-release-preflight-${{ github.run_id }}
+          unset-current-credentials: true
+
+      - name: Require deployed prod release control
+        if: steps.freshness.outputs.current == 'true'
+        run: |
+          set -euo pipefail
+          error_file="$(mktemp)"
+          if aws ssm get-parameter --name "$EXECUTOR_RELEASE_LAUNCH_PARAMETER" >/dev/null 2>"$error_file"; then
+            exit 0
+          fi
+          if grep -q "ParameterNotFound" "$error_file"; then
+            echo "::error::prod executor release control is not deployed. Complete the documented prod bootstrap (MonitoringStack, then the separately authorized ValkProdWorkerStack deploy), then rerun this workflow."
+          else
+            cat "$error_file" >&2
+          fi
+          exit 1
+
+      - name: Begin prod maintenance
+        id: maintenance
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        working-directory: infra
+        run: >-
+          PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
+          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --maintenance-operation begin
+          --region "$AWS_REGION"
+          --stage prod
+          --target-sha "$GITHUB_SHA"
+
+      - name: Restore prod deployment credentials
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+          role-session-name: valkyrie-prod-executor-deploy-${{ github.run_id }}
+          unset-current-credentials: true
+
+      - name: Setup Node.js
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Install CDK and infrastructure dependencies
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        run: |
+          npm install -g aws-cdk@2.1132.0
+          uv sync --frozen --python 3.12 --project infra
+
+      - name: Deploy prod core stacks under maintenance
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.core_maintenance_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        env:
+          SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
+          VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
+          DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID: ${{ secrets.DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID }}
+          AUTH_REQUIRED: "true"
+          DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
+          DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
+          SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SENTRY_RELEASE: ${{ github.sha }}
+        working-directory: infra
+        run: make deploy STAGE=prod SCOPE=core AWS_REGION="$AWS_REGION"
+
+      - name: Deploy prod executor stack
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_stack_deploy_required == 'true'
+        env:
+          AUTH_REQUIRED: "true"
+          DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
+          DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
+          SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
+          SANDBOX_CLEANUP_ENABLED: ${{ vars.SANDBOX_CLEANUP_ENABLED }}
+          SANDBOX_CLEANUP_PROVIDER: ${{ vars.SANDBOX_CLEANUP_PROVIDER }}
+          SANDBOX_CLEANUP_SECRET_NAME: ${{ secrets.SANDBOX_CLEANUP_SECRET_NAME }}
+        working-directory: infra
+        run: make deploy STAGE=prod SCOPE=executor AWS_REGION="$AWS_REGION"
+
+      - name: Configure prod release credentials
+        if: >-
+          always() && steps.freshness.outputs.current == 'true' &&
+          steps.validate.outcome == 'success' &&
+          (needs.classify-deployment.outputs.executor_release_required == 'true' ||
+           needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true' ||
+           steps.maintenance.outcome != 'skipped')
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.PRODUCTION_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-prod
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
+          role-session-name: valkyrie-prod-executor-release-${{ github.run_id }}
+          unset-current-credentials: true
+
+      - name: Publish and activate prod executor release
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_release_required == 'true'
+        working-directory: infra
+        run: >-
+          PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
+          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --artifact "$GITHUB_WORKSPACE/executor-release/executor.pex"
+          --manifest "$GITHUB_WORKSPACE/executor-release/manifest.json"
+          --region "$AWS_REGION"
+          --stage prod
+
+      - name: Finish prod maintenance
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
+           needs.classify-deployment.outputs.database_maintenance_required == 'true')
+        working-directory: infra
+        run: >-
+          PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
+          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --maintenance-operation finish
+          --region "$AWS_REGION"
+          --stage prod
+          --target-sha "$GITHUB_SHA"
+
+  deploy-bench-core:
+    if: >-
+      github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
+      needs.classify-deployment.outputs.core_maintenance_required != 'true' &&
+      needs.classify-deployment.outputs.database_maintenance_required != 'true'
+    needs: classify-deployment
+    concurrency:
+      group: valkyrie-prod-deploy
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04-arm
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}
+      AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
+      AWS_REGION: us-east-1
+      BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
+      PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Validate bench deployment inputs
+        run: |
+          set -euo pipefail
+          if [[ ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$PRODUCTION_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::The repository must define the bench and production account IDs as 12-digit Actions secrets."
+            exit 1
+          fi
+          if [[ "$BENCH_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID" ]]; then
+            echo "::error::BENCH_ACCOUNT_ID must not be the production AWS account."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: arn:aws:iam::${{ env.BENCH_ACCOUNT_ID }}:role/github-actions-valkyrie-deploy
+          aws-region: ${{ env.AWS_REGION }}
+          allowed-account-ids: ${{ env.BENCH_ACCOUNT_ID }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "20"
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+        with:
+          enable-cache: true
+          cache-dependency-glob: "infra/uv.lock"
+
+      - name: Install CDK and infrastructure dependencies
+        run: |
+          npm install -g aws-cdk@2.1132.0
+          uv sync --frozen --python 3.12 --project infra
+
+      - name: Deploy bench core stacks
         env:
           SLACK_WORKSPACE_ID: ${{ secrets.SLACK_WORKSPACE_ID }}
           VALKYRIE_ALERTS_SLACK_CHANNEL_ID: ${{ secrets.VALKYRIE_ALERTS_SLACK_CHANNEL_ID }}
@@ -220,7 +536,7 @@ jobs:
         working-directory: infra
         run: >-
           make deploy
-          STAGE=prod
+          STAGE=bench
           SCOPE=core
           AWS_REGION="$AWS_REGION"
 
@@ -247,13 +563,14 @@ jobs:
       AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+      BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
       CDK_DEFAULT_ACCOUNT: ${{ secrets.DEV_ACCOUNT_ID }}
       CDK_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
       DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
       DEV_ACCOUNT_ID: ${{ secrets.DEV_ACCOUNT_ID }}
+      PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}
       OPERATION: ${{ github.event_name == 'push' && 'deploy' || inputs.operation }}
-      PRODUCTION_ACCOUNT_ID: "613431292675"
       SCOPE: ${{ github.event_name == 'push' && 'core' || inputs.scope }}
       SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
       SENTRY_RELEASE: ${{ github.sha }}
@@ -282,12 +599,12 @@ jobs:
             echo "::error::The dev Environment must define AWS_DEPLOYMENT_ROLE_ORG_IDS and AWS_TRACKER_SECRET_NAME_PREFIXES before planning or deploying."
             exit 1
           fi
-          if [[ ! "$DEV_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
-            echo "::error::DEV_ACCOUNT_ID must be a 12-digit AWS account ID."
+          if [[ ! "$DEV_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$PRODUCTION_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::DEV_ACCOUNT_ID, VALKYRIE_BENCH_ACCOUNT_ID, and VALKYRIE_PRODUCTION_ACCOUNT_ID must be 12-digit AWS account IDs."
             exit 1
           fi
-          if [[ "$DEV_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID" ]]; then
-            echo "::error::DEV_ACCOUNT_ID must not be the production AWS account."
+          if [[ "$DEV_ACCOUNT_ID" == "$BENCH_ACCOUNT_ID" || "$DEV_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID" ]]; then
+            echo "::error::DEV_ACCOUNT_ID must not match the bench or production AWS account."
             exit 1
           fi
           if [[ "$AWS_REGION" != "us-east-1" ]]; then
@@ -379,11 +696,13 @@ jobs:
       AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_REGION: ${{ vars.AWS_REGION }}
       AWS_DEFAULT_REGION: ${{ vars.AWS_REGION }}
+      BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
       CDK_DEFAULT_ACCOUNT: ${{ secrets.DEV_ACCOUNT_ID }}
       CDK_DEFAULT_REGION: ${{ vars.AWS_REGION }}
       DESCOPE_MANAGEMENT_KEY_SECRET_NAME: ${{ secrets.DESCOPE_MANAGEMENT_KEY_SECRET_NAME }}
       DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}
       DEV_ACCOUNT_ID: ${{ secrets.DEV_ACCOUNT_ID }}
+      PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}
       EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/dev/executor-release/launch-config
       SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
 
@@ -407,6 +726,19 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      - name: Validate deployment account boundaries
+        if: steps.freshness.outputs.current == 'true'
+        run: |
+          set -euo pipefail
+          if [[ ! "$DEV_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$PRODUCTION_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::The dev Environment must define DEV_ACCOUNT_ID, VALKYRIE_BENCH_ACCOUNT_ID, and VALKYRIE_PRODUCTION_ACCOUNT_ID as 12-digit AWS account IDs."
+            exit 1
+          fi
+          if [[ "$DEV_ACCOUNT_ID" == "$BENCH_ACCOUNT_ID" || "$DEV_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID" ]]; then
+            echo "::error::DEV_ACCOUNT_ID must not match the bench or production AWS account."
+            exit 1
+          fi
 
       - name: Setup Python
         if: steps.freshness.outputs.current == 'true'
@@ -559,7 +891,7 @@ jobs:
           --stage dev
           --target-sha "$GITHUB_SHA"
 
-  executor-production:
+  executor-bench:
     if: >-
       always() && github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
       needs.classify-deployment.result == 'success' &&
@@ -568,8 +900,8 @@ jobs:
        needs.classify-deployment.outputs.database_maintenance_required == 'true') &&
       (needs.classify-deployment.outputs.core_maintenance_required == 'true' ||
        needs.classify-deployment.outputs.database_maintenance_required == 'true' ||
-       needs.deploy-production-core.result == 'success')
-    needs: [classify-deployment, deploy-production-core]
+       needs.deploy-bench-core.result == 'success')
+    needs: [classify-deployment, deploy-bench-core]
     concurrency:
       group: valkyrie-prod-deploy
       cancel-in-progress: false
@@ -583,10 +915,11 @@ jobs:
       AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}
       AWS_REGION: us-east-1
       EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod/executor-release/launch-config
-      PRODUCTION_ACCOUNT_ID: "613431292675"
+      BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
+      PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}
 
     steps:
-      - name: Verify current production executor revision
+      - name: Verify current bench executor revision
         id: freshness
         env:
           GH_TOKEN: ${{ github.token }}
@@ -605,6 +938,19 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
+
+      - name: Validate bench deployment inputs
+        if: steps.freshness.outputs.current == 'true'
+        run: |
+          set -euo pipefail
+          if [[ ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ || ! "$PRODUCTION_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::The repository must define the bench and production account IDs as 12-digit Actions secrets."
+            exit 1
+          fi
+          if [[ "$BENCH_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID" ]]; then
+            echo "::error::BENCH_ACCOUNT_ID must not be the production AWS account."
+            exit 1
+          fi
 
       - name: Setup Python
         if: steps.freshness.outputs.current == 'true'
@@ -631,17 +977,17 @@ jobs:
             --output-directory "$GITHUB_WORKSPACE/executor-release" \
             --source-revision "$GITHUB_SHA"
 
-      - name: Configure production release preflight credentials
+      - name: Configure bench release preflight credentials
         if: steps.freshness.outputs.current == 'true'
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::613431292675:role/ValkyrieExecutorRelease
+          role-to-assume: arn:aws:iam::${{ env.BENCH_ACCOUNT_ID }}:role/ValkyrieExecutorRelease
           aws-region: ${{ env.AWS_REGION }}
-          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
-          role-session-name: valkyrie-prod-release-preflight-${{ github.run_id }}
+          allowed-account-ids: ${{ env.BENCH_ACCOUNT_ID }}
+          role-session-name: valkyrie-bench-release-preflight-${{ github.run_id }}
           unset-current-credentials: true
 
-      - name: Require deployed production release control
+      - name: Require deployed bench release control
         if: steps.freshness.outputs.current == 'true'
         run: |
           set -euo pipefail
@@ -656,7 +1002,7 @@ jobs:
           fi
           exit 1
 
-      - name: Begin production maintenance
+      - name: Begin bench maintenance
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
@@ -664,23 +1010,23 @@ jobs:
         working-directory: infra
         run: >-
           PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
-          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --account-id "$BENCH_ACCOUNT_ID"
           --maintenance-operation begin
           --region "$AWS_REGION"
-          --stage prod
+          --stage bench
           --target-sha "$GITHUB_SHA"
 
-      - name: Restore production deployment credentials
+      - name: Restore bench deployment credentials
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_stack_deploy_required == 'true' ||
            needs.classify-deployment.outputs.database_maintenance_required == 'true')
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy
+          role-to-assume: arn:aws:iam::${{ env.BENCH_ACCOUNT_ID }}:role/github-actions-valkyrie-deploy
           aws-region: ${{ env.AWS_REGION }}
-          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
-          role-session-name: valkyrie-prod-executor-deploy-${{ github.run_id }}
+          allowed-account-ids: ${{ env.BENCH_ACCOUNT_ID }}
+          role-session-name: valkyrie-bench-executor-deploy-${{ github.run_id }}
           unset-current-credentials: true
 
       - name: Setup Node.js
@@ -701,7 +1047,7 @@ jobs:
           npm install -g aws-cdk@2.1132.0
           uv sync --frozen --python 3.12 --project infra
 
-      - name: Deploy production core stacks under maintenance
+      - name: Deploy bench core stacks under maintenance
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.core_maintenance_required == 'true' ||
@@ -717,9 +1063,9 @@ jobs:
           SENTRY_DSN_SECRET_NAME: ${{ secrets.SENTRY_DSN_SECRET_NAME }}
           SENTRY_RELEASE: ${{ github.sha }}
         working-directory: infra
-        run: make deploy STAGE=prod SCOPE=core AWS_REGION="$AWS_REGION"
+        run: make deploy STAGE=bench SCOPE=core AWS_REGION="$AWS_REGION"
 
-      - name: Deploy production executor stack
+      - name: Deploy bench executor stack
         if: >-
           steps.freshness.outputs.current == 'true' &&
           needs.classify-deployment.outputs.executor_stack_deploy_required == 'true'
@@ -732,9 +1078,9 @@ jobs:
           SANDBOX_CLEANUP_PROVIDER: ${{ vars.SANDBOX_CLEANUP_PROVIDER }}
           SANDBOX_CLEANUP_SECRET_NAME: ${{ secrets.SANDBOX_CLEANUP_SECRET_NAME }}
         working-directory: infra
-        run: make deploy STAGE=prod SCOPE=executor AWS_REGION="$AWS_REGION"
+        run: make deploy STAGE=bench SCOPE=executor AWS_REGION="$AWS_REGION"
 
-      - name: Configure production release credentials
+      - name: Configure bench release credentials
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_release_required == 'true' ||
@@ -742,26 +1088,26 @@ jobs:
            needs.classify-deployment.outputs.database_maintenance_required == 'true')
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
-          role-to-assume: arn:aws:iam::613431292675:role/ValkyrieExecutorRelease
+          role-to-assume: arn:aws:iam::${{ env.BENCH_ACCOUNT_ID }}:role/ValkyrieExecutorRelease
           aws-region: ${{ env.AWS_REGION }}
-          allowed-account-ids: ${{ env.PRODUCTION_ACCOUNT_ID }}
-          role-session-name: valkyrie-prod-executor-release-${{ github.run_id }}
+          allowed-account-ids: ${{ env.BENCH_ACCOUNT_ID }}
+          role-session-name: valkyrie-bench-executor-release-${{ github.run_id }}
           unset-current-credentials: true
 
-      - name: Publish and activate production executor release
+      - name: Publish and activate bench executor release
         if: >-
           steps.freshness.outputs.current == 'true' &&
           needs.classify-deployment.outputs.executor_release_required == 'true'
         working-directory: infra
         run: >-
           PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
-          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --account-id "$BENCH_ACCOUNT_ID"
           --artifact "$GITHUB_WORKSPACE/executor-release/executor.pex"
           --manifest "$GITHUB_WORKSPACE/executor-release/manifest.json"
           --region "$AWS_REGION"
-          --stage prod
+          --stage bench
 
-      - name: Finish production maintenance
+      - name: Finish bench maintenance
         if: >-
           steps.freshness.outputs.current == 'true' &&
           (needs.classify-deployment.outputs.executor_host_redeploy_required == 'true' ||
@@ -769,8 +1115,8 @@ jobs:
         working-directory: infra
         run: >-
           PYTHONPATH=. uv run --project executor_release --frozen python executor_release/main.py
-          --account-id "$PRODUCTION_ACCOUNT_ID"
+          --account-id "$BENCH_ACCOUNT_ID"
           --maintenance-operation finish
           --region "$AWS_REGION"
-          --stage prod
+          --stage bench
           --target-sha "$GITHUB_SHA"

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
+          path: trusted
           persist-credentials: false
           ref: ${{ env.BASE_SHA }}
 
@@ -54,46 +55,16 @@ jobs:
           SOURCE_SHA: ${{ env.BASE_SHA }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(git -C trusted rev-parse HEAD)" = "$SOURCE_SHA"
           target_branch="${TARGET_BRANCH#refs/heads/}"
-          case "$target_branch" in
-            dev)
-              stage=dev
-              stack_id=ValkDevWorkerStack
-              account_id=111111111111
-              ;;
-            prod)
-              stage=prod
-              stack_id=WorkerStack
-              account_id=613431292675
-              ;;
-            *)
-              echo "::error::Unsupported target branch '$target_branch'."
-              exit 1
-              ;;
-          esac
           npm install -g aws-cdk@2.1132.0
           artifact="$RUNNER_TEMP/worker-template-base"
-          assembly="$RUNNER_TEMP/cdk-base"
-          mkdir -p "$artifact"
-          (
-            cd infra
-            PRODUCTION_ACCOUNT_ID=613431292675 \
-            DEV_ACCOUNT_ID=111111111111 \
-            CDK_DEFAULT_ACCOUNT="$account_id" \
-            CDK_DEFAULT_REGION=us-east-1 \
-            AWS_REGION=us-east-1 \
-            STAGE="$stage" \
-            AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
-            AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
-            AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
-            SENTRY_DSN_SECRET_NAME=offline-synth \
-            DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
-            DESCOPE_PROJECT_ID=offline-synth \
-              uv run --frozen cdk synth "$stack_id" -c stage="$stage" --output "$assembly"
-          )
-          cp "$assembly/$stack_id.template.json" "$artifact/WorkerStack.template.json"
-          SOURCE_SHA="$SOURCE_SHA" TARGET_BRANCH="$target_branch" STACK_ID="$stack_id" \
+          bash trusted/.github/scripts/synthesize-worker-templates.sh \
+            "$SOURCE_SHA" "$target_branch" base "$artifact" trusted
+          mapfile -t stack_ids < "$artifact/stack-ids.txt"
+          rm "$artifact/stack-ids.txt"
+          STACK_IDS="$(IFS=,; echo "${stack_ids[*]}")" \
+            SOURCE_SHA="$SOURCE_SHA" TARGET_BRANCH="$target_branch" \
             python3 - <<'PY'
           import json
           import os
@@ -104,7 +75,7 @@ jobs:
               "run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "run_id": os.environ["GITHUB_RUN_ID"],
               "source_sha": os.environ["SOURCE_SHA"],
-              "stack_id": os.environ["STACK_ID"],
+              "stack_ids": os.environ["STACK_IDS"].split(","),
               "target_branch": os.environ["TARGET_BRANCH"],
           }
           (artifact / "manifest.json").write_text(json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
@@ -117,7 +88,7 @@ jobs:
           name: worker-template-base-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/worker-template-base/manifest.json
-            ${{ runner.temp }}/worker-template-base/WorkerStack.template.json
+            ${{ runner.temp }}/worker-template-base/*.template.json
           if-no-files-found: error
           retention-days: 1
 
@@ -131,10 +102,19 @@ jobs:
         id: identity
         run: echo "run_attempt=$GITHUB_RUN_ATTEMPT" >> "$GITHUB_OUTPUT"
 
+      - name: Checkout trusted synthesis helper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          path: trusted
+          persist-credentials: false
+          ref: ${{ env.BASE_SHA }}
+
       - name: Checkout exact candidate revision
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
+          path: candidate
           persist-credentials: false
           ref: ${{ env.HEAD_SHA }}
 
@@ -158,46 +138,17 @@ jobs:
           SOURCE_SHA: ${{ env.HEAD_SHA }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(git -C trusted rev-parse HEAD)" = "$BASE_SHA"
+          test "$(git -C candidate rev-parse HEAD)" = "$SOURCE_SHA"
           target_branch="${TARGET_BRANCH#refs/heads/}"
-          case "$target_branch" in
-            dev)
-              stage=dev
-              stack_id=ValkDevWorkerStack
-              account_id=111111111111
-              ;;
-            prod)
-              stage=prod
-              stack_id=WorkerStack
-              account_id=613431292675
-              ;;
-            *)
-              echo "::error::Unsupported target branch '$target_branch'."
-              exit 1
-              ;;
-          esac
           npm install -g aws-cdk@2.1132.0
           artifact="$RUNNER_TEMP/worker-template-head"
-          assembly="$RUNNER_TEMP/cdk-head"
-          mkdir -p "$artifact"
-          (
-            cd infra
-            PRODUCTION_ACCOUNT_ID=613431292675 \
-            DEV_ACCOUNT_ID=111111111111 \
-            CDK_DEFAULT_ACCOUNT="$account_id" \
-            CDK_DEFAULT_REGION=us-east-1 \
-            AWS_REGION=us-east-1 \
-            STAGE="$stage" \
-            AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001 \
-            AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth \
-            AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth \
-            SENTRY_DSN_SECRET_NAME=offline-synth \
-            DESCOPE_MANAGEMENT_KEY_SECRET_NAME=offline-synth \
-            DESCOPE_PROJECT_ID=offline-synth \
-              uv run --frozen cdk synth "$stack_id" -c stage="$stage" --output "$assembly"
-          )
-          cp "$assembly/$stack_id.template.json" "$artifact/WorkerStack.template.json"
-          SOURCE_SHA="$SOURCE_SHA" TARGET_BRANCH="$target_branch" STACK_ID="$stack_id" \
+          bash trusted/.github/scripts/synthesize-worker-templates.sh \
+            "$SOURCE_SHA" "$target_branch" head "$artifact" candidate
+          mapfile -t stack_ids < "$artifact/stack-ids.txt"
+          rm "$artifact/stack-ids.txt"
+          STACK_IDS="$(IFS=,; echo "${stack_ids[*]}")" \
+            SOURCE_SHA="$SOURCE_SHA" TARGET_BRANCH="$target_branch" \
             python3 - <<'PY'
           import json
           import os
@@ -208,7 +159,7 @@ jobs:
               "run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
               "run_id": os.environ["GITHUB_RUN_ID"],
               "source_sha": os.environ["SOURCE_SHA"],
-              "stack_id": os.environ["STACK_ID"],
+              "stack_ids": os.environ["STACK_IDS"].split(","),
               "target_branch": os.environ["TARGET_BRANCH"],
           }
           (artifact / "manifest.json").write_text(json.dumps(manifest, sort_keys=True) + "\n", encoding="utf-8")
@@ -221,7 +172,7 @@ jobs:
           name: worker-template-head-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
             ${{ runner.temp }}/worker-template-head/manifest.json
-            ${{ runner.temp }}/worker-template-head/WorkerStack.template.json
+            ${{ runner.temp }}/worker-template-head/*.template.json
           if-no-files-found: error
           retention-days: 1
 
@@ -284,9 +235,12 @@ jobs:
           from pathlib import Path
 
           target_branch = os.environ["TARGET_BRANCH"].removeprefix("refs/heads/")
-          stack_ids = {"dev": "ValkDevWorkerStack", "prod": "WorkerStack"}
+          stack_ids = {
+              "dev": ["ValkDevWorkerStack"],
+              "prod": ["WorkerStack", "ValkProdWorkerStack"],
+          }
           try:
-              expected_stack_id = stack_ids[target_branch]
+              expected_stack_ids = stack_ids[target_branch]
           except KeyError as error:
               raise SystemExit(f"Unsupported target branch {target_branch!r}") from error
 
@@ -306,30 +260,33 @@ jobs:
               if not artifact_id.isdecimal() or not artifact_run_attempt.isdecimal():
                   raise SystemExit(f"{label} artifact job outputs are not numeric")
               directory = Path(os.environ["RUNNER_TEMP"]) / f"worker-template-{label}"
-              expected_names = {"manifest.json", "WorkerStack.template.json"}
+              expected_names = {"manifest.json", *(f"{stack_id}.template.json" for stack_id in expected_stack_ids)}
               entries = list(directory.iterdir())
               names = {path.name for path in entries}
               if names != expected_names or any(not path.is_file() for path in entries):
                   raise SystemExit(f"Unexpected {label} artifact entries: {sorted(names)!r}")
-              template = directory / "WorkerStack.template.json"
               manifest_path = directory / "manifest.json"
-              if template.stat().st_size > 2_000_000:
-                  raise SystemExit(f"{label} WorkerStack template exceeds 2 MB")
               if manifest_path.stat().st_size > 10_000:
                   raise SystemExit(f"{label} manifest exceeds 10 KB")
-              template_payload = json.loads(template.read_text(encoding="utf-8"))
-              if not isinstance(template_payload, dict):
-                  raise SystemExit(f"{label} WorkerStack template must be a JSON object")
+              for stack_id in expected_stack_ids:
+                  template = directory / f"{stack_id}.template.json"
+                  if template.stat().st_size > 2_000_000:
+                      raise SystemExit(f"{label} {stack_id} template exceeds 2 MB")
+                  template_payload = json.loads(template.read_text(encoding="utf-8"))
+                  if not isinstance(template_payload, dict):
+                      raise SystemExit(f"{label} {stack_id} template must be a JSON object")
               manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
               if manifest != {
                   "run_attempt": int(artifact_run_attempt),
                   "run_id": os.environ["GITHUB_RUN_ID"],
                   "source_sha": source_sha,
-                  "stack_id": expected_stack_id,
+                  "stack_ids": expected_stack_ids,
                   "target_branch": target_branch,
               }:
                   raise SystemExit(f"{label} artifact manifest does not match trusted event identity")
-          print(f"expected_stack_id={expected_stack_id}")
+          print(f"expected_stack_id={expected_stack_ids[0]}")
+          if len(expected_stack_ids) > 1:
+              print(f"secondary_expected_stack_id={expected_stack_ids[1]}")
           print(f"target_branch={target_branch}")
           PY
 
@@ -337,13 +294,24 @@ jobs:
         id: classification
         run: |
           set -euo pipefail
-          python3 infra/classify_repository_change.py \
-            --base-sha "$BASE_SHA" \
-            --head-sha "$HEAD_SHA" \
-            --executor-base-template "$RUNNER_TEMP/worker-template-base/WorkerStack.template.json" \
-            --executor-head-template "$RUNNER_TEMP/worker-template-head/WorkerStack.template.json" \
-            --expected-stack-id "${{ steps.template.outputs.expected_stack_id }}" \
+          primary_stack_id="${{ steps.template.outputs.expected_stack_id }}"
+          secondary_stack_id="${{ steps.template.outputs.secondary_expected_stack_id }}"
+          arguments=(
+            --base-sha "$BASE_SHA"
+            --head-sha "$HEAD_SHA"
+            --executor-base-template "$RUNNER_TEMP/worker-template-base/$primary_stack_id.template.json"
+            --executor-head-template "$RUNNER_TEMP/worker-template-head/$primary_stack_id.template.json"
+            --expected-stack-id "$primary_stack_id"
             --output maintenance-classification.json
+          )
+          if [[ -n "$secondary_stack_id" ]]; then
+            arguments+=(
+              --secondary-executor-base-template "$RUNNER_TEMP/worker-template-base/$secondary_stack_id.template.json"
+              --secondary-executor-head-template "$RUNNER_TEMP/worker-template-head/$secondary_stack_id.template.json"
+              --secondary-expected-stack-id "$secondary_stack_id"
+            )
+          fi
+          python3 infra/classify_repository_change.py "${arguments[@]}"
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           import os

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -17,8 +17,45 @@ env:
   TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
 
 jobs:
-  synthesize-base:
+  resolve-synthesis-helper:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      sha: ${{ steps.target-revision.outputs.sha || steps.default-revision.outputs.sha }}
+    steps:
+      - name: Checkout exact trusted target revision
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ env.BASE_SHA }}
+
+      - name: Select target synthesis helper
+        id: target-revision
+        run: |
+          if [[ -f .github/scripts/synthesize-worker-templates.sh ]]; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout default-branch synthesis helper fallback
+        if: steps.target-revision.outputs.sha == ''
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Select default-branch synthesis helper
+        if: steps.target-revision.outputs.sha == ''
+        id: default-revision
+        run: |
+          test -f .github/scripts/synthesize-worker-templates.sh
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  synthesize-base:
+    needs: resolve-synthesis-helper
+    runs-on: ubuntu-24.04-arm
+    env:
+      SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}
     outputs:
       artifact_id: ${{ steps.upload-base.outputs.artifact-id }}
       run_attempt: ${{ steps.identity.outputs.run_attempt }}
@@ -34,6 +71,14 @@ jobs:
           path: trusted
           persist-credentials: false
           ref: ${{ env.BASE_SHA }}
+
+      - name: Checkout trusted synthesis helper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          path: workflow
+          persist-credentials: false
+          ref: ${{ env.SYNTHESIS_HELPER_SHA }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -56,10 +101,11 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git -C trusted rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(git -C workflow rev-parse HEAD)" = "$SYNTHESIS_HELPER_SHA"
           target_branch="${TARGET_BRANCH#refs/heads/}"
           npm install -g aws-cdk@2.1132.0
           artifact="$RUNNER_TEMP/worker-template-base"
-          bash trusted/.github/scripts/synthesize-worker-templates.sh \
+          bash workflow/.github/scripts/synthesize-worker-templates.sh \
             "$SOURCE_SHA" "$target_branch" base "$artifact" trusted
           mapfile -t stack_ids < "$artifact/stack-ids.txt"
           rm "$artifact/stack-ids.txt"
@@ -93,7 +139,10 @@ jobs:
           retention-days: 1
 
   synthesize-head:
+    needs: resolve-synthesis-helper
     runs-on: ubuntu-24.04-arm
+    env:
+      SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}
     outputs:
       artifact_id: ${{ steps.upload-head.outputs.artifact-id }}
       run_attempt: ${{ steps.identity.outputs.run_attempt }}
@@ -106,9 +155,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-          path: trusted
+          path: workflow
           persist-credentials: false
-          ref: ${{ env.BASE_SHA }}
+          ref: ${{ env.SYNTHESIS_HELPER_SHA }}
 
       - name: Checkout exact candidate revision
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -138,12 +187,12 @@ jobs:
           SOURCE_SHA: ${{ env.HEAD_SHA }}
         run: |
           set -euo pipefail
-          test "$(git -C trusted rev-parse HEAD)" = "$BASE_SHA"
+          test "$(git -C workflow rev-parse HEAD)" = "$SYNTHESIS_HELPER_SHA"
           test "$(git -C candidate rev-parse HEAD)" = "$SOURCE_SHA"
           target_branch="${TARGET_BRANCH#refs/heads/}"
           npm install -g aws-cdk@2.1132.0
           artifact="$RUNNER_TEMP/worker-template-head"
-          bash trusted/.github/scripts/synthesize-worker-templates.sh \
+          bash workflow/.github/scripts/synthesize-worker-templates.sh \
             "$SOURCE_SHA" "$target_branch" head "$artifact" candidate
           mapfile -t stack_ids < "$artifact/stack-ids.txt"
           rm "$artifact/stack-ids.txt"

--- a/.github/workflows/tracker-integration-tests.yaml
+++ b/.github/workflows/tracker-integration-tests.yaml
@@ -62,12 +62,29 @@ jobs:
           uv venv --python 3.12
           uv sync --group dev
 
+      - name: Validate bench account boundary
+        if: steps.rel.outputs.relevant == 'true'
+        env:
+          BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
+          TRACKER_INTEGRATION_ROLE_ARN: ${{ secrets.VALKYRIE_TRACKER_INTEGRATION_ROLE_ARN }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$BENCH_ACCOUNT_ID" =~ ^[0-9]{12}$ ]]; then
+            echo "::error::VALKYRIE_BENCH_ACCOUNT_ID must be a 12-digit Actions secret."
+            exit 1
+          fi
+          if [[ "$TRACKER_INTEGRATION_ROLE_ARN" != "arn:aws:iam::${BENCH_ACCOUNT_ID}:role/github-actions-valkyrie-tests" ]]; then
+            echo "::error::VALKYRIE_TRACKER_INTEGRATION_ROLE_ARN must name the approved Tracker test role in the bench account."
+            exit 1
+          fi
+
       - name: Configure AWS Credentials
         if: steps.rel.outputs.relevant == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::613431292675:role/github-actions-valkyrie-tests
+          role-to-assume: ${{ secrets.VALKYRIE_TRACKER_INTEGRATION_ROLE_ARN }}
           aws-region: us-east-1
+          allowed-account-ids: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}
 
       - name: Run live integration tests
         if: steps.rel.outputs.relevant == 'true'

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ uv tool install git+https://github.com/vals-ai/Valkyrie@prod
 valkyrie config init
 ```
 
-This will prompt you to choose between **hosted** and **self-hosted** mode, then collect the required credentials. See [Hosted vs Self-Hosted Mode](docs/HOSTED_MODE.md) for detailed setup instructions.
+This prompts for **hosted** or **self-hosted** mode. Hosted setup also asks whether your account uses the bench or production environment and remembers that choice for later commands. See [Hosted vs Self-Hosted Mode](docs/HOSTED_MODE.md) for detailed setup instructions.
+
+`VALKYRIE_ENV` is a legacy override and takes precedence over the saved selection. For compatibility, `VALKYRIE_ENV=prod` selects bench and `VALKYRIE_ENV=external` selects production. New configurations should use the saved `bench` or `prod` selection and leave `VALKYRIE_ENV` unset.
 
 To upsert a single key:
 

--- a/docs/HOSTED_MODE.md
+++ b/docs/HOSTED_MODE.md
@@ -23,11 +23,12 @@ Use Vals-hosted compute infrastructure. Data is isolated per organization throug
 valkyrie config init
 ```
 
-Choose **hosted** when prompted. Valkyrie asks for your Vals AI API key, validates it, and creates your organization. When the organization can use managed AWS, Valkyrie reads the deployment Region and S3 bucket from Tracker instead of asking for access keys.
+Choose **hosted** when prompted, then select the **bench** or **prod** hosted environment for your organization. Valkyrie asks for your Vals AI API key, validates it against that environment, and creates your organization. When the organization can use managed AWS, Valkyrie reads the deployment Region and S3 bucket from Tracker instead of asking for access keys.
 
 ```
 $ valkyrie config init
 Setup mode (hosted, self-hosted) [self-hosted]: hosted
+Hosted environment (bench, prod) [bench]: bench
 API Key: <your-vals-ai-api-key>
 Organization 'your-org' configured successfully.
 
@@ -35,6 +36,8 @@ Managed AWS execution is enabled. Local AWS operations will use the AWS SDK cred
 ```
 
 Your Vals AI API key is sent with every request to authenticate and scope data to your organization.
+
+`VALKYRIE_ENV` overrides the saved environment. Its shipped values retain their existing meaning: `VALKYRIE_ENV=prod` selects bench, while `VALKYRIE_ENV=external` selects production. Leave this variable unset when using the saved `bench` or `prod` selection.
 
 ### AWS execution mode
 

--- a/docs/executor-releases/README.md
+++ b/docs/executor-releases/README.md
@@ -223,9 +223,9 @@ admission target before committing. PostgreSQL serializes overlapping activation
 on the singleton admission row before either task creates or matches the release.
 
 Dev executor operations follow a successful core deployment unless an incompatible
-migration must run inside maintenance. Production executor operations use the
-protected `prod` GitHub Environment directly on the mutating job, mirroring the
-`dev` Environment wiring. The mutating executor job starts only after its
+migration must run inside maintenance. Bench executor operations use the existing
+protected `prod` GitHub Environment; production uses `prod-external`. Both are
+wired directly to their mutating jobs, like the `dev` Environment. Each mutating executor job starts only after its
 same-revision core dependency succeeds. The AWS accounts must already contain the
 account-owned GitHub OIDC provider used by the environment-bound release roles.
 
@@ -309,10 +309,9 @@ There is no two-release limit.
 ## Release-test
 
 The release-test stage is dev-sized and targets the account selected by
-`DEV_ACCOUNT_ID`; the target guard also permits an explicit production-account
-campaign. Production-account validation uses `STAGE=release-test`, account
-`613431292675`, and region `us-east-1`. Unrelated account resources remain outside
-the release-test boundary.
+`DEV_ACCOUNT_ID`. The coexistence procedure below runs it in the bench account
+by setting `DEV_ACCOUNT_ID` to `BENCH_ACCOUNT_ID`; the target guard still keeps
+the release-test resources inside the explicitly selected account.
 
 Release-test also publishes `/valkyrie/release-test/executor-release/launch-config`
 and the same sealed activation task used by deployment. It reuses the existing
@@ -330,9 +329,11 @@ internal.
 Before running the release-test driver, set:
 
 ```bash
-export RELEASE_TEST_DRIVER_SECRET_ARN=arn:aws:secretsmanager:us-east-1:613431292675:secret:YOUR_DRIVER_SECRET-SUFFIX
-export RELEASE_TEST_SANDBOX_PROVIDER_SECRET_ARN=arn:aws:secretsmanager:us-east-1:613431292675:secret:SANDBOX_PROVIDER_SECRET-SUFFIX
-export RELEASE_TEST_OPERATOR_PRINCIPAL_ARN=arn:aws:iam::613431292675:role/ROLE_NAME
+export BENCH_ACCOUNT_ID="<bench-account-id>"
+export PRODUCTION_ACCOUNT_ID="<production-account-id>"
+export RELEASE_TEST_DRIVER_SECRET_ARN="arn:aws:secretsmanager:us-east-1:${BENCH_ACCOUNT_ID}:secret:YOUR_DRIVER_SECRET-SUFFIX"
+export RELEASE_TEST_SANDBOX_PROVIDER_SECRET_ARN="arn:aws:secretsmanager:us-east-1:${BENCH_ACCOUNT_ID}:secret:SANDBOX_PROVIDER_SECRET-SUFFIX"
+export RELEASE_TEST_OPERATOR_PRINCIPAL_ARN="arn:aws:iam::${BENCH_ACCOUNT_ID}:role/ROLE_NAME"
 export RELEASE_TEST_IMAGE_TAG=package-r-RUN_ID
 ```
 
@@ -341,7 +342,7 @@ role, upload the executor artifact under its reserved prefix and require that th
 key does not already exist:
 
 ```bash
-export RELEASE_TEST_ARTIFACT_BUCKET=agentic-harness-release-test-613431292675
+export RELEASE_TEST_ARTIFACT_BUCKET="agentic-harness-release-test-${BENCH_ACCOUNT_ID}"
 export PACKAGE_R_EXECUTOR_ARTIFACT=/path/to/executor.pex
 aws s3api put-object \
   --bucket "$RELEASE_TEST_ARTIFACT_BUCKET" \
@@ -364,8 +365,8 @@ Release-test owns immutable `valkyrie/release-test/tracker` and
 `valkyrie/release-test/executor-host` ECR repositories. This avoids mutating the
 account-wide CDK bootstrap repository. Deploy Shared first when creating those
 repositories, build and push both ARM64 images with the same new immutable tag,
-then synthesize and deploy the dependent stacks with that tag. Dev and prod keep
-the existing CDK asset path.
+then synthesize and deploy the dependent stacks with that tag. Dev, bench, and
+prod keep the existing CDK asset path.
 
 Review all stacks and the driver separately before deployment. Release-test
 forces authentication on, so synthesis also needs the Descope project ID and
@@ -376,9 +377,9 @@ export DESCOPE_PROJECT_ID="release-test-descope-project-id"
 export DESCOPE_MANAGEMENT_KEY_SECRET_NAME="release-test-descope-management-key-secret"
 
 make plan STAGE=release-test SCOPE=all AWS_REGION=us-east-1 \
-  DEV_ACCOUNT_ID=613431292675 PROFILE=admin
+  DEV_ACCOUNT_ID="$BENCH_ACCOUNT_ID" PROFILE=admin
 make plan STAGE=release-test SCOPE=driver AWS_REGION=us-east-1 \
-  DEV_ACCOUNT_ID=613431292675 PROFILE=admin
+  DEV_ACCOUNT_ID="$BENCH_ACCOUNT_ID" PROFILE=admin
 ```
 
 The driver launch contract is published under

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,7 +1,8 @@
 .PHONY: help install lint typecheck test venv_check validate-scope preflight \
 	plan diff deploy deploy-shared deploy-tracker deploy-driver deploy-executor hotswap destroy
 
-PRODUCTION_ACCOUNT_ID ?= 613431292675
+BENCH_ACCOUNT_ID ?=
+PRODUCTION_ACCOUNT_ID ?=
 
 STAGE ?=
 AWS_REGION ?=
@@ -9,8 +10,8 @@ DEV_ACCOUNT_ID ?=
 PROFILE ?=
 SCOPE ?= all
 
-EXPECTED_ACCOUNT_ID = $(if $(filter dev release-test,$(STAGE)),$(DEV_ACCOUNT_ID),$(if $(filter prod,$(STAGE)),$(PRODUCTION_ACCOUNT_ID),))
-STACK_PREFIX = $(if $(filter dev,$(STAGE)),ValkDev,$(if $(filter release-test,$(STAGE)),ValkReleaseTest,))
+EXPECTED_ACCOUNT_ID = $(if $(filter dev release-test,$(STAGE)),$(DEV_ACCOUNT_ID),$(if $(filter bench,$(STAGE)),$(BENCH_ACCOUNT_ID),$(if $(filter prod,$(STAGE)),$(PRODUCTION_ACCOUNT_ID),)))
+STACK_PREFIX = $(if $(filter dev,$(STAGE)),ValkDev,$(if $(filter release-test,$(STAGE)),ValkReleaseTest,$(if $(filter prod,$(STAGE)),ValkProd,)))
 STACKS_shared = $(STACK_PREFIX)SharedStack
 STACKS_tracker = $(STACK_PREFIX)TrackerStack
 STACKS_driver = $(STACK_PREFIX)DriverStack
@@ -29,14 +30,14 @@ CDK_DEFAULT_REGION ?= $(AWS_REGION)
 CDK_CTX = -c stage=$(STAGE)
 CDK_PROFILE = $(if $(strip $(PROFILE)),--profile "$(PROFILE)",)
 
-export STAGE AWS_REGION DEV_ACCOUNT_ID PRODUCTION_ACCOUNT_ID PROFILE
+export STAGE AWS_REGION BENCH_ACCOUNT_ID DEV_ACCOUNT_ID PRODUCTION_ACCOUNT_ID PROFILE
 export CDK_DEFAULT_ACCOUNT CDK_DEFAULT_REGION
 
 help:
 	@echo "Makefile for Valkyrie infrastructure"
 	@echo ""
 	@echo "  make install                                  - Install CDK dependencies"
-	@echo "  make plan STAGE=dev|release-test|prod AWS_REGION=us-east-1 - Show a CDK diff"
+	@echo "  make plan STAGE=dev|release-test|bench|prod AWS_REGION=us-east-1 - Show a CDK diff"
 	@echo "  make deploy STAGE=<stage> AWS_REGION=us-east-1 - Deploy a component"
 	@echo "  make test                                     - Run infrastructure tests"
 	@echo "  make lint                                     - Check infrastructure formatting and lint"

--- a/infra/README.md
+++ b/infra/README.md
@@ -13,9 +13,12 @@ AWS CDK infrastructure for the Agentic Harness benchmark platform.
 physical CloudFormation name remains `WorkerStack` so deployments update the
 existing stack and retained resources in place.
 
-Production imports the existing `vals.ai` hosted zone. Development imports only
-the account-local `benchmark-tracker-dev.vals.ai` child zone. Each production
-and development Tracker stack creates and owns its ACM certificate.
+Bench imports the existing `vals.ai` hosted zone and retains the established
+unsuffixed stack and resource names. Development and production import
+account-local delegated child zones. Production stack ids use the `ValkProd`
+prefix and physical resources use the `-prod` suffix. Each production stage has independent service and database settings in
+`stage_config.py`. Each Tracker stack owns its ACM certificate in the account
+where it runs.
 
 ## Prerequisites
 
@@ -26,16 +29,16 @@ and development Tracker stack creates and owns its ACM certificate.
 
 The deployment account must be bootstrapped before deploying this application.
 Account setup owns the GitHub OIDC provider and deploy role and the child hosted
-zone. Before deploying the development Tracker, the production root zone must
-delegate `benchmark-tracker-dev.vals.ai` to the account-local child hosted zone
-so CDK DNS validation can complete. Configure the protected `dev` GitHub
+zone. Before deploying the development or production Tracker, the root
+zone must delegate its Tracker child zone to the target account so CDK DNS
+validation can complete. Configure the protected `dev` GitHub
 Environment with the `AWS_REGION=us-east-1` variable and the `DEV_ACCOUNT_ID`,
 `AWS_DEPLOY_ROLE_ARN`, `DESCOPE_PROJECT_ID`, and
 `DESCOPE_MANAGEMENT_KEY_SECRET_NAME` secrets (the last one names an
 account-local Secrets Manager secret holding the Descope management key).
 Managed AWS execution also requires these secrets in each enabled stage's
-protected GitHub Environment. The `dev` and `prod` environments hold their own
-values:
+protected GitHub Environment. The `dev`, `prod`, and `prod-external`
+environments hold their own values:
 
 - `AWS_DEPLOYMENT_ROLE_ORG_IDS` -- comma-separated organization UUIDs allowed
   to submit managed runs
@@ -50,17 +53,22 @@ Secrets Manager secret containing the DSN. Production also requires
 `DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
 whenever `AUTH_REQUIRED` is `true`. The dev Environment holds every dev
 deployment input as an Environment secret except `AWS_REGION`, which stays a
-variable. Production reads its managed AWS inventory from the `prod`
-Environment and retains the existing repository-level deployment secrets. The
+variable. Each production lane reads its managed AWS inventory from its matching
+Environment. Under **Settings → Secrets and variables → Actions → Repository
+secrets**, `VALKYRIE_BENCH_ACCOUNT_ID` holds the bench account ID and
+`VALKYRIE_PRODUCTION_ACCOUNT_ID` holds the production account ID. Deployment
+roles and `allowed-account-ids` constrain AWS access to the selected account. The
 `SANDBOX_CLEANUP_ENABLED` and `SANDBOX_CLEANUP_PROVIDER` toggles stay variables.
 The Sentry DSN is injected into both Tracker and ExecutorHost. The host
 propagates each run's trace and request context into its immutable executor
 artifact.
 
-Before production activation, configure the protected `prod` GitHub
-Environment with `AWS_DEPLOYMENT_ROLE_ORG_IDS` and
-`AWS_TRACKER_SECRET_NAME_PREFIXES`. Both production deploy jobs use that
-Environment. Both AWS accounts must already have the account-owned
+The existing `prod` GitHub Environment deploys the bench stage so its OIDC
+subject remains compatible with the established roles. Configure the new
+production account in the protected `prod-external` GitHub Environment. Both
+production Environments require their own
+`AWS_DEPLOYMENT_ROLE_ORG_IDS` and `AWS_TRACKER_SECRET_NAME_PREFIXES`. All target
+AWS accounts must already have the account-owned
 `token.actions.githubusercontent.com` OIDC provider with the
 `sts.amazonaws.com` audience. The stacks import that provider and create
 separate environment-bound executor release roles; they do not create a fallback
@@ -69,6 +77,7 @@ provider.
 The application imports these account-local values:
 
 - `/valkyrie/dev/dns/tracker/hosted-zone-id`
+- `/valkyrie/prod/dns/tracker/hosted-zone-id` in the production account
 - the Secrets Manager secret named by `DESCOPE_MANAGEMENT_KEY_SECRET_NAME`
 
 ## Setup
@@ -83,8 +92,9 @@ make install
 ## Deployment
 
 Production and development deploy automatically when changes reach `prod` and
-`dev`. The manual **Deploy to AWS** workflow on `dev` supports only
-`credentials-only` and `plan`; deployments come from branch pushes.
+`dev`. A `prod` push starts the bench and production lanes with
+separate concurrency controls. The manual **Deploy to AWS** workflow on `dev`
+supports only `credentials-only` and `plan`; deployments come from branch pushes.
 
 Core and executor changes use separate jobs but one deployment mutex per stage.
 A core-only change never builds an executor artifact, enters executor maintenance,
@@ -111,16 +121,18 @@ steps. The preflight rejects the wrong account, Region, or STS identity.
    deployment must receive the same organization and secret namespaces as CI.
 
 ```bash
-export DEV_ACCOUNT_ID=123456789012
+export DEV_ACCOUNT_ID="<dev-account-id>"
+export BENCH_ACCOUNT_ID="<bench-account-id>"
+export PRODUCTION_ACCOUNT_ID="<production-account-id>"
 export DESCOPE_PROJECT_ID="dev-project-id"
 export DESCOPE_MANAGEMENT_KEY_SECRET_NAME="dev-descope-management-key-secret"
 export AWS_DEPLOYMENT_ROLE_ORG_IDS="00000000-0000-0000-0000-000000000001"
 export AWS_TRACKER_SECRET_NAME_PREFIXES="benchmark-services/"
 ```
 
-   Use the target stage's values. Production also requires its existing
-   production deployment inputs, including `SENTRY_DSN_SECRET_NAME`. In GitHub,
-   the managed AWS values are under **Settings → Environments → dev or prod →
+   Use the target stage's values. Bench and production also require their
+   deployment inputs, including `SENTRY_DSN_SECRET_NAME`. In GitHub,
+   the managed AWS values are under **Settings → Environments → dev, prod, or prod-external →
    Environment secrets**. GitHub does not reveal stored secret values, so an
    administrator must obtain the approved values from the deployment owner.
 
@@ -137,6 +149,9 @@ export AWS_TRACKER_SECRET_NAME_PREFIXES="benchmark-services/"
 
 make plan STAGE=dev SCOPE=all AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
+
+make plan STAGE=bench SCOPE=all AWS_REGION=us-east-1 \
+  PROFILE=vals-bench-admin
 
 make plan STAGE=prod SCOPE=all AWS_REGION=us-east-1 \
   PROFILE=vals-prod-admin
@@ -160,15 +175,19 @@ make plan STAGE=prod SCOPE=all AWS_REGION=us-east-1 \
 make deploy STAGE=dev SCOPE=shared AWS_REGION=us-east-1 \
   DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" PROFILE=vals-dev-admin
 
+make deploy STAGE=bench SCOPE=shared AWS_REGION=us-east-1 \
+  PROFILE=vals-bench-admin
+
 make deploy STAGE=prod SCOPE=shared AWS_REGION=us-east-1 \
   PROFILE=vals-prod-admin
 ```
 
    This step is CLI-only because the manual GitHub workflow intentionally does
-   not offer deployment. Normal deployments come from a merge to `dev`.
+   not offer deployment. Dev deploys from `dev`; bench and production both
+   deploy from `prod`.
 
-   **Done when** -- CDK reports the selected stack deployed in the expected dev
-   account and its CloudFormation events contain no failed resources.
+   **Done when** -- CDK reports the selected stack deployed in the account for
+   the selected stage and its CloudFormation events contain no failed resources.
 
 `release-test` is an isolated, dev-sized deployment in the account selected by
 `DEV_ACCOUNT_ID`. It uses `-release-test` resource names and
@@ -177,7 +196,7 @@ the ALB DNS output is reachable from the VPC instead of creating a DNS record
 or certificate. Its benchmark-service base is
 `benchmarks.vals.ai`; no separate benchmark-service stack is created. Unlike
 `dev`, the target guard permits `release-test` to be explicitly deployed in the
-production account when coexistence validation requires it.
+bench or production account when coexistence validation requires it.
 
 ```bash
 make plan STAGE=release-test SCOPE=all AWS_REGION=us-east-1 \
@@ -187,14 +206,12 @@ make plan STAGE=release-test SCOPE=all AWS_REGION=us-east-1 \
 `SCOPE` accepts `shared`, `tracker`, `executor`, `monitoring`, `driver`
 (`release-test` only), `core`, or `all`. The `executor` scope targets the
 historical physical `WorkerStack` name. CDK follows the existing stack
-dependencies when an individual stack is selected. The
-Makefile defaults `PRODUCTION_ACCOUNT_ID` to the Vals production account so a
-dev target cannot select it accidentally. Self-hosted operators can override
-that value for their own production account.
+dependencies when an individual stack is selected. Production account IDs are
+required inputs and stay outside the repository.
 
 ## Benchmark Catalog
 
-`BENCHMARK_CATALOG_URL` points tracker-service at a benchmark catalog API. Set it for deployed tracker-service so `valkyrie config service list` can show the catalog of benchmarks hosted at that endpoint.
+`BENCHMARK_CATALOG_URL` optionally points tracker-service at a benchmark catalog API. When it is unset, `valkyrie config service list` returns an empty catalog.
 
 ```bash
 export BENCHMARK_CATALOG_URL=https://<api-id>.execute-api.us-east-1.amazonaws.com
@@ -202,7 +219,7 @@ export BENCHMARK_CATALOG_URL=https://<api-id>.execute-api.us-east-1.amazonaws.co
 
 ## Sandbox cleanup schedule
 
-Production includes an hourly EventBridge schedule for a singleton, 14-minute cleanup Lambda. The schedule is disabled
+Each production account includes an hourly EventBridge schedule for a singleton, 14-minute cleanup Lambda. The schedule is disabled
 unless `SANDBOX_CLEANUP_ENABLED` is exactly `true`; Scheduler delivery and asynchronous Lambda failures go to an encrypted
 dead-letter queue.
 

--- a/infra/app.py
+++ b/infra/app.py
@@ -16,7 +16,7 @@ from tracker_stack import TrackerStack
 
 app = cdk.App()
 stage = resolve(app)
-if not stage.is_prod:
+if not stage.is_bench:
     enforce_deployment_target(stage.name, os.environ)
 
 env = cdk.Environment(

--- a/infra/classify_repository_change.py
+++ b/infra/classify_repository_change.py
@@ -318,6 +318,13 @@ def classify_repository_change(
     )
 
 
+def combine_executor_effects(*effects: ExecutorHostTemplateEffect) -> ExecutorHostTemplateEffect:
+    return ExecutorHostTemplateEffect(
+        redeploy_required=any(effect.redeploy_required for effect in effects),
+        reasons=tuple(sorted({reason for effect in effects for reason in effect.reasons})),
+    )
+
+
 def _parse_arguments() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-sha", required=True)
@@ -326,6 +333,9 @@ def _parse_arguments() -> argparse.Namespace:
     parser.add_argument("--executor-base-template", type=Path, required=True)
     parser.add_argument("--executor-head-template", type=Path, required=True)
     parser.add_argument("--expected-stack-id", required=True)
+    parser.add_argument("--secondary-executor-base-template", type=Path)
+    parser.add_argument("--secondary-executor-head-template", type=Path)
+    parser.add_argument("--secondary-expected-stack-id")
     parser.add_argument("--output", type=Path, required=True)
     return parser.parse_args()
 
@@ -342,6 +352,24 @@ def main() -> None:
             cast(dict[str, object], head_template),
             expected_stack_id=arguments.expected_stack_id,
         )
+        secondary_inputs = (
+            arguments.secondary_executor_base_template,
+            arguments.secondary_executor_head_template,
+            arguments.secondary_expected_stack_id,
+        )
+        if any(secondary_inputs) and not all(secondary_inputs):
+            raise ValueError("Secondary WorkerStack classification requires both templates and the stack ID")
+        if all(secondary_inputs):
+            secondary_base_template = json.loads(arguments.secondary_executor_base_template.read_text(encoding="utf-8"))
+            secondary_head_template = json.loads(arguments.secondary_executor_head_template.read_text(encoding="utf-8"))
+            if not isinstance(secondary_base_template, dict) or not isinstance(secondary_head_template, dict):
+                raise ValueError("Secondary WorkerStack templates must be JSON objects")
+            secondary_effect = classify_executor_host_template_change(
+                cast(dict[str, object], secondary_base_template),
+                cast(dict[str, object], secondary_head_template),
+                expected_stack_id=arguments.secondary_expected_stack_id,
+            )
+            executor_effect = combine_executor_effects(executor_effect, secondary_effect)
         payload: dict[str, object] = asdict(
             classify_repository_change(
                 arguments.repository_root.resolve(),

--- a/infra/constants.py
+++ b/infra/constants.py
@@ -2,6 +2,8 @@
 
 import os
 
+from stage import resource_stage_name
+
 # VPC
 VPC_CIDR = "10.0.0.0/16"
 VPC_MAX_AZS = 2
@@ -84,7 +86,7 @@ DOCKER_ASSET_EXCLUDES = (
 
 
 def executor_release_launch_parameter(stage_name: str) -> str:
-    return f"/valkyrie/{stage_name}/executor-release/launch-config"
+    return f"/valkyrie/{resource_stage_name(stage_name)}/executor-release/launch-config"
 
 
 # Release-test service images. Dedicated repositories keep deployment writes
@@ -94,36 +96,32 @@ RELEASE_TEST_EXECUTOR_HOST_REPOSITORY_NAME = "valkyrie/release-test/executor-hos
 RELEASE_TEST_IMAGE_TAG_ENV = "RELEASE_TEST_IMAGE_TAG"
 
 
-# Stage-scoped account contract parameters. Release-test uses the same dev
-# account but must not overwrite dev's resource contract.
-def stage_parameter_name(dev_parameter: str, stage_name: str) -> str:
-    if stage_name == "dev":
-        return dev_parameter
-    return dev_parameter.replace("/dev/", f"/{stage_name}/", 1)
+# Stage-scoped account contract parameters.
+def stage_parameter_name(stage_name: str, parameter_path: str) -> str:
+    return f"/valkyrie/{resource_stage_name(stage_name)}/{parameter_path}"
 
 
-# Dev account prerequisites
-DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER = "/valkyrie/dev/dns/tracker/hosted-zone-id"
+TRACKER_HOSTED_ZONE_ID_PARAMETER_PATH = "dns/tracker/hosted-zone-id"
 
-# Dev shared-resource contract published for benchmark-service consumers.
+# Shared-resource contract published for benchmark-service consumers.
 # The benchmark-services registry resolves these names at deploy time; renaming
 # any of them is a cross-repo breaking change.
-DEV_SHARED_VPC_ID_PARAMETER = "/valkyrie/dev/shared/vpc-id"
-DEV_SHARED_AVAILABILITY_ZONES_PARAMETER = "/valkyrie/dev/shared/availability-zones"
-DEV_SHARED_PUBLIC_SUBNET_IDS_PARAMETER = "/valkyrie/dev/shared/public-subnet-ids"
-DEV_SHARED_CLUSTER_NAME_PARAMETER = "/valkyrie/dev/shared/cluster-name"
-DEV_SHARED_NAMESPACE_NAME_PARAMETER = "/valkyrie/dev/shared/cloud-map-namespace-name"
-DEV_SHARED_NAMESPACE_ID_PARAMETER = "/valkyrie/dev/shared/cloud-map-namespace-id"
-DEV_SHARED_NAMESPACE_ARN_PARAMETER = "/valkyrie/dev/shared/cloud-map-namespace-arn"
-DEV_SHARED_ARTIFACT_BUCKET_PARAMETER = "/valkyrie/dev/shared/artifact-bucket-name"
-DEV_SHARED_TRACKER_REPOSITORY_URI_PARAMETER = "/valkyrie/dev/shared/tracker-repository-uri"
-DEV_SHARED_EXECUTOR_HOST_REPOSITORY_URI_PARAMETER = "/valkyrie/dev/shared/executor-host-repository-uri"
-DEV_TRACKER_SECURITY_GROUP_PARAMETER = "/valkyrie/dev/tracker/security-group-id"
-DEV_TRACKER_ALB_DNS_PARAMETER = "/valkyrie/dev/tracker/alb-dns-name"
-DEV_DRIVER_TASK_DEFINITION_PARAMETER = "/valkyrie/dev/driver/task-definition-arn"
-DEV_DRIVER_SECURITY_GROUP_PARAMETER = "/valkyrie/dev/driver/security-group-id"
-DEV_DRIVER_LOG_GROUP_PARAMETER = "/valkyrie/dev/driver/log-group-name"
-DEV_DRIVER_OPERATOR_ROLE_PARAMETER = "/valkyrie/dev/driver/operator-role-arn"
+SHARED_VPC_ID_PARAMETER_PATH = "shared/vpc-id"
+SHARED_AVAILABILITY_ZONES_PARAMETER_PATH = "shared/availability-zones"
+SHARED_PUBLIC_SUBNET_IDS_PARAMETER_PATH = "shared/public-subnet-ids"
+SHARED_CLUSTER_NAME_PARAMETER_PATH = "shared/cluster-name"
+SHARED_NAMESPACE_NAME_PARAMETER_PATH = "shared/cloud-map-namespace-name"
+SHARED_NAMESPACE_ID_PARAMETER_PATH = "shared/cloud-map-namespace-id"
+SHARED_NAMESPACE_ARN_PARAMETER_PATH = "shared/cloud-map-namespace-arn"
+SHARED_ARTIFACT_BUCKET_PARAMETER_PATH = "shared/artifact-bucket-name"
+SHARED_TRACKER_REPOSITORY_URI_PARAMETER_PATH = "shared/tracker-repository-uri"
+SHARED_EXECUTOR_HOST_REPOSITORY_URI_PARAMETER_PATH = "shared/executor-host-repository-uri"
+TRACKER_SECURITY_GROUP_PARAMETER_PATH = "tracker/security-group-id"
+TRACKER_ALB_DNS_PARAMETER_PATH = "tracker/alb-dns-name"
+DRIVER_TASK_DEFINITION_PARAMETER_PATH = "driver/task-definition-arn"
+DRIVER_SECURITY_GROUP_PARAMETER_PATH = "driver/security-group-id"
+DRIVER_LOG_GROUP_PARAMETER_PATH = "driver/log-group-name"
+DRIVER_OPERATOR_ROLE_PARAMETER_PATH = "driver/operator-role-arn"
 
 RELEASE_TEST_DRIVER_SECRET_ARN_ENV = "RELEASE_TEST_DRIVER_SECRET_ARN"
 RELEASE_TEST_SANDBOX_PROVIDER_SECRET_ARN_ENV = "RELEASE_TEST_SANDBOX_PROVIDER_SECRET_ARN"

--- a/infra/deployment_target.py
+++ b/infra/deployment_target.py
@@ -35,25 +35,40 @@ class StsClient(Protocol):
 def target_from_environment(environment: Mapping[str, str]) -> DeploymentTarget:
     """Build and validate a deployment target without calling AWS."""
     stage = _required(environment, "STAGE")
-    if stage not in ("dev", "release-test", "prod"):
-        raise DeploymentTargetError("STAGE must be 'dev', 'release-test', or 'prod'.")
+    if stage not in ("dev", "release-test", "bench", "prod"):
+        raise DeploymentTargetError("STAGE must be 'dev', 'release-test', 'bench', or 'prod'.")
 
     region = _required(environment, "AWS_REGION")
     if region != DEPLOYMENT_REGION:
         raise DeploymentTargetError(f"AWS_REGION must be {DEPLOYMENT_REGION}; got {region}.")
 
-    production_account_id = _required(environment, "PRODUCTION_ACCOUNT_ID")
-    if not _ACCOUNT_ID_PATTERN.fullmatch(production_account_id):
-        raise DeploymentTargetError("PRODUCTION_ACCOUNT_ID must be a 12-digit AWS account ID.")
-
-    if stage in ("dev", "release-test"):
-        account_id = _required(environment, "DEV_ACCOUNT_ID")
-        if not _ACCOUNT_ID_PATTERN.fullmatch(account_id):
-            raise DeploymentTargetError("DEV_ACCOUNT_ID must be a 12-digit AWS account ID.")
-        if stage == "dev" and account_id == production_account_id:
-            raise DeploymentTargetError("DEV_ACCOUNT_ID must not be the production AWS account.")
+    if stage == "bench":
+        account_variable = "BENCH_ACCOUNT_ID"
+    elif stage == "prod":
+        account_variable = "PRODUCTION_ACCOUNT_ID"
     else:
-        account_id = production_account_id
+        account_variable = "DEV_ACCOUNT_ID"
+
+    account_id = _required(environment, account_variable)
+    if not _ACCOUNT_ID_PATTERN.fullmatch(account_id):
+        raise DeploymentTargetError(f"{account_variable} must be a 12-digit AWS account ID.")
+
+    required_counterpart = (
+        "PRODUCTION_ACCOUNT_ID" if stage == "bench" else "BENCH_ACCOUNT_ID" if stage == "prod" else None
+    )
+    if required_counterpart is not None:
+        _required(environment, required_counterpart)
+
+    for other_variable in ("DEV_ACCOUNT_ID", "BENCH_ACCOUNT_ID", "PRODUCTION_ACCOUNT_ID"):
+        if other_variable == account_variable:
+            continue
+        other_account_id = environment.get(other_variable, "").strip()
+        if not other_account_id:
+            continue
+        if not _ACCOUNT_ID_PATTERN.fullmatch(other_account_id):
+            raise DeploymentTargetError(f"{other_variable} must be a 12-digit AWS account ID.")
+        if stage != "release-test" and account_id == other_account_id:
+            raise DeploymentTargetError(f"{account_variable} must not match {other_variable}.")
 
     cdk_account_id = _required(environment, "CDK_DEFAULT_ACCOUNT")
     if cdk_account_id != account_id:

--- a/infra/driver_stack.py
+++ b/infra/driver_stack.py
@@ -18,11 +18,10 @@ from aws_cdk import (
     aws_ssm,
 )
 from constants import (
-    DEV_DRIVER_LOG_GROUP_PARAMETER,
-    DEV_DRIVER_OPERATOR_ROLE_PARAMETER,
-    DEV_DRIVER_SECURITY_GROUP_PARAMETER,
-    DEV_DRIVER_TASK_DEFINITION_PARAMETER,
-    DEV_TRACKER_ALB_DNS_PARAMETER,
+    DRIVER_LOG_GROUP_PARAMETER_PATH,
+    DRIVER_OPERATOR_ROLE_PARAMETER_PATH,
+    DRIVER_SECURITY_GROUP_PARAMETER_PATH,
+    DRIVER_TASK_DEFINITION_PARAMETER_PATH,
     DRIVER_LOG_GROUP_NAME,
     POSTGRES_DB,
     POSTGRES_PORT,
@@ -30,6 +29,7 @@ from constants import (
     RELEASE_TEST_DRIVER_SECRET_ARN_ENV,
     RELEASE_TEST_OPERATOR_PRINCIPAL_ARN_ENV,
     RELEASE_TEST_SANDBOX_PROVIDER_SECRET_ARN_ENV,
+    TRACKER_ALB_DNS_PARAMETER_PATH,
     VPC_CIDR,
     stage_parameter_name,
 )
@@ -83,7 +83,7 @@ class DriverStack(Stack):
         stage_config = config_for(stage)
         tracker_alb_dns = aws_ssm.StringParameter.value_for_string_parameter(
             self,
-            stage_parameter_name(DEV_TRACKER_ALB_DNS_PARAMETER, stage.name),
+            stage_parameter_name(stage.name, TRACKER_ALB_DNS_PARAMETER_PATH),
         )
         driver_image = aws_ecs.ContainerImage.from_ecr_repository(tracker_repository, image_tag)
         driver_secret = aws_secretsmanager.Secret.from_secret_complete_arn(
@@ -315,18 +315,18 @@ class DriverStack(Stack):
         parameters = (
             (
                 "DriverTaskDefinitionParameter",
-                DEV_DRIVER_TASK_DEFINITION_PARAMETER,
+                DRIVER_TASK_DEFINITION_PARAMETER_PATH,
                 self.task_definition.task_definition_arn,
             ),
             (
                 "DriverSecurityGroupParameter",
-                DEV_DRIVER_SECURITY_GROUP_PARAMETER,
+                DRIVER_SECURITY_GROUP_PARAMETER_PATH,
                 self.security_group.security_group_id,
             ),
-            ("DriverLogGroupParameter", DEV_DRIVER_LOG_GROUP_PARAMETER, self.log_group.log_group_name),
+            ("DriverLogGroupParameter", DRIVER_LOG_GROUP_PARAMETER_PATH, self.log_group.log_group_name),
             (
                 "DriverOperatorRoleParameter",
-                DEV_DRIVER_OPERATOR_ROLE_PARAMETER,
+                DRIVER_OPERATOR_ROLE_PARAMETER_PATH,
                 self.operator_role.role_arn,
             ),
         )
@@ -334,6 +334,6 @@ class DriverStack(Stack):
             aws_ssm.StringParameter(
                 self,
                 construct_id,
-                parameter_name=stage_parameter_name(parameter, stage.name),
+                parameter_name=stage_parameter_name(stage.name, parameter),
                 string_value=value,
             )

--- a/infra/executor_release/main.py
+++ b/infra/executor_release/main.py
@@ -248,7 +248,7 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("--maintenance-operation", choices=("begin", "finish"))
     parser.add_argument("--manifest", type=Path)
     parser.add_argument("--region", required=True)
-    parser.add_argument("--stage", choices=("dev", "prod", "release-test"), required=True)
+    parser.add_argument("--stage", choices=("bench", "dev", "prod", "release-test"), required=True)
     parser.add_argument("--target-sha")
     args = parser.parse_args(argv)
 

--- a/infra/executor_stack.py
+++ b/infra/executor_stack.py
@@ -249,7 +249,7 @@ class ExecutorStack(Stack):
             db_secret=db_credentials_secret,
         )
 
-        if stage.is_prod:
+        if stage.is_production:
             self._add_sandbox_cleanup_schedule(
                 stage=stage,
                 log_retention=stage_config.service_log_retention,
@@ -496,7 +496,6 @@ class ExecutorStack(Stack):
             "GitHubOidcProvider",
             f"arn:{self.partition}:iam::{self.account}:oidc-provider/token.actions.githubusercontent.com",
         )
-        github_environment = stage.name
         release_role = aws_iam.Role(
             self,
             "ExecutorReleaseRole",
@@ -509,7 +508,7 @@ class ExecutorStack(Stack):
                         "StringEquals": {
                             "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
                             "token.actions.githubusercontent.com:sub": (
-                                f"repo:vals-ai/Valkyrie:environment:{github_environment}"
+                                f"repo:vals-ai/Valkyrie:environment:{stage.github_environment}"
                             ),
                         }
                     },

--- a/infra/shared.py
+++ b/infra/shared.py
@@ -21,16 +21,16 @@ from aws_cdk import (
 from constants import (
     CLUSTER_NAME,
     DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL_ID_ENV,
-    DEV_SHARED_ARTIFACT_BUCKET_PARAMETER,
-    DEV_SHARED_AVAILABILITY_ZONES_PARAMETER,
-    DEV_SHARED_CLUSTER_NAME_PARAMETER,
-    DEV_SHARED_EXECUTOR_HOST_REPOSITORY_URI_PARAMETER,
-    DEV_SHARED_NAMESPACE_ARN_PARAMETER,
-    DEV_SHARED_NAMESPACE_ID_PARAMETER,
-    DEV_SHARED_NAMESPACE_NAME_PARAMETER,
-    DEV_SHARED_PUBLIC_SUBNET_IDS_PARAMETER,
-    DEV_SHARED_TRACKER_REPOSITORY_URI_PARAMETER,
-    DEV_SHARED_VPC_ID_PARAMETER,
+    SHARED_ARTIFACT_BUCKET_PARAMETER_PATH,
+    SHARED_AVAILABILITY_ZONES_PARAMETER_PATH,
+    SHARED_CLUSTER_NAME_PARAMETER_PATH,
+    SHARED_EXECUTOR_HOST_REPOSITORY_URI_PARAMETER_PATH,
+    SHARED_NAMESPACE_ARN_PARAMETER_PATH,
+    SHARED_NAMESPACE_ID_PARAMETER_PATH,
+    SHARED_NAMESPACE_NAME_PARAMETER_PATH,
+    SHARED_PUBLIC_SUBNET_IDS_PARAMETER_PATH,
+    SHARED_TRACKER_REPOSITORY_URI_PARAMETER_PATH,
+    SHARED_VPC_ID_PARAMETER_PATH,
     ELASTICACHE_NODE_TYPE,
     NAMESPACE,
     RELEASE_TEST_EXECUTOR_HOST_REPOSITORY_NAME,
@@ -100,7 +100,7 @@ class SharedStack(Stack):
         )
 
         self.hosted_zone: aws_route53.IHostedZone | None = None
-        if self.stage.is_prod:
+        if self.stage.is_bench:
             self.hosted_zone = aws_route53.HostedZone.from_lookup(
                 self,
                 "HostedZone",
@@ -118,10 +118,10 @@ class SharedStack(Stack):
             bucket_name=bucket_name,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             block_public_access=aws_s3.BlockPublicAccess.BLOCK_ALL,
-            encryption=None if self.stage.is_prod else aws_s3.BucketEncryption.S3_MANAGED,
-            enforce_ssl=None if self.stage.is_prod else True,
-            object_ownership=None if self.stage.is_prod else aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
-            versioned=None if self.stage.is_prod else True,
+            encryption=None if self.stage.is_bench else aws_s3.BucketEncryption.S3_MANAGED,
+            enforce_ssl=None if self.stage.is_bench else True,
+            object_ownership=None if self.stage.is_bench else aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
+            versioned=None if self.stage.is_bench else True,
             lifecycle_rules=[
                 aws_s3.LifecycleRule(abort_incomplete_multipart_upload_after=cdk.Duration.days(1)),
             ],
@@ -191,7 +191,7 @@ class SharedStack(Stack):
             ],
         )
 
-        if not self.stage.is_prod:
+        if not self.stage.is_bench:
             self._publish_shared_contract()
 
     def _publish_shared_contract(self) -> None:
@@ -199,64 +199,64 @@ class SharedStack(Stack):
         aws_ssm.StringParameter(
             self,
             "SharedVpcIdParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_VPC_ID_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_VPC_ID_PARAMETER_PATH),
             string_value=self.vpc.vpc_id,
         )
         aws_ssm.StringListParameter(
             self,
             "SharedAvailabilityZonesParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_AVAILABILITY_ZONES_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_AVAILABILITY_ZONES_PARAMETER_PATH),
             string_list_value=self.vpc.availability_zones,
         )
         aws_ssm.StringListParameter(
             self,
             "SharedPublicSubnetIdsParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_PUBLIC_SUBNET_IDS_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_PUBLIC_SUBNET_IDS_PARAMETER_PATH),
             string_list_value=[subnet.subnet_id for subnet in self.vpc.public_subnets],
         )
         aws_ssm.StringParameter(
             self,
             "SharedClusterNameParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_CLUSTER_NAME_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_CLUSTER_NAME_PARAMETER_PATH),
             string_value=self.cluster.cluster_name,
         )
         aws_ssm.StringParameter(
             self,
             "SharedNamespaceNameParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_NAMESPACE_NAME_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_NAMESPACE_NAME_PARAMETER_PATH),
             string_value=self.namespace.namespace_name,
         )
         aws_ssm.StringParameter(
             self,
             "SharedNamespaceIdParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_NAMESPACE_ID_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_NAMESPACE_ID_PARAMETER_PATH),
             string_value=self.namespace.namespace_id,
         )
         aws_ssm.StringParameter(
             self,
             "SharedNamespaceArnParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_NAMESPACE_ARN_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_NAMESPACE_ARN_PARAMETER_PATH),
             string_value=self.namespace.namespace_arn,
         )
         aws_ssm.StringParameter(
             self,
             "SharedArtifactBucketParameter",
-            parameter_name=stage_parameter_name(DEV_SHARED_ARTIFACT_BUCKET_PARAMETER, self.stage.name),
+            parameter_name=stage_parameter_name(self.stage.name, SHARED_ARTIFACT_BUCKET_PARAMETER_PATH),
             string_value=self.bucket.bucket_name,
         )
         if self.tracker_repository is not None and self.executor_host_repository is not None:
             aws_ssm.StringParameter(
                 self,
                 "SharedTrackerRepositoryUriParameter",
-                parameter_name=stage_parameter_name(DEV_SHARED_TRACKER_REPOSITORY_URI_PARAMETER, self.stage.name),
+                parameter_name=stage_parameter_name(self.stage.name, SHARED_TRACKER_REPOSITORY_URI_PARAMETER_PATH),
                 string_value=self.tracker_repository.repository_uri,
             )
             aws_ssm.StringParameter(
                 self,
                 "SharedExecutorHostRepositoryUriParameter",
                 parameter_name=stage_parameter_name(
-                    DEV_SHARED_EXECUTOR_HOST_REPOSITORY_URI_PARAMETER,
                     self.stage.name,
+                    SHARED_EXECUTOR_HOST_REPOSITORY_URI_PARAMETER_PATH,
                 ),
                 string_value=self.executor_host_repository.repository_uri,
             )

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -13,7 +13,10 @@ release-test -> stacks get a "ValkReleaseTest" prefix and "-release-test"
 
 from __future__ import annotations
 
-import aws_cdk as cdk
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aws_cdk as cdk
 
 BENCH = "bench"
 PROD = "prod"

--- a/infra/stage.py
+++ b/infra/stage.py
@@ -1,7 +1,9 @@
 """Stage-aware naming helper.
 
-prod  -> every helper is the identity function, so `cdk synth -c stage=prod` is
-        byte-identical to the pre-refactor `cdk synth`.
+bench -> deploys to the benchmark account while retaining the established prod
+        stack ids, physical names, parameter paths, and Tracker FQDN.
+prod  -> externally facing production account: stacks get a "ValkProd"
+        construct-id prefix and physical/FQDN names get a "-prod" suffix.
 dev   -> stacks get a "ValkDev" construct-id prefix; physical names get a "-dev"
         suffix; FQDNs get "-dev" on their first label.
 release-test -> stacks get a "ValkReleaseTest" prefix and "-release-test"
@@ -13,12 +15,29 @@ from __future__ import annotations
 
 import aws_cdk as cdk
 
+BENCH = "bench"
 PROD = "prod"
 DEV = "dev"
 RELEASE_TEST = "release-test"
 DEV_STACK_PREFIX = "ValkDev"
+PROD_STACK_PREFIX = "ValkProd"
 RELEASE_TEST_STACK_PREFIX = "ValkReleaseTest"
-_SUPPORTED_STAGES = (PROD, DEV, RELEASE_TEST)
+_SUPPORTED_STAGES = (BENCH, PROD, DEV, RELEASE_TEST)
+
+# Bench retains the resource identity deployed before the account was renamed.
+_STACK_PREFIXES = {
+    BENCH: "",
+    PROD: PROD_STACK_PREFIX,
+    DEV: DEV_STACK_PREFIX,
+    RELEASE_TEST: RELEASE_TEST_STACK_PREFIX,
+}
+_RESOURCE_STAGE_NAMES = {BENCH: "prod", PROD: PROD, DEV: DEV, RELEASE_TEST: RELEASE_TEST}
+_GITHUB_ENVIRONMENTS = {BENCH: "prod", PROD: "prod-external", DEV: DEV, RELEASE_TEST: RELEASE_TEST}
+
+
+def resource_stage_name(stage_name: str) -> str:
+    """Return the stable stage component used by deployed resource contracts."""
+    return _RESOURCE_STAGE_NAMES[stage_name]
 
 
 class Stage:
@@ -26,33 +45,41 @@ class Stage:
         self.name: str = name
 
     @property
-    def is_prod(self) -> bool:
-        return self.name == PROD
+    def is_production(self) -> bool:
+        """Whether the stage serves production traffic and takes production settings."""
+        return self.name in (BENCH, PROD)
+
+    @property
+    def is_bench(self) -> bool:
+        """Whether the stage owns the established unsuffixed resource names."""
+        return self.name == BENCH
 
     @property
     def is_release_test(self) -> bool:
         return self.name == RELEASE_TEST
 
+    @property
+    def github_environment(self) -> str:
+        """Return the stable GitHub OIDC environment subject for this stage."""
+        return _GITHUB_ENVIRONMENTS[self.name]
+
     def stack_id(self, base: str) -> str:
-        if self.is_prod:
-            return base
-        prefix = RELEASE_TEST_STACK_PREFIX if self.is_release_test else DEV_STACK_PREFIX
-        return f"{prefix}{base}"
+        return f"{_STACK_PREFIXES[self.name]}{base}"
 
     def phys(self, name: str) -> str:
-        return name if self.is_prod else f"{name}-{self.name}"
+        return name if self.is_bench else f"{name}-{self.name}"
 
     def domain(self, fqdn: str) -> str:
         # "benchmark-tracker.vals.ai" -> "benchmark-tracker-dev.vals.ai"
         assert "." in fqdn, f"domain() requires a FQDN with a dot, got {fqdn!r}"
-        if self.is_prod:
+        if self.is_bench:
             return fqdn
         first, _, rest = fqdn.partition(".")
         return f"{first}-{self.name}.{rest}"
 
 
 def resolve(app: cdk.App) -> Stage:
-    name = app.node.try_get_context("stage") or PROD
+    name = app.node.try_get_context("stage") or BENCH
     if name not in _SUPPORTED_STAGES:
         raise ValueError(f"unknown stage {name!r}; expected one of {_SUPPORTED_STAGES!r}")
     return Stage(name)

--- a/infra/stage_config.py
+++ b/infra/stage_config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, replace
 from uuid import UUID
 
 from aws_cdk import aws_logs
-from stage import DEV, PROD, RELEASE_TEST, Stage
+from stage import BENCH, DEV, PROD, RELEASE_TEST, Stage
 
 
 _SECRET_NAME_PREFIX_PATTERN = re.compile(r"[A-Za-z0-9/_+=.@-]+")
@@ -102,7 +102,7 @@ class StageConfig:
     managed_aws: ManagedAWSRuntimeConfig
 
 
-PROD_CONFIG = StageConfig(
+BENCH_CONFIG = StageConfig(
     runtime_environment="production",
     tracker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=1, max_tasks=2),
     worker=ServiceConfig(cpu=8192, memory_mib=32768, min_tasks=4, max_tasks=8),
@@ -120,6 +120,26 @@ PROD_CONFIG = StageConfig(
         executor_all_secret_access=True,
         tracker_lambda_function_name_patterns=_TRACKER_ANALYZER_LAMBDA_PATTERNS,
         executor_lambda_function_name_patterns=_EXECUTOR_OUTPUT_LAMBDA_PATTERNS,
+    ),
+)
+
+PROD_CONFIG = StageConfig(
+    runtime_environment="production",
+    tracker=ServiceConfig(cpu=4096, memory_mib=8192, min_tasks=1, max_tasks=2),
+    worker=ServiceConfig(cpu=8192, memory_mib=32768, min_tasks=4, max_tasks=8),
+    database=DatabaseConfig(
+        instance_class="r7g.large",
+        allocated_storage_gb=20,
+        backup_retention_days=7,
+        connection_alarm_threshold=135,
+    ),
+    service_log_retention=aws_logs.RetentionDays.ONE_YEAR,
+    managed_aws=ManagedAWSRuntimeConfig(
+        benchmark_log_group_prefix="/valkyrie/benchmarks",
+        benchmark_log_retention_days=365,
+        submissions_enabled=True,
+        executor_all_secret_access=True,
+        executor_lambda_function_name_patterns=("vals-format-lambda",),
     ),
 )
 
@@ -160,6 +180,7 @@ RELEASE_TEST_BENCHMARK_SERVICE_BASE_URL = "benchmarks.vals.ai"
 
 
 _STAGE_CONFIGS = {
+    BENCH: BENCH_CONFIG,
     PROD: PROD_CONFIG,
     DEV: DEV_CONFIG,
     RELEASE_TEST: RELEASE_TEST_CONFIG,
@@ -170,9 +191,11 @@ def config_for(stage: Stage) -> StageConfig:
     try:
         config = _STAGE_CONFIGS[stage.name]
     except KeyError:
-        raise ValueError(f"unknown stage {stage.name!r}; expected {PROD!r}, {DEV!r}, or 'release-test'") from None
+        raise ValueError(
+            f"unknown stage {stage.name!r}; expected {BENCH!r}, {PROD!r}, {DEV!r}, or 'release-test'"
+        ) from None
 
-    if stage.name not in {DEV, PROD}:
+    if stage.name not in {BENCH, DEV, PROD}:
         return config
 
     deployment_role_org_ids = _csv_environment("AWS_DEPLOYMENT_ROLE_ORG_IDS")

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -412,7 +412,32 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("--secondary-executor-head-template", classification_workflow)
         self.assertIn("--secondary-expected-stack-id", classification_workflow)
         self.assertIn("ValkProdWorkerStack", classification_workflow)
-        self.assertEqual(classification_workflow.count("synthesize-worker-templates.sh"), 2)
+        self.assertEqual(
+            classification_workflow.count("bash workflow/.github/scripts/synthesize-worker-templates.sh"),
+            2,
+        )
+        self.assertIn("resolve-synthesis-helper:", classification_workflow)
+        resolver = classification_workflow.split("  resolve-synthesis-helper:", maxsplit=1)[1].split(
+            "  synthesize-base:", maxsplit=1
+        )[0]
+        self.assertIn("ref: ${{ env.BASE_SHA }}", resolver)
+        self.assertIn("if: steps.target-revision.outputs.sha == ''", resolver)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", resolver)
+        self.assertLess(
+            resolver.index("ref: ${{ env.BASE_SHA }}"),
+            resolver.index("ref: ${{ github.event.repository.default_branch }}"),
+        )
+        self.assertIn(
+            "sha: ${{ steps.target-revision.outputs.sha || steps.default-revision.outputs.sha }}",
+            resolver,
+        )
+        self.assertEqual(classification_workflow.count("needs: resolve-synthesis-helper"), 2)
+        self.assertEqual(
+            classification_workflow.count("SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}"),
+            2,
+        )
+        self.assertEqual(classification_workflow.count("ref: ${{ env.SYNTHESIS_HELPER_SHA }}"), 2)
+        self.assertEqual(classification_workflow.count("git -C workflow rev-parse HEAD"), 2)
         self.assertIn("pull_request_target:", classification_workflow)
         self.assertIn("synthesize-base:", classification_workflow)
         self.assertIn("synthesize-head:", classification_workflow)

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -3,43 +3,103 @@
 Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_deploy_workflow.py
 """
 
+import re
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "deploy.yaml"
 EXECUTOR_BUILD_WORKFLOW = ROOT / ".github" / "workflows" / "executor-build.yaml"
+TRACKER_LIVE_WORKFLOW = ROOT / ".github" / "workflows" / "tracker-integration-tests.yaml"
+WORKER_SYNTHESIS = ROOT / ".github" / "scripts" / "synthesize-worker-templates.sh"
+
+_NEXT_JOB = re.compile(r"\n  [A-Za-z0-9_-]+:\n")
+
+
+def _job(workflow: str, job_id: str) -> str:
+    """Return the workflow text of one job, up to the next top-level job id."""
+    body = workflow.split(f"  {job_id}:", maxsplit=1)[1]
+    next_job = _NEXT_JOB.search(body)
+    return body[: next_job.start()] if next_job else body
 
 
 class DeployWorkflowTest(unittest.TestCase):
     def test_core_deployments_do_not_depend_on_executor_work(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        production_core = workflow.split("  deploy-production-core:", maxsplit=1)[1].split(
-            "  run-dev-operation:", maxsplit=1
-        )[0]
-        dev_core = workflow.split("  run-dev-operation:", maxsplit=1)[1].split("  executor-development:", maxsplit=1)[0]
+        bench_core = _job(workflow, "deploy-bench-core")
+        prod_core = _job(workflow, "deploy-prod-core")
+        dev_core = _job(workflow, "run-dev-operation")
+
+        for deployment_job in (dev_core, bench_core, prod_core):
+            self.assertIn(
+                "BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}",
+                deployment_job,
+            )
+            self.assertIn(
+                "PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}",
+                deployment_job,
+            )
+
+        self.assertIn("12-digit AWS account IDs", dev_core)
+        for production_job in (bench_core, prod_core):
+            self.assertIn("12-digit Actions secret", production_job)
+
+        self.assertIn('"$DEV_ACCOUNT_ID" == "$BENCH_ACCOUNT_ID"', dev_core)
+        self.assertIn('"$DEV_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID"', dev_core)
 
         self.assertIn("branches: [dev, prod]", workflow)
         self.assertIn("workflow_dispatch:", workflow)
         manual_inputs = workflow.split("  workflow_dispatch:", maxsplit=1)[1].split("permissions:", maxsplit=1)[0]
         self.assertNotIn("- deploy", manual_inputs)
-        self.assertIn("needs: classify-deployment", production_core)
-        self.assertIn("group: valkyrie-prod-deploy", production_core)
-        self.assertIn("core_maintenance_required != 'true'", production_core)
-        self.assertIn("database_maintenance_required != 'true'", production_core)
-        self.assertIn("SCOPE=core", production_core)
+        self.assertEqual(
+            [line.strip() for line in bench_core.splitlines() if line.startswith("    needs:")],
+            ["needs: classify-deployment"],
+        )
+        self.assertNotIn("deploy-prod-core", bench_core)
+        self.assertIn("group: valkyrie-prod-deploy", bench_core)
+        self.assertIn("core_maintenance_required != 'true'", bench_core)
+        self.assertIn("database_maintenance_required != 'true'", bench_core)
+        self.assertIn("SCOPE=core", bench_core)
+        self.assertIn("Validate bench deployment inputs", bench_core)
+        self.assertIn("environment: prod", bench_core)
+        self.assertIn("STAGE=bench", bench_core)
         self.assertIn(
             "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
-            production_core,
+            bench_core,
         )
         self.assertIn(
             "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
-            production_core,
+            bench_core,
         )
-        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", production_core)
-        self.assertNotIn("services/executor_artifact/build.py", production_core)
-        self.assertNotIn("executor_release/main.py", production_core)
-        self.assertNotIn("maintenance-operation", production_core)
+        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", bench_core)
+        self.assertNotIn("services/executor_artifact/build.py", bench_core)
+        self.assertNotIn("executor_release/main.py", bench_core)
+        self.assertNotIn("maintenance-operation", bench_core)
+        self.assertEqual(
+            [line.strip() for line in prod_core.splitlines() if line.startswith("    needs:")],
+            ["needs: classify-deployment"],
+        )
+        self.assertNotIn("deploy-bench-core", prod_core)
+        self.assertIn("group: valkyrie-production-deploy", prod_core)
+        self.assertIn("github.ref == 'refs/heads/prod'", prod_core)
+        self.assertIn("environment: prod-external", prod_core)
+        self.assertIn(
+            "PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}",
+            prod_core,
+        )
+        self.assertIn("role-to-assume: ${{ env.AWS_DEPLOY_ROLE_ARN }}", prod_core)
+        self.assertIn("Validate prod deployment inputs", prod_core)
+        self.assertIn("bench and production account IDs as 12-digit Actions secrets", prod_core)
+        self.assertIn("AWS_DEPLOY_ROLE_ARN must name a role in the approved prod account", prod_core)
+        self.assertIn("must not be the bench AWS account", prod_core)
+        self.assertIn("STAGE=prod", prod_core)
+        self.assertIn("SCOPE=core", prod_core)
+        self.assertNotIn("services/executor_artifact/build.py", prod_core)
+        self.assertNotIn("executor_release/main.py", prod_core)
+        self.assertIn('AUTH_REQUIRED: "true"', prod_core)
+        self.assertIn("DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}", prod_core)
+        self.assertIn("BENCHMARK_CATALOG_URL: ${{ secrets.BENCHMARK_CATALOG_URL }}", prod_core)
+        self.assertNotIn("must define BENCHMARK_CATALOG_URL", prod_core)
         self.assertIn("needs: classify-deployment", dev_core)
         self.assertIn("group: valkyrie-dev-${{ github.event_name == 'push' && 'deploy' || github.run_id }}", dev_core)
         self.assertIn("core_maintenance_required != 'true'", dev_core)
@@ -79,13 +139,28 @@ class DeployWorkflowTest(unittest.TestCase):
 
     def test_executor_jobs_own_build_deploy_activation_and_maintenance(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        bench_executor = _job(workflow, "executor-bench")
+        prod_executor = _job(workflow, "executor-prod")
 
-        for executor_job, stage in ((dev_executor, "dev"), (prod_executor, "production")):
+        for executor_job, stage in (
+            (dev_executor, "dev"),
+            (bench_executor, "bench"),
+            (prod_executor, "prod"),
+        ):
             with self.subTest(stage=stage):
+                self.assertIn(
+                    "BENCH_ACCOUNT_ID: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}",
+                    executor_job,
+                )
+                self.assertIn(
+                    "PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}",
+                    executor_job,
+                )
+                if stage == "dev":
+                    self.assertIn("12-digit AWS account IDs", executor_job)
+                else:
+                    self.assertIn("12-digit Actions secret", executor_job)
                 self.assertIn("executor_stack_deploy_required", executor_job)
                 self.assertIn("executor_host_redeploy_required", executor_job)
                 self.assertIn("executor_release_required", executor_job)
@@ -114,6 +189,8 @@ class DeployWorkflowTest(unittest.TestCase):
                 self.assertLess(executor_job.index("SCOPE=executor"), executor_job.index("Publish and activate"))
                 self.assertLess(executor_job.index("Publish and activate"), executor_job.index("Finish"))
 
+        self.assertIn('"$DEV_ACCOUNT_ID" == "$BENCH_ACCOUNT_ID"', dev_executor)
+        self.assertIn('"$DEV_ACCOUNT_ID" == "$PRODUCTION_ACCOUNT_ID"', dev_executor)
         self.assertIn("needs: [classify-deployment, run-dev-operation]", dev_executor)
         self.assertIn("environment: dev", dev_executor)
         self.assertIn(
@@ -125,36 +202,64 @@ class DeployWorkflowTest(unittest.TestCase):
             dev_executor,
         )
         self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", dev_executor)
-        self.assertIn("needs: [classify-deployment, deploy-production-core]", prod_executor)
-        self.assertIn("environment: prod", prod_executor)
+        self.assertIn("needs: [classify-deployment, deploy-bench-core]", bench_executor)
+        self.assertIn("environment: prod", bench_executor)
         self.assertIn(
             "AWS_DEPLOYMENT_ROLE_ORG_IDS: ${{ secrets.AWS_DEPLOYMENT_ROLE_ORG_IDS }}",
-            prod_executor,
+            bench_executor,
         )
         self.assertIn(
             "AWS_TRACKER_SECRET_NAME_PREFIXES: ${{ secrets.AWS_TRACKER_SECRET_NAME_PREFIXES }}",
+            bench_executor,
+        )
+        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", bench_executor)
+        self.assertIn("needs: [classify-deployment, deploy-prod-core]", prod_executor)
+        self.assertIn("environment: prod-external", prod_executor)
+        self.assertIn(
+            "PRODUCTION_ACCOUNT_ID: ${{ secrets.VALKYRIE_PRODUCTION_ACCOUNT_ID }}",
             prod_executor,
         )
-        self.assertNotIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES", prod_executor)
+        self.assertIn('AUTH_REQUIRED: "true"', prod_executor)
+        self.assertIn("DESCOPE_PROJECT_ID: ${{ secrets.DESCOPE_PROJECT_ID }}", prod_executor)
+        self.assertIn("Validate prod deployment inputs", prod_executor)
+        self.assertIn("bench and production account IDs as 12-digit Actions secrets", prod_executor)
+        self.assertIn("AWS_DEPLOY_ROLE_ARN must name a role in the approved prod account", prod_executor)
+        prod_release_credentials = prod_executor.split("      - name: Configure prod release credentials", maxsplit=1)[
+            1
+        ].split("        uses:", maxsplit=1)[0]
+        self.assertIn("steps.validate.outcome == 'success'", prod_release_credentials)
+        self.assertEqual(prod_executor.count("--stage prod"), 3)
         self.assertNotIn("production-executor-approval", workflow)
         self.assertNotIn("production-release", workflow)
         self.assertEqual(
             workflow.count("PYTHONPATH=services/tracker/src python services/executor_artifact/build.py"),
-            2,
+            3,
         )
-        self.assertEqual(workflow.count("--maintenance-operation begin"), 2)
-        self.assertEqual(workflow.count("--maintenance-operation finish"), 2)
+        self.assertEqual(workflow.count("--maintenance-operation begin"), 3)
+        self.assertEqual(workflow.count("--maintenance-operation finish"), 3)
+
+    def test_live_tracker_credentials_use_the_approved_bench_account(self) -> None:
+        workflow = TRACKER_LIVE_WORKFLOW.read_text(encoding="utf-8")
+
+        validation_index = workflow.index("Validate bench account boundary")
+        credentials_index = workflow.index("Configure AWS Credentials")
+
+        self.assertLess(validation_index, credentials_index)
+        self.assertIn("VALKYRIE_BENCH_ACCOUNT_ID must be a 12-digit Actions secret", workflow)
+        self.assertIn("VALKYRIE_TRACKER_INTEGRATION_ROLE_ARN", workflow)
+        self.assertIn("must name the approved Tracker test role", workflow)
+        self.assertIn("role-to-assume: ${{ secrets.VALKYRIE_TRACKER_INTEGRATION_ROLE_ARN }}", workflow)
+        self.assertIn("allowed-account-ids: ${{ secrets.VALKYRIE_BENCH_ACCOUNT_ID }}", workflow)
         self.assertNotIn("actions/upload-artifact", workflow)
         self.assertNotIn("actions/download-artifact", workflow)
 
     def test_maintenance_paths_bypass_the_skipped_core_job_and_preserve_failed_fences(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        bench_executor = _job(workflow, "executor-bench")
+        prod_executor = _job(workflow, "executor-prod")
 
-        for executor_job in (dev_executor, prod_executor):
+        for executor_job in (dev_executor, bench_executor, prod_executor):
             job_condition = executor_job.split("    needs:", maxsplit=1)[0]
             self.assertIn("always()", job_condition)
             self.assertIn("core_maintenance_required == 'true'", job_condition)
@@ -168,15 +273,17 @@ class DeployWorkflowTest(unittest.TestCase):
             self.assertIn("database_maintenance_required == 'true'", core_under_maintenance)
 
             finish = executor_job.rsplit("      - name: Finish", maxsplit=1)[1]
-            self.assertNotIn("always()", finish)
             self.assertIn("--maintenance-operation finish", finish)
+
+        prod_finish = prod_executor.rsplit("      - name: Finish", maxsplit=1)[1]
+        self.assertNotIn("always()", prod_finish)
+        self.assertIn("executor_host_redeploy_required == 'true'", prod_finish)
 
     def test_executor_bootstrap_fails_closed_until_release_control_exists(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        bench_executor = _job(workflow, "executor-bench")
+        prod_executor = _job(workflow, "executor-prod")
 
         stages = (
             (
@@ -184,19 +291,28 @@ class DeployWorkflowTest(unittest.TestCase):
                 "dev",
                 "arn:aws:iam::${{ env.DEV_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-dev",
                 "${{ env.AWS_DEPLOY_ROLE_ARN }}",
+                "physical WorkerStack bootstrap",
+            ),
+            (
+                bench_executor,
+                "bench",
+                "arn:aws:iam::${{ env.BENCH_ACCOUNT_ID }}:role/ValkyrieExecutorRelease",
+                "arn:aws:iam::${{ env.BENCH_ACCOUNT_ID }}:role/github-actions-valkyrie-deploy",
+                "physical WorkerStack bootstrap",
             ),
             (
                 prod_executor,
-                "production",
-                "arn:aws:iam::613431292675:role/ValkyrieExecutorRelease",
-                "arn:aws:iam::613431292675:role/github-actions-valkyrie-deploy",
+                "prod",
+                "arn:aws:iam::${{ env.PRODUCTION_ACCOUNT_ID }}:role/ValkyrieExecutorRelease-prod",
+                "${{ env.AWS_DEPLOY_ROLE_ARN }}",
+                "ValkProdWorkerStack deploy",
             ),
         )
-        for executor_job, stage, release_role, deployment_role in stages:
+        for executor_job, stage, release_role, deployment_role, bootstrap_hint in stages:
             with self.subTest(stage=stage):
                 self.assertIn("aws ssm get-parameter", executor_job)
                 self.assertIn("ParameterNotFound", executor_job)
-                self.assertIn("physical WorkerStack bootstrap", executor_job)
+                self.assertIn(bootstrap_hint, executor_job)
                 self.assertNotIn("describe-stacks", executor_job)
                 self.assertNotIn("steps.executor-stack.outputs.exists", executor_job)
 
@@ -246,19 +362,23 @@ class DeployWorkflowTest(unittest.TestCase):
         )
         self.assertIn(
             "EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod/executor-release/launch-config",
+            bench_executor,
+        )
+        self.assertIn(
+            "EXECUTOR_RELEASE_LAUNCH_PARAMETER: /valkyrie/prod/executor-release/launch-config",
             prod_executor,
         )
 
     def test_mutations_share_stage_mutex_and_stale_executor_jobs_do_nothing(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        dev_executor = workflow.split("  executor-development:", maxsplit=1)[1].split(
-            "  executor-production:", maxsplit=1
-        )[0]
-        prod_executor = workflow.split("  executor-production:", maxsplit=1)[1]
+        dev_executor = _job(workflow, "executor-development")
+        bench_executor = _job(workflow, "executor-bench")
+        prod_executor = _job(workflow, "executor-prod")
 
-        self.assertEqual(workflow.count("group: valkyrie-prod-deploy"), 2)
+        self.assertEqual(workflow.count("group: valkyrie-prod-deploy\n"), 2)
+        self.assertEqual(workflow.count("group: valkyrie-production-deploy\n"), 2)
         self.assertIn("group: valkyrie-dev-deploy", dev_executor)
-        for executor_job in (dev_executor, prod_executor):
+        for executor_job in (dev_executor, bench_executor, prod_executor):
             self.assertIn("gh api", executor_job)
             self.assertIn("id: freshness", executor_job)
             self.assertGreaterEqual(executor_job.count("steps.freshness.outputs.current == 'true'"), 14)
@@ -268,6 +388,7 @@ class DeployWorkflowTest(unittest.TestCase):
         classification_workflow = (
             Path(__file__).parents[2] / ".github" / "workflows" / "maintenance-classification.yaml"
         ).read_text(encoding="utf-8")
+        synthesis = WORKER_SYNTHESIS.read_text(encoding="utf-8")
 
         command = "python3 infra/classify_repository_change.py"
         self.assertIn(command, workflow)
@@ -283,29 +404,28 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("--executor-base-template", workflow)
         self.assertIn("--executor-head-template", workflow)
         self.assertIn("--expected-stack-id", workflow)
+        self.assertIn("--secondary-executor-base-template", workflow)
+        self.assertIn("--secondary-executor-head-template", workflow)
+        self.assertIn("--secondary-expected-stack-id", workflow)
+        self.assertEqual(workflow.count("synthesize-worker-templates.sh"), 2)
+        self.assertIn("--secondary-executor-base-template", classification_workflow)
+        self.assertIn("--secondary-executor-head-template", classification_workflow)
+        self.assertIn("--secondary-expected-stack-id", classification_workflow)
+        self.assertIn("ValkProdWorkerStack", classification_workflow)
+        self.assertEqual(classification_workflow.count("synthesize-worker-templates.sh"), 2)
         self.assertIn("pull_request_target:", classification_workflow)
         self.assertIn("synthesize-base:", classification_workflow)
         self.assertIn("synthesize-head:", classification_workflow)
         self.assertIn("needs: [synthesize-base, synthesize-head]", classification_workflow)
         self.assertEqual(classification_workflow.count("enable-cache: false"), 2)
-        self.assertEqual(
-            classification_workflow.count("AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001"),
-            2,
-        )
-        self.assertEqual(
-            classification_workflow.count("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth"),
-            2,
-        )
-        self.assertEqual(
-            classification_workflow.count("AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth"),
-            2,
-        )
-        self.assertIn(
-            "AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001",
-            workflow,
-        )
-        self.assertIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth", workflow)
-        self.assertIn("AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth", workflow)
+        self.assertIn("ValkProdWorkerStack", synthesis)
+        self.assertIn("BENCH_ACCOUNT_ID=222222222222", synthesis)
+        self.assertIn("production_account_id=333333333333", synthesis)
+        self.assertIn('PRODUCTION_ACCOUNT_ID="$production_account_id"', synthesis)
+        self.assertIn("AWS_DEPLOYMENT_ROLE_ORG_IDS=00000000-0000-0000-0000-000000000001", synthesis)
+        self.assertIn("AWS_EXECUTOR_SECRET_NAME_PREFIXES=offline-synth", synthesis)
+        self.assertIn("AWS_TRACKER_SECRET_NAME_PREFIXES=offline-synth", synthesis)
+        self.assertIn("BENCHMARK_CATALOG_URL=https://offline.invalid", synthesis)
         self.assertNotIn("id-token: write", classification_workflow)
         trusted_checkout = classification_workflow.split("      - name: Checkout trusted classifier", maxsplit=1)[
             1
@@ -409,7 +529,7 @@ class DeployWorkflowTest(unittest.TestCase):
     def test_deployment_tools_are_pinned_and_release_dependencies_are_isolated(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
 
-        self.assertEqual(workflow.count("npm install -g aws-cdk@2.1132.0"), 5)
+        self.assertEqual(workflow.count("npm install -g aws-cdk@2.1132.0"), 7)
         self.assertIn("uv sync --frozen --python 3.12 --project infra", workflow)
         self.assertIn("infra/executor_release/uv.lock", workflow)
         self.assertIn("services/executor_artifact/uv.lock", workflow)

--- a/infra/tests/test_deployment_target.py
+++ b/infra/tests/test_deployment_target.py
@@ -11,15 +11,23 @@ from deployment_target import (
 )
 
 DEV_ACCOUNT_ID = "123456789012"
-PRODUCTION_ACCOUNT_ID = "210987654321"
+BENCH_ACCOUNT_ID = "210987654321"
+PRODUCTION_ACCOUNT_ID = "321098765432"
 
 
 def environment_for(stage: str) -> dict[str, str]:
-    account_id = DEV_ACCOUNT_ID if stage in ("dev", "release-test") else PRODUCTION_ACCOUNT_ID
+    account_id = (
+        DEV_ACCOUNT_ID
+        if stage in ("dev", "release-test")
+        else PRODUCTION_ACCOUNT_ID
+        if stage == "prod"
+        else BENCH_ACCOUNT_ID
+    )
     return {
         "STAGE": stage,
         "AWS_REGION": DEPLOYMENT_REGION,
         "DEV_ACCOUNT_ID": DEV_ACCOUNT_ID,
+        "BENCH_ACCOUNT_ID": BENCH_ACCOUNT_ID,
         "PRODUCTION_ACCOUNT_ID": PRODUCTION_ACCOUNT_ID,
         "CDK_DEFAULT_ACCOUNT": account_id,
         "CDK_DEFAULT_REGION": DEPLOYMENT_REGION,
@@ -27,8 +35,12 @@ def environment_for(stage: str) -> dict[str, str]:
 
 
 class DeploymentTargetTest(unittest.TestCase):
-    def test_accepts_exact_dev_and_prod_targets(self) -> None:
-        for stage, account_id in (("dev", DEV_ACCOUNT_ID), ("prod", PRODUCTION_ACCOUNT_ID)):
+    def test_accepts_exact_deployment_targets(self) -> None:
+        for stage, account_id in (
+            ("dev", DEV_ACCOUNT_ID),
+            ("bench", BENCH_ACCOUNT_ID),
+            ("prod", PRODUCTION_ACCOUNT_ID),
+        ):
             with self.subTest(stage=stage):
                 self.assertEqual(
                     target_from_environment(environment_for(stage)),
@@ -41,6 +53,15 @@ class DeploymentTargetTest(unittest.TestCase):
             DeploymentTarget(stage="release-test", account_id=DEV_ACCOUNT_ID, region=DEPLOYMENT_REGION),
         )
 
+    def test_accepts_release_test_in_bench_account(self) -> None:
+        environment = environment_for("release-test")
+        environment["DEV_ACCOUNT_ID"] = BENCH_ACCOUNT_ID
+        environment["CDK_DEFAULT_ACCOUNT"] = BENCH_ACCOUNT_ID
+        self.assertEqual(
+            target_from_environment(environment),
+            DeploymentTarget(stage="release-test", account_id=BENCH_ACCOUNT_ID, region=DEPLOYMENT_REGION),
+        )
+
     def test_accepts_release_test_in_production_account(self) -> None:
         environment = environment_for("release-test")
         environment["DEV_ACCOUNT_ID"] = PRODUCTION_ACCOUNT_ID
@@ -50,10 +71,44 @@ class DeploymentTargetTest(unittest.TestCase):
             DeploymentTarget(stage="release-test", account_id=PRODUCTION_ACCOUNT_ID, region=DEPLOYMENT_REGION),
         )
 
+    def test_dev_and_release_test_do_not_require_production_accounts(self) -> None:
+        for stage, unrelated_variables in (
+            ("dev", ("BENCH_ACCOUNT_ID", "PRODUCTION_ACCOUNT_ID")),
+            ("release-test", ("BENCH_ACCOUNT_ID", "PRODUCTION_ACCOUNT_ID")),
+        ):
+            with self.subTest(stage=stage):
+                environment = environment_for(stage)
+                for variable in unrelated_variables:
+                    del environment[variable]
+                target_from_environment(environment)
+
+    def test_bench_and_prod_require_each_other_account(self) -> None:
+        for stage, required_variable in (
+            ("bench", "PRODUCTION_ACCOUNT_ID"),
+            ("prod", "BENCH_ACCOUNT_ID"),
+        ):
+            with self.subTest(stage=stage):
+                environment = environment_for(stage)
+                del environment[required_variable]
+                with self.assertRaisesRegex(DeploymentTargetError, f"{required_variable} is required"):
+                    target_from_environment(environment)
+
+    def test_rejects_selected_account_that_matches_supplied_account(self) -> None:
+        for stage, selected_variable, other_variable in (
+            ("dev", "DEV_ACCOUNT_ID", "BENCH_ACCOUNT_ID"),
+            ("bench", "BENCH_ACCOUNT_ID", "PRODUCTION_ACCOUNT_ID"),
+            ("prod", "PRODUCTION_ACCOUNT_ID", "BENCH_ACCOUNT_ID"),
+        ):
+            with self.subTest(stage=stage):
+                environment = environment_for(stage)
+                environment[selected_variable] = environment[other_variable]
+                environment["CDK_DEFAULT_ACCOUNT"] = environment[other_variable]
+                with self.assertRaisesRegex(DeploymentTargetError, "must not match"):
+                    target_from_environment(environment)
+
     def test_rejects_target_mismatches(self) -> None:
         cases = (
             ("AWS_REGION", "us-west-2", "AWS_REGION must be us-east-1"),
-            ("DEV_ACCOUNT_ID", PRODUCTION_ACCOUNT_ID, "must not be the production"),
             ("CDK_DEFAULT_ACCOUNT", "999999999999", "CDK_DEFAULT_ACCOUNT must be"),
             ("CDK_DEFAULT_REGION", "us-west-2", "CDK_DEFAULT_REGION must match"),
         )
@@ -61,8 +116,6 @@ class DeploymentTargetTest(unittest.TestCase):
             with self.subTest(variable=variable):
                 environment = environment_for("dev")
                 environment[variable] = value
-                if variable == "DEV_ACCOUNT_ID":
-                    environment["CDK_DEFAULT_ACCOUNT"] = value
                 with self.assertRaisesRegex(DeploymentTargetError, message):
                     target_from_environment(environment)
 

--- a/infra/tests/test_dev_account.py
+++ b/infra/tests/test_dev_account.py
@@ -14,22 +14,23 @@ import aws_cdk as cdk
 from aws_cdk import assertions
 
 from constants import (
-    DEV_SHARED_ARTIFACT_BUCKET_PARAMETER,
-    DEV_SHARED_AVAILABILITY_ZONES_PARAMETER,
-    DEV_SHARED_CLUSTER_NAME_PARAMETER,
-    DEV_SHARED_NAMESPACE_ARN_PARAMETER,
-    DEV_SHARED_NAMESPACE_ID_PARAMETER,
-    DEV_SHARED_NAMESPACE_NAME_PARAMETER,
-    DEV_SHARED_PUBLIC_SUBNET_IDS_PARAMETER,
-    DEV_SHARED_VPC_ID_PARAMETER,
-    DEV_TRACKER_ALB_DNS_PARAMETER,
-    DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER,
-    DEV_TRACKER_SECURITY_GROUP_PARAMETER,
+    SHARED_ARTIFACT_BUCKET_PARAMETER_PATH,
+    SHARED_AVAILABILITY_ZONES_PARAMETER_PATH,
+    SHARED_CLUSTER_NAME_PARAMETER_PATH,
+    SHARED_NAMESPACE_ARN_PARAMETER_PATH,
+    SHARED_NAMESPACE_ID_PARAMETER_PATH,
+    SHARED_NAMESPACE_NAME_PARAMETER_PATH,
+    SHARED_PUBLIC_SUBNET_IDS_PARAMETER_PATH,
+    SHARED_VPC_ID_PARAMETER_PATH,
+    TRACKER_ALB_DNS_PARAMETER_PATH,
+    TRACKER_HOSTED_ZONE_ID_PARAMETER_PATH,
+    TRACKER_SECURITY_GROUP_PARAMETER_PATH,
     executor_release_launch_parameter,
+    stage_parameter_name,
 )
 from shared import SharedStack
 from executor_stack import ExecutorStack
-from stage import DEV, PROD, RELEASE_TEST, Stage
+from stage import BENCH, DEV, RELEASE_TEST, Stage
 from tracker_stack import TrackerStack
 
 TEST_ACCOUNT = "123456789012"
@@ -41,7 +42,7 @@ TEST_CONTEXT = {
         f"{TEST_REGION}b",
     ]
 }
-PROD_CONTEXT = {
+BENCH_CONTEXT = {
     **TEST_CONTEXT,
     f"hosted-zone:account={TEST_ACCOUNT}:domainName=vals.ai:region={TEST_REGION}": {
         "Id": "/hostedzone/Z0000000000000000000",
@@ -50,18 +51,21 @@ PROD_CONTEXT = {
 }
 
 DEV_SHARED_CONTRACT_PARAMETERS = {
-    DEV_SHARED_VPC_ID_PARAMETER,
-    DEV_SHARED_AVAILABILITY_ZONES_PARAMETER,
-    DEV_SHARED_PUBLIC_SUBNET_IDS_PARAMETER,
-    DEV_SHARED_CLUSTER_NAME_PARAMETER,
-    DEV_SHARED_NAMESPACE_NAME_PARAMETER,
-    DEV_SHARED_NAMESPACE_ID_PARAMETER,
-    DEV_SHARED_NAMESPACE_ARN_PARAMETER,
-    DEV_SHARED_ARTIFACT_BUCKET_PARAMETER,
+    stage_parameter_name(DEV, path)
+    for path in (
+        SHARED_VPC_ID_PARAMETER_PATH,
+        SHARED_AVAILABILITY_ZONES_PARAMETER_PATH,
+        SHARED_PUBLIC_SUBNET_IDS_PARAMETER_PATH,
+        SHARED_CLUSTER_NAME_PARAMETER_PATH,
+        SHARED_NAMESPACE_NAME_PARAMETER_PATH,
+        SHARED_NAMESPACE_ID_PARAMETER_PATH,
+        SHARED_NAMESPACE_ARN_PARAMETER_PATH,
+        SHARED_ARTIFACT_BUCKET_PARAMETER_PATH,
+    )
 }
 DEV_TRACKER_CONTRACT_PARAMETERS = {
-    DEV_TRACKER_SECURITY_GROUP_PARAMETER,
-    DEV_TRACKER_ALB_DNS_PARAMETER,
+    stage_parameter_name(DEV, TRACKER_SECURITY_GROUP_PARAMETER_PATH),
+    stage_parameter_name(DEV, TRACKER_ALB_DNS_PARAMETER_PATH),
 }
 EXECUTOR_CONTRACT_PARAMETERS = {executor_release_launch_parameter(DEV)}
 DESCOPE_MANAGEMENT_KEY_SECRET_NAME = "example-descope-management-key"
@@ -228,7 +232,10 @@ class DevAccountInfrastructureTest(unittest.TestCase):
             tracker_template = dev_tracker_template()
 
         template = cast(Mapping[str, object], tracker_template.to_json())
-        hosted_zone_parameter = ssm_parameter_id(template, DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER)
+        hosted_zone_parameter = ssm_parameter_id(
+            template,
+            stage_parameter_name(DEV, TRACKER_HOSTED_ZONE_ID_PARAMETER_PATH),
+        )
         rendered = json.dumps(template)
         iam_policies = tracker_template.find_resources("AWS::IAM::Policy")
         delete_statements = [
@@ -380,7 +387,7 @@ class DevAccountInfrastructureTest(unittest.TestCase):
             "AWS_TRACKER_SECRET_NAME_PREFIXES": DEV_AUTH_ENV["AWS_TRACKER_SECRET_NAME_PREFIXES"],
         }
         with mock.patch.dict(os.environ, managed_runtime_environment, clear=True):
-            with self.assertRaisesRegex(ValueError, "Development deployments require DESCOPE_PROJECT_ID"):
+            with self.assertRaisesRegex(ValueError, "dev deployments require DESCOPE_PROJECT_ID"):
                 dev_tracker_template()
 
     def test_dev_stacks_publish_the_shared_resource_contract(self) -> None:
@@ -393,9 +400,9 @@ class DevAccountInfrastructureTest(unittest.TestCase):
         self.assertEqual(published_parameter_names(tracker_template), DEV_TRACKER_CONTRACT_PARAMETERS)
         self.assertEqual(published_parameter_names(executor_template), EXECUTOR_CONTRACT_PARAMETERS)
 
-    def test_prod_shared_stack_publishes_no_contract_parameters(self) -> None:
-        app = cdk.App(context=PROD_CONTEXT)
-        stage = Stage(PROD)
+    def test_bench_shared_stack_publishes_no_contract_parameters(self) -> None:
+        app = cdk.App(context=BENCH_CONTEXT)
+        stage = Stage(BENCH)
         shared = SharedStack(app, stage.stack_id("SharedStack"), stage=stage, env=TEST_ENV)
         template = assertions.Template.from_stack(shared)
         self.assertFalse(template.find_resources("AWS::SSM::Parameter"))

--- a/infra/tests/test_executor_release.py
+++ b/infra/tests/test_executor_release.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import os
 import subprocess
-import sys
 import tempfile
 import unittest
 from collections.abc import Mapping
@@ -108,7 +107,16 @@ class ExecutorReleaseTest(unittest.TestCase):
     def test_nested_cli_imports_in_workflow_environment(self) -> None:
         infra_directory = Path(__file__).parents[1]
         result = subprocess.run(
-            [sys.executable, "executor_release/main.py", "--help"],
+            [
+                "uv",
+                "run",
+                "--project",
+                "executor_release",
+                "--frozen",
+                "python",
+                "executor_release/main.py",
+                "--help",
+            ],
             cwd=infra_directory,
             env={**os.environ, "PYTHONPATH": "."},
             capture_output=True,

--- a/infra/tests/test_maintenance_classifier.py
+++ b/infra/tests/test_maintenance_classifier.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 import tempfile
@@ -9,6 +10,24 @@ from classify_executor_template_change import ExecutorHostTemplateEffect
 
 _MIGRATION_DIRECTORY = "services/tracker/src/tracker/database/migrations/versions"
 _NO_EXECUTOR_EFFECT = ExecutorHostTemplateEffect(redeploy_required=False, reasons=())
+
+
+def _executor_template(stack_id: str, *, image: str) -> dict[str, object]:
+    task_id = "ExecutorHostTaskDef"
+    return {
+        "Resources": {
+            task_id: {
+                "Type": "AWS::ECS::TaskDefinition",
+                "Properties": {"ContainerDefinitions": [{"Name": "ExecutorHost", "Image": image}]},
+                "Metadata": {"aws:cdk:path": f"{stack_id}/ExecutorHostTaskDef/Resource"},
+            },
+            "ExecutorHostService": {
+                "Type": "AWS::ECS::Service",
+                "Properties": {"TaskDefinition": {"Ref": task_id}},
+                "Metadata": {"aws:cdk:path": f"{stack_id}/ExecutorHostService/Service"},
+            },
+        }
+    }
 
 
 class MaintenanceClassifierTest(unittest.TestCase):
@@ -419,6 +438,70 @@ def upgrade() -> None:
             result.reasons,
             ["executor-core-change", "executor-host-task-definition-changed"],
         )
+
+    def test_combined_bench_and_prod_templates_preserve_either_redeploy_effect(self) -> None:
+        bench = ExecutorHostTemplateEffect(redeploy_required=False, reasons=())
+        prod = ExecutorHostTemplateEffect(
+            redeploy_required=True,
+            reasons=("executor-host-service-changed",),
+        )
+
+        result = classify_repository_change.combine_executor_effects(bench, prod)
+
+        self.assertTrue(result.redeploy_required)
+        self.assertEqual(result.reasons, ("executor-host-service-changed",))
+
+    def test_cli_classifies_prod_worker_change_and_rejects_partial_secondary_input(self) -> None:
+        templates = {
+            "bench-base.json": _executor_template("WorkerStack", image="image:base"),
+            "bench-head.json": _executor_template("WorkerStack", image="image:base"),
+            "prod-base.json": _executor_template("ValkProdWorkerStack", image="image:base"),
+            "prod-head.json": _executor_template("ValkProdWorkerStack", image="image:changed"),
+        }
+        for name, template in templates.items():
+            (self.repository / name).write_text(json.dumps(template), encoding="utf-8")
+
+        output = self.repository / "classification.json"
+        command = [
+            sys.executable,
+            str(Path(classify_repository_change.__file__)),
+            "--base-sha",
+            self.base_sha,
+            "--head-sha",
+            self.base_sha,
+            "--repository-root",
+            str(self.repository),
+            "--executor-base-template",
+            str(self.repository / "bench-base.json"),
+            "--executor-head-template",
+            str(self.repository / "bench-head.json"),
+            "--expected-stack-id",
+            "WorkerStack",
+            "--secondary-executor-base-template",
+            str(self.repository / "prod-base.json"),
+            "--secondary-executor-head-template",
+            str(self.repository / "prod-head.json"),
+            "--secondary-expected-stack-id",
+            "ValkProdWorkerStack",
+            "--output",
+            str(output),
+        ]
+
+        completed = subprocess.run(command, cwd=self.repository, check=False, capture_output=True, text=True)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(json.loads(output.read_text(encoding="utf-8"))["classification"], "maintenance-required")
+
+        partial = subprocess.run(
+            command[: command.index("--secondary-executor-head-template")] + command[-2:],
+            cwd=self.repository,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(partial.returncode, 2)
+        self.assertIn("requires both templates and the stack ID", output.read_text(encoding="utf-8"))
 
     def test_executor_source_change_requires_stack_without_assuming_maintenance(self) -> None:
         head_sha = self._commit_file("services/executor_host/supervisor.py", "changed = True\n")

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -399,19 +399,21 @@ class MonitoringStackTest(unittest.TestCase):
                 {"Port": "443", "Protocol": "HTTPS", "StatusCode": "HTTP_301"},
             )
 
-        for stage_name, publicly_accessible, storage_encrypted in (
-            (BENCH, True, False),
-            (PROD, False, True),
-            (DEV, False, False),
-            (RELEASE_TEST, False, False),
+        for stage_name, publicly_accessible in (
+            (BENCH, True),
+            (PROD, False),
+            (DEV, False),
+            (RELEASE_TEST, False),
         ):
-            tracker_templates[stage_name].has_resource_properties(
-                "AWS::RDS::DBInstance",
-                {
-                    "PubliclyAccessible": publicly_accessible,
-                    "StorageEncrypted": storage_encrypted,
-                },
-            )
+            databases = tracker_templates[stage_name].find_resources("AWS::RDS::DBInstance")
+            self.assertEqual(len(databases), 1)
+
+            properties = next(iter(databases.values()))["Properties"]
+            self.assertEqual(properties["PubliclyAccessible"], publicly_accessible)
+            if stage_name == PROD:
+                self.assertIs(properties["StorageEncrypted"], True)
+            else:
+                self.assertNotIn("StorageEncrypted", properties)
 
         for stage_name in (BENCH, PROD, DEV):
             self.assertEqual(

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -27,6 +27,7 @@ from constants import (
     SANDBOX_CLEANUP_SCHEDULE_NAME,
     SANDBOX_CLEANUP_SECRET_NAME,
     SLACK_WORKSPACE_ID_ENV,
+    TRACKER_DOMAIN,
     TRACKER_LOG_GROUP_NAME,
     VALKYRIE_ALERTS_SLACK_CHANNEL_ID_ENV,
     WORKER_LOG_GROUP_NAME,
@@ -35,7 +36,7 @@ from constants import (
 from monitoring_stack import MonitoringStack
 from shared import SharedStack
 from executor_stack import ExecutorStack
-from stage import DEV, DEV_STACK_PREFIX, PROD, RELEASE_TEST, Stage
+from stage import DEV, DEV_STACK_PREFIX, BENCH, PROD, RELEASE_TEST, Stage
 from stage_config import DEV_CONFIG, config_for
 from tracker_stack import TrackerStack
 
@@ -58,10 +59,16 @@ TEST_DEV_ENV = {
     "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
     "SENTRY_DSN_SECRET_NAME": TEST_SENTRY_DSN_SECRET_NAME,
 }
-TEST_PROD_ENV = {
+TEST_BENCH_ENV = {
     "AWS_DEPLOYMENT_ROLE_ORG_IDS": TEST_MANAGED_ORG_ID,
     "AWS_TRACKER_SECRET_NAME_PREFIXES": TEST_TRACKER_SECRET_NAME_PREFIX,
     "SENTRY_DSN_SECRET_NAME": TEST_SENTRY_DSN_SECRET_NAME,
+}
+TEST_PROD_ENV = {
+    **TEST_BENCH_ENV,
+    "BENCHMARK_CATALOG_URL": "https://catalog.example",
+    "DESCOPE_PROJECT_ID": "prod-descope-project",
+    "DESCOPE_MANAGEMENT_KEY_SECRET_NAME": TEST_DESCOPE_MANAGEMENT_KEY_SECRET_NAME,
 }
 TEST_RELEASE_TEST_ENV = {
     "DESCOPE_PROJECT_ID": "release-test",
@@ -98,7 +105,16 @@ def _has_logical_id_prefix(template: assertions.Template, resource_type: str, pr
     return any(logical_id.startswith(prefix) for logical_id in template.find_resources(resource_type))
 
 
-def _monitoring_template(stage_name: str = PROD) -> assertions.Template:
+def _stage_environment(stage_name: str) -> dict[str, str]:
+    if stage_name == DEV:
+        return TEST_DEV_ENV
+    if stage_name == PROD:
+        return TEST_PROD_ENV
+
+    return TEST_BENCH_ENV
+
+
+def _monitoring_template(stage_name: str = BENCH) -> assertions.Template:
     app = cdk.App()
     stage = Stage(stage_name)
     resources = cdk.Stack(
@@ -139,8 +155,7 @@ def _monitoring_template(stage_name: str = PROD) -> assertions.Template:
         engine="redis",
         num_cache_nodes=1,
     )
-    stage_environment = TEST_DEV_ENV if stage_name == DEV else TEST_PROD_ENV
-    with mock.patch.dict(os.environ, stage_environment, clear=False):
+    with mock.patch.dict(os.environ, _stage_environment(stage_name), clear=False):
         monitoring = MonitoringStack(
             app,
             "MonitoringStack",
@@ -157,7 +172,7 @@ def _monitoring_template(stage_name: str = PROD) -> assertions.Template:
     return assertions.Template.from_stack(monitoring)
 
 
-def _shared_template(stage_name: str = PROD) -> assertions.Template:
+def _shared_template(stage_name: str = BENCH) -> assertions.Template:
     app = cdk.App(context=SHARED_STACK_CONTEXT)
     stage = Stage(stage_name)
     shared = SharedStack(
@@ -237,7 +252,11 @@ def service_templates(
 
 class MonitoringStackTest(unittest.TestCase):
     def test_hosted_managed_runtime_requires_deployment_authority(self) -> None:
-        for stage_name, stage_environment in ((DEV, TEST_DEV_ENV), (PROD, TEST_PROD_ENV)):
+        for stage_name, stage_environment in (
+            (DEV, TEST_DEV_ENV),
+            (BENCH, TEST_BENCH_ENV),
+            (PROD, TEST_PROD_ENV),
+        ):
             for variable in (
                 "AWS_DEPLOYMENT_ROLE_ORG_IDS",
                 "AWS_TRACKER_SECRET_NAME_PREFIXES",
@@ -250,7 +269,7 @@ class MonitoringStackTest(unittest.TestCase):
                             config_for(Stage(stage_name))
 
     def test_offline_synth_uses_safe_managed_runtime_placeholders(self) -> None:
-        for stage_name in (DEV, PROD):
+        for stage_name in (DEV, BENCH, PROD):
             with self.subTest(stage=stage_name):
                 with mock.patch.dict(os.environ, {"DESCOPE_PROJECT_ID": "offline-synth"}, clear=True):
                     managed_aws = config_for(Stage(stage_name)).managed_aws
@@ -261,8 +280,91 @@ class MonitoringStackTest(unittest.TestCase):
                 self.assertTrue(managed_aws.executor_all_secret_access)
 
     def test_dev_stack_ids_are_valk_scoped(self) -> None:
-        self.assertEqual(Stage(PROD).stack_id("TrackerStack"), "TrackerStack")
+        self.assertEqual(Stage(BENCH).stack_id("TrackerStack"), "TrackerStack")
         self.assertEqual(Stage(DEV).stack_id("TrackerStack"), f"{DEV_STACK_PREFIX}TrackerStack")
+
+    def test_prod_names_never_collide_with_bench(self) -> None:
+        stage = Stage(PROD)
+        self.assertEqual(stage.stack_id("WorkerStack"), "ValkProdWorkerStack")
+        self.assertEqual(stage.phys("AgenticHarnessCluster"), "AgenticHarnessCluster-prod")
+        self.assertEqual(stage.domain(TRACKER_DOMAIN), "benchmark-tracker-prod.vals.ai")
+        self.assertTrue(stage.is_production)
+        self.assertFalse(stage.is_bench)
+
+    def test_prod_is_production_shaped_and_physically_isolated(self) -> None:
+        prod_environment_without_catalog = {
+            name: value for name, value in TEST_PROD_ENV.items() if name != "BENCHMARK_CATALOG_URL"
+        }
+        with mock.patch.dict(os.environ, prod_environment_without_catalog, clear=True):
+            tracker_template, executor_template, monitoring_template = service_templates(PROD)
+
+        tracker_template.has_resource_properties(
+            "AWS::Logs::LogGroup",
+            {"LogGroupName": f"{TRACKER_LOG_GROUP_NAME}-prod", "RetentionInDays": 365},
+        )
+        self.assertEqual(len(tracker_template.find_resources("AWS::CertificateManager::Certificate")), 1)
+        self.assertIn(
+            "benchmark-tracker-prod.vals.ai",
+            json.dumps(tracker_template.find_resources("AWS::Route53::RecordSet")),
+        )
+        tracker_environment = [
+            variable
+            for task_definition in tracker_template.find_resources("AWS::ECS::TaskDefinition").values()
+            for container in task_definition["Properties"]["ContainerDefinitions"]
+            for variable in container.get("Environment", [])
+        ]
+        self.assertIn({"Name": "AUTH_REQUIRED", "Value": "true"}, tracker_environment)
+        self.assertIn(
+            {"Name": "DESCOPE_PROJECT_ID", "Value": TEST_PROD_ENV["DESCOPE_PROJECT_ID"]},
+            tracker_environment,
+        )
+        self.assertIn(
+            {"Name": "BENCHMARK_CATALOG_URL", "Value": ""},
+            tracker_environment,
+        )
+        self.assertIn(
+            "/valkyrie/prod/dns/tracker/hosted-zone-id",
+            json.dumps(tracker_template.to_json()),
+        )
+
+        shared_parameter_names = {
+            resource["Properties"]["Name"]
+            for resource in _shared_template(PROD).find_resources("AWS::SSM::Parameter").values()
+        }
+        self.assertIn("/valkyrie/prod/shared/vpc-id", shared_parameter_names)
+
+        parameter_names = [
+            resource["Properties"]["Name"]
+            for resource in executor_template.find_resources("AWS::SSM::Parameter").values()
+        ]
+        self.assertIn("/valkyrie/prod/executor-release/launch-config", parameter_names)
+        self.assertTrue(all("/valkyrie/prod/" in name for name in parameter_names))
+        roles = executor_template.find_resources("AWS::IAM::Role")
+        release_role = next(
+            role for role in roles.values() if role["Properties"].get("RoleName") == "ValkyrieExecutorRelease-prod"
+        )
+        self.assertIn(
+            "repo:vals-ai/Valkyrie:environment:prod-external",
+            json.dumps(release_role["Properties"]["AssumeRolePolicyDocument"]),
+        )
+        executor_template.has_resource_properties(
+            "AWS::Logs::LogGroup",
+            {"LogGroupName": f"{WORKER_LOG_GROUP_NAME}-prod", "RetentionInDays": 365},
+        )
+        executor_template.resource_count_is("AWS::Scheduler::Schedule", 1)
+
+        for template in (tracker_template, executor_template, monitoring_template):
+            for resource_type, name_property in (
+                ("AWS::ECS::Service", "ServiceName"),
+                ("AWS::Logs::LogGroup", "LogGroupName"),
+                ("AWS::CloudWatch::Alarm", "AlarmName"),
+                ("AWS::SNS::Topic", "TopicName"),
+                ("AWS::IAM::Role", "RoleName"),
+            ):
+                for resource in template.find_resources(resource_type).values():
+                    name = resource["Properties"].get(name_property)
+                    if isinstance(name, str):
+                        self.assertTrue(name.endswith("-prod"), name)
 
     def test_release_test_names_are_namespaced(self) -> None:
         stage = Stage(RELEASE_TEST)
@@ -273,6 +375,7 @@ class MonitoringStackTest(unittest.TestCase):
     def test_tracker_transport_follows_stage_contract(self) -> None:
         tracker_templates: dict[str, assertions.Template] = {}
         for stage_name, environment in (
+            (BENCH, TEST_BENCH_ENV),
             (PROD, TEST_PROD_ENV),
             (DEV, TEST_DEV_ENV),
             (RELEASE_TEST, TEST_RELEASE_TEST_ENV),
@@ -280,7 +383,7 @@ class MonitoringStackTest(unittest.TestCase):
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
                 tracker_templates[stage_name] = service_templates(stage_name)[0]
 
-        for stage_name in (PROD, DEV):
+        for stage_name in (BENCH, PROD, DEV):
             listeners = {
                 (resource["Properties"]["Port"], resource["Properties"]["Protocol"]): resource
                 for resource in tracker_templates[stage_name]
@@ -296,7 +399,21 @@ class MonitoringStackTest(unittest.TestCase):
                 {"Port": "443", "Protocol": "HTTPS", "StatusCode": "HTTP_301"},
             )
 
-        for stage_name in (PROD, DEV):
+        for stage_name, publicly_accessible, storage_encrypted in (
+            (BENCH, True, False),
+            (PROD, False, True),
+            (DEV, False, False),
+            (RELEASE_TEST, False, False),
+        ):
+            tracker_templates[stage_name].has_resource_properties(
+                "AWS::RDS::DBInstance",
+                {
+                    "PubliclyAccessible": publicly_accessible,
+                    "StorageEncrypted": storage_encrypted,
+                },
+            )
+
+        for stage_name in (BENCH, PROD, DEV):
             self.assertEqual(
                 len(tracker_templates[stage_name].find_resources("AWS::CertificateManager::Certificate")),
                 1,
@@ -315,7 +432,7 @@ class MonitoringStackTest(unittest.TestCase):
 
     def test_redis_ingress_is_limited_to_tracker_and_executor_host(self) -> None:
         for stage_name, environment in (
-            (PROD, TEST_PROD_ENV),
+            (BENCH, TEST_BENCH_ENV),
             (DEV, TEST_DEV_ENV),
             (RELEASE_TEST, TEST_RELEASE_TEST_ENV),
         ):
@@ -435,10 +552,10 @@ class MonitoringStackTest(unittest.TestCase):
     def test_release_roles_are_bound_to_stage_environments(self) -> None:
         for stage, role_name, expected_subject in (
             (DEV, "ValkyrieExecutorRelease-dev", "repo:vals-ai/Valkyrie:environment:dev"),
-            (PROD, "ValkyrieExecutorRelease", "repo:vals-ai/Valkyrie:environment:prod"),
+            (BENCH, "ValkyrieExecutorRelease", "repo:vals-ai/Valkyrie:environment:prod"),
         ):
             with self.subTest(stage=stage):
-                env = TEST_DEV_ENV if stage == DEV else TEST_PROD_ENV
+                env = TEST_DEV_ENV if stage == DEV else TEST_BENCH_ENV
                 with mock.patch.dict(os.environ, env, clear=False):
                     _, executor_template, _ = service_templates(stage)
                 roles = executor_template.find_resources("AWS::IAM::Role")
@@ -448,8 +565,8 @@ class MonitoringStackTest(unittest.TestCase):
                 self.assertNotIn("production-release", trust)
                 self.assertNotIn("refs/heads/prod", trust)
 
-        with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=False):
-            synthesized = json.dumps(service_templates(PROD)[1].to_json())
+        with mock.patch.dict(os.environ, TEST_BENCH_ENV, clear=False):
+            synthesized = json.dumps(service_templates(BENCH)[1].to_json())
         self.assertIn("tracker.executor.release_entrypoint", synthesized)
         self.assertIn("ecs:UpdateTaskProtection", synthesized)
         self.assertIn("ecs:StopTask", synthesized)
@@ -498,8 +615,8 @@ class MonitoringStackTest(unittest.TestCase):
         )
 
     def test_executor_stack_owns_the_host_and_release_control(self) -> None:
-        with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=False):
-            _, executor_template, monitoring_template = service_templates(PROD)
+        with mock.patch.dict(os.environ, TEST_BENCH_ENV, clear=False):
+            _, executor_template, monitoring_template = service_templates(BENCH)
         services = executor_template.find_resources("AWS::ECS::Service")
         task_definitions = executor_template.find_resources("AWS::ECS::TaskDefinition")
         scalable_targets = executor_template.find_resources("AWS::ApplicationAutoScaling::ScalableTarget")
@@ -683,10 +800,11 @@ class MonitoringStackTest(unittest.TestCase):
 
     def test_service_environment_labels_follow_stage(self) -> None:
         for stage_name, expected_environment, expected_namespace in (
-            (PROD, "production", "local"),
+            (BENCH, "production", "local"),
+            (PROD, "production", "local-prod"),
             (DEV, "dev", "local-dev"),
         ):
-            environment = TEST_DEV_ENV if stage_name == DEV else TEST_PROD_ENV
+            environment = _stage_environment(stage_name)
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
                 tracker_template, executor_template, _ = service_templates(stage_name)
 
@@ -730,8 +848,8 @@ class MonitoringStackTest(unittest.TestCase):
         executor_template.resource_count_is("AWS::SQS::Queue", 0)
 
     def test_prod_sandbox_cleanup_is_disabled_and_bounded_by_default(self) -> None:
-        with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=True):
-            _, executor_template, _ = service_templates(PROD)
+        with mock.patch.dict(os.environ, TEST_BENCH_ENV, clear=True):
+            _, executor_template, _ = service_templates(BENCH)
 
         executor_template.resource_count_is("AWS::Scheduler::Schedule", 1)
         executor_template.resource_count_is("AWS::Lambda::Function", 1)
@@ -794,7 +912,7 @@ class MonitoringStackTest(unittest.TestCase):
                 mock.patch.dict(
                     os.environ,
                     {
-                        **TEST_PROD_ENV,
+                        **TEST_BENCH_ENV,
                         "SANDBOX_CLEANUP_ENABLED": enabled,
                         "SANDBOX_CLEANUP_PROVIDER": "daytona",
                         "SANDBOX_CLEANUP_SECRET_NAME": "custom/cleanup-credentials",
@@ -802,7 +920,7 @@ class MonitoringStackTest(unittest.TestCase):
                     clear=True,
                 ),
             ):
-                _, executor_template, _ = service_templates(PROD)
+                _, executor_template, _ = service_templates(BENCH)
 
             executor_template.has_resource_properties(
                 "AWS::Scheduler::Schedule",
@@ -824,7 +942,7 @@ class MonitoringStackTest(unittest.TestCase):
             )
 
     def test_deployed_stages_require_sentry_secret(self) -> None:
-        for stage, environment in ((DEV, TEST_DEV_ENV), (PROD, TEST_PROD_ENV)):
+        for stage, environment in ((DEV, TEST_DEV_ENV), (BENCH, TEST_BENCH_ENV)):
             environment_without_sentry = {
                 key: value for key, value in environment.items() if key != "SENTRY_DSN_SECRET_NAME"
             }

--- a/infra/tests/test_runtime_iam.py
+++ b/infra/tests/test_runtime_iam.py
@@ -9,14 +9,14 @@ import aws_cdk as cdk
 from aws_cdk import assertions, aws_s3
 
 from runtime_iam import create_executor_task_role, create_tracker_task_role
-from stage import DEV, PROD, RELEASE_TEST, Stage
-from stage_config import DEV_CONFIG, PROD_CONFIG, ManagedAWSRuntimeConfig
+from stage import BENCH, DEV, RELEASE_TEST, Stage
+from stage_config import BENCH_CONFIG, DEV_CONFIG, ManagedAWSRuntimeConfig
 from test_monitoring_stack import (
     TEST_AWS_ACCOUNT,
     TEST_AWS_REGION,
+    TEST_BENCH_ENV,
     TEST_DEV_ENV,
     TEST_MANAGED_ORG_ID,
-    TEST_PROD_ENV,
     TEST_RELEASE_TEST_ENV,
     TEST_TRACKER_SECRET_NAME_PREFIX,
     JsonObject,
@@ -289,9 +289,9 @@ class RuntimeIamTest(unittest.TestCase):
                     )
                     self.assertEqual(lambda_statement["Resource"], _lambda_function_resource("analysis-*"))
 
-    def test_prod_managed_runtime_uses_prod_inventory_and_task_roles(self) -> None:
-        with mock.patch.dict(os.environ, TEST_PROD_ENV, clear=True):
-            tracker_template, executor_template, _ = service_templates(PROD)
+    def test_bench_managed_runtime_uses_bench_inventory_and_task_roles(self) -> None:
+        with mock.patch.dict(os.environ, TEST_BENCH_ENV, clear=True):
+            tracker_template, executor_template, _ = service_templates(BENCH)
 
         expected_environment = assertions.Match.array_with(
             [
@@ -339,7 +339,7 @@ class RuntimeIamTest(unittest.TestCase):
                         lambda_statements[0]["Resource"],
                         [
                             _lambda_function_resource(pattern)
-                            for pattern in PROD_CONFIG.managed_aws.executor_lambda_function_name_patterns
+                            for pattern in BENCH_CONFIG.managed_aws.executor_lambda_function_name_patterns
                         ],
                     )
                 else:

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -31,24 +31,24 @@ from constants import (
     CONTAINER_HEALTH_RETRIES,
     CONTAINER_HEALTH_START_PERIOD_SECONDS,
     CONTAINER_HEALTH_TIMEOUT_SECONDS,
-    DEV_TRACKER_ALB_DNS_PARAMETER,
-    DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER,
-    DEV_TRACKER_SECURITY_GROUP_PARAMETER,
     DOCKER_ASSET_EXCLUDES,
     POSTGRES_DB,
     POSTGRES_PORT,
     POSTGRES_USER,
     REDIS_PORT,
     TRACKER_DOMAIN,
+    TRACKER_ALB_DNS_PARAMETER_PATH,
+    TRACKER_HOSTED_ZONE_ID_PARAMETER_PATH,
     TRACKER_LOG_GROUP_NAME,
     TRACKER_PORT,
     TRACKER_SCALING_CPU_PERCENT,
+    TRACKER_SECURITY_GROUP_PARAMETER_PATH,
     VPC_CIDR,
     stage_parameter_name,
 )
 from constructs import Construct
 from runtime_iam import create_tracker_task_role, managed_runtime_environment
-from stage import Stage
+from stage import PROD, Stage
 from stage_config import benchmark_service_base_url, config_for
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
@@ -142,7 +142,8 @@ class TrackerStack(Stack):
             credentials=aws_rds.Credentials.from_secret(db_credentials_secret),
             database_name=POSTGRES_DB,
             allocated_storage=stage_config.database.allocated_storage_gb,
-            publicly_accessible=stage.is_prod,
+            publicly_accessible=stage.is_bench,
+            storage_encrypted=stage.name == PROD,
             deletion_protection=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             backup_retention=Duration.days(stage_config.database.backup_retention_days),
@@ -173,11 +174,12 @@ class TrackerStack(Stack):
             sentry_secrets["SENTRY_DSN"] = aws_ecs.Secret.from_secrets_manager(sentry_secret)
 
         auth_required = os.environ.get("AUTH_REQUIRED", "false")
+        benchmark_catalog_url = os.environ.get("BENCHMARK_CATALOG_URL", "")
         descope_project_id = os.environ.get("DESCOPE_PROJECT_ID", "")
-        if not stage.is_prod:
+        if not stage.is_bench:
             auth_required = "true"
             if not descope_project_id:
-                raise ValueError("Development deployments require DESCOPE_PROJECT_ID.")
+                raise ValueError(f"{stage.name} deployments require DESCOPE_PROJECT_ID.")
 
         descope_secrets: dict[str, aws_ecs.Secret] = {}
         if auth_required.lower() == "true":
@@ -226,7 +228,7 @@ class TrackerStack(Stack):
                 **db_env,
                 "REDIS_URL": redis_url,
                 "AUTH_REQUIRED": auth_required,
-                "BENCHMARK_CATALOG_URL": os.environ.get("BENCHMARK_CATALOG_URL", ""),
+                "BENCHMARK_CATALOG_URL": benchmark_catalog_url,
                 "DESCOPE_PROJECT_ID": descope_project_id,
                 "SENTRY_RELEASE": os.environ.get("SENTRY_RELEASE", ""),
             },
@@ -247,19 +249,19 @@ class TrackerStack(Stack):
 
         tracker_domain: str | None = None
         tracker_hosted_zone: aws_route53.IHostedZone | None = None
-        if stage.is_prod:
+        if stage.is_bench:
             if hosted_zone is None:
-                raise ValueError("Production requires the vals.ai hosted zone")
-            tracker_domain = TRACKER_DOMAIN
+                raise ValueError("Bench requires the vals.ai hosted zone")
+            tracker_domain = stage.domain(TRACKER_DOMAIN)
             tracker_hosted_zone = hosted_zone
         elif not stage.is_release_test:
             tracker_domain = stage.domain(TRACKER_DOMAIN)
             tracker_hosted_zone = aws_route53.HostedZone.from_hosted_zone_attributes(
                 self,
-                "DevTrackerHostedZone",
+                "TrackerHostedZone",
                 hosted_zone_id=aws_ssm.StringParameter.value_for_string_parameter(
                     self,
-                    DEV_TRACKER_HOSTED_ZONE_ID_PARAMETER,
+                    stage_parameter_name(stage.name, TRACKER_HOSTED_ZONE_ID_PARAMETER_PATH),
                 ),
                 zone_name=tracker_domain,
             )
@@ -289,9 +291,7 @@ class TrackerStack(Stack):
         # Expose the inner FargateService for cross-stack security group rules.
         self.tracker_fargate_service = self.service.service
 
-        # Cloud Map registration for internal access.
-        # Intentionally unstaged: dev gets its own namespace, and benchmark
-        # services reach the tracker by the same internal name in either env.
+        # The stage-specific namespace isolates the stable tracker service name.
         self.service.service.enable_cloud_map(
             name="tracker",
             cloud_map_namespace=namespace,
@@ -360,16 +360,16 @@ class TrackerStack(Stack):
             description="Allow VPC services to connect to RDS",
         )
 
-        if not stage.is_prod:
+        if not stage.is_bench:
             aws_ssm.StringParameter(
                 self,
                 "TrackerSecurityGroupParameter",
-                parameter_name=stage_parameter_name(DEV_TRACKER_SECURITY_GROUP_PARAMETER, stage.name),
+                parameter_name=stage_parameter_name(stage.name, TRACKER_SECURITY_GROUP_PARAMETER_PATH),
                 string_value=tracker_security_group.security_group_id,
             )
             aws_ssm.StringParameter(
                 self,
                 "TrackerAlbDnsParameter",
-                parameter_name=stage_parameter_name(DEV_TRACKER_ALB_DNS_PARAMETER, stage.name),
+                parameter_name=stage_parameter_name(stage.name, TRACKER_ALB_DNS_PARAMETER_PATH),
                 string_value=self.service.load_balancer.load_balancer_dns_name,
             )

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -143,7 +143,7 @@ class TrackerStack(Stack):
             database_name=POSTGRES_DB,
             allocated_storage=stage_config.database.allocated_storage_gb,
             publicly_accessible=stage.is_bench,
-            storage_encrypted=stage.name == PROD,
+            storage_encrypted=True if stage.name == PROD else None,
             deletion_protection=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             backup_retention=Duration.days(stage_config.database.backup_retention_days),

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.32.0" }
 tracker = { path = "../tracker" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.34.0" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.32.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
+version = "0.34.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0#567c3766ebcca38c49a53939c7357c1bda496982" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.32.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.34.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/logging/config.py
+++ b/services/tracker/src/tracker/logging/config.py
@@ -52,6 +52,7 @@ _DEVELOPMENT_FORMATTER = {
 
 _FORMATTERS = {
     "production": _JSON_FORMATTER,
+    "prod": _JSON_FORMATTER,
     "dev": _JSON_FORMATTER,
     "development": _DEVELOPMENT_FORMATTER,
     "release-test": _DEVELOPMENT_FORMATTER,

--- a/services/tracker/tests/integration/live/storage/test_upload_artifacts_images.py
+++ b/services/tracker/tests/integration/live/storage/test_upload_artifacts_images.py
@@ -19,7 +19,7 @@ from tracker.types import HarnessConfig
 # Images covering the major package families
 _IMAGES = [
     ("python:3.11-slim", "python-slim-apt"),
-    ("python:3.11-alpine", "python-alpine-apk"),
+    ("python:3.11-alpine3.20", "python-alpine-apk"),
     ("debian:bookworm-slim", "debian-apt"),
     ("ubuntu:24.04", "ubuntu-apt"),
     ("fedora:40", "fedora-dnf"),

--- a/services/tracker/tests/unit/logging/test_logging.py
+++ b/services/tracker/tests/unit/logging/test_logging.py
@@ -184,6 +184,7 @@ class TestConfigureLogging:
             ("development", "tracker.test_dev", "hello dev", False, False),
             ("release-test", "tracker.test_release_test", "hello release-test", False, False),
             ("production", "tracker.test_prod", "hello prod", True, True),
+            ("prod", "tracker.test_public_prod", "hello public prod", True, True),
             ("dev", "tracker.test_deployed_dev", "hello deployed dev", True, False),
         ],
     )

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.32.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
+version = "0.34.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0#567c3766ebcca38c49a53939c7357c1bda496982" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/src/valkyrie/cli/config/settings.py
+++ b/src/valkyrie/cli/config/settings.py
@@ -4,7 +4,12 @@ from typing import Any
 import click
 
 from valkyrie.cli.exceptions import TrackerServiceError
-from valkyrie.cli.runtime_config import config_location
+from valkyrie.cli.runtime_config import (
+    ENVIRONMENT_CONFIG_KEY,
+    TRACKER_SERVICE_URL_ENV_VAR,
+    config_location,
+    tracker_url_for_environment,
+)
 from valkyrie.cli.tracker_client import TrackerService
 from valkyrie.cli.config.state import ConfigValue, load_config, read_config_if_exists, write_config
 
@@ -68,13 +73,20 @@ def init() -> None:
     environment_variables = _REQUIRED_ENVIRONMENT_VARIABLES
 
     if mode == "hosted":
+        environment = click.prompt(
+            "Hosted environment",
+            type=click.Choice(["bench", "prod"]),
+            default="bench",
+        )
+        current_config[ENVIRONMENT_CONFIG_KEY] = environment
+        tracker_url = os.environ.get(TRACKER_SERVICE_URL_ENV_VAR) or tracker_url_for_environment(environment)
         api_key = (os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key")).strip()
         _rotate_matching_benchmark_auth(current_config, api_key)
         current_config["api_key"] = api_key
 
         try:
-            result = TrackerService.init_org(api_key)
-            runtime = TrackerService.aws_runtime_metadata(api_key)
+            result = TrackerService.init_org(api_key, tracker_url)
+            runtime = TrackerService.aws_runtime_metadata(api_key, tracker_url)
         except TrackerServiceError as e:
             raise click.ClickException(str(e)) from e
         click.echo(f"Organization '{result['org_name']}' configured successfully.\n")
@@ -138,6 +150,7 @@ def init() -> None:
 
     if mode != "hosted":
         current_config.pop("api_key", None)
+        current_config.pop(ENVIRONMENT_CONFIG_KEY, None)
 
     write_config(current_config)
 

--- a/src/valkyrie/cli/run/resume.py
+++ b/src/valkyrie/cli/run/resume.py
@@ -55,6 +55,15 @@ from valkyrie.cli.tracker_client import TrackerService
     help="Secret as ENV_VAR aws_secret_name (e.g., -s ANTHROPIC_API_KEY YourAnthropicKeySecret)",
 )
 @click.option(
+    "--header",
+    "-H",
+    "headers",
+    multiple=True,
+    nargs=2,
+    type=(str, str),
+    help="Custom header for benchmark service requests (e.g., -H Authorization my-credential)",
+)
+@click.option(
     "--update-agent",
     "-u",
     is_flag=True,
@@ -88,6 +97,7 @@ def resume(
     task_ids: str | None,
     task_ids_file: str | None,
     secrets: tuple[tuple[str, str]],
+    headers: tuple[tuple[str, str], ...],
     update_agent: bool,
     from_scratch: bool,
     benchmark_url: str | None,
@@ -108,7 +118,7 @@ def resume(
     try:
         with TrackerService() as tracker:
             benchmark_info = tracker.fetch_benchmark(run_id)
-            service_headers = benchmark_service_headers(benchmark_info.benchmark_name)
+            service_headers = benchmark_service_headers(benchmark_info.benchmark_name, headers)
 
             if update_agent:
                 metadata = tracker.fetch_benchmark_metadata(run_id)

--- a/src/valkyrie/cli/runtime_config.py
+++ b/src/valkyrie/cli/runtime_config.py
@@ -3,35 +3,68 @@
 import os
 from pathlib import Path
 
-PROD_ENVIRONMENT = "prod"
+import yaml
+
+BENCH_ENVIRONMENT = "bench"
+PRODUCTION_ENVIRONMENT = "prod"
 DEV_ENVIRONMENT = "dev"
 
 VALKYRIE_ENV_ENV_VAR = "VALKYRIE_ENV"
 TRACKER_SERVICE_URL_ENV_VAR = "TRACKER_SERVICE_URL"
 VALKYRIE_CONFIG_PATH_ENV_VAR = "VALKYRIE_CONFIG_PATH"
+ENVIRONMENT_CONFIG_KEY = "environment"
 
-PROD_TRACKER_URL = "https://benchmark-tracker.vals.ai"
+BENCH_TRACKER_URL = "https://benchmark-tracker.vals.ai"
+PRODUCTION_TRACKER_URL = "https://benchmark-tracker-prod.vals.ai"
 DEV_TRACKER_URL = "https://benchmark-tracker-dev.vals.ai"
 
-PROD_CONFIG_PATH = Path("~/.config/valkyrie/valkyrie.yaml")
+HOSTED_CONFIG_PATH = Path("~/.config/valkyrie/valkyrie.yaml")
 DEV_CONFIG_PATH = Path("~/.config/valkyrie/dev.yaml")
 
 _TRACKER_URLS = {
-    PROD_ENVIRONMENT: PROD_TRACKER_URL,
+    BENCH_ENVIRONMENT: BENCH_TRACKER_URL,
+    PRODUCTION_ENVIRONMENT: PRODUCTION_TRACKER_URL,
     DEV_ENVIRONMENT: DEV_TRACKER_URL,
 }
-_CONFIG_PATHS = {
-    PROD_ENVIRONMENT: PROD_CONFIG_PATH,
-    DEV_ENVIRONMENT: DEV_CONFIG_PATH,
+_ENVIRONMENT_OVERRIDES = {
+    "bench": BENCH_ENVIRONMENT,
+    "dev": DEV_ENVIRONMENT,
+    # "prod" shipped as the selector for the Tracker now named bench.
+    "prod": BENCH_ENVIRONMENT,
+    "external": PRODUCTION_ENVIRONMENT,
 }
+
+
+def tracker_url_for_environment(environment: str) -> str:
+    """Return the Tracker URL for a validated runtime environment."""
+    return _TRACKER_URLS[environment]
+
+
+def _environment_from_override(selector: str) -> str:
+    selector = selector.lower()
+    try:
+        return _ENVIRONMENT_OVERRIDES[selector]
+    except KeyError:
+        valid_selectors = ", ".join(sorted(_ENVIRONMENT_OVERRIDES))
+        raise ValueError(f"Unknown {VALKYRIE_ENV_ENV_VAR}={selector!r}. Must be one of: {valid_selectors}") from None
 
 
 def selected_environment() -> str:
     """Return the configured Valkyrie CLI environment."""
-    environment = os.environ.get(VALKYRIE_ENV_ENV_VAR, PROD_ENVIRONMENT).lower()
+    environment_override = os.environ.get(VALKYRIE_ENV_ENV_VAR)
+    if environment_override is None:
+        selection_path = config_location()
+        if selection_path.exists():
+            payload = yaml.safe_load(selection_path.read_text(encoding="utf-8")) or {}
+            environment = payload.get(ENVIRONMENT_CONFIG_KEY, BENCH_ENVIRONMENT)
+        else:
+            environment = BENCH_ENVIRONMENT
+    else:
+        environment = _environment_from_override(environment_override)
+    environment = environment.lower()
     if environment not in _TRACKER_URLS:
         valid_environments = ", ".join(sorted(_TRACKER_URLS))
-        raise ValueError(f"Unknown {VALKYRIE_ENV_ENV_VAR}={environment!r}. Must be one of: {valid_environments}")
+        raise ValueError(f"Config key {ENVIRONMENT_CONFIG_KEY!r} must be one of: {valid_environments}")
 
     return environment
 
@@ -49,4 +82,7 @@ def config_location() -> Path:
     if path := os.environ.get(VALKYRIE_CONFIG_PATH_ENV_VAR):
         return Path(path).expanduser()
 
-    return _CONFIG_PATHS[selected_environment()].expanduser()
+    environment_override = os.environ.get(VALKYRIE_ENV_ENV_VAR)
+    if environment_override is not None and _environment_from_override(environment_override) == DEV_ENVIRONMENT:
+        return DEV_CONFIG_PATH.expanduser()
+    return HOSTED_CONFIG_PATH.expanduser()

--- a/tests/unit/cli/config/test_settings.py
+++ b/tests/unit/cli/config/test_settings.py
@@ -48,10 +48,29 @@ def test_init_self_hosted_strips_whitespace(config_path: Path, monkeypatch: pyte
     }
 
 
-def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize(
+    ("selection", "environment", "tracker_url", "tracker_url_override"),
+    [
+        ("bench", "bench", "https://benchmark-tracker.vals.ai", None),
+        ("prod", "prod", "https://benchmark-tracker-prod.vals.ai", None),
+        ("prod", "prod", "https://tracker.example.test", "https://tracker.example.test"),
+    ],
+)
+def test_init_hosted_strips_api_key(
+    config_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    selection: str,
+    environment: str,
+    tracker_url: str,
+    tracker_url_override: str | None,
+) -> None:
     for key in settings._REQUIRED_ENVIRONMENT_VARIABLES:
         monkeypatch.delenv(key, raising=False)
     monkeypatch.delenv("VALKYRIE_API_KEY", raising=False)
+    if tracker_url_override is None:
+        monkeypatch.delenv(settings.TRACKER_SERVICE_URL_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(settings.TRACKER_SERVICE_URL_ENV_VAR, tracker_url_override)
     config_path.write_text(
         yaml.safe_dump(
             {
@@ -65,19 +84,20 @@ def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.Monke
         )
     )
 
-    init_org_calls: list[str] = []
+    init_org_calls: list[tuple[str, str]] = []
+    runtime_metadata_calls: list[tuple[str, str]] = []
 
-    def mock_init_org(api_key: str) -> dict[str, object]:
-        init_org_calls.append(api_key)
+    def mock_init_org(api_key: str, base_url: str) -> dict[str, object]:
+        init_org_calls.append((api_key, base_url))
 
         return {"org_name": "test-org"}
 
+    def mock_aws_runtime_metadata(api_key: str, base_url: str) -> SimpleNamespace:
+        runtime_metadata_calls.append((api_key, base_url))
+        return SimpleNamespace(mode="access_key", region=None, s3_bucket=None)
+
     monkeypatch.setattr(settings.TrackerService, "init_org", mock_init_org)
-    monkeypatch.setattr(
-        settings.TrackerService,
-        "aws_runtime_metadata",
-        lambda _api_key: SimpleNamespace(mode="access_key", region=None, s3_bucket=None),
-    )
+    monkeypatch.setattr(settings.TrackerService, "aws_runtime_metadata", mock_aws_runtime_metadata)
 
     runner = CliRunner()
     result = runner.invoke(
@@ -85,6 +105,7 @@ def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.Monke
         input="\n".join(
             [
                 "hosted",
+                selection,
                 "  secret-key  ",
                 "aws-key",
                 "aws-secret",
@@ -98,9 +119,11 @@ def test_init_hosted_strips_api_key(config_path: Path, monkeypatch: pytest.Monke
     )
 
     assert result.exit_code == 0, result.output
-    assert init_org_calls == ["secret-key"]
+    assert init_org_calls == [("secret-key", tracker_url)]
+    assert runtime_metadata_calls == [("secret-key", tracker_url)]
     config = yaml.safe_load(config_path.read_text())
     assert config["api_key"] == "secret-key"
+    assert config["environment"] == environment
     assert config["benchmark_auth"] == {
         "raw-key-service": "secret-key",
         "bearer-service": "Bearer secret-key",
@@ -125,15 +148,15 @@ def test_init_hosted_managed_aws_omits_static_keys(config_path: Path, monkeypatc
     monkeypatch.setattr(
         settings.TrackerService,
         "init_org",
-        lambda _api_key: {"org_name": "test-org"},
+        lambda _api_key, _base_url: {"org_name": "test-org"},
     )
     monkeypatch.setattr(
         settings.TrackerService,
         "aws_runtime_metadata",
-        lambda _api_key: SimpleNamespace(mode="managed", region="us-east-1", s3_bucket="managed-bucket"),
+        lambda _api_key, _base_url: SimpleNamespace(mode="managed", region="us-east-1", s3_bucket="managed-bucket"),
     )
 
-    result = CliRunner().invoke(settings.init, input="hosted\nvals-key\n\n\n")
+    result = CliRunner().invoke(settings.init, input="hosted\nbench\nvals-key\n\n\n")
 
     assert result.exit_code == 0, result.output
     config = yaml.safe_load(config_path.read_text())
@@ -153,15 +176,15 @@ def test_init_hosted_names_incomplete_managed_aws_config(monkeypatch: pytest.Mon
     monkeypatch.setattr(
         settings.TrackerService,
         "init_org",
-        lambda _api_key: {"org_name": "test-org"},
+        lambda _api_key, _base_url: {"org_name": "test-org"},
     )
     monkeypatch.setattr(
         settings.TrackerService,
         "aws_runtime_metadata",
-        lambda _api_key: SimpleNamespace(mode="managed", region=None, s3_bucket="managed-bucket"),
+        lambda _api_key, _base_url: SimpleNamespace(mode="managed", region=None, s3_bucket="managed-bucket"),
     )
 
-    result = CliRunner().invoke(settings.init, input="hosted\nvals-key\n")
+    result = CliRunner().invoke(settings.init, input="hosted\nbench\nvals-key\n")
 
     assert result.exit_code == 1
     assert "Managed AWS configuration is missing its Region or S3 bucket" in result.output
@@ -173,15 +196,15 @@ def test_init_hosted_names_runtime_discovery_failure(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(
         settings.TrackerService,
         "init_org",
-        lambda _api_key: {"org_name": "test-org"},
+        lambda _api_key, _base_url: {"org_name": "test-org"},
     )
 
-    def fail_runtime_discovery(_api_key: str) -> None:
+    def fail_runtime_discovery(_api_key: str, _base_url: str) -> None:
         raise settings.TrackerServiceError("Failed to resolve AWS runtime: service unavailable")
 
     monkeypatch.setattr(settings.TrackerService, "aws_runtime_metadata", fail_runtime_discovery)
 
-    result = CliRunner().invoke(settings.init, input="hosted\nvals-key\n")
+    result = CliRunner().invoke(settings.init, input="hosted\nbench\nvals-key\n")
 
     assert result.exit_code == 1
     assert "Error: Failed to resolve AWS runtime: service unavailable" in result.output

--- a/tests/unit/cli/run/test_resume.py
+++ b/tests/unit/cli/run/test_resume.py
@@ -1,0 +1,82 @@
+"""Tests for resuming and retrying runs.
+
+Run: uv run pytest tests/unit/cli/run/test_resume.py
+
+Covers benchmark service header forwarding for custom services.
+"""
+
+from importlib import import_module
+from uuid import UUID
+
+import pytest
+from click.testing import CliRunner
+from tracker.database.models import RetryMode
+from tracker.types import FetchBenchmarkResponse, RetryOrResumeBenchmarkResponse
+
+from tests.unit.cli.factories import make_fetch_response
+
+resume_module = import_module("valkyrie.cli.run.resume")
+service_headers_module = import_module("valkyrie.cli.service_headers")
+
+
+class MockTrackerService:
+    """Record retry/resume requests made by the CLI command."""
+
+    calls: list[dict[str, object]] = []
+
+    def __enter__(self) -> "MockTrackerService":
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        return None
+
+    def fetch_benchmark(self, benchmark_id: UUID) -> FetchBenchmarkResponse:
+        return make_fetch_response(benchmark_id)
+
+    def retry_or_resume_benchmark(
+        self,
+        benchmark_id: UUID,
+        retry: bool,
+        retry_mode: RetryMode,
+        concurrency: int | None,
+        task_ids: list[str],
+        service_headers: dict[str, str] | None = None,
+        secrets: dict[str, str] | None = None,
+        benchmark_url: str | None = None,
+    ) -> RetryOrResumeBenchmarkResponse:
+        self.calls.append({"benchmark_id": benchmark_id, "service_headers": service_headers})
+        return RetryOrResumeBenchmarkResponse(status="success")
+
+
+@pytest.fixture(autouse=True)
+def reset_calls() -> None:
+    """Reset recorded requests so each test is isolated."""
+    MockTrackerService.calls = []
+
+
+def test_resume_forwards_custom_headers(
+    cli_runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Send `-H` headers to the tracker so custom benchmark services authenticate."""
+    run_id = UUID("123e4567-e89b-12d3-a456-426614174000")
+    monkeypatch.setattr(resume_module, "TrackerService", MockTrackerService)
+
+    def no_configured_auth(_benchmark_name: str) -> str | None:
+        return None
+
+    monkeypatch.setattr(
+        service_headers_module.TrackerService,
+        "get_benchmark_auth",
+        staticmethod(no_configured_auth),
+    )
+
+    result = cli_runner.invoke(
+        resume_module.resume,
+        [str(run_id), "-H", "x-descope-api-key", "secret-value"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert MockTrackerService.calls == [
+        {"benchmark_id": run_id, "service_headers": {"x-descope-api-key": "secret-value"}}
+    ]

--- a/tests/unit/cli/test_runtime_config.py
+++ b/tests/unit/cli/test_runtime_config.py
@@ -7,12 +7,13 @@ from pathlib import Path
 
 import pytest
 
+from valkyrie.cli import runtime_config
 from valkyrie.cli.runtime_config import (
+    BENCH_ENVIRONMENT,
+    BENCH_TRACKER_URL,
     DEV_CONFIG_PATH,
     DEV_TRACKER_URL,
-    PROD_CONFIG_PATH,
-    PROD_ENVIRONMENT,
-    PROD_TRACKER_URL,
+    PRODUCTION_TRACKER_URL,
     VALKYRIE_CONFIG_PATH_ENV_VAR,
     VALKYRIE_ENV_ENV_VAR,
     TRACKER_SERVICE_URL_ENV_VAR,
@@ -23,16 +24,34 @@ from valkyrie.cli.runtime_config import (
 
 
 @pytest.fixture(autouse=True)
-def clear_runtime_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def clear_runtime_config_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv(VALKYRIE_ENV_ENV_VAR, raising=False)
     monkeypatch.delenv(TRACKER_SERVICE_URL_ENV_VAR, raising=False)
     monkeypatch.delenv(VALKYRIE_CONFIG_PATH_ENV_VAR, raising=False)
+    monkeypatch.setattr(runtime_config, "HOSTED_CONFIG_PATH", tmp_path / "valkyrie.yaml")
 
 
-def test_default_environment_keeps_existing_prod_config() -> None:
-    assert selected_environment() == PROD_ENVIRONMENT
-    assert tracker_service_url() == PROD_TRACKER_URL
-    assert config_location() == PROD_CONFIG_PATH.expanduser()
+def test_default_environment_keeps_existing_bench_config() -> None:
+    assert selected_environment() == BENCH_ENVIRONMENT
+    assert tracker_service_url() == BENCH_TRACKER_URL
+    assert config_location() == runtime_config.HOSTED_CONFIG_PATH
+
+
+@pytest.mark.parametrize(
+    ("environment", "tracker_url"),
+    [
+        ("prod", BENCH_TRACKER_URL),
+        ("external", PRODUCTION_TRACKER_URL),
+    ],
+)
+def test_explicit_environment_preserves_public_selector_compatibility(
+    monkeypatch: pytest.MonkeyPatch,
+    environment: str,
+    tracker_url: str,
+) -> None:
+    monkeypatch.setenv(VALKYRIE_ENV_ENV_VAR, environment)
+
+    assert tracker_service_url() == tracker_url
 
 
 def test_dev_environment_uses_dev_tracker_and_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -40,6 +59,20 @@ def test_dev_environment_uses_dev_tracker_and_config(monkeypatch: pytest.MonkeyP
 
     assert tracker_service_url() == DEV_TRACKER_URL
     assert config_location() == DEV_CONFIG_PATH.expanduser()
+
+
+def test_prod_environment_uses_persisted_tracker_selection() -> None:
+    runtime_config.HOSTED_CONFIG_PATH.write_text("environment: prod\n", encoding="utf-8")
+
+    assert tracker_service_url() == PRODUCTION_TRACKER_URL
+    assert config_location() == runtime_config.HOSTED_CONFIG_PATH
+
+
+def test_unknown_persisted_environment_is_rejected() -> None:
+    runtime_config.HOSTED_CONFIG_PATH.write_text("environment: staging\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Config key 'environment' must be one of: bench, dev, prod"):
+        selected_environment()
 
 
 def test_explicit_tracker_url_overrides_selected_environment(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -63,5 +96,8 @@ def test_explicit_config_path_overrides_selected_environment(
 def test_unknown_environment_is_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv(VALKYRIE_ENV_ENV_VAR, "staging")
 
-    with pytest.raises(ValueError, match="Unknown VALKYRIE_ENV='staging'"):
+    with pytest.raises(
+        ValueError,
+        match="Unknown VALKYRIE_ENV='staging'. Must be one of: bench, dev, external, prod",
+    ):
         selected_environment()

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.32.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
+version = "0.34.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0#567c3766ebcca38c49a53939c7357c1bda496982" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
External production environment (plus post-merge check and executor release fixes), CLI forwards -H headers on run resume/retry

## Commits
- fix: keep cdk out of executor release (#751) (17508fa6) by Braden Wicker
- fix: repair post-merge production checks (#750) (c2d44fbd) by Braden Wicker
- feat: add external production environment (#733) (4dc22028) by Braden Wicker
- feat(cli): forward -H headers on run resume/retry (#744) (302d92ec) by Langston Nashold

Link to Devin session: https://app.devin.ai/sessions/cc33fb81f0194bc9b771d8dcc8163457
Open in Devin Desktop: https://app.devin.ai/desktop/session/cc33fb81f0194bc9b771d8dcc8163457?variant=devin
Requested by: @BradenBug