### PR TITLE
fix: pin alpine live test image

### DIFF
--- a/services/tracker/tests/integration/live/storage/test_upload_artifacts_images.py
+++ b/services/tracker/tests/integration/live/storage/test_upload_artifacts_images.py
@@ -19,7 +19,7 @@ from tracker.types import HarnessConfig
 # Images covering the major package families
 _IMAGES = [
     ("python:3.11-slim", "python-slim-apt"),
-    ("python:3.11-alpine", "python-alpine-apk"),
+    ("python:3.11-alpine3.20", "python-alpine-apk"),
     ("debian:bookworm-slim", "debian-apt"),
     ("ubuntu:24.04", "ubuntu-apt"),
     ("fedora:40", "fedora-dnf"),


### PR DESCRIPTION
## Human Description

### Why

fix integ tests

---

The live Tracker suite used the mutable `python:3.11-alpine` tag. That tag moved to Alpine 3.24 on September 1, after which Daytona consistently placed the sandbox in `ERROR` with no provider error reason. The test now uses the explicit Alpine 3.20 variant already supported by the suite.

## Testing

- Created `python:3.11-alpine3.20` with the bench Daytona configuration; it reached `STARTED` in 12 seconds and was deleted successfully.
- The complete live suite was not rerun locally. Its first full run will be the Tracker live integration check on the `dev` to `prod` release PR after this merges.

Design: not architectural (pins an existing live-test fixture without changing runtime behavior)
