### PR TITLE
Use Descope auth for Cyber Range

### DIFF
--- a/src/valkyrie/cli/service_headers.py
+++ b/src/valkyrie/cli/service_headers.py
@@ -11,6 +11,9 @@ def benchmark_service_headers(
     service_headers: dict[str, str] = {}
     auth_credential = TrackerService.get_benchmark_auth(benchmark_name)
     if auth_credential:
-        service_headers["Authorization"] = str(auth_credential)
+        if benchmark_name == "cyber-range":
+            service_headers["x-descope-api-key"] = str(auth_credential).removeprefix("Bearer ")
+        else:
+            service_headers["Authorization"] = str(auth_credential)
     service_headers.update(headers)
     return service_headers

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -1086,6 +1086,18 @@ def test_run_start_sends_configured_service_auth_and_cli_headers(
         assert start_kwargs["service_headers"] == expected_headers
 
 
+def test_cyber_range_auth_uses_descope_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        service_headers.TrackerService,
+        "get_benchmark_auth",
+        staticmethod(lambda _benchmark_name: "Bearer configured"),
+    )
+
+    assert service_headers.benchmark_service_headers("cyber-range") == {"x-descope-api-key": "configured"}
+
+
 def test_run_label_cli_options_and_client_requests(
     monkeypatch: pytest.MonkeyPatch,
     mock_client: MockClient,


### PR DESCRIPTION
Cyber Range benchmark services use the create-benchmark-service Descope authentication header.

Changes:
- Send `x-descope-api-key` for Cyber Range benchmark credentials.
- Strip the legacy `Bearer ` prefix.
- Preserve `Authorization` for all other benchmarks.
- Add one focused regression test.

Validation: focused tests passed; Ruff passed; live task listing returned 43 Cyber Range task IDs with managed AWS config.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->