### PR TITLE
fix(tracker): retry service-reported broken sandboxes on a fresh sandbox #patch

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -10,4 +10,4 @@ prerelease = "allow"
 
 [tool.uv.sources]
 tracker = { path = "../tracker" }
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.35.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.1" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.35.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0#35ace8c30585b1bbe872b20b5078894ba818517d" }
+version = "0.37.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1#1a8e6d63c2575a20fa0c1dcc6565128181657486" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "sentry-sdk[fastapi]==2.58.0",
   "python-json-logger>=3.2.1",
   "python-dotenv>=1.2.2",
-  "create-benchmark-service>=0.22.4",
+  "create-benchmark-service>=0.37.1",
   "aioboto3>=7.0.0",
 ]
 
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.35.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.1" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -80,6 +80,11 @@ logger = get_logger(__name__)
 _PTY_TASK_RETRY_LIMIT: int = 1
 _SANDBOX_RETRY_DELAY_SECONDS: float = 2
 
+# Messages a benchmark service reports when the sandbox itself is unusable (e.g.
+# the provider provisioned a rootfs missing the snapshot's baked content). Only
+# a fresh sandbox can recover, so these retry as setup failures.
+_BROKEN_SANDBOX_ERROR_MESSAGES = ("docker daemon is not ready inside the sandbox",)
+
 
 class BenchmarkServiceWebSocketDNSResolutionError(BenchmarkServiceError):
     """A benchmark-service WebSocket could not resolve its destination host."""
