### PR TITLE
chore: pin CBS v0.35.0

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -10,4 +10,4 @@ prerelease = "allow"
 
 [tool.uv.sources]
 tracker = { path = "../tracker" }
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "df91887ea6844cf086644334674e2586c3c4d3ed" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.35.0" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.34.1.dev17+gdf91887ea"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=df91887ea6844cf086644334674e2586c3c4d3ed#df91887ea6844cf086644334674e2586c3c4d3ed" }
+version = "0.35.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0#35ace8c30585b1bbe872b20b5078894ba818517d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=df91887ea6844cf086644334674e2586c3c4d3ed" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "df91887ea6844cf086644334674e2586c3c4d3ed" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.35.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.34.1.dev17+gdf91887ea"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=df91887ea6844cf086644334674e2586c3c4d3ed#df91887ea6844cf086644334674e2586c3c4d3ed" }
+version = "0.35.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0#35ace8c30585b1bbe872b20b5078894ba818517d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=df91887ea6844cf086644334674e2586c3c4d3ed" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.34.1.dev17+gdf91887ea"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=df91887ea6844cf086644334674e2586c3c4d3ed#df91887ea6844cf086644334674e2586c3c4d3ed" }
+version = "0.35.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0#35ace8c30585b1bbe872b20b5078894ba818517d" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=df91887ea6844cf086644334674e2586c3c4d3ed" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## What changed

Replace Valkyrie’s temporary CBS review-head pin with released tag `v0.35.0` across Tracker, the Executor artifact, and all three lockfiles.

## Why

CBS #128 is merged and tagged. The previous `df91887…` revision and `v0.35.0` resolve to the same source tree, so this makes dependency provenance release-based without changing runtime code.

## How tested

- `uv lock --check`
- `(cd services/tracker && uv lock --check)`
- `(cd services/executor_artifact && uv lock --check)`
- Executor locked dependency export resolves CBS commit `35ace8c…`
- Tracker runtime import reports CBS `0.35.0` and exposes the admission API
- `uv run --project services/tracker --locked pytest services/tracker/tests/unit/scheduler/test_admission.py services/tracker/tests/unit/test_sandbox.py` — 62 passed
- `uv run --project services/tracker --locked pytest services/executor_artifact/tests/test_build.py` — 3 passed

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/766" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->