### PR TITLE
fix: repair post-merge production checks

### DIFF
--- a/.github/scripts/synthesize-worker-templates.sh
+++ b/.github/scripts/synthesize-worker-templates.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# PR classification runs this helper from a trusted default-branch revision while
+# PR classification runs this helper from a trusted branch revision while
 # synthesizing source revisions with synthetic account IDs and no AWS access.
 revision="${1:?revision is required}"
 target_branch="${2:?target branch is required}"

--- a/.github/scripts/synthesize-worker-templates.sh
+++ b/.github/scripts/synthesize-worker-templates.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# PR classification runs this helper from the trusted base revision while
-# synthesizing candidate source with synthetic account IDs and no AWS access.
+# PR classification runs this helper from a trusted default-branch revision while
+# synthesizing source revisions with synthetic account IDs and no AWS access.
 revision="${1:?revision is required}"
 target_branch="${2:?target branch is required}"
 label="${3:?label is required}"

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -17,8 +17,27 @@ env:
   TARGET_BRANCH: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
 
 jobs:
-  synthesize-base:
+  resolve-synthesis-helper:
     runs-on: ubuntu-24.04-arm
+    outputs:
+      sha: ${{ steps.revision.outputs.sha }}
+    steps:
+      - name: Checkout trusted synthesis helper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Record trusted synthesis helper revision
+        id: revision
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  synthesize-base:
+    needs: resolve-synthesis-helper
+    runs-on: ubuntu-24.04-arm
+    env:
+      SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}
     outputs:
       artifact_id: ${{ steps.upload-base.outputs.artifact-id }}
       run_attempt: ${{ steps.identity.outputs.run_attempt }}
@@ -34,6 +53,14 @@ jobs:
           path: trusted
           persist-credentials: false
           ref: ${{ env.BASE_SHA }}
+
+      - name: Checkout trusted synthesis helper
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          path: workflow
+          persist-credentials: false
+          ref: ${{ env.SYNTHESIS_HELPER_SHA }}
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -56,10 +83,11 @@ jobs:
         run: |
           set -euo pipefail
           test "$(git -C trusted rev-parse HEAD)" = "$SOURCE_SHA"
+          test "$(git -C workflow rev-parse HEAD)" = "$SYNTHESIS_HELPER_SHA"
           target_branch="${TARGET_BRANCH#refs/heads/}"
           npm install -g aws-cdk@2.1132.0
           artifact="$RUNNER_TEMP/worker-template-base"
-          bash trusted/.github/scripts/synthesize-worker-templates.sh \
+          bash workflow/.github/scripts/synthesize-worker-templates.sh \
             "$SOURCE_SHA" "$target_branch" base "$artifact" trusted
           mapfile -t stack_ids < "$artifact/stack-ids.txt"
           rm "$artifact/stack-ids.txt"
@@ -93,7 +121,10 @@ jobs:
           retention-days: 1
 
   synthesize-head:
+    needs: resolve-synthesis-helper
     runs-on: ubuntu-24.04-arm
+    env:
+      SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}
     outputs:
       artifact_id: ${{ steps.upload-head.outputs.artifact-id }}
       run_attempt: ${{ steps.identity.outputs.run_attempt }}
@@ -106,9 +137,9 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
-          path: trusted
+          path: workflow
           persist-credentials: false
-          ref: ${{ env.BASE_SHA }}
+          ref: ${{ env.SYNTHESIS_HELPER_SHA }}
 
       - name: Checkout exact candidate revision
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -138,12 +169,12 @@ jobs:
           SOURCE_SHA: ${{ env.HEAD_SHA }}
         run: |
           set -euo pipefail
-          test "$(git -C trusted rev-parse HEAD)" = "$BASE_SHA"
+          test "$(git -C workflow rev-parse HEAD)" = "$SYNTHESIS_HELPER_SHA"
           test "$(git -C candidate rev-parse HEAD)" = "$SOURCE_SHA"
           target_branch="${TARGET_BRANCH#refs/heads/}"
           npm install -g aws-cdk@2.1132.0
           artifact="$RUNNER_TEMP/worker-template-head"
