### PR TITLE
fix(sdk): accept the CLI's environment key and target its tracker #patch

### DIFF
--- a/docs/reference/sdk/models/config.mdx
+++ b/docs/reference/sdk/models/config.mdx
@@ -11,9 +11,13 @@ This page documents all 1 public types in the `Config` family in source order. U
 
 Validated SDK configuration using ``valkyrie.yaml`` field aliases.
 
-Config model · 13 fields
+Config model · 14 fields
 
 **Fields**
+
+<div className="border-b border-gray-200 py-3 dark:border-gray-800">
+  <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"><span className="break-all font-mono text-sm">{"environment"}</span><span className="min-w-0 break-words text-sm text-gray-500 dark:text-gray-400">optional · Literal['bench', 'prod', 'dev'] · default: <code>{"'bench'"}</code></span></div>
+</div>
 
 <div className="border-b border-gray-200 py-3 dark:border-gray-800">
   <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"><span className="break-all font-mono text-sm">{"api_key"}</span><span className="min-w-0 break-words text-sm text-gray-500 dark:text-gray-400">optional · SecretStr | None · default: <code>{"None"}</code></span></div>

--- a/packages/valkyrie-sdk/pyproject.toml
+++ b/packages/valkyrie-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "valkyrie-sdk"
-version = "0.2.9"
+version = "0.2.10"
 description = "Async Python SDK for managing Valkyrie benchmark runs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/client.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/client.py
@@ -11,14 +11,14 @@ from typing import Any, TypeVar
 import httpx
 from pydantic import BaseModel
 
-from valkyrie.sdk.config import DEFAULT_CONFIG_PATH, ValkyrieConfig
+from valkyrie.sdk.config import DEFAULT_CONFIG_PATH, TRACKER_URLS, ValkyrieConfig
 from valkyrie.sdk.errors import ValkyrieAPIError, ValkyrieTransportError
 from valkyrie.sdk.resources.agents import AgentsResource
 from valkyrie.sdk.resources.benchmarks import BenchmarksResource
 from valkyrie.sdk.resources.runs import RunsResource
 from valkyrie.sdk.resources.services import BenchmarkServicesResource
 
-DEFAULT_BASE_URL = "https://benchmark-tracker.vals.ai"
+DEFAULT_BASE_URL = TRACKER_URLS["bench"]
 ResponseModel = TypeVar("ResponseModel", bound=BaseModel)
 
 
@@ -34,7 +34,7 @@ class ValkyrieClient:
         transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self.config = config
