### PR TITLE
Respect environment selection during managed initialization #patch

### DIFF
--- a/src/valkyrie/cli/config/settings.py
+++ b/src/valkyrie/cli/config/settings.py
@@ -7,7 +7,9 @@ from valkyrie.cli.exceptions import TrackerServiceError
 from valkyrie.cli.runtime_config import (
     ENVIRONMENT_CONFIG_KEY,
     TRACKER_SERVICE_URL_ENV_VAR,
+    VALKYRIE_ENV_ENV_VAR,
     config_location,
+    selected_environment,
     tracker_url_for_environment,
 )
 from valkyrie.cli.tracker_client import TrackerService
@@ -73,11 +75,15 @@ def init() -> None:
     environment_variables = _REQUIRED_ENVIRONMENT_VARIABLES
 
     if mode == "hosted":
-        environment = click.prompt(
-            "Hosted environment",
-            type=click.Choice(["bench", "prod"]),
-            default="bench",
-        )
+        if os.environ.get(VALKYRIE_ENV_ENV_VAR) is not None:
+            environment = selected_environment()
+            click.echo(f"Hosted environment: {environment} (from {VALKYRIE_ENV_ENV_VAR})")
+        else:
+            environment = click.prompt(
+                "Hosted environment",
+                type=click.Choice(["bench", "prod"]),
+                default="bench",
+            )
         current_config[ENVIRONMENT_CONFIG_KEY] = environment
         tracker_url = os.environ.get(TRACKER_SERVICE_URL_ENV_VAR) or tracker_url_for_environment(environment)
         api_key = (os.environ.get("VALKYRIE_API_KEY") or click.prompt("API Key")).strip()
@@ -119,8 +125,9 @@ def init() -> None:
             )
             if removed_static_credentials:
                 click.echo(
-                    "Existing static AWS credentials were removed. Restore them before retrying or resuming "
-                    "an access-key run.\n"
+                    "Existing static AWS credentials were removed. Keep this config keyless; use the legacy "
+                    "recovery console for existing access-key runs:\n"
+                    "https://dashboards.vals.ai/valkyrie/prod/legacy-recovery\n"
                 )
 
     collected_keys: dict[str, str] = {}

--- a/tests/unit/cli/config/test_settings.py
+++ b/tests/unit/cli/config/test_settings.py
@@ -167,7 +167,48 @@ def test_init_hosted_managed_aws_omits_static_keys(config_path: Path, monkeypatc
     assert config["LOG_RETENTION_POLICY"] == "365"
     assert not settings._STATIC_AWS_CREDENTIAL_KEYS.intersection(config)
     assert "Local AWS operations will use the AWS SDK credential chain" in result.output
-    assert "Restore them before retrying or resuming an access-key run" in result.output
+    assert "Keep this config keyless" in result.output
+    assert "https://dashboards.vals.ai/valkyrie/prod/legacy-recovery" in result.output
+
+
+@pytest.mark.parametrize(
+    ("selector", "environment", "tracker_url"),
+    [
+        ("dev", "dev", "https://benchmark-tracker-dev.vals.ai"),
+        ("prod", "bench", "https://benchmark-tracker.vals.ai"),
+        ("external", "prod", "https://benchmark-tracker-prod.vals.ai"),
+    ],
+)
+def test_managed_init_uses_selected_environment_resources(
+    config_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    selector: str,
+    environment: str,
+    tracker_url: str,
+) -> None:
+    monkeypatch.setenv("VALKYRIE_ENV", selector)
+    monkeypatch.setenv("VALKYRIE_API_KEY", "assigned-key")
+    monkeypatch.delenv(settings.TRACKER_SERVICE_URL_ENV_VAR, raising=False)
+    calls: list[str] = []
+
+    def init_org(_api_key: str, base_url: str) -> dict[str, str]:
+        calls.append(base_url)
+        return {"org_name": "test-org"}
+
+    def runtime(_api_key: str, base_url: str) -> SimpleNamespace:
+        calls.append(base_url)
+        return SimpleNamespace(mode="managed", region="us-east-1", s3_bucket=f"{environment}-bucket")
+
+    monkeypatch.setattr(settings.TrackerService, "init_org", init_org)
+    monkeypatch.setattr(settings.TrackerService, "aws_runtime_metadata", runtime)
+    result = CliRunner().invoke(settings.init, input="hosted\n\n\n")
+
+    assert result.exit_code == 0, result.output
+    assert calls == [tracker_url, tracker_url]
+    saved = yaml.safe_load(config_path.read_text())
+    assert saved["environment"] == environment
+    assert saved["S3_BUCKET"] == f"{environment}-bucket"
+    assert not settings._STATIC_AWS_CREDENTIAL_KEYS.intersection(saved)
 
 
 @pytest.mark.usefixtures("config_path")


### PR DESCRIPTION
`VALKYRIE_ENV=dev valkyrie config init` could initialize the bench Tracker and save its AWS resource names into `dev.yaml`, because hosted setup ignored the selected CLI environment. Hosted initialization now uses the environment selector for both organization setup and runtime discovery, while retaining the existing interactive choice when no selector is set.

The migration message now directs historical access-key runs to the recovery console instead of recommending that users restore static credentials into their normal managed config.

Validation: 23 configuration/runtime-selection tests passed, including dev, the compatibility `prod` selector, and `external`; Ruff passed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->