### PR TITLE
fix(tracker): isolate Sentry task context

### DIFF
--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -122,6 +122,17 @@ def capture_exception(error: BaseException) -> None:
         logger.warning("Failed to capture exception: %s: %s", type(telemetry_error).__name__, telemetry_error)
 
 
+def clear_sandbox_context() -> None:
+    """Remove sandbox identity before a task begins another attempt."""
+    try:
+        scope = sentry_sdk.get_isolation_scope()
+        scope.remove_tag("sandbox_id")
+        scope.remove_tag("sandbox_name")
+        scope.remove_context("sandbox")
+    except Exception as e:
+        logger.warning("clear_sandbox_context failed: %s: %s", type(e).__name__, e)
+
+
 def set_sandbox_context(sandbox: Any, *, image: str | None = None) -> None:
     """Attach sandbox identifiers to Sentry tags/context, not metric attributes."""
     try:

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -1,5 +1,7 @@
 """Sentry SDK initialization for Valkyrie service processes."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 import logging
 import os
 from typing import Any, cast
@@ -12,9 +14,21 @@ from sentry_sdk.integrations.otlp import OTLPIntegration
 from sentry_sdk.types import Event, Hint, Log
 
 from tracker.exceptions import SSLConnectionError
+from tracker.logging import task_id_var
 from tracker.logging.context import get_context_tags
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def task_scope(task_id: str) -> Iterator[None]:
+    """Isolate Sentry events and logging context for one tracked task."""
+    with sentry_sdk.isolation_scope():
+        token = task_id_var.set(task_id)
+        try:
+            yield
+        finally:
+            task_id_var.reset(token)
 
 
 def _before_send(

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -61,10 +61,10 @@ from tracker.exceptions import (
     TrackerServiceError,
 )
 from tracker.executor.execution_authority import ExecutionAuthority, lock_execution_authority
-from tracker.logging import get_logger, task_id_var
+from tracker.logging import get_logger
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, error_span, incr
-from tracker.observability.sentry import capture_exception
+from tracker.observability.sentry import capture_exception, task_scope
 from tracker.observability.tracing import observability_span
 from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.scheduler.admission import SandboxQueueContext, enter_queued_sandbox
@@ -273,37 +273,38 @@ class TrackedTask:
                 self._status = TrackedTaskStatus.RUNNING
                 return await self._coro
 
-        try:
-            self._task = asyncio.create_task(_wrap_coro())
-            return await self._task
-        except asyncio.CancelledError:
-            logger.warning(f"Task {task_row.task_id} was cancelled")
-            # Need to clean up the coroutine if we cancelled the task
-            self._coro.close()
+        with task_scope(task_row.task_id):
+            try:
+                self._task = asyncio.create_task(_wrap_coro())
+                return await self._task
+            except asyncio.CancelledError:
+                logger.warning(f"Task {task_row.task_id} was cancelled")
+                # Need to clean up the coroutine if we cancelled the task
+                self._coro.close()
 
-            # When we cancel we return the task id still so that we can track the task when we create the final evaluation row
-            return {task_row.task_id: None}
-        except Exception as e:
-            error_message = f"Task error was not handled: {_exception_message(e)}\n{traceback.format_exc()}"
-            logger.error(error_message)
-            logfire.exception("tracked_task_run failed")
-            capture_exception(e)
-            with Session(bind=engine) as session:
-                task = fetch_task_row(task_row.id, session, self._org)
-                commit_task_error(
-                    task,
-                    session,
-                    error_message,
-                    producer="sandbox_provider" if isinstance(e, SandboxSetupError) else "tracker",
-                    operation="setup" if isinstance(e, SandboxSetupError) else "process_task",
-                    error_type=type(e).__name__,
-                    expected_started_at=task_row.started_at,
-                    authority=self._authority,
-                )
+                # When we cancel we return the task id still so that we can track the task when we create the final evaluation row
+                return {task_row.task_id: None}
+            except Exception as e:
+                error_message = f"Task error was not handled: {_exception_message(e)}\n{traceback.format_exc()}"
+                logger.error(error_message)
+                logfire.exception("tracked_task_run failed")
+                capture_exception(e)
+                with Session(bind=engine) as session:
+                    task = fetch_task_row(task_row.id, session, self._org)
+                    commit_task_error(
+                        task,
+                        session,
+                        error_message,
+                        producer="sandbox_provider" if isinstance(e, SandboxSetupError) else "tracker",
+                        operation="setup" if isinstance(e, SandboxSetupError) else "process_task",
+                        error_type=type(e).__name__,
+                        expected_started_at=task_row.started_at,
+                        authority=self._authority,
+                    )
 
-            return {task_row.task_id: None}
-        finally:
-            self._status = TrackedTaskStatus.DONE
+                return {task_row.task_id: None}
+            finally:
+                self._status = TrackedTaskStatus.DONE
 
 
 class TaskMonitor:
@@ -648,7 +649,6 @@ async def _process_task_attempt(
     NOTE: When we close the sandbox the agent process will be killed and we will instantly go to evaluating,
     the evaluation will fail since the instance no longer exists. We handle this inside of the exception caught.
     """