@@ -754,6 +759,21 @@ async def _process_task_attempt(
     def task_is_stopped() -> bool:
         return not execution_is_current()
 
+    def return_queued_task_to_pending() -> bool:
+        """Release a queued task so a fresh-sandbox retry can re-admit it."""
+        if queue_context is None:
+            return True
+        with Session(bind=engine) as task_session:
+            return commit_task_status_transition(
+                task_row.id,
+                task_session,
+                org,
+                TaskStatus.PENDING,
+                expected_started_at=attempt_started_at,
+                expected_status=expected_failure_status,
+                authority=authority,
+            )
+
     def commit_terminal_error(
         exc: BaseException,
         error_message: str,
@@ -1244,18 +1264,8 @@ async def _process_task_attempt(
     except SandboxSetupError as e:
         if task_is_stopped():
             return {task_id: None}
-        if queue_context is not None:
-            with Session(bind=engine) as task_session:
-                if not commit_task_status_transition(
-                    task_row.id,
-                    task_session,
-                    org,
-                    TaskStatus.PENDING,
-                    expected_started_at=attempt_started_at,
-                    expected_status=expected_failure_status,
-                    authority=authority,
-                ):
-                    return {task_id: None}
+        if not return_queued_task_to_pending():
+            return {task_id: None}
         log_output(f"\n[ERROR] {_exception_message(e)}")
         raise
     except SandboxNotFoundError as e:
@@ -1376,6 +1386,11 @@ async def _process_task_attempt(
         if task_is_stopped():
             return {task_id: None}
         error_message = _exception_message(e)
+        if any(message in error_message for message in _BROKEN_SANDBOX_ERROR_MESSAGES):
+            if not return_queued_task_to_pending():
+                return {task_id: None}
+            log_output(f"\n[ERROR] {error_message}")
+            raise SandboxSetupError(error_message) from e
         log_output(f"\n[ERROR] {error_message}")
 
         return commit_terminal_error(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -1381,8 +1381,8 @@ async def _process_task_attempt(
         if task_is_stopped():
             return {task_id: None}
         error_message = _exception_message(e)
-        # A service that found an unusable sandbox (e.g. a rootfs missing the
-        # snapshot's baked content) can only recover on a fresh sandbox.
+        # This is necessary because Daytona routes tasks to bad nodes. We should
+        # remove this when Daytona fixes their infrastructure.
         if "docker daemon is not ready inside the sandbox" in error_message:
             if not return_queued_task_to_pending():
                 return {task_id: None}

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -80,11 +80,6 @@ logger = get_logger(__name__)
 _PTY_TASK_RETRY_LIMIT: int = 1
 _SANDBOX_RETRY_DELAY_SECONDS: float = 2
 
-# Messages a benchmark service reports when the sandbox itself is unusable (e.g.
-# the provider provisioned a rootfs missing the snapshot's baked content). Only
-# a fresh sandbox can recover, so these retry as setup failures.
-_BROKEN_SANDBOX_ERROR_MESSAGES = ("docker daemon is not ready inside the sandbox",)
-
 
 class BenchmarkServiceWebSocketDNSResolutionError(BenchmarkServiceError):
     """A benchmark-service WebSocket could not resolve its destination host."""
@@ -1386,7 +1381,9 @@ async def _process_task_attempt(
         if task_is_stopped():
             return {task_id: None}
         error_message = _exception_message(e)
-        if any(message in error_message for message in _BROKEN_SANDBOX_ERROR_MESSAGES):
+        # A service that found an unusable sandbox (e.g. a rootfs missing the
+        # snapshot's baked content) can only recover on a fresh sandbox.
+        if "docker daemon is not ready inside the sandbox" in error_message:
             if not return_queued_task_to_pending():
                 return {task_id: None}
             log_output(f"\n[ERROR] {error_message}")

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -13,6 +13,7 @@ import pytest
 from benchmark_service import SandboxNotFoundError, SandboxRecoveryPolicy
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
 from benchmark_service.schemas import RetrieveTaskResponse, SetupTaskResponse, VolumeMount
+from sqlalchemy.engine import Engine
 from sqlmodel import Session, col, desc, select
 
 from tests.unit.utils.task_execution_support import (
@@ -22,6 +23,7 @@ from tests.unit.utils.task_execution_support import (
     make_retrieve_task_response,
     run_process_task,
 )
+from tracker.scheduler.admission import SandboxQueueContext
 from tracker.aws.runtime import AWSRuntime
 from tracker.database.models import (
     AgentContractRequest,
@@ -332,6 +334,86 @@ class TestTaskExecutionRetry:
 
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
+        error_results = database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).all()
+        assert [result for result in error_results if result.retry_scheduled] == []
+
+    @pytest.mark.parametrize("failure_site", ["queued_admission", "service_setup"])
+    async def test_process_task_releases_queued_task_when_pending_transition_refused(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+        failure_site: str,
+    ) -> None:
+        """A queued task whose PENDING transition is refused ends without a retry.
+
+        Both retry-eligible failures must return a queued task to PENDING before
+        re-raising so the retry can be re-admitted; a refused transition means
+        the task is owned elsewhere and the attempt stops.
+
+        Test cases:
+        - the setup error surfaces during queued admission (SandboxSetupError)
+        - the setup error is reported by the benchmark service (BenchmarkServiceError)
+        """
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+
+        mock_sandbox = AsyncMock()
+        mock_sandbox.id = "mock-sandbox-queued"
+        mock_sandbox.name = mock_sandbox.id
+
+        async def _mock_enter_queued_sandbox(*_args: Any, **_kwargs: Any) -> AsyncMock:
+            if failure_site == "queued_admission":
+                raise SandboxSetupError("provisioner rejected the sandbox")
+            return mock_sandbox
+
+        async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+            raise BenchmarkServiceError(
+                "docker daemon is not ready inside the sandbox: "
+                "nohup: failed to run command 'dockerd': No such file or directory"
+            )
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return make_retrieve_task_response(problem_path="/tmp/problem.txt")
+
+        transition_statuses: list[TaskStatus] = []
+
+        def _refuse_pending_transition(*args: Any, **_kwargs: Any) -> bool:
+            transition_statuses.append(args[3])
+            return False
+
+        task_engine = database_session.get_bind()
+        assert isinstance(task_engine, Engine)
+        queue_context = SandboxQueueContext(
+            provider=Mock(),
+            pool_id="pool_test",
+            engine=task_engine,
+        )
+        monkeypatch.setattr(task_execution_module, "enter_queued_sandbox", _mock_enter_queued_sandbox)
+        monkeypatch.setattr(task_execution_module, "commit_task_status_transition", _refuse_pending_transition)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await run_process_task(
+            start_benchmark_request,
+            task_row,
+            benchmark_id,
+            aws_runtime,
+            authority,
+            queue_context=queue_context,
+        )
+
+        assert result == {"task_0": None}
+        assert transition_statuses == [TaskStatus.PENDING]
         error_results = database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).all()
         assert [result for result in error_results if result.retry_scheduled] == []
 

--- a/services/tracker/tests/unit/utils/test_task_execution_retry.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_retry.py
@@ -12,7 +12,7 @@ from uuid import UUID
 import pytest
 from benchmark_service import SandboxNotFoundError, SandboxRecoveryPolicy
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError
-from benchmark_service.schemas import RetrieveTaskResponse, VolumeMount
+from benchmark_service.schemas import RetrieveTaskResponse, SetupTaskResponse, VolumeMount
 from sqlmodel import Session, col, desc, select
 
 from tests.unit.utils.task_execution_support import (
@@ -193,6 +193,147 @@ class TestTaskExecutionRetry:
             assert terminal_result.failed_attempt_number is None
         else:
             assert terminal_results == []
+
+    async def test_process_task_retries_when_service_reports_broken_sandbox(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        """A service-reported broken sandbox retries on a fresh sandbox instead of failing terminally.
+
+        Test cases:
+        - setup_task raises a service error matching the broken-sandbox signature on attempt 1
+        - process_task retries with a new sandbox and the task finishes
+        - The recorded failure is marked retry_scheduled as a sandbox setup failure
+        - A service error without the signature still commits a terminal error
+        """
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+
+        sandbox_entry_count = 0
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            nonlocal sandbox_entry_count
+            sandbox_entry_count += 1
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = f"mock-sandbox-{sandbox_entry_count}"
+            mock_sandbox.name = f"mock-sandbox-{sandbox_entry_count}"
+            yield mock_sandbox
+
+        setup_call_count = 0
+        service_error = (
+            "docker daemon is not ready inside the sandbox: "
+            "nohup: failed to run command 'dockerd': No such file or directory"
+        )
+
+        async def _fails_first_setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+            nonlocal setup_call_count
+            setup_call_count += 1
+            if setup_call_count == 1:
+                raise BenchmarkServiceError(service_error)
+            return SetupTaskResponse(status="ok")
+
+        async def _mock_run_agent(*_args: Any, **_kwargs: Any) -> tuple[None, float]:
+            return None, 0.0
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return make_retrieve_task_response(problem_path="/tmp/problem.txt")
+
+        async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {"status": "success", "score": 1.0}
+
+        monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _fails_first_setup_task)
+        monkeypatch.setattr("tracker.utils.task_execution.run_agent", _mock_run_agent)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": {"status": "success", "score": 1.0}}
+        assert sandbox_entry_count == 2
+        assert setup_call_count == 2
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.FINISHED
+
+        error_results = database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).all()
+        retry_results = [result for result in error_results if result.retry_scheduled]
+        assert len(retry_results) == 1
+        assert retry_results[0].error_message == f"Sandbox error: {service_error}"
+        assert retry_results[0].producer == "sandbox_provider"
+        assert retry_results[0].operation == "setup"
+        assert retry_results[0].error_type == "SandboxSetupError"
+        assert retry_results[0].failed_attempt_number == 1
+        assert [result for result in error_results if not result.retry_scheduled] == []
+
+    async def test_process_task_still_terminates_on_other_service_errors(
+        self,
+        contract: AgentContractRequest,
+        database_session: Session,
+        monkeypatch: pytest.MonkeyPatch,
+        harness_config: HarnessConfig,
+        aws_runtime: AWSRuntime,
+    ) -> None:
+        """A service error without the broken-sandbox signature stays terminal.
+
+        Test cases:
+        - setup_task raises an unrelated BenchmarkServiceError
+        - No retry is scheduled and the task ends in ERROR
+        """
+        start_benchmark_request, task_row, benchmark_id, authority = create_task_environment(
+            contract,
+            database_session,
+            harness_config,
+        )
+        monkeypatch.setattr(task_execution_module, "_SANDBOX_RETRY_DELAY_SECONDS", 0)
+        monkeypatch.setattr("tracker.utils.task_execution.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.run_orchestration.engine", database_session.bind)
+        monkeypatch.setattr("tracker.utils.task_execution.buffer_logs", Mock())
+
+        sandbox_entry_count = 0
+
+        @asynccontextmanager
+        async def _mock_create_sandbox(*_args: Any, **_kwargs: Any) -> AsyncGenerator[AsyncMock, None]:
+            nonlocal sandbox_entry_count
+            sandbox_entry_count += 1
+            mock_sandbox = AsyncMock()
+            mock_sandbox.id = f"mock-sandbox-{sandbox_entry_count}"
+            mock_sandbox.name = mock_sandbox.id
+            yield mock_sandbox
+
+        service_error = "ProgramBench task container failed to start: task_cleanroom: Pulling from programbench/test"
+
+        async def _mock_setup_task(*_args: Any, **_kwargs: Any) -> SetupTaskResponse:
+            raise BenchmarkServiceError(service_error)
+
+        async def _mock_retrieve_task(*_args: Any, **_kwargs: Any) -> RetrieveTaskResponse:
+            return make_retrieve_task_response(problem_path="/tmp/problem.txt")
+
+        monkeypatch.setattr("tracker.utils.task_execution.create_sandbox", _mock_create_sandbox)
+        monkeypatch.setattr(BenchmarkServiceClient, "setup_task", _mock_setup_task)
+        monkeypatch.setattr(BenchmarkServiceClient, "retrieve_task", _mock_retrieve_task)
+
+        result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
+
+        assert result == {"task_0": None}
+        assert sandbox_entry_count == 1
+
+        database_session.refresh(task_row)
+        assert task_row.status == TaskStatus.ERROR
+        error_results = database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).all()
+        assert [result for result in error_results if result.retry_scheduled] == []
 
     async def test_revoked_dispatch_does_not_begin_the_second_automatic_attempt(
         self,

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.35.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0#35ace8c30585b1bbe872b20b5078894ba818517d" }
+version = "0.37.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1#1a8e6d63c2575a20fa0c1dcc6565128181657486" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.35.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0#35ace8c30585b1bbe872b20b5078894ba818517d" }
+version = "0.37.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1#1a8e6d63c2575a20fa0c1dcc6565128181657486" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.35.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary

When Daytona provisions a sandbox whose rootfs is missing the snapshot's baked content (observed: `nohup: failed to run command 'dockerd': No such file or directory` while `flock`/`mkdir` in /usr/bin worked seconds earlier), the benchmark service reports it back over the websocket as a generic `BenchmarkServiceError` — the tracker commits it as a terminal error and the task dies. This classifies that service-reported signature as a `SandboxSetupError` so the existing fresh-sandbox retry in `run_with_sandbox_recovery` fires: a new `create_sandbox` lands the retry on a different runner, which is what actually recovers a bad node-lottery allocation.

Evidence for the root cause (per-runner provisioning variance on Daytona's side, not our code) is in [#769](https://github.com/vals-ai/Valkyrie/pull/769) discussion and the Daytona sandbox IDs there.

## Changes

- `task_execution.py`: inside `except BenchmarkServiceError`, the known broken-sandbox signature (`docker daemon is not ready inside the sandbox`) is re-raised as `SandboxSetupError`, so `retryable_attempt_errors=(SandboxSetupError,)` retries the attempt on a fresh sandbox. All other service errors still commit a terminal error.
- Extracted `return_queued_task_to_pending()` from the `except SandboxSetupError` handler: an exception raised inside a sibling `except` block does not re-enter it, so the reclassified error must run the queue-context PENDING transition itself before raising.
- `pyproject.toml` / locks: pin `create-benchmark-service` to `v0.37.1` — the `daytona<2` bound there stops `uv tool install --prerelease=allow` from resolving the broken `daytona 2.0.0rc1` (cli-tool-smoke-test `ImportError: AsyncDaytona`). Same bump as #769; whichever lands first, the other's pin diff dedupes.
- Tests: service-reported dockerd-missing error → two sandboxes created, task finishes, one `retry_scheduled` `SandboxSetupError` result; unrelated service error → still terminal, no retry.

## Related Issues

- vcb / vcb-1-100 "dockerd missing in the Daytona sandbox" failures — the audit metadata to attribute future occurrences is in #769.

## Type of Change

- [x] Bug fix

## Testing

- [x] Added/updated unit tests
- [ ] Manually tested — the retry path was exercised end-to-end in `tests/unit/utils/test_task_execution_retry.py` (mocked sandbox boundary). Not live-tested against a real run: the failure needs a genuinely corrupt Daytona provisioning, which cannot be triggered on demand.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

## Human Description

### Why


### How


Link to Devin session: https://app.devin.ai/sessions/3b3d057b89764d2c9a5065fe62ab09ba
Open in Devin Desktop: https://app.devin.ai/desktop/session/3b3d057b89764d2c9a5065fe62ab09ba?variant=devin
Requested by: @lgnashold
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/770" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->