### PR TITLE
chore(deps): bump create-benchmark-service to v0.37.2 #patch

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -10,4 +10,4 @@ prerelease = "allow"
 
 [tool.uv.sources]
 tracker = { path = "../tracker" }
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.1" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.2" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.37.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1#1a8e6d63c2575a20fa0c1dcc6565128181657486" }
+version = "0.37.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2#74d5398dc3805ac67ccaadc77225c21c0b764feb" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1837,7 +1837,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "sentry-sdk[fastapi]==2.58.0",
   "python-json-logger>=3.2.1",
   "python-dotenv>=1.2.2",
-  "create-benchmark-service>=0.37.1",
+  "create-benchmark-service>=0.37.2",
   "aioboto3>=7.0.0",
 ]
 
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.1" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.2" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.37.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1#1a8e6d63c2575a20fa0c1dcc6565128181657486" }
+version = "0.37.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2#74d5398dc3805ac67ccaadc77225c21c0b764feb" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2116,7 +2116,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.37.1"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1#1a8e6d63c2575a20fa0c1dcc6565128181657486" }
+version = "0.37.2"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2#74d5398dc3805ac67ccaadc77225c21c0b764feb" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2312,7 +2312,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.1" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
Pin the tracker and executor_artifact to create-benchmark-service v0.37.2 (`74d5398`), which includes CBS #159 (stop leaking the DinD shell env into `docker compose exec`).

The tracker wraps the outer Daytona sandbox in its own `ComposeSandbox` (`tracker/sandbox.py`), so it is the tracker's CBS pin — not the benchmark service's — that decides which env vars reach the task container when the tracker installs/runs the agent. On v0.37.1 `_COMPOSE_EXEC_ENV_ARGS` forwards every outer var, including `HOME=/root`, into the task container. Terminal-Bench 4 tasks whose images run as non-root (`rs-archive-clone`, `risk-scorer-replay`, `fp8-rmsnorm-gemm`, `coq-block-bound`, `freecad-*`) then fail terminus2 setup with `mkdir: cannot create directory '/root': Permission denied` → `Agent command failed with exit code 1`. terminal-bench-benchmark-service is already on 0.37.2; this brings the tracker in line.

## Changes
- `services/tracker/pyproject.toml`, `services/executor_artifact/pyproject.toml`: `rev = "v0.37.1"` → `"v0.37.2"` (and `>=0.37.2` requirement)
- `uv.lock`, `services/tracker/uv.lock`, `services/executor_artifact/uv.lock`: regenerated with `uv lock`

## Related Issues
Terminal-Bench 4 runs `890627e3`, `15a0b554`, `d349a238`, `cdf97d61`, `e269d0bc`, `7866f20c` (bench).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Docs / config

## Testing
- [ ] Added/updated unit tests
- [ ] Manually tested

Not yet live-tested: the fix requires the tracker to be deployed. Evidence of the failure on the current deployment: CloudWatch `/valkyrie/benchmarks/15a0b554-55bb-45ab-bb00-04e1dcbdf535` stream `rs-archive-clone_65b1615e3630b` (retry at 5:31 PM PT, service already on CBS 0.37.2) ends with `mkdir: cannot create directory ‘/root’: Permission denied` / `[ERROR] Sandbox error: Agent command failed with exit code 1`; same for `risk-scorer-replay` on `cdf97d61`. After deploy, the plan is `valk run retry <run_id>` on the six runs and confirm those tasks get past agent install.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed

Link to Devin session: https://app.devin.ai/sessions/ab228f1b5e394a04b114515d56ae3c4a
Open in Devin Desktop: https://app.devin.ai/desktop/session/ab228f1b5e394a04b114515d56ae3c4a?variant=devin
Requested by: @conjfrnk
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/771" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->