### PR TITLE
feat: add tracker ALB access logs #minor

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -4,6 +4,7 @@ AWS CDK infrastructure for Valkyrie's tracker, executor, storage, networking, an
 
 - [Public self-hosting guide](../docs/self-hosting/infrastructure.mdx)
 - [Executor release and deployment runbook](executor-releases/README.md)
+- [Tracker ALB access-log runbook](tracker-alb-access-logs.md)
 
 The self-hosting guide documents reusable architecture and configuration. The executor runbook contains Vals-specific deployment, release activation, recovery, and retirement procedures for maintainers.
 

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -432,6 +432,159 @@ class MonitoringStackTest(unittest.TestCase):
             1,
         )
 
+    def test_production_tracker_access_logs_are_restricted_and_queryable(self) -> None:
+        for stage_name, environment in ((BENCH, TEST_BENCH_ENV), (PROD, TEST_PROD_ENV)):
+            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
+                tracker_template = service_templates(stage_name)[0]
+
+            buckets = tracker_template.find_resources("AWS::S3::Bucket")
+            self.assertEqual(len(buckets), 1)
+            bucket_logical_id = next(iter(buckets))
+            _, load_balancer = next(
+                iter(tracker_template.find_resources("AWS::ElasticLoadBalancingV2::LoadBalancer").items())
+            )
+            bucket_policy_logical_id = next(iter(tracker_template.find_resources("AWS::S3::BucketPolicy")))
+            load_balancer_dependencies = load_balancer.get("DependsOn", [])
+            if isinstance(load_balancer_dependencies, str):
+                load_balancer_dependencies = [load_balancer_dependencies]
+            self.assertIn(bucket_policy_logical_id, load_balancer_dependencies)
+            load_balancer_attributes = {
+                attribute["Key"]: attribute["Value"]
+                for attribute in load_balancer["Properties"]["LoadBalancerAttributes"]
+            }
+            self.assertEqual(load_balancer_attributes["access_logs.s3.enabled"], "true")
+            self.assertEqual(load_balancer_attributes["access_logs.s3.bucket"], {"Ref": bucket_logical_id})
+            self.assertEqual(load_balancer_attributes["access_logs.s3.prefix"], "tracker-alb")
+            tracker_template.has_resource_properties(
+                "AWS::S3::Bucket",
+                {
+                    "BucketEncryption": {
+                        "ServerSideEncryptionConfiguration": [
+                            {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
+                        ]
+                    },
+                    "LifecycleConfiguration": {"Rules": [{"ExpirationInDays": 90, "Status": "Enabled"}]},
+                    "OwnershipControls": {"Rules": [{"ObjectOwnership": "BucketOwnerEnforced"}]},
+                    "PublicAccessBlockConfiguration": {
+                        "BlockPublicAcls": True,
+                        "BlockPublicPolicy": True,
+                        "IgnorePublicAcls": True,
+                        "RestrictPublicBuckets": True,
+                    },
+                },
+            )
+            bucket_policy = next(iter(tracker_template.find_resources("AWS::S3::BucketPolicy").values()))["Properties"][
+                "PolicyDocument"
+            ]
+            delivery_statement = next(
+                statement
+                for statement in bucket_policy["Statement"]
+                if statement.get("Sid") == "AllowTrackerAlbLogDelivery"
+            )
+            self.assertEqual(delivery_statement["Action"], "s3:PutObject")
+            self.assertEqual(
+                delivery_statement["Principal"],
+                {"Service": "logdelivery.elasticloadbalancing.amazonaws.com"},
+            )
+            self.assertEqual(
+                delivery_statement["Condition"]["StringEquals"]["aws:SourceAccount"],
+                TEST_AWS_ACCOUNT,
+            )
+            source_arn = json.dumps(delivery_statement["Condition"]["ArnLike"]["aws:SourceArn"])
+            self.assertIn("elasticloadbalancing", source_arn)
+            self.assertIn(TEST_AWS_REGION, source_arn)
+            self.assertIn(TEST_AWS_ACCOUNT, source_arn)
+            self.assertIn("loadbalancer/*", source_arn)
+            delivery_resource = json.dumps(delivery_statement["Resource"])
+            self.assertIn(f"tracker-alb/AWSLogs/{TEST_AWS_ACCOUNT}/*", delivery_resource)
+            self.assertTrue(
+                any(
+                    statement["Effect"] == "Deny"
+                    and statement["Action"] == "s3:*"
+                    and statement["Condition"] == {"Bool": {"aws:SecureTransport": "false"}}
+                    for statement in bucket_policy["Statement"]
+                )
+            )
+            glue_table = next(iter(tracker_template.find_resources("AWS::Glue::Table").values()))["Properties"]
+            table_input = glue_table["TableInput"]
+            self.assertEqual(table_input["Name"], "requests")
+            self.assertEqual(table_input["PartitionKeys"], [{"Name": "day", "Type": "string"}])
+            self.assertEqual(table_input["Parameters"]["projection.enabled"], "true")
+            self.assertEqual(table_input["Parameters"]["projection.day.type"], "date")
+            self.assertEqual(table_input["Parameters"]["projection.day.format"], "yyyy/MM/dd")
+            projected_location = json.dumps(table_input["Parameters"]["storage.location.template"])
+            self.assertIn("${day}/", projected_location)
+            storage_descriptor = table_input["StorageDescriptor"]
+            self.assertEqual(
+                storage_descriptor["SerdeInfo"]["SerializationLibrary"],
+                "org.apache.hadoop.hive.serde2.RegexSerDe",
+            )
+            self.assertTrue(storage_descriptor["SerdeInfo"]["Parameters"]["input.regex"])
+            self.assertTrue(
+                {
+                    "client_ip",
+                    "request_verb",
+                    "request_url",
+                    "user_agent",
+                    "elb_status_code",
+                    "target_status_code",
+                    "target_ip",
+                    "target_port",
+                    "request_processing_time",
+                    "target_processing_time",
+                    "response_processing_time",
+                    "trace_id",
+                }
+                <= {column["Name"] for column in storage_descriptor["Columns"]}
+            )
+
+            named_query = next(iter(tracker_template.find_resources("AWS::Athena::NamedQuery").values()))["Properties"]
+            self.assertEqual(named_query["Database"], "tracker_alb_access_logs")
+            self.assertEqual(named_query["Name"], "tracker-alb-request-window")
+            self.assertEqual(named_query["WorkGroup"], {"Ref": "TrackerAlbAccessLogWorkGroup"})
+            for query_fragment in (
+                "client_ip",
+                "request_verb",
+                "request_url",
+                "user_agent",
+                "elb_status_code",
+                "target_status_code",
+                "target_address",
+                "request_processing_time",
+                "target_processing_time",
+                "response_processing_time",
+                "trace_id",
+                "day BETWEEN date_format(start_utc",
+                "date_format(end_utc + interval '1' day",
+                "from_iso8601_timestamp(time) BETWEEN start_utc AND end_utc",
+            ):
+                self.assertIn(query_fragment, named_query["QueryString"])
+
+            workgroup = next(iter(tracker_template.find_resources("AWS::Athena::WorkGroup").values()))["Properties"]
+            self.assertEqual(workgroup["Name"], "tracker-alb-access-logs")
+            workgroup_configuration = workgroup["WorkGroupConfiguration"]
+            self.assertIs(workgroup_configuration["EnforceWorkGroupConfiguration"], True)
+            self.assertIs(workgroup_configuration["PublishCloudWatchMetricsEnabled"], False)
+            result_configuration = workgroup_configuration["ResultConfiguration"]
+            self.assertEqual(result_configuration["EncryptionConfiguration"], {"EncryptionOption": "SSE_S3"})
+            self.assertEqual(result_configuration["ExpectedBucketOwner"], TEST_AWS_ACCOUNT)
+            result_location = json.dumps(result_configuration["OutputLocation"])
+            self.assertIn("s3://", result_location)
+            self.assertIn("/athena-results/", result_location)
+
+        for stage_name, environment in ((DEV, TEST_DEV_ENV), (RELEASE_TEST, TEST_RELEASE_TEST_ENV)):
+            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
+                tracker_template = service_templates(stage_name)[0]
+
+            self.assertFalse(tracker_template.find_resources("AWS::Glue::Table"))
+            self.assertFalse(tracker_template.find_resources("AWS::Athena::NamedQuery"))
+            self.assertFalse(tracker_template.find_resources("AWS::Athena::WorkGroup"))
+            load_balancer = next(
+                iter(tracker_template.find_resources("AWS::ElasticLoadBalancingV2::LoadBalancer").values())
+            )
+            attributes = load_balancer["Properties"].get("LoadBalancerAttributes", [])
+            self.assertNotIn("access_logs.s3.enabled", {attribute["Key"] for attribute in attributes})
+
     def test_redis_ingress_is_limited_to_tracker_and_executor_host(self) -> None:
         for stage_name, environment in (
             (BENCH, TEST_BENCH_ENV),

--- a/infra/tests/test_monitoring_stack.py
+++ b/infra/tests/test_monitoring_stack.py
@@ -432,8 +432,12 @@ class MonitoringStackTest(unittest.TestCase):
             1,
         )
 
-    def test_production_tracker_access_logs_are_restricted_and_queryable(self) -> None:
-        for stage_name, environment in ((BENCH, TEST_BENCH_ENV), (PROD, TEST_PROD_ENV)):
+    def test_deployed_tracker_access_logs_are_restricted_and_queryable(self) -> None:
+        for stage_name, environment, retention_days in (
+            (DEV, TEST_DEV_ENV, 7),
+            (BENCH, TEST_BENCH_ENV, 365),
+            (PROD, TEST_PROD_ENV, 365),
+        ):
             with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
                 tracker_template = service_templates(stage_name)[0]
 
@@ -463,7 +467,7 @@ class MonitoringStackTest(unittest.TestCase):
                             {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}
                         ]
                     },