-          bash trusted/.github/scripts/synthesize-worker-templates.sh \
+          bash workflow/.github/scripts/synthesize-worker-templates.sh \
             "$SOURCE_SHA" "$target_branch" head "$artifact" candidate
           mapfile -t stack_ids < "$artifact/stack-ids.txt"
           rm "$artifact/stack-ids.txt"

--- a/.github/workflows/maintenance-classification.yaml
+++ b/.github/workflows/maintenance-classification.yaml
@@ -20,18 +20,36 @@ jobs:
   resolve-synthesis-helper:
     runs-on: ubuntu-24.04-arm
     outputs:
-      sha: ${{ steps.revision.outputs.sha }}
+      sha: ${{ steps.target-revision.outputs.sha || steps.default-revision.outputs.sha }}
     steps:
-      - name: Checkout trusted synthesis helper
+      - name: Checkout exact trusted target revision
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ env.BASE_SHA }}
+
+      - name: Select target synthesis helper
+        id: target-revision
+        run: |
+          if [[ -f .github/scripts/synthesize-worker-templates.sh ]]; then
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout default-branch synthesis helper fallback
+        if: steps.target-revision.outputs.sha == ''
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           persist-credentials: false
           ref: ${{ github.event.repository.default_branch }}
 
-      - name: Record trusted synthesis helper revision
-        id: revision
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Select default-branch synthesis helper
+        if: steps.target-revision.outputs.sha == ''
+        id: default-revision
+        run: |
+          test -f .github/scripts/synthesize-worker-templates.sh
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   synthesize-base:
     needs: resolve-synthesis-helper

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -413,6 +413,15 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("--secondary-expected-stack-id", classification_workflow)
         self.assertIn("ValkProdWorkerStack", classification_workflow)
         self.assertEqual(classification_workflow.count("synthesize-worker-templates.sh"), 2)
+        self.assertIn("resolve-synthesis-helper:", classification_workflow)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", classification_workflow)
+        self.assertEqual(classification_workflow.count("needs: resolve-synthesis-helper"), 2)
+        self.assertEqual(
+            classification_workflow.count("SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}"),
+            2,
+        )
+        self.assertEqual(classification_workflow.count("ref: ${{ env.SYNTHESIS_HELPER_SHA }}"), 2)
+        self.assertEqual(classification_workflow.count("git -C workflow rev-parse HEAD"), 2)
         self.assertIn("pull_request_target:", classification_workflow)
         self.assertIn("synthesize-base:", classification_workflow)
         self.assertIn("synthesize-head:", classification_workflow)

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -412,9 +412,25 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("--secondary-executor-head-template", classification_workflow)
         self.assertIn("--secondary-expected-stack-id", classification_workflow)
         self.assertIn("ValkProdWorkerStack", classification_workflow)
-        self.assertEqual(classification_workflow.count("synthesize-worker-templates.sh"), 2)
+        self.assertEqual(
+            classification_workflow.count("bash workflow/.github/scripts/synthesize-worker-templates.sh"),
+            2,
+        )
         self.assertIn("resolve-synthesis-helper:", classification_workflow)
-        self.assertIn("ref: ${{ github.event.repository.default_branch }}", classification_workflow)
+        resolver = classification_workflow.split("  resolve-synthesis-helper:", maxsplit=1)[1].split(
+            "  synthesize-base:", maxsplit=1
+        )[0]
+        self.assertIn("ref: ${{ env.BASE_SHA }}", resolver)
+        self.assertIn("if: steps.target-revision.outputs.sha == ''", resolver)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", resolver)
+        self.assertLess(
+            resolver.index("ref: ${{ env.BASE_SHA }}"),
+            resolver.index("ref: ${{ github.event.repository.default_branch }}"),
+        )
+        self.assertIn(
+            "sha: ${{ steps.target-revision.outputs.sha || steps.default-revision.outputs.sha }}",
+            resolver,
+        )
         self.assertEqual(classification_workflow.count("needs: resolve-synthesis-helper"), 2)
         self.assertEqual(
             classification_workflow.count("SYNTHESIS_HELPER_SHA: ${{ needs.resolve-synthesis-helper.outputs.sha }}"),

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -399,19 +399,21 @@ class MonitoringStackTest(unittest.TestCase):
                 {"Port": "443", "Protocol": "HTTPS", "StatusCode": "HTTP_301"},
             )
 
