### PR TITLE
fix: withhold provider keys from gateway-backed sandboxes #patch

### DIFF
--- a/services/tracker/src/tracker/runtime/secrets.py
+++ b/services/tracker/src/tracker/runtime/secrets.py
@@ -57,28 +57,17 @@ DIRECT_PROVIDER_CREDENTIAL_ENV_NAMES = frozenset(
     }
 )
 
-_MODEL_GATEWAY_CLIENT_ENV_NAMES = frozenset(
-    {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"}
-)
+_MODEL_GATEWAY_CLIENT_ENV_NAMES = frozenset({"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"})
 
 
-def gateway_routing_enabled(
-    secret_names: Collection[str], kwargs: Mapping[str, str]
-) -> bool:
+def gateway_routing_enabled(secret_names: Collection[str], kwargs: Mapping[str, str]) -> bool:
     """Return whether a run has selected a complete Model Gateway route."""
-    return (
-        kwargs.get("no_model_gateway") != "True"
-        and _MODEL_GATEWAY_CLIENT_ENV_NAMES <= set(secret_names)
-    )
+    return kwargs.get("no_model_gateway") != "True" and _MODEL_GATEWAY_CLIENT_ENV_NAMES <= set(secret_names)
 
 
 def without_direct_provider_credentials(values: Mapping[str, T]) -> dict[str, T]:
     """Copy an environment-like mapping without direct model credentials."""
-    return {
-        name: value
-        for name, value in values.items()
-        if name not in DIRECT_PROVIDER_CREDENTIAL_ENV_NAMES
-    }
+    return {name: value for name, value in values.items() if name not in DIRECT_PROVIDER_CREDENTIAL_ENV_NAMES}
 
 
 class SecretStore(Protocol):

--- a/services/tracker/src/tracker/runtime/secrets.py
+++ b/services/tracker/src/tracker/runtime/secrets.py
@@ -1,6 +1,7 @@
 """Provider-neutral secret reads and reference resolution."""
 
-from typing import Protocol, TypeAlias
+from collections.abc import Collection, Mapping
+from typing import Protocol, TypeAlias, TypeVar
 
 from tracker.exceptions import SecretsError
 
@@ -8,6 +9,76 @@ from tracker.exceptions import SecretsError
 JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
 SecretValue: TypeAlias = JsonValue
+T = TypeVar("T")
+
+
+# Credentials that let a sandbox bypass Model Gateway and call a model provider
+# directly. This is deliberately an allowlist so credentials for model-adjacent
+# tools such as Tavily are not removed.
+DIRECT_PROVIDER_CREDENTIAL_ENV_NAMES = frozenset(
+    {
+        "AI21LABS_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_API_KEY_2",
+        "ANT_API_KEY",
+        "ARCEE_API_KEY",
+        "AZURE_API_KEY",
+        "BASETEN_API_KEY",
+        "COHERE_API_KEY",
+        "DASHSCOPE_API_KEY",
+        "DASHSCOPE_CN_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "DEEPSEEK_KEY",
+        "FIREWORKS_API_KEY",
+        "GCP_CREDS",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "KIMI_API_KEY",
+        "KIMI_PUBLIC_API_KEY",
+        "MERCURY_API_KEY",
+        "MERCURY_KEY",
+        "META_API_KEY",
+        "MINIMAX_API_KEY",
+        "MISTRAL_API_KEY",
+        "NVIDIA_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "PERPLEXITY_API_KEY",
+        "PERPLEXITY_KEY",
+        "POOLSIDE_API_KEY",
+        "THOMSONREUTERS_API_KEY",
+        "TINKER_API_KEY",
+        "TOGETHER_API_KEY",
+        "VERCEL_API_KEY",
+        "XAI_API_KEY",
+        "XIAOMI_API_KEY",
+        "ZAI_API_KEY",
+    }
+)
+
+_MODEL_GATEWAY_CLIENT_ENV_NAMES = frozenset(
+    {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"}
+)
+
+
+def gateway_routing_enabled(
+    secret_names: Collection[str], kwargs: Mapping[str, str]
+) -> bool:
+    """Return whether a run has selected a complete Model Gateway route."""
+    return (
+        kwargs.get("no_model_gateway") != "True"
+        and _MODEL_GATEWAY_CLIENT_ENV_NAMES <= set(secret_names)
+    )
+
+
+def without_direct_provider_credentials(values: Mapping[str, T]) -> dict[str, T]:
+    """Copy an environment-like mapping without direct model credentials."""
+    return {
+        name: value
+        for name, value in values.items()
+        if name not in DIRECT_PROVIDER_CREDENTIAL_ENV_NAMES
+    }
 
 
 class SecretStore(Protocol):

--- a/services/tracker/src/tracker/runtime/secrets.py
+++ b/services/tracker/src/tracker/runtime/secrets.py
@@ -22,6 +22,9 @@ DIRECT_PROVIDER_CREDENTIAL_ENV_NAMES = frozenset(
         "ANTHROPIC_API_KEY_2",
         "ANT_API_KEY",
         "ARCEE_API_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
         "AZURE_API_KEY",
         "BASETEN_API_KEY",
         "COHERE_API_KEY",
@@ -63,6 +66,11 @@ _MODEL_GATEWAY_CLIENT_ENV_NAMES = frozenset({"MODEL_GATEWAY_URL", "MODEL_GATEWAY
 def gateway_routing_enabled(secret_names: Collection[str], kwargs: Mapping[str, str]) -> bool:
     """Return whether a run has selected a complete Model Gateway route."""
     return kwargs.get("no_model_gateway") != "True" and _MODEL_GATEWAY_CLIENT_ENV_NAMES <= set(secret_names)
+
+
+def direct_provider_routing_forced(kwargs: Mapping[str, str]) -> bool:
+    """Return whether the contract explicitly requires direct-provider routing."""
+    return kwargs.get("no_model_gateway") == "True"
 
 
 def without_direct_provider_credentials(values: Mapping[str, T]) -> dict[str, T]:

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -21,7 +21,11 @@ from tracker.aws.cloudwatch_logs import CloudWatchBenchmarkLogSink
 from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import SecretsManagerStore
-from tracker.runtime.secrets import resolve_secrets
+from tracker.runtime.secrets import (
+    gateway_routing_enabled,
+    resolve_secrets,
+    without_direct_provider_credentials,
+)
 from tracker.config import AUTH_REQUIRED, broker
 from tracker.database.models import (
     Benchmark,
@@ -410,7 +414,13 @@ def _preflight_managed_aws(
         secret_store,
         request.sandbox_provider,
     )
-    resolve_secrets(request.contract.secrets, secret_store)
+    contract = request.contract
+    secret_refs = (
+        without_direct_provider_credentials(contract.secrets)
+        if gateway_routing_enabled(contract.secrets.keys(), contract.kwargs)
+        else contract.secrets
+    )
+    resolve_secrets(secret_refs, secret_store)
     if request.webhook_secret_name and request.webhook_intervals:
         secret_store.get(request.webhook_secret_name)
     if request.lambda_function:

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -22,7 +22,7 @@ from tracker.aws.resolver import deployment_aws_runtime
 from tracker.aws.runtime import AWSRuntime
 from tracker.aws.secrets import SecretsManagerStore
 from tracker.runtime.secrets import (
-    gateway_routing_enabled,
+    direct_provider_routing_forced,
     resolve_secrets,
     without_direct_provider_credentials,
 )
@@ -415,10 +415,13 @@ def _preflight_managed_aws(
         request.sandbox_provider,
     )
     contract = request.contract
+    # Benchmark-owned task secrets and recovery state can complete the gateway
+    # route later. Defer provider-reference validation until task execution
+    # unless the contract explicitly requires direct-provider routing.
     secret_refs = (
-        without_direct_provider_credentials(contract.secrets)
-        if gateway_routing_enabled(contract.secrets.keys(), contract.kwargs)
-        else contract.secrets
+        contract.secrets
+        if direct_provider_routing_forced(contract.kwargs)
+        else without_direct_provider_credentials(contract.secrets)
     )
     resolve_secrets(secret_refs, secret_store)
     if request.webhook_secret_name and request.webhook_intervals:

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -940,16 +940,10 @@ async def _process_task_attempt(
 
         contract = start_benchmark_request.contract
         gateway_backed = gateway_routing_enabled(
-            contract.secrets.keys()
-            | task_data.sandbox_secrets.keys()
-            | recovery_attempt.environment.keys(),
+            contract.secrets.keys() | task_data.sandbox_secrets.keys() | recovery_attempt.environment.keys(),
             contract.kwargs,
         )
-        secret_refs = (
-            without_direct_provider_credentials(contract.secrets)
-            if gateway_backed
-            else contract.secrets
-        )
+        secret_refs = without_direct_provider_credentials(contract.secrets) if gateway_backed else contract.secrets
         env_vars = {
             **resolve_secrets(secret_refs, SecretsManagerStore(aws_runtime.clients)),
             "RUN_ID": str(benchmark_id),

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -34,7 +34,11 @@ from tracker.aws.s3 import S3ObjectStore
 from tracker.runtime.artifacts import task_artifact_key
 from tracker.runtime.logs import BenchmarkLogSink
 from tracker.aws.secrets import SecretsManagerStore
-from tracker.runtime.secrets import resolve_secrets
+from tracker.runtime.secrets import (
+    gateway_routing_enabled,
+    resolve_secrets,
+    without_direct_provider_credentials,
+)
 from tracker.config import ENVIRONMENT
 from tracker.database.models import (
     AgentCausedExitReason,
@@ -934,11 +938,23 @@ async def _process_task_attempt(
         if benchmark_started_by_email:
             identity["email"] = benchmark_started_by_email
 
+        contract = start_benchmark_request.contract
+        gateway_backed = gateway_routing_enabled(
+            contract.secrets.keys()
+            | task_data.sandbox_secrets.keys()
+            | recovery_attempt.environment.keys(),
+            contract.kwargs,
+        )
+        secret_refs = (
+            without_direct_provider_credentials(contract.secrets)
+            if gateway_backed
+            else contract.secrets
+        )
         env_vars = {
-            **resolve_secrets(start_benchmark_request.contract.secrets, SecretsManagerStore(aws_runtime.clients)),
+            **resolve_secrets(secret_refs, SecretsManagerStore(aws_runtime.clients)),
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
-            **_attested_inference_settings(start_benchmark_request.contract),
+            **_attested_inference_settings(contract),
             "IDENTITY": json.dumps(identity),
             # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics
             # are filterable per benchmark run and separable from other environments sharing the
@@ -948,6 +964,13 @@ async def _process_task_attempt(
             ),
             **recovery_attempt.environment,
         }
+        sandbox_secrets = task_data.sandbox_secrets
+        if gateway_backed:
+            # Filter both sources after assembly as well, so provider-confirmed
+            # recovery state and benchmark-owned native secret references cannot
+            # reintroduce a direct-provider credential into a gateway run.
+            env_vars = without_direct_provider_credentials(env_vars)
+            sandbox_secrets = without_direct_provider_credentials(sandbox_secrets)
 
         # We don't want to track the task until the sandbox is actually created.
         task_breakdown = TaskBreakdown()
@@ -960,7 +983,7 @@ async def _process_task_attempt(
             source=task_data.source,
             labels=labels,
             env_vars=env_vars,
-            sandbox_secrets=task_data.sandbox_secrets,
+            sandbox_secrets=sandbox_secrets,
             resources=task_data.resources,
             volumes=task_data.volumes,
             creation_semaphore=creation_semaphore,

--- a/services/tracker/tests/unit/runtime/test_secrets.py
+++ b/services/tracker/tests/unit/runtime/test_secrets.py
@@ -7,6 +7,7 @@ import pytest
 from tracker.exceptions import SecretsError
 from tracker.runtime.secrets import (
     SecretValue,
+    direct_provider_routing_forced,
     gateway_routing_enabled,
     resolve_secrets,
     without_direct_provider_credentials,
@@ -76,12 +77,27 @@ def test_gateway_routing_enabled(secret_names: set[str], kwargs: dict[str, str],
     assert gateway_routing_enabled(secret_names, kwargs) is expected
 
 
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        ({}, False),
+        ({"no_model_gateway": "False"}, False),
+        ({"no_model_gateway": "True"}, True),
+    ],
+)
+def test_direct_provider_routing_forced(kwargs: dict[str, str], expected: bool) -> None:
+    assert direct_provider_routing_forced(kwargs) is expected
+
+
 def test_without_direct_provider_credentials_preserves_gateway_and_tool_keys() -> None:
     assert without_direct_provider_credentials(
         {
             "MODEL_GATEWAY_API_KEY": "gateway",
             "OPENAI_API_KEY": "provider",
             "GCP_CREDS": "provider-json",
+            "AWS_ACCESS_KEY_ID": "bedrock-provider",
+            "AWS_SECRET_ACCESS_KEY": "bedrock-provider",
+            "AWS_SESSION_TOKEN": "bedrock-provider",
             "TAVILY_API_KEY": "tool",
         }
     ) == {

--- a/services/tracker/tests/unit/runtime/test_secrets.py
+++ b/services/tracker/tests/unit/runtime/test_secrets.py
@@ -72,9 +72,7 @@ def test_resolve_secrets_stringifies_non_object_values(value: SecretValue) -> No
         ({"MODEL_GATEWAY_URL"}, {}, False),
     ],
 )
-def test_gateway_routing_enabled(
-    secret_names: set[str], kwargs: dict[str, str], expected: bool
-) -> None:
+def test_gateway_routing_enabled(secret_names: set[str], kwargs: dict[str, str], expected: bool) -> None:
     assert gateway_routing_enabled(secret_names, kwargs) is expected
 
 

--- a/services/tracker/tests/unit/runtime/test_secrets.py
+++ b/services/tracker/tests/unit/runtime/test_secrets.py
@@ -5,7 +5,12 @@ from collections.abc import Mapping
 import pytest
 
 from tracker.exceptions import SecretsError
-from tracker.runtime.secrets import SecretValue, resolve_secrets
+from tracker.runtime.secrets import (
+    SecretValue,
+    gateway_routing_enabled,
+    resolve_secrets,
+    without_direct_provider_credentials,
+)
 
 
 class RecordingSecretStore:
@@ -48,3 +53,40 @@ def test_resolve_secrets_stringifies_non_object_values(value: SecretValue) -> No
     store = RecordingSecretStore({"shared": value})
 
     assert resolve_secrets({"TOKEN": "shared"}, store)["TOKEN"] == str(value)
+
+
+@pytest.mark.parametrize(
+    ("secret_names", "kwargs", "expected"),
+    [
+        ({"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"}, {}, True),
+        (
+            {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"},
+            {"no_model_gateway": "False"},
+            True,
+        ),
+        (
+            {"MODEL_GATEWAY_URL", "MODEL_GATEWAY_API_KEY"},
+            {"no_model_gateway": "True"},
+            False,
+        ),
+        ({"MODEL_GATEWAY_URL"}, {}, False),
+    ],
+)
+def test_gateway_routing_enabled(
+    secret_names: set[str], kwargs: dict[str, str], expected: bool
+) -> None:
+    assert gateway_routing_enabled(secret_names, kwargs) is expected
+
+
+def test_without_direct_provider_credentials_preserves_gateway_and_tool_keys() -> None:
+    assert without_direct_provider_credentials(
+        {
+            "MODEL_GATEWAY_API_KEY": "gateway",
+            "OPENAI_API_KEY": "provider",
+            "GCP_CREDS": "provider-json",
+            "TAVILY_API_KEY": "tool",
+        }
+    ) == {
+        "MODEL_GATEWAY_API_KEY": "gateway",
+        "TAVILY_API_KEY": "tool",
+    }

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -480,6 +480,86 @@ def test_managed_execution_preflight_does_not_resolve_gateway_bypass_keys(
     ]
 
 
+def test_managed_execution_preflight_defers_provider_refs_until_task_route_is_known(
+    contract: AgentContractRequest,
+    aws_runtime: AWSRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = contract.model_copy(
+        update={
+            "secrets": {
+                "MODEL_GATEWAY_URL": "gateway-config",
+                "OPENAI_API_KEY": "unavailable-provider-bundle",
+                "TAVILY_API_KEY": "tool-secret",
+            },
+        }
+    )
+    request = _managed_request(contract)
+    execution = _parse_queued_execution(None, None, None, _execution_context(request, uuid4()))
+    provider_config = cast(SandboxProviderConfig, MagicMock())
+    resolved_inputs: list[dict[str, str]] = []
+
+    monkeypatch.setattr(
+        CloudWatchBenchmarkLogSink,
+        "create_benchmark",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
+        lambda *_args, **_kwargs: provider_config,
+    )
+
+    def capture_secret_refs(secrets: dict[str, str], *_args: Any, **_kwargs: Any) -> dict[str, str]:
+        resolved_inputs.append(secrets)
+        return {}
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", capture_secret_refs)
+
+    assert _preflight_managed_aws(execution, aws_runtime) is provider_config
+    assert resolved_inputs == [
+        {
+            "MODEL_GATEWAY_URL": "gateway-config",
+            "TAVILY_API_KEY": "tool-secret",
+        }
+    ]
+
+
+def test_managed_execution_preflight_resolves_provider_refs_for_explicit_direct_route(
+    contract: AgentContractRequest,
+    aws_runtime: AWSRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = contract.model_copy(
+        update={
+            "kwargs": {"no_model_gateway": "True"},
+            "secrets": {"OPENAI_API_KEY": "provider-bundle"},
+        }
+    )
+    request = _managed_request(contract)
+    execution = _parse_queued_execution(None, None, None, _execution_context(request, uuid4()))
+    provider_config = cast(SandboxProviderConfig, MagicMock())
+    resolved_inputs: list[dict[str, str]] = []
+
+    monkeypatch.setattr(
+        CloudWatchBenchmarkLogSink,
+        "create_benchmark",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
+        lambda *_args, **_kwargs: provider_config,
+    )
+
+    def capture_secret_refs(secrets: dict[str, str], *_args: Any, **_kwargs: Any) -> dict[str, str]:
+        resolved_inputs.append(secrets)
+        return {}
+
+    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", capture_secret_refs)
+
+    assert _preflight_managed_aws(execution, aws_runtime) is provider_config
+    assert resolved_inputs == [{"OPENAI_API_KEY": "provider-bundle"}]
+
+
 async def test_managed_preflight_failure_happens_before_sandbox(
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -450,9 +450,7 @@ def test_managed_execution_preflight_does_not_resolve_gateway_bypass_keys(
         }
     )
     request = _managed_request(contract)
-    execution = _parse_queued_execution(
-        None, None, None, _execution_context(request, uuid4())
-    )
+    execution = _parse_queued_execution(None, None, None, _execution_context(request, uuid4()))
     provider_config = cast(SandboxProviderConfig, MagicMock())
     resolved_inputs: list[dict[str, str]] = []
 
@@ -466,15 +464,11 @@ def test_managed_execution_preflight_does_not_resolve_gateway_bypass_keys(
         lambda *_args, **_kwargs: provider_config,
     )
 
-    def capture_secret_refs(
-        secrets: dict[str, str], *_args: Any, **_kwargs: Any
-    ) -> dict[str, str]:
+    def capture_secret_refs(secrets: dict[str, str], *_args: Any, **_kwargs: Any) -> dict[str, str]:
         resolved_inputs.append(secrets)
         return {}
 
-    monkeypatch.setattr(
-        "tracker.utils.run_orchestration.resolve_secrets", capture_secret_refs
-    )
+    monkeypatch.setattr("tracker.utils.run_orchestration.resolve_secrets", capture_secret_refs)
 
     assert _preflight_managed_aws(execution, aws_runtime) is provider_config
     assert resolved_inputs == [

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -433,6 +433,59 @@ def test_managed_execution_preflight_checks_aws_dependencies_in_order(
     assert calls == ["logs", "sandbox_provider_secret", "agent_secrets", "webhook_secret", "lambda"]
 
 
+def test_managed_execution_preflight_does_not_resolve_gateway_bypass_keys(
+    contract: AgentContractRequest,
+    aws_runtime: AWSRuntime,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contract = contract.model_copy(
+        update={
+            "kwargs": {"no_model_gateway": "False"},
+            "secrets": {
+                "MODEL_GATEWAY_URL": "gateway-config",
+                "MODEL_GATEWAY_API_KEY": "gateway-config",
+                "OPENAI_API_KEY": "provider-bundle",
+                "TAVILY_API_KEY": "tool-secret",
+            },
+        }
+    )
+    request = _managed_request(contract)
+    execution = _parse_queued_execution(
+        None, None, None, _execution_context(request, uuid4())
+    )
+    provider_config = cast(SandboxProviderConfig, MagicMock())
+    resolved_inputs: list[dict[str, str]] = []
+
+    monkeypatch.setattr(
+        CloudWatchBenchmarkLogSink,
+        "create_benchmark",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "tracker.utils.run_orchestration.fetch_sandbox_provider_config",
+        lambda *_args, **_kwargs: provider_config,
+    )
+
+    def capture_secret_refs(
+        secrets: dict[str, str], *_args: Any, **_kwargs: Any
+    ) -> dict[str, str]:
+        resolved_inputs.append(secrets)
+        return {}
+
+    monkeypatch.setattr(
+        "tracker.utils.run_orchestration.resolve_secrets", capture_secret_refs
+    )
+
+    assert _preflight_managed_aws(execution, aws_runtime) is provider_config
+    assert resolved_inputs == [
+        {
+            "MODEL_GATEWAY_URL": "gateway-config",
+            "MODEL_GATEWAY_API_KEY": "gateway-config",
+            "TAVILY_API_KEY": "tool-secret",
+        }
+    ]
+
+
 async def test_managed_preflight_failure_happens_before_sandbox(
     contract: AgentContractRequest,
     aws_runtime: AWSRuntime,

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -249,6 +249,127 @@ class TestProcessTaskEnvironment:
         assert "TAVILY_API_KEY" not in captured["env_vars"]
 
     @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_gateway_run_does_not_resolve_or_inject_direct_provider_credentials(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        contract = contract.model_copy(
+            update={
+                "kwargs": {"no_model_gateway": "False"},
+                "secrets": {
+                    "MODEL_GATEWAY_URL": "gateway-config",
+                    "MODEL_GATEWAY_API_KEY": "gateway-config",
+                    "OPENAI_API_KEY": "provider-bundle",
+                    "TAVILY_API_KEY": "tool-secret",
+                },
+            }
+        )
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        captured: dict[str, dict[str, str]] = {}
+        resolved_inputs: list[dict[str, str]] = []
+
+        def _mock_resolve_secrets(
+            secrets: dict[str, str], *_args: Any, **_kwargs: Any
+        ) -> dict[str, str]:
+            resolved_inputs.append(secrets)
+            return {name: f"resolved-{name}" for name in secrets}
+
+        @asynccontextmanager
+        async def _capture_sandbox(
+            *_args: Any, **kwargs: Any
+        ) -> AsyncGenerator[SimpleNamespace, None]:
+            captured["env_vars"] = kwargs["env_vars"]
+            captured["sandbox_secrets"] = kwargs["sandbox_secrets"]
+            yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> Any:
+            response = make_retrieve_task_response()
+            response.sandbox_secrets = {
+                "ANTHROPIC_API_KEY": "native-provider-secret",
+                "BENCHMARK_TOOL_API_KEY": "native-tool-secret",
+            }
+            return response
+
+        monkeypatch.setattr(utils_module, "resolve_secrets", _mock_resolve_secrets)
+        monkeypatch.setattr(utils_module, "create_sandbox", _capture_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await run_process_task(
+            start_benchmark_request, task_row, benchmark_id, aws_runtime, authority
+        )
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert resolved_inputs == [
+            {
+                "MODEL_GATEWAY_URL": "gateway-config",
+                "MODEL_GATEWAY_API_KEY": "gateway-config",
+                "TAVILY_API_KEY": "tool-secret",
+            }
+        ]
+        assert "OPENAI_API_KEY" not in captured["env_vars"]
+        assert captured["env_vars"]["TAVILY_API_KEY"] == "resolved-TAVILY_API_KEY"
+        assert captured["sandbox_secrets"] == {
+            "BENCHMARK_TOOL_API_KEY": "native-tool-secret"
+        }
+
+    @pytest.mark.usefixtures("process_benchmark_env")
+    async def test_direct_provider_escape_hatch_preserves_provider_credentials(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        contract = contract.model_copy(
+            update={
+                "kwargs": {"no_model_gateway": "True"},
+                "secrets": {
+                    "MODEL_GATEWAY_URL": "gateway-config",
+                    "MODEL_GATEWAY_API_KEY": "gateway-config",
+                    "OPENAI_API_KEY": "provider-bundle",
+                },
+            }
+        )
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        captured_env_vars: list[dict[str, str]] = []
+
+        def _resolve_direct_secrets(
+            secrets: dict[str, str], *_args: Any, **_kwargs: Any
+        ) -> dict[str, str]:
+            return {name: f"resolved-{name}" for name in secrets}
+
+        monkeypatch.setattr(
+            utils_module,
+            "resolve_secrets",
+            _resolve_direct_secrets,
+        )
+        monkeypatch.setattr(
+            utils_module,
+            "create_sandbox",
+            partial(_capture_sandbox_environment, captured_env_vars),
+        )
+
+        result = await run_process_task(
+            start_benchmark_request, task_row, benchmark_id, aws_runtime, authority
+        )
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert captured_env_vars[0]["OPENAI_API_KEY"] == "resolved-OPENAI_API_KEY"
+
+    @pytest.mark.usefixtures("process_benchmark_env")
     async def test_stopped_task_output_is_fenced_while_sibling_keeps_dispatch_active(
         self,
         contract: AgentContractRequest,

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -276,16 +276,12 @@ class TestProcessTaskEnvironment:
         captured: dict[str, dict[str, str]] = {}
         resolved_inputs: list[dict[str, str]] = []
 
-        def _mock_resolve_secrets(
-            secrets: dict[str, str], *_args: Any, **_kwargs: Any
-        ) -> dict[str, str]:
+        def _mock_resolve_secrets(secrets: dict[str, str], *_args: Any, **_kwargs: Any) -> dict[str, str]:
             resolved_inputs.append(secrets)
             return {name: f"resolved-{name}" for name in secrets}
 
         @asynccontextmanager
-        async def _capture_sandbox(
-            *_args: Any, **kwargs: Any
-        ) -> AsyncGenerator[SimpleNamespace, None]:
+        async def _capture_sandbox(*_args: Any, **kwargs: Any) -> AsyncGenerator[SimpleNamespace, None]:
             captured["env_vars"] = kwargs["env_vars"]
             captured["sandbox_secrets"] = kwargs["sandbox_secrets"]
             yield SimpleNamespace(id="mock-sandbox-id", name="mock-sandbox-name")
@@ -302,9 +298,7 @@ class TestProcessTaskEnvironment:
         monkeypatch.setattr(utils_module, "create_sandbox", _capture_sandbox)
         monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
 
-        result = await run_process_task(
-            start_benchmark_request, task_row, benchmark_id, aws_runtime, authority
-        )
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 
         assert result == {"task_0": {"status": "success", "score": 1.0}}
         assert resolved_inputs == [
@@ -316,9 +310,7 @@ class TestProcessTaskEnvironment:
         ]
         assert "OPENAI_API_KEY" not in captured["env_vars"]
         assert captured["env_vars"]["TAVILY_API_KEY"] == "resolved-TAVILY_API_KEY"
-        assert captured["sandbox_secrets"] == {
-            "BENCHMARK_TOOL_API_KEY": "native-tool-secret"
-        }
+        assert captured["sandbox_secrets"] == {"BENCHMARK_TOOL_API_KEY": "native-tool-secret"}
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_direct_provider_escape_hatch_preserves_provider_credentials(
@@ -346,9 +338,7 @@ class TestProcessTaskEnvironment:
         )
         captured_env_vars: list[dict[str, str]] = []
 
-        def _resolve_direct_secrets(
-            secrets: dict[str, str], *_args: Any, **_kwargs: Any
-        ) -> dict[str, str]:
+        def _resolve_direct_secrets(secrets: dict[str, str], *_args: Any, **_kwargs: Any) -> dict[str, str]:
             return {name: f"resolved-{name}" for name in secrets}
 
         monkeypatch.setattr(
@@ -362,9 +352,7 @@ class TestProcessTaskEnvironment:
             partial(_capture_sandbox_environment, captured_env_vars),
         )
 
-        result = await run_process_task(
-            start_benchmark_request, task_row, benchmark_id, aws_runtime, authority
-        )
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 
         assert result == {"task_0": {"status": "success", "score": 1.0}}
         assert captured_env_vars[0]["OPENAI_API_KEY"] == "resolved-OPENAI_API_KEY"


### PR DESCRIPTION
## Context

25 of 32 current gateway-capable agent contracts also carry direct provider credentials for the no_model_gateway escape hatch. On normal gateway runs those credentials are unnecessary and expose an accounting and service-perimeter bypass to shell-capable agents.

## Changes

- Identify a gateway route only when both gateway credentials are present and no_model_gateway is not True.
- Remove direct provider references, including the Bedrock AWS credential triplet, before managed preflight and secret resolution.
- Defer provider-secret preflight while task-owned secrets may complete the gateway route; explicit direct-provider runs remain preflighted.
- Withhold keys from plaintext environment variables, recovery environment variables, and provider-native sandbox secrets.
- Keep tool credentials and preserve the explicit direct-provider escape hatch.

## Testing

- VALS_SERVER_ENV=LOCAL IN_GITHUB_ACTION=true uv run pytest services/tracker/tests/unit -q — 703 passed
- make format-check
- Ruff passed for tracker source and unit tests.
- Basedpyright passed for the changed tracker source files.

Companion model-proxy PR: https://github.com/vals-ai/model-proxy/pull/1131