-    task_id_var.set(task_id)
     sentry_sdk.set_tag("benchmark_name", start_benchmark_request.benchmark_name)
     sentry_sdk.set_tag("agent_name", start_benchmark_request.contract.name)
 

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -64,7 +64,7 @@ from tracker.executor.execution_authority import ExecutionAuthority, lock_execut
 from tracker.logging import get_logger
 from tracker.notifications import NotificationContext, SlackNotifier
 from tracker.observability import elapsed_ms, error_span, incr
-from tracker.observability.sentry import capture_exception, task_scope
+from tracker.observability.sentry import capture_exception, clear_sandbox_context, task_scope
 from tracker.observability.tracing import observability_span
 from tracker.sandbox import DependencySetupMode, create_sandbox, run_agent, upload_agent_artifacts
 from tracker.scheduler.admission import SandboxQueueContext, enter_queued_sandbox
@@ -582,6 +582,7 @@ async def process_task(
     async def run_attempt(
         recovery_attempt: SandboxRecoveryAttempt,
     ) -> dict[str, dict[str, Any] | None]:
+        clear_sandbox_context()
         return await _process_task_attempt(
             task_row=task_row,
             start_benchmark_request=start_benchmark_request,

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -268,14 +268,10 @@ async def test_retry_attempt_clears_previous_sandbox_identity(
 
     async def process_attempt(**kwargs: Any) -> dict[str, dict[str, object] | None]:
         if kwargs["recovery_attempt"].number == 1:
-            sentry_module.set_sandbox_context(
-                SimpleNamespace(id="sandbox-first", name="sandbox-first-name")
-            )
+            sentry_module.set_sandbox_context(SimpleNamespace(id="sandbox-first", name="sandbox-first-name"))
             raise SandboxSetupError("retry after first sandbox")
 
-        sentry_sdk.capture_exception(
-            RuntimeError("second attempt failed before sandbox assignment")
-        )
+        sentry_sdk.capture_exception(RuntimeError("second attempt failed before sandbox assignment"))
         return {"task-0": {"ok": True}}
 
     monkeypatch.setattr(task_execution, "_process_task_attempt", process_attempt)

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -3,7 +3,10 @@
 Run: uv run pytest tests/unit/observability/test_sentry.py
 """
 
+import asyncio
+
 from collections.abc import Callable
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import Mock
@@ -14,6 +17,9 @@ from sentry_sdk.integrations.otlp import OTLPIntegration
 from sentry_sdk.types import Event, Hint, Log
 
 import tracker.observability.sentry as sentry_module
+import tracker.utils.task_execution as task_execution
+from tracker.database.models import Org, Task
+from tracker.executor.execution_authority import ExecutionAuthority
 from tracker.exceptions import SandboxError, SSLConnectionError
 
 BeforeSend = Callable[[Event, Hint], Event | None]
@@ -150,3 +156,86 @@ class TestSentrySetup:
         sentry_module.init_sentry("valkyrie-worker", environment="production")
 
         init_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[Event] = []
+    rows: dict[str, SimpleNamespace] = {}
+
+    class FakeSession:
+        def __init__(self, **_kwargs: object) -> None:
+            pass
+
+        def __enter__(self) -> "FakeSession":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            pass
+
+    def fetch_task(task_id: object, _session: object, _org: object) -> SimpleNamespace:
+        return rows[str(task_id)]
+
+    monkeypatch.setattr(task_execution, "Session", FakeSession)
+    monkeypatch.setattr(task_execution, "fetch_task_row", fetch_task)
+    monkeypatch.setattr(task_execution, "commit_task_error", lambda *_args, **_kwargs: None)
+
+    async def run_tasks() -> None:
+        ready = 0
+        release = asyncio.Event()
+
+        async def body(task_id: str, sandbox_id: str, *, fail: bool) -> dict[str, dict[str, object] | None]:
+            nonlocal ready
+            sentry_module.set_sandbox_context(SimpleNamespace(id=sandbox_id, name=f"{sandbox_id}-name"))
+            sentry_sdk.capture_message("sandbox event")
+            ready += 1
+            if ready == 2:
+                release.set()
+            await release.wait()
+            if fail:
+                raise RuntimeError("outer failure")
+            return {task_id: {"ok": True}}
+
+        for task_id in ("task-a", "task-b"):
+            rows[task_id] = SimpleNamespace(
+                id=task_id,
+                task_id=task_id,
+                started_at=datetime.now(UTC),
+            )
+
+        task_a = task_execution.TrackedTask(
+            body("task-a", "sandbox-a", fail=False), cast(Org, object()), cast(ExecutionAuthority, object()), datetime.now(UTC)
+        )
+        task_b = task_execution.TrackedTask(
+            body("task-b", "sandbox-b", fail=True), cast(Org, object()), cast(ExecutionAuthority, object()), datetime.now(UTC)
+        )
+        await asyncio.gather(
+            task_a.run(None, cast(Task, rows["task-a"])), task_b.run(None, cast(Task, rows["task-b"]))
+        )
+
+    with sentry_sdk.init(
+        dsn="https://public@example.com/1",
+        transport=events.append,
+        default_integrations=False,
+        before_send=sentry_module._before_send,
+    ):
+        await run_tasks()
+        sentry_sdk.capture_message("after tasks")
+
+    task_events = [event for event in events if event.get("tags", {}).get("task_id")]
+    assert len(task_events) == 3
+    task_tags = [cast(dict[str, str], event.get("tags", {})) for event in task_events]
+    assert {(tags["task_id"], tags["sandbox_id"]) for tags in task_tags} == {
+        ("task-a", "sandbox-a"),
+        ("task-b", "sandbox-b"),
+    }
+    exception_events = [event for event in task_events if "exception" in event]
+    assert len(exception_events) == 1
+    assert cast(dict[str, str], exception_events[0].get("tags")) == {
+        "task_id": "task-b",
+        "sandbox_id": "sandbox-b",
+        "sandbox_name": "sandbox-b-name",
+    }
+    assert events[-1].get("tags") == {}

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -273,7 +273,9 @@ async def test_retry_attempt_clears_previous_sandbox_identity(
             )
             raise SandboxSetupError("retry after first sandbox")
 
-        sentry_sdk.capture_exception(RuntimeError("second attempt failed before sandbox assignment"))
+        sentry_sdk.capture_exception(
+            RuntimeError("second attempt failed before sandbox assignment")
+        )
         return {"task-0": {"ok": True}}
 
     monkeypatch.setattr(task_execution, "_process_task_attempt", process_attempt)

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -206,14 +206,18 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
             )
 
         task_a = task_execution.TrackedTask(
-            body("task-a", "sandbox-a", fail=False), cast(Org, object()), cast(ExecutionAuthority, object()), datetime.now(UTC)
+            body("task-a", "sandbox-a", fail=False),
+            cast(Org, object()),
+            cast(ExecutionAuthority, object()),
+            datetime.now(UTC),
         )
         task_b = task_execution.TrackedTask(
-            body("task-b", "sandbox-b", fail=True), cast(Org, object()), cast(ExecutionAuthority, object()), datetime.now(UTC)
+            body("task-b", "sandbox-b", fail=True),
+            cast(Org, object()),
+            cast(ExecutionAuthority, object()),
+            datetime.now(UTC),
         )
-        await asyncio.gather(
-            task_a.run(None, cast(Task, rows["task-a"])), task_b.run(None, cast(Task, rows["task-b"]))
-        )
+        await asyncio.gather(task_a.run(None, cast(Task, rows["task-a"])), task_b.run(None, cast(Task, rows["task-b"])))
 
     with sentry_sdk.init(
         dsn="https://public@example.com/1",

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -8,7 +8,7 @@ import asyncio
 from collections.abc import Callable
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, cast
 from unittest.mock import Mock
 
 import pytest
@@ -20,7 +20,7 @@ import tracker.observability.sentry as sentry_module
 import tracker.utils.task_execution as task_execution
 from tracker.database.models import Org, Task
 from tracker.executor.execution_authority import ExecutionAuthority
-from tracker.exceptions import SandboxError, SSLConnectionError
+from tracker.exceptions import SandboxError, SandboxSetupError, SSLConnectionError
 
 BeforeSend = Callable[[Event, Hint], Event | None]
 BeforeSendLog = Callable[[Log, Hint], Log | None]
@@ -245,3 +245,68 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
         "sandbox_name": "sandbox-b-name",
     }
     assert events[-1].get("tags") == {}
+
+
+@pytest.mark.asyncio
+async def test_retry_attempt_clears_previous_sandbox_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[Event] = []
+
+    class FakeBenchmarkService:
+        async def run_with_sandbox_recovery(
+            self,
+            *,
+            operation: Callable[[Any], Any],
+            **_kwargs: object,
+        ) -> dict[str, dict[str, object] | None]:
+            try:
+                await operation(SimpleNamespace(number=1))
+            except SandboxSetupError:
+                pass
+            return await operation(SimpleNamespace(number=2))
+
+    async def process_attempt(**kwargs: Any) -> dict[str, dict[str, object] | None]:
+        if kwargs["recovery_attempt"].number == 1:
+            sentry_module.set_sandbox_context(
+                SimpleNamespace(id="sandbox-first", name="sandbox-first-name")
+            )
+            raise SandboxSetupError("retry after first sandbox")
+
+        sentry_sdk.capture_exception(RuntimeError("second attempt failed before sandbox assignment"))
+        return {"task-0": {"ok": True}}
+
+    monkeypatch.setattr(task_execution, "_process_task_attempt", process_attempt)
+
+    with sentry_sdk.init(
+        dsn="https://public@example.com/1",
+        transport=events.append,
+        default_integrations=False,
+        before_send=_before_send(),
+    ):
+        with sentry_module.task_scope("task-0"):
+            result = await task_execution.process_task(
+                task_row=cast(Any, object()),
+                start_benchmark_request=cast(
+                    Any,
+                    SimpleNamespace(
+                        benchmark_name="retry-sandbox-context",
+                        contract=SimpleNamespace(name="test-agent"),
+                        dataset=None,
+                    ),
+                ),
+                benchmark_service=cast(Any, FakeBenchmarkService()),
+                benchmark_id=cast(Any, "benchmark-0"),
+                task_id="task-0",
+                aws_runtime=cast(Any, object()),
+                org=cast(Any, object()),
+                sandbox_provider_config=cast(Any, object()),
+                creation_semaphore=cast(Any, object()),
+                authority=cast(Any, object()),
+            )
+
+    assert result == {"task-0": {"ok": True}}
+    retry_event = next(event for event in events if "exception" in event)
+    retry_tags = cast(dict[str, str], retry_event.get("tags", {}))
+    assert retry_tags == {"task_id": "task-0"}
+    assert "sandbox" not in retry_event.get("contexts", {})


### PR DESCRIPTION
## Summary

Keep Sentry task identity isolated for the full tracked-task lifetime and clear attempt-owned sandbox identity before every sandbox-recovery attempt.

This prevents concurrent tasks from leaking correlation state and prevents a retry that fails before replacement-sandbox assignment from inheriting the previous attempt's sandbox tags or context.

## Changes

- add one task-owned Sentry isolation scope around execution, persistence, outer exception capture, and terminal status
- bind and restore `task_id_var` within that scope
- add `clear_sandbox_context()` for sandbox tags and structured context
- invoke sandbox cleanup at the existing sequential recovery-attempt boundary while preserving task identity
- add concurrent, post-scope, and retry-before-replacement regression coverage

## Related Issues

Part of #104.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

## Testing

```text
cd services/tracker && uv run pytest tests/unit/observability/test_sentry.py tests/unit/utils/test_task_execution_retry.py -q
25 passed
```

The focused result included six Sentry SDK deprecation warnings from the added isolation tests. Targeted diagnostics and `git diff --check` passed. The final Ruff formatter check and final-head CI pass.

## Live validation

On 2026-09-11 UTC, Tracker revision `506400723c211501789872d67b3e113aa607b9b6` was exercised locally with create-benchmark-service PR #160 revision `00f995d5714b5a7ce435d39c88218684046fe41f` against real Daytona, AWS CloudWatch/S3, and the `vals-ai/valkyrie` Sentry project under `environment=local-e2e`.

Result: `3 passed` in `45.07s`.

- Success benchmark: `45869484-6c86-4d4e-9030-f2b6b11f6544`.
- Controlled-error benchmark: `99f3541b-5cba-40ba-b991-b34cef12573d`.
- Retry-isolation benchmark: `f3d9616e-16ea-48ed-a1cd-02ae16bd83f6`.
- The retry's first attempt created real sandbox `6eb9ebb2-5dd4-4721-a500-7f12713b5278`, reached the existing CBS-to-`SandboxSetupError` recovery path, and tore the sandbox down.
- The second attempt deterministically failed at Tracker's real per-attempt secret-resolution boundary before replacement-sandbox creation.
- Sentry captured the terminal Tracker error exactly once with `task_id=local-telemetry-retry-error` and empty `sandbox_id`, `sandbox_name`, and `image` fields. This distinguishes the cleared second-attempt state from the first sandbox identity.
- Tracker/CBS HTTP and WebSocket spans shared trace IDs; three sandbox-create duration metrics arrived for the three real sandbox creations.
- All three Daytona label queries returned `active_sandboxes=0`; all three temporary S3 prefixes were empty after cleanup.
- Each benchmark created one CloudWatch log group with one stream and 1-day retention.

Representative traces:

- success retrieve: https://vals-ai.sentry.io/explore/traces/trace/01a08dcee698f52773732911f79a201b
- controlled error: https://vals-ai.sentry.io/explore/traces/trace/01a08dcf3ddd074443d2d3926e271c8f
- retry attempt 1: https://vals-ai.sentry.io/explore/traces/trace/01a08dcf662196c55a9afd36b2092e2d

The current PR head is `fd8e804f5535b9c6f8df399ce6a970e03d8340e6`. Its only change after the live-tested revision is Ruff formatting in the retry regression test; runtime source is identical.

## Validation boundary

- The harness calls `process_benchmark` directly and does not exercise Taskiq's `LoggingContextMiddleware` entrypoint.
- Retry attempt 2 is deterministic injection at a real per-attempt boundary; attempt 1, recovery, sandbox lifecycle, persistence, and telemetry are real.
- No production benchmark or deployment was run.