-        for stage_name, publicly_accessible, storage_encrypted in (
-            (BENCH, True, False),
-            (PROD, False, True),
-            (DEV, False, False),
-            (RELEASE_TEST, False, False),
+        for stage_name, publicly_accessible in (
+            (BENCH, True),
+            (PROD, False),
+            (DEV, False),
+            (RELEASE_TEST, False),
         ):
-            tracker_templates[stage_name].has_resource_properties(
-                "AWS::RDS::DBInstance",
-                {
-                    "PubliclyAccessible": publicly_accessible,
-                    "StorageEncrypted": storage_encrypted,
-                },
-            )
+            databases = tracker_templates[stage_name].find_resources("AWS::RDS::DBInstance")
+            self.assertEqual(len(databases), 1)
+
+            properties = next(iter(databases.values()))["Properties"]
+            self.assertEqual(properties["PubliclyAccessible"], publicly_accessible)
+            if stage_name == PROD:
+                self.assertIs(properties["StorageEncrypted"], True)
+            else:
+                self.assertNotIn("StorageEncrypted", properties)
 
         for stage_name in (BENCH, PROD, DEV):
             self.assertEqual(

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -143,7 +143,7 @@ class TrackerStack(Stack):
             database_name=POSTGRES_DB,
             allocated_storage=stage_config.database.allocated_storage_gb,
             publicly_accessible=stage.is_bench,
-            storage_encrypted=stage.name == PROD,
+            storage_encrypted=True if stage.name == PROD else None,
             deletion_protection=True,
             removal_policy=cdk.RemovalPolicy.RETAIN,
             backup_retention=Duration.days(stage_config.database.backup_retention_days),

--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -9,5 +9,5 @@ dependencies = ["tracker"]
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.32.0" }
 tracker = { path = "../tracker" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.34.0" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.32.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
+version = "0.34.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0#567c3766ebcca38c49a53939c7357c1bda496982" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.32.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.34.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.32.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
+version = "0.34.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0#567c3766ebcca38c49a53939c7357c1bda496982" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.32.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0#d70607f54ba802705bd0867ab405051dff11b10d" }
+version = "0.34.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0#567c3766ebcca38c49a53939c7357c1bda496982" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.32.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.34.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
The external-production merge revealed three independent configuration failures:
1. Dev deployment attempted to replace its retained database because CloudFormation received an explicit `StorageEncrypted: false`.
2. Maintenance classification could not synthesize the older `prod` base because that revision does not contain the new helper script.
3. The CBS version check also found that Valkyrie was behind the current release.

This change:
1. keeps existing dev and bench database templates unchanged,
2. enables encrypted storage for new external-production databases,
3. runs maintenance synthesis through a trusted helper from the target branch with a protected-default-branch fallback,
4. and updates CBS to `v0.34.0`.

Companion workflow fix: https://github.com/vals-ai/.github/pull/30

## What changed

- Emit `StorageEncrypted: true` only for external production; omit the replacement-only property for existing dev and bench databases.
- Use the exact target/base revision for the synthesis helper when it contains the helper; otherwise fall back to the protected default branch. Candidate code never supplies the helper.
- Pin Tracker and the immutable executor artifact to CBS `v0.34.0`.

## How to review

Start with the stage-specific RDS assertion in `infra/tests/test_monitoring_stack.py`. For maintenance classification, verify that source code still comes from the exact base or candidate revision while the helper comes from either the exact target/base revision or the protected default branch, never the candidate revision.

## Testing

Not yet live-tested

Design: not architectural (the fixes preserve the existing deployment lanes and resource ownership boundaries)