### PR TITLE
fix: keep cdk out of executor release

### DIFF
--- a/infra/stage.py
+++ b/infra/stage.py
@@ -13,7 +13,10 @@ release-test -> stacks get a "ValkReleaseTest" prefix and "-release-test"
 
 from __future__ import annotations
 
-import aws_cdk as cdk
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aws_cdk as cdk
 
 BENCH = "bench"
 PROD = "prod"

--- a/infra/tests/test_executor_release.py
+++ b/infra/tests/test_executor_release.py
@@ -2,7 +2,6 @@ import hashlib
 import json
 import os
 import subprocess
-import sys
 import tempfile
 import unittest
 from collections.abc import Mapping
@@ -108,7 +107,16 @@ class ExecutorReleaseTest(unittest.TestCase):
     def test_nested_cli_imports_in_workflow_environment(self) -> None:
         infra_directory = Path(__file__).parents[1]
         result = subprocess.run(
-            [sys.executable, "executor_release/main.py", "--help"],
+            [
+                "uv",
+                "run",
+                "--project",
+                "executor_release",
+                "--frozen",
+                "python",
+                "executor_release/main.py",
+                "--help",
+            ],
             cwd=infra_directory,
             env={**os.environ, "PYTHONPATH": "."},
             capture_output=True,


### PR DESCRIPTION
### Why

Fix deploy workflow

### What

The dev executor deployment completed its stack update, then the standalone release publisher failed before making an AWS call. Importing the release parameter helper pulled in `stage.py`, whose runtime CDK import is unavailable in the publisher's intentionally small environment.

This change keeps CDK available for static type checking without importing it at runtime. The existing CLI import regression now executes the same isolated uv project command used by the deployment workflow.

Failed job: https://github.com/vals-ai/Valkyrie/actions/runs/33682561107/job/100424844780

## Testing

Not yet live-tested. After merge, confirm the `Deploy to AWS` workflow publishes and activates the dev executor release.

Design: not architectural (this restores the existing dependency boundary without changing deployment behavior)
