### PR TITLE
Pass runtime S3 bucket to completion callbacks

### DIFF
--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -641,6 +641,10 @@ async def process_benchmark(
                 lambda_payload = benchmark_row.arguments.model_dump()
                 lambda_payload["benchmark_id"] = str(benchmark_id)
                 lambda_payload["benchmark_name"] = benchmark_row.name
+                # Completion callbacks must read and write artifacts in the same
+                # stage-specific bucket used by this run. Lambda defaults are not
+                # sufficient because dev and production use different buckets.
+                lambda_payload["bucket"] = aws_runtime.resources.s3_bucket
 
         async with hold_dispatch_authority(authority) as (_, benchmark_row):
             await upload_final_view(benchmark_row, final_view, aws_runtime)

--- a/services/tracker/tests/unit/test_managed_execution.py
+++ b/services/tracker/tests/unit/test_managed_execution.py
@@ -350,8 +350,11 @@ async def test_managed_execution_completes_with_the_deployment_runtime(
         assert runtime is aws_runtime
         calls.append("s3-final-upload")
 
-    def invoke_post_run(clients: object, _function_name: str, _payload: object, **_kwargs: Any) -> dict[str, Any]:
+    def invoke_post_run(
+        clients: object, _function_name: str, payload: dict[str, Any], **_kwargs: Any
+    ) -> dict[str, Any]:
         assert clients is aws_runtime.clients
+        assert payload["bucket"] == aws_runtime.resources.s3_bucket
         calls.append("lambda-post-run")
         return {}
 

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -641,6 +641,7 @@ class TestRunRecovery:
         assert benchmark_row.status == BenchmarkStatus.FINISHED, benchmark_row.error_message
         assert len(captured_lambda_payloads) == 1
         assert captured_lambda_payloads[0]["benchmark_name"] == "swebench"
+        assert captured_lambda_payloads[0]["bucket"] == harness_config.s3_bucket
 
     @pytest.mark.parametrize(
         ("retry_mode", "eval_resume_state", "expected_status", "expected_state"),


### PR DESCRIPTION
## Summary
- includes the resolved run-time S3 bucket in completion-callback payloads
- prevents development finalizers from silently defaulting to the production results bucket

## Why
A managed dev run completed successfully, but `vals-format-lambda` received no bucket and defaulted to `agentic-harness`, which the dev Lambda role cannot read. The finalizer must use the same stage-specific bucket as the tracker run.

## Validation
- `uv run pytest -q services/tracker/tests/unit/utils/test_run_recovery.py -k test_stop_and_resume`
- focused test asserts the callback receives the harness bucket
- `ruff check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->