-                    "LifecycleConfiguration": {"Rules": [{"ExpirationInDays": 90, "Status": "Enabled"}]},
+                    "LifecycleConfiguration": {"Rules": [{"ExpirationInDays": retention_days, "Status": "Enabled"}]},
                     "OwnershipControls": {"Rules": [{"ObjectOwnership": "BucketOwnerEnforced"}]},
                     "PublicAccessBlockConfiguration": {
                         "BlockPublicAcls": True,
@@ -480,6 +484,10 @@ class MonitoringStackTest(unittest.TestCase):
                 statement
                 for statement in bucket_policy["Statement"]
                 if statement.get("Sid") == "AllowTrackerAlbLogDelivery"
+            )
+            self.assertEqual(
+                [statement for statement in bucket_policy["Statement"] if statement["Effect"] == "Allow"],
+                [delivery_statement],
             )
             self.assertEqual(delivery_statement["Action"], "s3:PutObject")
             self.assertEqual(
@@ -572,18 +580,19 @@ class MonitoringStackTest(unittest.TestCase):
             self.assertIn("s3://", result_location)
             self.assertIn("/athena-results/", result_location)
 
-        for stage_name, environment in ((DEV, TEST_DEV_ENV), (RELEASE_TEST, TEST_RELEASE_TEST_ENV)):
-            with self.subTest(stage=stage_name), mock.patch.dict(os.environ, environment, clear=True):
-                tracker_template = service_templates(stage_name)[0]
+        with mock.patch.dict(os.environ, TEST_RELEASE_TEST_ENV, clear=True):
+            tracker_template = service_templates(RELEASE_TEST)[0]
 
-            self.assertFalse(tracker_template.find_resources("AWS::Glue::Table"))
-            self.assertFalse(tracker_template.find_resources("AWS::Athena::NamedQuery"))
-            self.assertFalse(tracker_template.find_resources("AWS::Athena::WorkGroup"))
-            load_balancer = next(
-                iter(tracker_template.find_resources("AWS::ElasticLoadBalancingV2::LoadBalancer").values())
-            )
-            attributes = load_balancer["Properties"].get("LoadBalancerAttributes", [])
-            self.assertNotIn("access_logs.s3.enabled", {attribute["Key"] for attribute in attributes})
+        self.assertFalse(tracker_template.find_resources("AWS::Glue::Table"))
+        self.assertFalse(tracker_template.find_resources("AWS::Athena::NamedQuery"))
+        self.assertFalse(tracker_template.find_resources("AWS::Athena::WorkGroup"))
+        self.assertFalse(tracker_template.find_resources("AWS::S3::Bucket"))
+        self.assertFalse(tracker_template.find_resources("AWS::S3::BucketPolicy"))
+        load_balancer = next(
+            iter(tracker_template.find_resources("AWS::ElasticLoadBalancingV2::LoadBalancer").values())
+        )
+        attributes = load_balancer["Properties"].get("LoadBalancerAttributes", [])
+        self.assertNotIn("access_logs.s3.enabled", {attribute["Key"] for attribute in attributes})
 
     def test_redis_ingress_is_limited_to_tracker_and_executor_host(self) -> None:
         for stage_name, environment in (

--- a/infra/tracker-alb-access-logs.md
+++ b/infra/tracker-alb-access-logs.md
@@ -1,0 +1,108 @@
+# Tracker ALB access logs
+
+Each production Tracker load balancer writes restricted request evidence to its own S3 bucket. The bucket uses SSE-S3, blocks public access, requires TLS, and expires objects after 90 days. Its bucket policy permits only the Elastic Load Balancing delivery service for load balancers in the same account and Region. The logs are not copied to CloudWatch Logs.
+
+ALB access logs include client or upstream-proxy IP addresses, full request URIs, user agents, status codes, target addresses, latency fields, and `X-Amzn-Trace-Id`. Treat the bucket and Athena results as restricted operational data. Access comes from the responder's existing AWS IAM permissions; this stack grants no new read access.
+
+AWS delivers access logs approximately every five minutes with eventual consistency. Delivery is best effort and can include duplicate coverage, so these logs support incident diagnosis rather than complete request accounting.
+
+## Find the log resources
+
+1. Open the Tracker stack outputs.
+
+   **Why** -- Each production account has its own generated bucket name. The stack output identifies the bucket without relying on a copied value.
+
+   In the AWS console, open **CloudFormation → Stacks → TrackerStack** for the internal production account or **ValkProdTrackerStack** for external production, then open **Outputs**. Find `TrackerAlbAccessLogBucketName`, `TrackerAlbAccessLogDatabaseName`, and `TrackerAlbAccessLogWorkGroupName`.
+
+   CLI alternative:
+
+   ```bash
+   aws cloudformation describe-stacks \
+     --stack-name TrackerStack \
+     --query 'Stacks[0].Outputs[?starts_with(OutputKey, `TrackerAlbAccessLog`)].[OutputKey,OutputValue]' \
+     --output table
+   ```
+
+   Use `ValkProdTrackerStack` for external production and select the profile for the intended account.
+
+   **Done when** -- The outputs show a dedicated access-log bucket, the `tracker_alb_access_logs` database, and the `tracker-alb-access-logs` workgroup in the expected account and Region.
+
+2. Confirm log delivery when investigating a recent event.
+
+   **Why** -- Enabling access logs causes the load balancer to write a permission test object immediately, but request logs arrive asynchronously.
+
+   In the S3 console, open the output bucket and browse to `tracker-alb/AWSLogs/<account-id>/`. Confirm `ELBAccessLogTestFile` exists, then browse through `elasticloadbalancing/<region>/<yyyy>/<mm>/<dd>/` for `.log.gz` objects covering the UTC incident window.
+
+   CLI alternative:
+
+   ```bash
+   aws s3api list-objects-v2 \
+     --bucket <TrackerAlbAccessLogBucketName> \
+     --prefix tracker-alb/AWSLogs/<account-id>/ \
+     --query 'Contents[-10:].[LastModified,Key]' \
+     --output table
+   ```
+
+   **Done when** -- The test object exists and at least one compressed access-log object has arrived for a request made after deployment.
+
+## Query a UTC incident window
+
+1. Open the saved Athena query.
+
+   **Why** -- The provisioned Glue table follows AWS's ALB log schema and projects date partitions automatically. Responders do not need a crawler, `ALTER TABLE`, or local parsing.
+
+   In the AWS console, open **Athena → Query editor**, select the `tracker-alb-access-logs` workgroup and `tracker_alb_access_logs` database, then choose **Saved queries → tracker-alb-request-window**. The workgroup enforces SSE-S3 query results under `athena-results/` in the same restricted bucket; responders cannot redirect results to another location.
+
+   CLI alternative: use `aws athena get-named-query` to retrieve the saved SQL and `aws athena start-query-execution --work-group tracker-alb-access-logs` after setting the intended UTC bounds. The enforced workgroup supplies the result location and encryption.
+
+   **Done when** -- The saved query opens against the `requests` table in the enforced workgroup and its `bounds` CTE shows a one-hour UTC window ending now.
+
+2. Set and run the incident window.
+
+   **Why** -- Filtering both the projected `day` partition and the parsed event timestamp limits scanned data while preserving exact UTC boundaries. The query includes the next delivery-date partition because a request completed just before midnight can be delivered in a log object dated just after midnight.
+
+   For a fixed window, replace the two expressions in the `bounds` CTE with ISO-8601 UTC timestamps:
+
+   ```sql
+   WITH bounds AS (
+       SELECT
+           from_iso8601_timestamp('2026-09-03T08:45:00Z') AS start_utc,
+           from_iso8601_timestamp('2026-09-03T09:15:00Z') AS end_utc
+   )
+   ```
+
+   Run the full saved query. It returns request time, client or proxy IP, method and URI, user agent, ALB and target status, target address, the three latency segments, and the ALB trace ID.
+
+   **Done when** -- Results cover the intended UTC window, or the empty result is interpreted alongside the approximately five-minute delivery delay and best-effort limitation.
+
+3. Correlate a known request with Tracker logs.
+
+   **Why** -- The ALB entry shows the network path and supplies the durable trace ID; Tracker's existing access record confirms that the request reached the application without requiring a Tracker rollout.
+
+   Send a request to a unique nonexistent path and record the UTC time. A `404` response is expected and does not mutate Tracker state:
+
+   ```bash
+   curl -i "https://<tracker-host>/alb-log-correlation-<UTC-timestamp>"
+   ```
+
+   Find that path in the Athena result. In **CloudWatch → Log groups**, open the Tracker log group for the same stage and match the existing access record by its tight UTC window, method, unique path, and `404` status. Record the ALB row's `trace_id` with the incident evidence. Do not attempt to match IP addresses: the ALB `target_address` is the Tracker task, while Tracker sees an ALB node as the connecting client.
+
+   CLI alternative:
+
+   ```bash
+   aws logs filter-log-events \
+     --log-group-name /valkyrie/tracker \
+     --filter-pattern '"<METHOD> <PATH>"' \
+     --start-time <window-start-epoch-ms> \
+     --end-time <window-end-epoch-ms>
+   ```
+
+   Use the stage-qualified Tracker log group name for external production.
+
+   **Done when** -- One ALB row and one Tracker access record match on UTC time, method, unique path, and status, and the ALB trace ID is recorded with the evidence.
+
+## Request-URI safety boundary
+
+ALB logging preserves the request URI, including its query string. Tracker authentication and secret material use headers or request bodies. The query parameters audited when this logging was introduced are identifiers, filters, pagination, ordering, connection and retry controls, task selections, model and dataset selectors, labels, and UTC date bounds. No Tracker route accepts credentials, tokens, API keys, secret values, or secret names in its query string.
+
+Do not introduce a query parameter carrying credential or secret material. Use an authorization header, `X-Api-Key`, or a validated request-body field appropriate to the existing endpoint contract.

--- a/infra/tracker-alb-access-logs.md
+++ b/infra/tracker-alb-access-logs.md
@@ -1,6 +1,6 @@
 # Tracker ALB access logs
 
-Each production Tracker load balancer writes restricted request evidence to its own S3 bucket. The bucket uses SSE-S3, blocks public access, requires TLS, and expires objects after 90 days. Its bucket policy permits only the Elastic Load Balancing delivery service for load balancers in the same account and Region. The logs are not copied to CloudWatch Logs.
+The dev, bench, and external production Tracker load balancers each write restricted request evidence to their own S3 bucket. Each bucket uses SSE-S3, blocks public access, and requires TLS. Dev objects expire after 7 days; bench and external production objects expire after 365 days. The bucket policy permits only the Elastic Load Balancing delivery service for load balancers in the same account and Region. The logs are not copied to CloudWatch Logs.
 
 ALB access logs include client or upstream-proxy IP addresses, full request URIs, user agents, status codes, target addresses, latency fields, and `X-Amzn-Trace-Id`. Treat the bucket and Athena results as restricted operational data. Access comes from the responder's existing AWS IAM permissions; this stack grants no new read access.
 
@@ -10,9 +10,9 @@ AWS delivers access logs approximately every five minutes with eventual consiste
 
 1. Open the Tracker stack outputs.
 
-   **Why** -- Each production account has its own generated bucket name. The stack output identifies the bucket without relying on a copied value.
+   **Why** -- Each deployed account has its own generated bucket name. The stack output identifies the bucket without relying on a copied value.
 
-   In the AWS console, open **CloudFormation → Stacks → TrackerStack** for the internal production account or **ValkProdTrackerStack** for external production, then open **Outputs**. Find `TrackerAlbAccessLogBucketName`, `TrackerAlbAccessLogDatabaseName`, and `TrackerAlbAccessLogWorkGroupName`.
+   In the AWS console, open **CloudFormation → Stacks**, choose `ValkDevTrackerStack` for dev, `TrackerStack` for bench, or `ValkProdTrackerStack` for external production, then open **Outputs**. Find `TrackerAlbAccessLogBucketName`, `TrackerAlbAccessLogDatabaseName`, and `TrackerAlbAccessLogWorkGroupName`.
 
    CLI alternative:
 
@@ -23,7 +23,7 @@ AWS delivers access logs approximately every five minutes with eventual consiste
      --output table
    ```
 
-   Use `ValkProdTrackerStack` for external production and select the profile for the intended account.
+   Use `ValkDevTrackerStack` for dev or `ValkProdTrackerStack` for external production, and select the profile for the intended account.
 
    **Done when** -- The outputs show a dedicated access-log bucket, the `tracker_alb_access_logs` database, and the `tracker-alb-access-logs` workgroup in the expected account and Region.
 
@@ -97,7 +97,7 @@ AWS delivers access logs approximately every five minutes with eventual consiste
      --end-time <window-end-epoch-ms>
    ```
 
-   Use the stage-qualified Tracker log group name for external production.
+   Use the stage-qualified Tracker log group name for dev or external production.
 
    **Done when** -- One ALB row and one Tracker access record match on UTC time, method, unique path, and status, and the ALB trace ID is recorded with the evidence.
 

--- a/infra/tracker_access_logs.py
+++ b/infra/tracker_access_logs.py
@@ -9,7 +9,8 @@ from constructs import Construct
 from stage import Stage
 
 ACCESS_LOG_PREFIX = "tracker-alb"
-ACCESS_LOG_RETENTION_DAYS = 90
+PRODUCTION_ACCESS_LOG_RETENTION_DAYS = 365
+DEV_ACCESS_LOG_RETENTION_DAYS = 7
 ATHENA_DATABASE_NAME = "tracker_alb_access_logs"
 ATHENA_TABLE_NAME = "requests"
 ATHENA_WORKGROUP_NAME = "tracker-alb-access-logs"
@@ -66,11 +67,12 @@ def create_tracker_access_logs(
     stage: Stage,
     load_balancer: aws_elasticloadbalancingv2.ApplicationLoadBalancer,
 ) -> None:
-    """Create production Tracker ALB access-log storage and its Athena catalog."""
-    if not stage.is_production:
+    """Create deployed Tracker ALB access-log storage and its Athena catalog."""
+    if stage.is_release_test:
         return
 
     stack = cdk.Stack.of(scope)
+    retention_days = PRODUCTION_ACCESS_LOG_RETENTION_DAYS if stage.is_production else DEV_ACCESS_LOG_RETENTION_DAYS
     bucket = aws_s3.Bucket(
         scope,
         "TrackerAlbAccessLogBucket",
@@ -80,7 +82,7 @@ def create_tracker_access_logs(
         object_ownership=aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
         lifecycle_rules=[
             aws_s3.LifecycleRule(
-                expiration=cdk.Duration.days(ACCESS_LOG_RETENTION_DAYS),
+                expiration=cdk.Duration.days(retention_days),
             )
         ],
         removal_policy=cdk.RemovalPolicy.RETAIN,

--- a/infra/tracker_access_logs.py
+++ b/infra/tracker_access_logs.py
@@ -1,0 +1,227 @@
+"""Restricted ALB access-log storage and query resources for Tracker."""
+
+from typing import cast
+
+import aws_cdk as cdk
+from aws_cdk import aws_athena, aws_elasticloadbalancingv2, aws_glue, aws_iam, aws_s3
+from constructs import Construct
+
+from stage import Stage
+
+ACCESS_LOG_PREFIX = "tracker-alb"
+ACCESS_LOG_RETENTION_DAYS = 90
+ATHENA_DATABASE_NAME = "tracker_alb_access_logs"
+ATHENA_TABLE_NAME = "requests"
+ATHENA_WORKGROUP_NAME = "tracker-alb-access-logs"
+
+_ALB_LOG_COLUMNS = (
+    ("type", "string"),
+    ("time", "string"),
+    ("elb", "string"),
+    ("client_ip", "string"),
+    ("client_port", "int"),
+    ("target_ip", "string"),
+    ("target_port", "int"),
+    ("request_processing_time", "double"),
+    ("target_processing_time", "double"),
+    ("response_processing_time", "double"),
+    ("elb_status_code", "int"),
+    ("target_status_code", "string"),
+    ("received_bytes", "bigint"),
+    ("sent_bytes", "bigint"),
+    ("request_verb", "string"),
+    ("request_url", "string"),
+    ("request_proto", "string"),
+    ("user_agent", "string"),
+    ("ssl_cipher", "string"),
+    ("ssl_protocol", "string"),
+    ("target_group_arn", "string"),
+    ("trace_id", "string"),
+    ("domain_name", "string"),
+    ("chosen_cert_arn", "string"),
+    ("matched_rule_priority", "string"),
+    ("request_creation_time", "string"),
+    ("actions_executed", "string"),
+    ("redirect_url", "string"),
+    ("lambda_error_reason", "string"),
+    ("target_port_list", "string"),
+    ("target_status_code_list", "string"),
+    ("classification", "string"),
+    ("classification_reason", "string"),
+    ("conn_trace_id", "string"),
+)
+
+_ALB_LOG_INPUT_REGEX = (
+    r"([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*):([0-9]*) ([^ ]*)[:-]([0-9]*) "
+    r"([-.0-9]*) ([-.0-9]*) ([-.0-9]*) (|[-0-9]*) (-|[-0-9]*) ([-0-9]*) ([-0-9]*) "
+    r'"([^ ]*) (.*) (- |[^ ]*)" "([^"]*)" ([A-Z0-9-_]+) ([A-Za-z0-9.-]*) ([^ ]*) '
+    r'"([^"]*)" "([^"]*)" "([^"]*)" ([-.0-9]*) ([^ ]*) "([^"]*)" "([^"]*)" '
+    r'"([^ ]*)" "([^\s]+?)" "([^\s]+)" "([^ ]*)" "([^ ]*)" ?([^ ]*)? ?( .*)?'
+)
+
+
+def create_tracker_access_logs(
+    scope: Construct,
+    *,
+    stage: Stage,
+    load_balancer: aws_elasticloadbalancingv2.ApplicationLoadBalancer,
+) -> None:
+    """Create production Tracker ALB access-log storage and its Athena catalog."""
+    if not stage.is_production:
+        return
+
+    stack = cdk.Stack.of(scope)
+    bucket = aws_s3.Bucket(
+        scope,
+        "TrackerAlbAccessLogBucket",
+        block_public_access=aws_s3.BlockPublicAccess.BLOCK_ALL,
+        encryption=aws_s3.BucketEncryption.S3_MANAGED,
+        enforce_ssl=True,
+        object_ownership=aws_s3.ObjectOwnership.BUCKET_OWNER_ENFORCED,
+        lifecycle_rules=[
+            aws_s3.LifecycleRule(
+                expiration=cdk.Duration.days(ACCESS_LOG_RETENTION_DAYS),
+            )
+        ],
+        removal_policy=cdk.RemovalPolicy.RETAIN,
+    )
+    bucket.add_to_resource_policy(
+        aws_iam.PolicyStatement(
+            sid="AllowTrackerAlbLogDelivery",
+            principals=[
+                cast(
+                    aws_iam.IPrincipal,
+                    aws_iam.ServicePrincipal("logdelivery.elasticloadbalancing.amazonaws.com"),
+                )
+            ],
+            actions=["s3:PutObject"],
+            resources=[bucket.arn_for_objects(f"{ACCESS_LOG_PREFIX}/AWSLogs/{stack.account}/*")],
+            conditions={
+                "StringEquals": {"aws:SourceAccount": stack.account},
+                "ArnLike": {
+                    "aws:SourceArn": (
+                        f"arn:{stack.partition}:elasticloadbalancing:{stack.region}:{stack.account}:loadbalancer/*"
+                    )
+                },
+            },
+        )
+    )
+
+    load_balancer.set_attribute("access_logs.s3.enabled", "true")
+    load_balancer.set_attribute("access_logs.s3.bucket", bucket.bucket_name)
+    load_balancer.set_attribute("access_logs.s3.prefix", ACCESS_LOG_PREFIX)
+    bucket_policy = bucket.policy
+    cfn_load_balancer = load_balancer.node.default_child
+    cfn_bucket_policy = bucket_policy.node.default_child if bucket_policy is not None else None
+    if not isinstance(cfn_load_balancer, cdk.CfnResource) or not isinstance(cfn_bucket_policy, cdk.CfnResource):
+        raise RuntimeError("Tracker ALB access logging requires synthesized load balancer and bucket policy resources")
+    cfn_load_balancer.add_dependency(cfn_bucket_policy)
+
+    database = aws_glue.CfnDatabase(
+        scope,
+        "TrackerAlbAccessLogDatabase",
+        catalog_id=stack.account,
+        database_input=aws_glue.CfnDatabase.DatabaseInputProperty(
+            name=ATHENA_DATABASE_NAME,
+            description="Restricted Tracker Application Load Balancer access logs",
+        ),
+    )
+    log_root = (
+        f"s3://{bucket.bucket_name}/{ACCESS_LOG_PREFIX}/AWSLogs/{stack.account}/elasticloadbalancing/{stack.region}/"
+    )
+    table = aws_glue.CfnTable(
+        scope,
+        "TrackerAlbAccessLogTable",
+        catalog_id=stack.account,
+        database_name=ATHENA_DATABASE_NAME,
+        table_input=aws_glue.CfnTable.TableInputProperty(
+            name=ATHENA_TABLE_NAME,
+            description="Tracker ALB request evidence with projected UTC day partitions",
+            table_type="EXTERNAL_TABLE",
+            parameters={
+                "EXTERNAL": "TRUE",
+                "projection.enabled": "true",
+                "projection.day.type": "date",
+                "projection.day.range": "2026/09/01,NOW",
+                "projection.day.format": "yyyy/MM/dd",
+                "projection.day.interval": "1",
+                "projection.day.interval.unit": "DAYS",
+                "storage.location.template": f"{log_root}${{day}}/",
+            },
+            partition_keys=[aws_glue.CfnTable.ColumnProperty(name="day", type="string")],
+            storage_descriptor=aws_glue.CfnTable.StorageDescriptorProperty(
+                columns=[
+                    aws_glue.CfnTable.ColumnProperty(name=name, type=column_type)
+                    for name, column_type in _ALB_LOG_COLUMNS
+                ],
+                compressed=True,
+                input_format="org.apache.hadoop.mapred.TextInputFormat",
+                output_format="org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                location=log_root,
+                serde_info=aws_glue.CfnTable.SerdeInfoProperty(
+                    serialization_library="org.apache.hadoop.hive.serde2.RegexSerDe",
+                    parameters={
+                        "serialization.format": "1",
+                        "input.regex": _ALB_LOG_INPUT_REGEX,
+                    },
+                ),
+            ),
+        ),
+    )
+    table.add_dependency(database)
+
+    workgroup = aws_athena.CfnWorkGroup(
+        scope,
+        "TrackerAlbAccessLogWorkGroup",
+        name=ATHENA_WORKGROUP_NAME,
+        description="Restricted Tracker ALB incident queries",
+        work_group_configuration=aws_athena.CfnWorkGroup.WorkGroupConfigurationProperty(
+            enforce_work_group_configuration=True,
+            publish_cloud_watch_metrics_enabled=False,
+            result_configuration=aws_athena.CfnWorkGroup.ResultConfigurationProperty(
+                encryption_configuration=aws_athena.CfnWorkGroup.EncryptionConfigurationProperty(
+                    encryption_option="SSE_S3",
+                ),
+                expected_bucket_owner=stack.account,
+                output_location=f"s3://{bucket.bucket_name}/athena-results/",
+            ),
+        ),
+    )
+
+    query = aws_athena.CfnNamedQuery(
+        scope,
+        "TrackerAlbRequestWindowQuery",
+        database=ATHENA_DATABASE_NAME,
+        name="tracker-alb-request-window",
+        description="Tracker ALB requests in an editable UTC time window",
+        work_group=workgroup.ref,
+        query_string=f"""WITH bounds AS (
+    SELECT
+        current_timestamp - interval '1' hour AS start_utc,
+        current_timestamp AS end_utc
+)
+SELECT
+    from_iso8601_timestamp(time) AS request_time_utc,
+    client_ip,
+    request_verb,
+    request_url,
+    user_agent,
+    elb_status_code,
+    target_status_code,
+    concat(target_ip, ':', cast(target_port AS varchar)) AS target_address,
+    request_processing_time,
+    target_processing_time,
+    response_processing_time,
+    trace_id
+FROM {ATHENA_TABLE_NAME}
+CROSS JOIN bounds
+WHERE day BETWEEN date_format(start_utc, '%Y/%m/%d') AND date_format(end_utc + interval '1' day, '%Y/%m/%d')
+  AND from_iso8601_timestamp(time) BETWEEN start_utc AND end_utc
+ORDER BY request_time_utc
+""",
+    )
+    query.add_dependency(table)
+
+    cdk.CfnOutput(scope, "TrackerAlbAccessLogBucketName", value=bucket.bucket_name)
+    cdk.CfnOutput(scope, "TrackerAlbAccessLogDatabaseName", value=ATHENA_DATABASE_NAME)
+    cdk.CfnOutput(scope, "TrackerAlbAccessLogWorkGroupName", value=ATHENA_WORKGROUP_NAME)

--- a/infra/tracker_stack.py
+++ b/infra/tracker_stack.py
@@ -50,6 +50,7 @@ from constructs import Construct
 from runtime_iam import create_tracker_task_role, managed_runtime_environment
 from stage import PROD, Stage
 from stage_config import benchmark_service_base_url, config_for
+from tracker_access_logs import create_tracker_access_logs
 
 _ARM64_PLATFORM = aws_ecs.RuntimePlatform(
     cpu_architecture=aws_ecs.CpuArchitecture.ARM64,
@@ -286,6 +287,12 @@ class TrackerStack(Stack):
             open_listener=False,
             assign_public_ip=True,
             public_load_balancer=not stage.is_release_test,
+        )
+
+        create_tracker_access_logs(
+            self,
+            stage=stage,
+            load_balancer=self.service.load_balancer,
         )
 
         # Expose the inner FargateService for cross-stack security group rules.


### PR DESCRIPTION
## Human Description

### Why

Allow us to see who's making what requests to help us better debug issues

---

A previous Tracker outage included 2,201 task-list requests, but we could not identify the initiating client because ALB access logging was disabled. This change retains restricted request-level evidence and makes it queryable without another deployment or ad hoc parsing.

Closes vals-ai/valkyrie-ticket-library#153

## What changed

- Enable access logging for the dev, bench, and external production Tracker ALBs with an explicit S3 bucket and prefix.
- Store logs in dedicated SSE-S3 buckets that block public access, require TLS, and limit ALB delivery by source account and load balancer ARN. Dev objects expire after 7 days; bench and external production objects expire after 365 days.
- Provision a projected Glue table, an enforced Athena workgroup, and a saved UTC-window query that returns the caller, request, response, latency, target, and trace fields needed during an incident.
- Document the incident query and correlation procedure, restricted-data boundary, delivery limitations, and the audit confirming current public Tracker routes do not accept credentials or secrets in query parameters.

## How to review

Start with `infra/tracker_access_logs.py`, especially the S3 delivery policy and projected table definition. The resource flow is:

```mermaid
flowchart LR
    Client --> ALB[Tracker ALB]
    ALB -->|access logs| S3[Restricted S3 bucket]
    Athena --> Glue[Projected Glue table]
    Glue --> S3
    Responder --> Athena
    Athena -->|query results| S3
```

The CDK convenience method for ALB logging does not apply the source-account and load-balancer-ARN restrictions required here, so the bucket policy is explicit. Athena and Glue expose only low-level CDK resources in the pinned dependency version.

## Testing

Dev live test passed at merge commit `0566d733`. The automatic dev core deployment completed successfully. CloudFormation updated the existing ALB and ECS service in place. It registered task-definition revision 80 and rolled the dev task because `SENTRY_RELEASE` changed from the prior dev SHA to the merge SHA; the container image, CPU, memory, task role, and execution role were unchanged. Tracker completed the rollout at 1/1 running with zero pending tasks.

The ALB enabled the intended bucket and prefix, the delivery test file and real request-log objects arrived, and the bucket reported SSE-S3, blocked public access, and 7-day expiration. The deployed saved Athena query succeeded through the enforced workgroup and returned a unique 404 request with the required request, response, target, latency, and trace fields. Tracker's CloudWatch access log contained exactly one matching record at the same millisecond, method, path, and status.

Bench and external production were not deployed. Before the bench deployment, repeat the CDK diff because the current bench environment has unrelated Tracker image drift from `dev` that proposes a task rollout even though this change does not modify Tracker task sources.

Design: architectural (adds a restricted request-log storage and query boundary)