-        resolved_base_url = base_url or os.environ.get("TRACKER_SERVICE_URL", DEFAULT_BASE_URL)
+        resolved_base_url = base_url or os.environ.get("TRACKER_SERVICE_URL") or config.tracker_url
         self._timeout = timeout if isinstance(timeout, httpx.Timeout) else httpx.Timeout(timeout)
         self._client = httpx.AsyncClient(
             base_url=resolved_base_url.rstrip("/"),

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/config.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/config.py
@@ -1,7 +1,7 @@
 """Typed configuration for the Valkyrie SDK."""
 
 from pathlib import Path
-from typing import TypeVar, cast
+from typing import Literal, TypeVar, cast
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, ValidationError, field_validator, model_validator
@@ -10,6 +10,11 @@ from valkyrie.sdk.errors import ValkyrieConfigError
 from valkyrie.sdk.models import AWSCredentials, HarnessConfig
 
 DEFAULT_CONFIG_PATH = Path("~/.config/valkyrie/valkyrie.yaml")
+TRACKER_URLS: dict[str, str] = {
+    "bench": "https://benchmark-tracker.vals.ai",
+    "prod": "https://benchmark-tracker-prod.vals.ai",
+    "dev": "https://benchmark-tracker-dev.vals.ai",
+}
 ConfigT = TypeVar("ConfigT", bound="ValkyrieConfig")
 
 
@@ -18,6 +23,7 @@ class ValkyrieConfig(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
+    environment: Literal["bench", "prod", "dev"] = "bench"
     api_key: SecretStr | None = Field(default=None, repr=False)
     aws_access_key_id: SecretStr | None = Field(default=None, alias="AWS_ACCESS_KEY_ID", repr=False)
     aws_secret_access_key: SecretStr | None = Field(default=None, alias="AWS_SECRET_ACCESS_KEY", repr=False)
@@ -60,6 +66,11 @@ class ValkyrieConfig(BaseModel):
         if self.aws_access_key_id is None and self.aws_session_token is not None:
             raise ValueError("AWS_SESSION_TOKEN requires AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY")
         return self
+
+    @property
+    def tracker_url(self) -> str:
+        """Tracker base URL for the configured environment."""
+        return TRACKER_URLS[self.environment]
 
     @field_validator("custom_benchmark_services")
     @classmethod

--- a/packages/valkyrie-sdk/src/valkyrie/sdk/config.py
+++ b/packages/valkyrie-sdk/src/valkyrie/sdk/config.py
@@ -70,6 +70,10 @@ class ValkyrieConfig(BaseModel):
     @property
     def tracker_url(self) -> str:
         """Tracker base URL for the configured environment."""
+        if self.environment not in TRACKER_URLS:
+            raise ValkyrieConfigError(
+                f"Unsupported environment {self.environment!r}; expected one of: {', '.join(TRACKER_URLS)}"
+            )
         return TRACKER_URLS[self.environment]
 
     @field_validator("custom_benchmark_services")

--- a/tests/unit/sdk/test_sdk.py
+++ b/tests/unit/sdk/test_sdk.py
@@ -60,6 +60,30 @@ default_sandbox_provider: daytona
     assert config.request_headers()["X-Harness-Aws-Access-Key-Id"] == "aws-key"
 
 
+def test_config_environment_selects_tracker_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, sdk_config) -> None:
+    monkeypatch.delenv("TRACKER_SERVICE_URL", raising=False)
+    config_path = tmp_path / "valkyrie.yaml"
+    config_path.write_text(
+        """
+environment: prod
+api_key: vals-key
+AWS_DEFAULT_REGION: us-west-2
+S3_BUCKET: runs-bucket
+sandbox_providers:
+  daytona: DaytonaSecret
+""".strip(),
+        encoding="utf-8",
+    )
+
+    client = ValkyrieClient.from_config(config_path)
+
+    assert client.config.tracker_url == "https://benchmark-tracker-prod.vals.ai"
+    assert str(client._client.base_url) == "https://benchmark-tracker-prod.vals.ai"
+    assert sdk_config().tracker_url == "https://benchmark-tracker.vals.ai"
+    with pytest.raises(ValidationError, match="environment"):
+        sdk_config(environment="staging")
+
+
 def test_config_redacts_secrets_and_unwraps_them_for_requests(sdk_config) -> None:
     config = sdk_config()
 

--- a/uv.lock
+++ b/uv.lock
@@ -2538,7 +2538,7 @@ dev = [
 
 [[package]]
 name = "valkyrie-sdk"
-version = "0.2.9"
+version = "0.2.10"
 source = { editable = "packages/valkyrie-sdk" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
Since #733, `valk config init` writes `environment: bench|prod|dev` into `~/.config/valkyrie/valkyrie.yaml`. `ValkyrieConfig` has `extra="forbid"`, so any SDK consumer loading that file (e.g. `bench-valk-run` in vals-ai/benchmarks) fails with `environment: Extra inputs are not permitted` until the line is hand-deleted. Even then the SDK always targeted the bench tracker, ignoring the environment the CLI was configured for.

## Changes
- `ValkyrieConfig.environment: Literal["bench", "prod", "dev"] = "bench"` plus `tracker_url` property (URL map mirrors `cli/runtime_config.py`).
- `ValkyrieClient` base URL resolution: `base_url` arg → `TRACKER_SERVICE_URL` env → `config.tracker_url` (previously the hardcoded bench URL). `DEFAULT_BASE_URL` is unchanged in value.
- SDK 0.2.9 → 0.2.10; regenerated `docs/reference/sdk/models/config.mdx`.

## Related Issues
Follow-up to #733.

## Type of Change
- [x] Bug fix

## Testing
- [x] Added/updated unit tests (`test_config_environment_selects_tracker_url`)
- [x] Manually tested — on the bench instance with the real `valk config init`-generated yaml (`environment: bench` present), `ValkyrieClient.from_config()` now loads and `client.runs.fetch(UUID("6896b742-2242-4f77-8a60-d0ec56737a6f"))` returned the `fabv2-internal` run from `https://benchmark-tracker.vals.ai`. The same config raised `extra_forbidden` on 0.2.9.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/958c29219dc44d999c2eb5d39bfb67c3
Open in Devin Desktop: https://app.devin.ai/desktop/session/958c29219dc44d999c2eb5d39bfb67c3?variant=devin
Requested by: @JarettForzano
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/754" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->