### PR TITLE
docs(integrations): a failing post-run lambda does not error the run

### DIFF
--- a/docs/integrations/post-run-lambda.mdx
+++ b/docs/integrations/post-run-lambda.mdx
@@ -12,7 +12,7 @@ valkyrie run start \
   --lambda my-post-benchmark-handler
 ```
 
-The lambda is invoked once after all tasks finish and results are uploaded. If the lambda fails (uncaught exception or `statusCode >= 400`), the run will be marked as `ERROR`.
+The lambda is invoked once after all tasks finish and results are uploaded. By that point the run's status is already terminal, so a lambda that fails — an uncaught exception, or a `statusCode >= 400` — does **not** change it: the run stays `FINISHED` and the failure is recorded in the tracker logs. Check those logs to confirm your lambda ran; a green run is not evidence that it did.
 
 ## Payload
 

--- a/docs/integrations/post-run-lambda.mdx
+++ b/docs/integrations/post-run-lambda.mdx
@@ -12,7 +12,7 @@ valkyrie run start \
   --lambda my-post-benchmark-handler
 ```
 
-The lambda is invoked once after all tasks finish and results are uploaded. By that point the run's status is already terminal, so a lambda that fails — an uncaught exception, or a `statusCode >= 400` — does **not** change it: the run stays `FINISHED` and the failure is recorded in the tracker logs. Check those logs to confirm your lambda ran; a green run is not evidence that it did.
+The lambda is invoked once after all tasks finish and results are uploaded. By that point the run's status is already terminal, so a lambda that fails — an uncaught exception, or a `statusCode >= 400` — does **not** change it: the run stays `FINISHED` and the failure is recorded in the tracker logs. The tracker logs only a failure, so to confirm your lambda ran at all, check its own CloudWatch logs; a green run is not evidence that it did.
 
 ## Payload
 


### PR DESCRIPTION
## Summary

`docs/integrations/post-run-lambda.mdx` said a failing post-run lambda marks the run `ERROR`. It does not, and has not:

```diff
-If the lambda fails (uncaught exception or `statusCode >= 400`), the run will be marked as `ERROR`.
+By that point the run's status is already terminal, so a lambda that fails does **not** change it:
+the run stays `FINISHED` and the failure is recorded in the tracker logs.
```

`process_benchmark` calls `set_benchmark_final_status` before invoking the callback, so by the time a failure propagates, `commit_benchmark_error` fails its `require_in_progress` check on `lock_execution_authority` and rolls back. The exception is logged and captured; the status is untouched.

## Verification

Not just read from the source — exercised against the current tracker. A completion callback raising `LambdaError` inside `process_benchmark` leaves:

```
status=FINISHED  error_message=None
```

`uv run pytest tests/unit/docs` passes; no test asserted the old wording.

## Why it's worth fixing

The documented behaviour is the reassuring one, which makes it the more dangerous error. Anyone using run status to confirm their lambda ran sees a green run whether the artifact was produced or not — which is exactly how a silently failing post-run lambda stays invisible. The page now points at the tracker logs and says plainly that a green run is not evidence the lambda ran.

Docs only; no behaviour change.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/765" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->