### PR TITLE
Preserve terminal artifacts and published agent aliases (#734)

### DIFF
--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -5,7 +5,6 @@ import shlex
 import time
 import uuid
 from asyncio import Semaphore
-from collections import deque
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from enum import Enum
@@ -481,7 +480,6 @@ _TIMEOUT_EXIT_CODE: int = 124
 _OS_KILL_EXIT_CODE: int = 137
 _SUCCESS_EXIT_CODE: int = 0
 _STATUS_DIR = "/tmp/.valkyrie"
-_OUTPUT_TAIL_MAX_CHARS = 64 * 1024
 _EGRESS_RETRY = retry(
     retry=retry_if_exception_type(ProviderSandboxError) & retry_if_not_exception_type(SandboxNotFoundError),
     reraise=True,
@@ -552,10 +550,6 @@ async def stream_command_output(
     command: str,
     on_output: Callable[[str], None],
 ) -> tuple[AgentCausedExitReason | None, float]:
-    # Bounded tail of recent output, kept only for error messages; capped by characters
-    # rather than chunk count since a single chunk can be arbitrarily large.
-    output: deque[str] = deque()
-    output_chars = 0
     run_id = uuid.uuid4().hex
     start_ns_path = f"{_STATUS_DIR}/{run_id}.start_ns"
     end_ns_path = f"{_STATUS_DIR}/{run_id}.end_ns"
@@ -576,10 +570,6 @@ async def stream_command_output(
         try:
             async for data in sandbox.command(timed_command):
                 on_output(data)
-                output.append(data)
-                output_chars += len(data)
-                while output_chars > _OUTPUT_TAIL_MAX_CHARS and len(output) > 1:
-                    output_chars -= len(output.popleft())
         except ProviderSandboxCommandError as e:
             exit_code = e.exit_code
         except SandboxNotFoundError:
@@ -601,10 +591,8 @@ async def stream_command_output(
         if exit_code == _OS_KILL_EXIT_CODE:
             return AgentCausedExitReason.OS_KILLED, duration
 
-        tail = "".join(output).strip().splitlines()
-        recent = "\n".join(tail[-10:]) if tail else "(no output)"
         sentry_sdk.set_tag("agent_exit_code", str(exit_code))
-        raise AgentRunFailedError(f"Failed to run command {command}, exit code: {exit_code}\nLast output:\n{recent}")
+        raise AgentRunFailedError(f"Agent command failed with exit code {exit_code}")
     finally:
         try:
             await _exec(sandbox, f"rm -f {shlex.quote(start_ns_path)} {shlex.quote(end_ns_path)}")
@@ -888,13 +876,76 @@ async def run_agent(
     # Create cwd if it does not already exist
     await _exec(sandbox, f"mkdir -p {shlex.quote(cwd)}")
 
-    # Run the agent without including task directory dependencies
-    exit_reason, agent_run_time = await _stream_command_output_with_egress_allowlist(
-        sandbox,
-        f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}",
-        log_output,
-        contract.egress_allowlist,
-    )
+    async def upload_outputs(*, preserve_agent_error: bool = False) -> None:
+        errors: list[Exception] = []
+        if contract.final_output:
+            try:
+                result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
+                if (
+                    result.exit_code == _SUCCESS_EXIT_CODE
+                    and agent_output_s3_key
+                    and (execution_is_current is None or execution_is_current())
+                ):
+                    await archive_and_upload_output(
+                        sandbox,
+                        contract.final_output,
+                        agent_output_s3_key,
+                        object_store,
+                        benchmark_id=benchmark_id,
+                        task_id=task_id,
+                        execution_is_current=execution_is_current,
+                    )
+            except Exception as error:
+                errors.append(error)
+                logger.exception(
+                    "Failed to collect final agent output",
+                    extra={
+                        "sandbox_id": sandbox.id,
+                        "sandbox_name": sandbox.name,
+                        "benchmark_id": benchmark_id,
+                        "task_id": task_id,
+                    },
+                )
+
+        if contract.output_artifacts:
+            try:
+                if benchmark_id is None:
+                    raise SandboxError("benchmark_id is required to upload output artifacts")
+                await upload_output_artifacts(
+                    sandbox,
+                    contract.output_artifacts,
+                    benchmark_id,
+                    task_id,
+                    object_store,
+                    execution_is_current,
+                )
+            except Exception as error:
+                errors.append(error)
+                logger.exception(
+                    "Failed to collect declared agent artifacts",
+                    extra={
+                        "sandbox_id": sandbox.id,
+                        "sandbox_name": sandbox.name,
+                        "benchmark_id": benchmark_id,
+                        "task_id": task_id,
+                    },
+                )
+
+        if errors and not preserve_agent_error:
+            raise errors[0]
+
+    # A nonzero exit is terminal evidence; collect declared outputs while the
+    # sandbox is still available.
+    try:
+        exit_reason, agent_run_time = await _stream_command_output_with_egress_allowlist(
+            sandbox,
+            f"cd {shlex.quote(cwd)} && PYTHONSAFEPATH=1 {run_cmd}",
+            log_output,
+            contract.egress_allowlist,
+        )
+    except Exception:
+        await upload_outputs(preserve_agent_error=True)
+        raise
 
     if exit_reason == AgentCausedExitReason.TIMEOUT:
         log_output(
@@ -905,35 +956,7 @@ async def run_agent(
             f"[WARNING]:`{contract.name}` was killed by the OS (exit code {_OS_KILL_EXIT_CODE}, likely out-of-memory). The process has been terminated and evaluation will proceed."
         )
 
-    # Upload any output from the agent to S3
-    if contract.final_output:
-        result = await _exec(sandbox, f"test -e {shlex.quote(contract.final_output)}")
-        if (
-            result.exit_code == _SUCCESS_EXIT_CODE
-            and agent_output_s3_key
-            and (execution_is_current is None or execution_is_current())
-        ):
-            await archive_and_upload_output(
-                sandbox,
-                contract.final_output,
-                agent_output_s3_key,
-                object_store,
-                benchmark_id=benchmark_id,
-                task_id=task_id,
-                execution_is_current=execution_is_current,
-            )
-
-    if contract.output_artifacts:
-        if benchmark_id is None:
-            raise SandboxError("benchmark_id is required to upload output artifacts")
-        await upload_output_artifacts(
-            sandbox,
-            contract.output_artifacts,
-            benchmark_id,
-            task_id,
-            object_store,
-            execution_is_current,
-        )
+    await upload_outputs()
 
     # Return why the agent terminated abnormally, or None on clean exit
     return exit_reason, agent_run_time

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -633,6 +633,100 @@ class TestRunAgent:
 
         assert artifact_calls == ["benchmark-123:task_0:artifacts/result.json"]
 
+    async def test_run_agent_collects_outputs_before_reraising_agent_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        store = _mock_object_store()
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="",
+            run_cmd="exit 23",
+            final_output="/logs",
+            output_artifacts=["artifacts/result.json"],
+        )
+        archive_output = AsyncMock()
+        upload_artifacts = AsyncMock()
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
+            if command.startswith("mkdir -p") or command == "test -e /logs":
+                return ExecResult(exit_code=0, output="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fail_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            raise AgentRunFailedError("agent exited 23")
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fail_agent)
+        monkeypatch.setattr(sandbox_module, "archive_and_upload_output", archive_output)
+        monkeypatch.setattr(sandbox_module, "upload_output_artifacts", upload_artifacts)
+
+        sandbox = Mock(id="sandbox-123", name="task-alias")
+        with pytest.raises(AgentRunFailedError, match="agent exited 23"):
+            await run_agent(
+                sandbox,
+                contract,
+                "/tmp/problem.txt",
+                "task_0",
+                _ignore_output,
+                "/testbed",
+                object_store=store,
+                agent_output_s3_key="benchmarks/benchmark-123/task_0/agent_output.tar.gz",
+                benchmark_id="benchmark-123",
+            )
+
+        archive_output.assert_awaited_once()
+        upload_artifacts.assert_awaited_once()
+
+    async def test_run_agent_preserves_agent_error_when_terminal_upload_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        store = _mock_object_store()
+        contract = AgentContractRequest(
+            name="test-agent",
+            install_cmd="",
+            run_cmd="exit 23",
+            final_output="/logs",
+            output_artifacts=["artifacts/result.json"],
+        )
+        upload_artifacts = AsyncMock()
+
+        async def fake_exec(_sandbox: Any, command: str) -> ExecResult:
+            if command.startswith("mkdir -p") or command == "test -e /logs":
+                return ExecResult(exit_code=0, output="")
+            raise AssertionError(f"unexpected command: {command}")
+
+        async def fail_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            raise AgentRunFailedError("agent exited 23")
+
+        monkeypatch.setattr(sandbox_module, "_exec", fake_exec)
+        monkeypatch.setattr(sandbox_module, "stream_command_output", fail_agent)
+        monkeypatch.setattr(
+            sandbox_module,
+            "archive_and_upload_output",
+            AsyncMock(side_effect=OutputArtifactError("terminal upload failed")),
+        )
+        monkeypatch.setattr(sandbox_module, "upload_output_artifacts", upload_artifacts)
+
+        sandbox = Mock(id="sandbox-123", name="task-alias")
+        with pytest.raises(AgentRunFailedError, match="agent exited 23"):
+            await run_agent(
+                sandbox,
+                contract,
+                "/tmp/problem.txt",
+                "task_0",
+                _ignore_output,
+                "/testbed",
+                object_store=store,
+                agent_output_s3_key="benchmarks/benchmark-123/task_0/agent_output.tar.gz",
+                benchmark_id="benchmark-123",
+            )
+
+        upload_artifacts.assert_awaited_once()
+
     async def test_run_agent_threads_benchmark_id_to_archive_and_upload(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1773,7 +1867,7 @@ class TestStreamCommandOutputAgentFailure:
         assert duration >= 0
 
     @pytest.mark.parametrize("exit_code", [1, 2, 127])
-    async def test_non_zero_exit_raises_agent_run_failed_and_tags_exit_code(
+    async def test_non_zero_exit_raises_prompt_free_agent_error_and_tags_exit_code(
         self, monkeypatch: pytest.MonkeyPatch, exit_code: int
     ) -> None:
         async def stream_command(_command: str) -> AsyncIterator[str]:
@@ -1797,22 +1891,14 @@ class TestStreamCommandOutputAgentFailure:
 
         assert isinstance(exc_info.value, SandboxError)
         assert not isinstance(exc_info.value, SandboxSetupError)
-        assert f"exit code: {exit_code}" in str(exc_info.value)
-        assert "last line" in str(exc_info.value)
+        assert str(exc_info.value) == f"Sandbox error: Agent command failed with exit code {exit_code}"
+        assert "last line" not in str(exc_info.value)
+        assert "run-agent.sh" not in str(exc_info.value)
         assert tagged == {"agent_exit_code": str(exit_code)}
 
-    async def test_output_tail_is_byte_capped(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """
-        Test cases:
-        - Output retained for the failure message is capped by characters, not chunk count.
-        - The newest output survives while old output beyond the cap is dropped.
-        """
-        tail_cap = getattr(sandbox_module, "_OUTPUT_TAIL_MAX_CHARS")
-
+    async def test_arbitrary_agent_output_is_not_persisted_in_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         async def stream_command(_command: str) -> AsyncIterator[str]:
-            yield "old-marker\n"
-            yield "x" * (tail_cap + 1) + "\n"
-            yield "new-marker\n"
+            yield "prompt secret and attacker-controlled output\n"
             raise ProviderSandboxCommandError(1)
 
         mock_sandbox = Mock()
@@ -1827,7 +1913,13 @@ class TestStreamCommandOutputAgentFailure:
         monkeypatch.setattr("tracker.sandbox.sentry_sdk.set_tag", fake_set_tag)
 
         with pytest.raises(AgentRunFailedError) as exc_info:
-            await sandbox_module.stream_command_output(mock_sandbox, "run-agent.sh", on_output=lambda _: None)
+            await sandbox_module.stream_command_output(
+                mock_sandbox,
+                "run-agent.sh --secret value",
+                on_output=lambda _: None,
+            )
 
-        assert "new-marker" in str(exc_info.value)
-        assert "old-marker" not in str(exc_info.value)
+        assert str(exc_info.value) == "Sandbox error: Agent command failed with exit code 1"
+        assert "prompt" not in str(exc_info.value)
+        assert "secret" not in str(exc_info.value)
+        assert "run-agent.sh" not in str(exc_info.value)

--- a/src/valkyrie/cli/agent/storage.py
+++ b/src/valkyrie/cli/agent/storage.py
@@ -9,6 +9,7 @@ from typing import cast
 
 import click
 import yaml
+from botocore.exceptions import ClientError
 from tracker import handle_s3_error
 from tracker.aws.s3 import (
     copy_s3_object,
@@ -190,6 +191,33 @@ async def push_agent(agent_name: str, agent_path: Path):
                     UploadId=upload_id,
                 )
                 raise
+
+
+@handle_s3_error(message="Failed to publish local agent without overwriting an alias")
+async def push_agent_if_absent(agent_name: str, agent_path: Path) -> bool:
+    """Atomically create a shared agent alias, returning False on a collision."""
+    bucket_name = cli_s3.fetch_bucket_name()
+    with get_agent_zip_stream(agent_name=agent_name, agent_path=agent_path) as file_stream:
+        file_stream.seek(0, 2)
+        file_size = file_stream.tell()
+        file_stream.seek(0)
+        async with cli_s3.s3_client() as client:
+            try:
+                await client.put_object(
+                    Bucket=bucket_name,
+                    Key=get_contract_s3_key(agent_name),
+                    Body=file_stream,
+                    ContentLength=file_size,
+                    IfNoneMatch="*",
+                    Metadata={"uploaded_at": datetime.now(timezone.utc).isoformat()},
+                )
+            except ClientError as error:
+                code = str(error.response.get("Error", {}).get("Code", ""))
+                status = error.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+                if code in {"PreconditionFailed", "412"} or status == 412:
+                    return False
+                raise
+    return True
 
 
 async def update_benchmark_agent_version(agent_name: str, benchmark_id: str) -> None:

--- a/src/valkyrie/cli/run/start.py
+++ b/src/valkyrie/cli/run/start.py
@@ -12,7 +12,7 @@ from tracker.types import StartBenchmarkResponse
 from valkyrie.cli.exceptions import BundlerError, ContractValidationError, TrackerServiceError
 from valkyrie.cli.run.progress import stream_benchmark_status
 from valkyrie.cli.run.task_ids import resolve_task_ids
-from valkyrie.cli.agent.storage import get_contract_from_s3, push_agent
+from valkyrie.cli.agent.storage import get_contract_from_s3, push_agent_if_absent
 from valkyrie.cli.display import local_time
 from valkyrie.cli.service_headers import benchmark_service_headers
 from valkyrie.cli.tracker_client import TrackerService, response_error_detail
@@ -361,7 +361,13 @@ def start(
                 agent_path / "contract.yaml",
             )
             contract = get_contract(contract_file, agent_config)
-            asyncio.run(push_agent(contract.name, agent_path))
+            if not asyncio.run(push_agent_if_absent(contract.name, agent_path)):
+                raise click.UsageError(
+                    f"A published agent named '{contract.name}' already exists. "
+                    "Refusing to overwrite it as a side effect of run start. "
+                    f"Use --agent {contract.name} to run the published release, "
+                    "or explicitly publish the local directory under a different name first."
+                )
             if managed_execution:
                 contract = AgentContractRequest(
                     name=contract.name,

--- a/tests/unit/cli/agent/test_storage.py
+++ b/tests/unit/cli/agent/test_storage.py
@@ -11,6 +11,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from botocore.exceptions import ClientError
 from tracker.aws.clients import ExplicitCredentialsAWSClientProvider
 from tracker.exceptions import S3Error
 
@@ -242,3 +243,35 @@ class TestPushAgent:
             UploadId="upload-failure",
         )
         failing_client.complete_multipart_upload.assert_not_awaited()
+
+    async def test_run_start_publish_atomically_refuses_alias_collision(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        archive = b"agent archive"
+        successful_client = AsyncMock()
+        conflicting_client = AsyncMock()
+        conflicting_client.put_object.side_effect = ClientError(
+            {
+                "Error": {"Code": "PreconditionFailed"},
+                "ResponseMetadata": {"HTTPStatusCode": 412},
+            },
+            "PutObject",
+        )
+        clients: list[AsyncMock] = [successful_client, conflicting_client]
+
+        def mock_zip_stream(**_kwargs: Any) -> nullcontext[io.BytesIO]:
+            return nullcontext(io.BytesIO(archive))
+
+        _configure_s3_clients(monkeypatch, clients)
+        monkeypatch.setattr(storage, "get_agent_zip_stream", mock_zip_stream)
+
+        assert await storage.push_agent_if_absent("demo", Path("/unused")) is True
+        assert await storage.push_agent_if_absent("demo", Path("/unused")) is False
+
+        successful_call = successful_client.put_object.await_args
+        assert successful_call is not None
+        assert successful_call.kwargs["Bucket"] == "agent-bucket"
+        assert successful_call.kwargs["Key"] == "agents/demo.zip"
+        assert successful_call.kwargs["ContentLength"] == len(archive)
+        assert successful_call.kwargs["IfNoneMatch"] == "*"

--- a/tests/unit/cli/run/test_start.py
+++ b/tests/unit/cli/run/test_start.py
@@ -62,6 +62,7 @@ class StartTestbed:
         self.resolve_remote = AsyncMock(
             return_value=AgentContractRequest(name="remote-agent", install_cmd="echo install", run_cmd="echo run")
         )
+        self.publish_local_agent = AsyncMock(return_value=True)
         self.resolve_tasks = MagicMock(return_value=None)
         self.resolve_headers = MagicMock(return_value={})
         self.stream_status = MagicMock()
@@ -74,6 +75,7 @@ class StartTestbed:
             self.resolve_tasks,
             self.resolve_headers,
             self.stream_status,
+            self.publish_local_agent,
         ):
             boundary.reset_mock()
         self.tracker.start_benchmark.side_effect = responses
@@ -107,6 +109,11 @@ def start_testbed(monkeypatch: pytest.MonkeyPatch, cli_runner: CliRunner) -> Sta
     monkeypatch.setattr(start_module, "resolve_task_ids", testbed.resolve_tasks)
     monkeypatch.setattr(start_module, "benchmark_service_headers", testbed.resolve_headers)
     monkeypatch.setattr(start_module, "stream_benchmark_status", testbed.stream_status)
+    monkeypatch.setattr(
+        start_module,
+        "push_agent_if_absent",
+        testbed.publish_local_agent,
+    )
     testbed.set_responses([_start_response(_FIRST_RUN_ID)])
 
     return testbed
@@ -250,9 +257,8 @@ class TestCountedStarts:
         get_contract = MagicMock(
             return_value=AgentContractRequest(name="local-agent", install_cmd="echo install", run_cmd="echo run")
         )
-        push_agent = AsyncMock()
+        push_agent = start_testbed.publish_local_agent
         monkeypatch.setattr(start_module, "get_contract", get_contract)
-        monkeypatch.setattr(start_module, "push_agent", push_agent)
         start_testbed.set_responses([_start_response(_FIRST_RUN_ID), _start_response(_SECOND_RUN_ID)])
 
         # Start two runs from the local agent.
@@ -302,9 +308,8 @@ class TestCountedStarts:
                 run_cmd="echo run",
             )
         )
-        push_agent = AsyncMock()
+        push_agent = start_testbed.publish_local_agent
         monkeypatch.setattr(start_module, "get_contract", get_contract)
-        monkeypatch.setattr(start_module, "push_agent", push_agent)
         start_testbed.tracker_factory.parse_config_keys.return_value = {}
 
         result = start_testbed.cli_runner.invoke(
@@ -330,6 +335,42 @@ class TestCountedStarts:
             model="anthropic/claude-opus-5",
             kwargs={"variant": "max"},
         )
+
+    def test_local_start_refuses_to_overwrite_published_agent(
+        self,
+        start_testbed: StartTestbed,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        local_agent = tmp_path / "local-agent"
+        local_agent.mkdir()
+        (local_agent / "contract.yaml").write_text(
+            "name: local-agent\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            start_module,
+            "get_contract",
+            MagicMock(
+                return_value=AgentContractRequest(
+                    name="local-agent",
+                    install_cmd="echo install",
+                    run_cmd="echo run",
+                )
+            ),
+        )
+        start_testbed.publish_local_agent.return_value = False
+
+        result = start_testbed.cli_runner.invoke(
+            start_command,
+            ["--agent", str(local_agent), "--benchmark", "swebench"],
+        )
+
+        assert result.exit_code == 2
+        assert "Refusing to overwrite it as a side effect of run start" in result.output
+        assert "Use --agent local-agent" in result.output
+        start_testbed.publish_local_agent.assert_awaited_once_with("local-agent", local_agent)
+        start_testbed.tracker.start_benchmark.assert_not_called()
 
     def test_invalid_options_precede_side_effects(self, start_testbed: StartTestbed) -> None:
         """


### PR DESCRIPTION
* Preserve terminal artifacts on agent failure

* Refuse implicit published agent overwrite

* Collect terminal output channels independently

* Create local agent aliases atomically

---------

## Summary
<!-- What does this PR do? Why is it needed? -->

## Changes
<!-- List the key changes made -->
- 

## Related Issues
<!-- Link any related issues -->
Closes #

## Type of Change
<!-- What changed? -->
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
<!-- How was this tested? -->
- [ ] Added/updated unit tests
- [ ] Manually tested

## Checklist
<!-- Did you complete these before requesting a review? -->
- [ ] Self-reviewed the diff
- [ ] No debug/dead code left in
- [ ] Docs updated if needed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->