### PR TITLE
feat(tracker): audit Daytona sandbox allocation metadata at create

### DIFF
--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -123,6 +123,10 @@ def set_sandbox_context(sandbox: Any, *, image: str | None = None) -> None:
         if image is not None:
             context["image"] = image
 
+        metadata = getattr(sandbox, "provider_metadata", None)
+        if metadata:
+            context["provider_metadata"] = metadata
+
         sentry_sdk.set_context("sandbox", context)
     except Exception as e:
         logger.warning("set_sandbox_context failed: %s: %s", type(e).__name__, e)

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -316,6 +316,11 @@ async def create_sandbox(
                 sandbox = await asyncio.shield(creation_task)
             except asyncio.CancelledError:
                 sandbox = await creation_task
+                try:
+                    audit_sandbox_create(sandbox)
+                except Exception:
+                    # Must not replace the original cancellation.
+                    logger.exception("audit_sandbox_create failed for %s", sandbox.name)
                 await delete_sandbox(sandbox, provider, initiated_by="create_cancelled")
                 raise
     except Exception as e:
@@ -328,9 +333,9 @@ async def create_sandbox(
         tags={"image": _metric_source_name(source)},
     )
     set_sandbox_context(sandbox, image=source_name)
-    audit_sandbox_create(sandbox)
 
     try:
+        audit_sandbox_create(sandbox)
         yield sandbox
     except Exception as e:
         logger.error(f"Error during sandbox execution {sandbox.name}: {e}")

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -88,6 +88,23 @@ SandboxDeleteInitiator = Literal["create_cancelled", "force_stop", "orphan_clean
 SandboxDeleteOutcome = Literal["deleted", "already_gone", "cancelled", "failed"]
 
 
+def audit_sandbox_create(sandbox: Sandbox) -> None:
+    # Mirrors audit_sandbox_delete; provider_metadata carries provider-reported
+    # allocation fields (e.g. runner id) that are unrecoverable after deletion.
+    labels = sandbox.labels or {}
+    logger.info(
+        "sandbox.create",
+        extra={
+            "sandbox_id": sandbox.id,
+            "sandbox_name": sandbox.name,
+            "benchmark_id": labels.get("Id"),
+            "benchmark_name": labels.get("Benchmark"),
+            "task_id": labels.get("Task"),
+            "provider_metadata": sandbox.provider_metadata,
+        },
+    )
+
+
 def audit_sandbox_delete(
     sandbox: Sandbox,
     initiated_by: SandboxDeleteInitiator,
@@ -311,6 +328,7 @@ async def create_sandbox(
         tags={"image": _metric_source_name(source)},
     )
     set_sandbox_context(sandbox, image=source_name)
+    audit_sandbox_create(sandbox)
 
     try:
         yield sandbox

--- a/services/tracker/tests/unit/observability/test_observability.py
+++ b/services/tracker/tests/unit/observability/test_observability.py
@@ -261,6 +261,30 @@ class TestSandboxContext:
             }
         }
 
+    def test_set_sandbox_context_includes_provider_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Provider allocation fields must be carried into the Sentry context.
+
+        Test cases:
+        - A populated provider_metadata mapping is included in the sandbox context.
+        """
+        contexts: dict[str, dict[str, Any]] = {}
+
+        def fake_set_context(key: str, value: dict[str, Any]) -> None:
+            contexts[key] = value
+
+        monkeypatch.setattr(sentry_module.sentry_sdk, "set_tag", Mock())
+        monkeypatch.setattr(sentry_module.sentry_sdk, "set_context", fake_set_context)
+
+        sandbox = SimpleNamespace(
+            id="sandbox-123",
+            name="bench-task-1",
+            provider_metadata={"runner_id": "runner-1", "snapshot": "snap-name"},
+        )
+
+        sentry_module.set_sandbox_context(sandbox)
+
+        assert contexts["sandbox"]["provider_metadata"] == {"runner_id": "runner-1", "snapshot": "snap-name"}
+
     def test_set_sandbox_context_failures_are_logged_without_propagating(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Sentry context failures must not block sandbox execution.
 

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1349,6 +1349,8 @@ class TestSandboxLifecycle:
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = {}
+        mock_sandbox.provider_metadata = {}
         active_sandbox_ids: set[str] = set()
         creation_started = asyncio.Event()
         release_creation = asyncio.Event()
@@ -1399,6 +1401,63 @@ class TestSandboxLifecycle:
         await remote_creation_task
         assert active_sandbox_ids == set()
         assert deletion_initiators == ["create_cancelled"]
+
+    async def test_create_sandbox_cancelled_audit_failure_still_deletes(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A failing audit on the cancelled-create path must not skip the delete or replace the cancellation."""
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        creation_started = asyncio.Event()
+        release_creation = asyncio.Event()
+
+        async def remote_create() -> AsyncMock:
+            creation_started.set()
+            await release_creation.wait()
+            return mock_sandbox
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncMock:
+            creation_task = asyncio.create_task(remote_create())
+            return await asyncio.shield(creation_task)
+
+        deleted: list[AsyncMock] = []
+
+        async def mock_delete_sandbox(sandbox: AsyncMock, _provider: Any, **_kwargs: Any) -> None:
+            deleted.append(sandbox)
+
+        audited: list[AsyncMock] = []
+
+        def failing_audit(sandbox: AsyncMock) -> None:
+            audited.append(sandbox)
+            raise RuntimeError("audit sink unavailable")
+
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", mock_delete_sandbox)
+        monkeypatch.setattr(sandbox_module, "audit_sandbox_create", failing_audit)
+
+        async def use_sandbox() -> None:
+            async with create_sandbox(
+                provider=AsyncMock(),
+                sandbox_name="task-alias",
+                source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+                resources=Resources(vcpu=2, memory=4, disk=5),
+                creation_semaphore=asyncio.Semaphore(1),
+            ):
+                pass
+
+        context_task = asyncio.create_task(use_sandbox())
+        await creation_started.wait()
+
+        context_task.cancel()
+        release_creation.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await context_task
+
+        assert audited == [mock_sandbox]
+        assert deleted == [mock_sandbox]
 
     async def test_create_sandbox_audits_provider_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The create audit record carries provider-reported allocation fields."""

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1202,6 +1202,8 @@ class TestSandboxLifecycle:
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-123"
         mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = {}
+        mock_sandbox.provider_metadata = {}
 
         distributions: list[tuple[str, float, dict[str, str]]] = []
         context_calls: list[tuple[str, str]] = []
@@ -1249,7 +1251,7 @@ class TestSandboxLifecycle:
 
     async def test_create_sandbox_randomizes_only_direct_names(self, monkeypatch: pytest.MonkeyPatch) -> None:
         created_names: list[str] = []
-        mock_sandbox = AsyncMock(id="sandbox-123", name="task-alias")
+        mock_sandbox = AsyncMock(id="sandbox-123", name="task-alias", labels={}, provider_metadata={})
 
         async def mock_create_sandbox(
             _provider: Any,
@@ -1397,6 +1399,43 @@ class TestSandboxLifecycle:
         await remote_creation_task
         assert active_sandbox_ids == set()
         assert deletion_initiators == ["create_cancelled"]
+
+    async def test_create_sandbox_audits_provider_metadata(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The create audit record carries provider-reported allocation fields."""
+        mock_sandbox = Mock()
+        mock_sandbox.id = "sandbox-123"
+        mock_sandbox.name = "task-alias"
+        mock_sandbox.labels = {"Benchmark": "swebench", "Id": "bench-1", "Task": "task_0"}
+        mock_sandbox.provider_metadata = {"runner_id": "runner-1", "snapshot": "snap-name"}
+
+        async def mock_create_sandbox(*_args: Any, **_kwargs: Any) -> Mock:
+            return mock_sandbox
+
+        logger_mock = Mock()
+        monkeypatch.setattr(sandbox_module, "_create_sandbox", mock_create_sandbox)
+        monkeypatch.setattr(sandbox_module, "delete_sandbox", AsyncMock())
+        monkeypatch.setattr(sandbox_module, "distribution", Mock())
+        monkeypatch.setattr(sandbox_module, "set_sandbox_context", Mock())
+        monkeypatch.setattr(sandbox_module, "logger", logger_mock)
+
+        async with create_sandbox(
+            provider=Mock(),
+            sandbox_name="task-alias",
+            source=ImageSource(image="ghcr.io/vals/swebench:latest"),
+            resources=Resources(vcpu=2, memory=4, disk=5),
+            creation_semaphore=asyncio.Semaphore(1),
+        ):
+            pass
+
+        audit_call = next(c for c in logger_mock.info.call_args_list if c.args == ("sandbox.create",))
+        assert audit_call.kwargs["extra"] == {
+            "sandbox_id": "sandbox-123",
+            "sandbox_name": "task-alias",
+            "benchmark_id": "bench-1",
+            "benchmark_name": "swebench",
+            "task_id": "task_0",
+            "provider_metadata": {"runner_id": "runner-1", "snapshot": "snap-name"},
+        }
 
     async def test_create_sandbox_teardown_names_initiator(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Normal context-manager exit attributes the deletion to task_teardown in the audit trail."""


### PR DESCRIPTION
## Summary

Daytona has been provisioning sandboxes whose rootfs doesn't match the requested snapshot (e.g. `/usr/bin/dockerd` ENOENT in vcb-1-100, ~4% of creates on run `8ab5b88a` / `b5ada27a`). Once the sandbox is deleted its provider record is gone (404), so we cannot attribute a bad occurrence to a runner afterward.

This PR records the provider-reported allocation fields at sandbox create time — the only moment they're observable — via a new `audit_sandbox_create` log event and the Sentry `sandbox` context, carrying `sandbox.provider_metadata` (`runner_id`, `daemon_version`, `warm_pool_id`, `snapshot`, `target`) added in create-benchmark-service v0.37.0. The audit event mirrors the existing `sandbox.delete` event's fields (benchmark/task ids from labels) so a create and its deletes join on `sandbox_id`/`sandbox_name`.

## Changes

- `services/tracker/src/tracker/sandbox.py`: new `audit_sandbox_create(sandbox)` emitting `sandbox.create` with `sandbox_id`, `sandbox_name`, `benchmark_id`, `benchmark_name`, `task_id`, `provider_metadata`; called inside `create_sandbox`'s `try` (before `yield`) so an audit failure still runs the `finally` teardown, and also called on the `CancelledError` path before the late-arriving sandbox is deleted (swallowed there so it can't replace the cancellation or skip the delete).
- `services/tracker/src/tracker/observability/sentry.py`: `set_sandbox_context` adds `provider_metadata` to the `sandbox` context when present.
- `services/tracker/tests/unit/test_sandbox.py`: `test_create_sandbox_audits_provider_metadata` asserts the audit payload; two existing tests set `labels`/`provider_metadata` on their `AsyncMock` sandboxes (bare `AsyncMock` attributes would otherwise log Mocks and emit a never-awaited coroutine warning).

Note: requires `create-benchmark-service>=0.37.0` for `Sandbox.provider_metadata` — `dev` already pins v0.37.2 via #770, so no dependency changes remain in this PR after rebase.

## Related Issues

- Companion to https://github.com/vals-ai/create-benchmark-service/pull/157 (merged → `provider_metadata`), https://github.com/vals-ai/Valkyrie/pull/770 (merged — retry on service-reported broken sandboxes), https://github.com/vals-ai/create-benchmark-service/pull/158 (merged → v0.37.1, `daytona<2` bound).

## Type of Change

- [x] New feature

## Testing

- [x] Added/updated unit tests
- [x] Manually tested: `DaytonaSandboxProvider.create_sandbox` on CBS v0.37.0 against the real Daytona org (`us-west-3`, snapshot `vcb100-openhands-12c16g30d-d831e2d7255e`) returned `provider_metadata = {'runner_id': '5d4fbbfb-e2bd-4a52-8289-efeee7ce8bdd', 'snapshot': 'vcb100-openhands-12c16g30d-d831e2d7255e', 'target': 'us-west-3'}` — i.e. the values this PR logs are populated on the live path. The Valkyrie audit path itself is unit-tested; not exercised in a hosted run yet.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

## Human Description

### Why

<!-- author-written: why this change is needed -->

### How

<!-- author-written: how the approach works -->


Link to Devin session: https://app.devin.ai/sessions/3b3d057b89764d2c9a5065fe62ab09ba
Open in Devin Desktop: https://app.devin.ai/desktop/session/3b3d057b89764d2c9a5065fe62ab09ba?variant=devin
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->