### PR TITLE
fix(cli): use managed auth for Cyber Range

### DIFF
--- a/src/valkyrie/cli/service_headers.py
+++ b/src/valkyrie/cli/service_headers.py
@@ -11,6 +11,9 @@ def benchmark_service_headers(
     service_headers: dict[str, str] = {}
     auth_credential = TrackerService.get_benchmark_auth(benchmark_name)
     if auth_credential:
-        service_headers["Authorization"] = str(auth_credential)
+        if benchmark_name == "cyber-range":
+            service_headers["x-descope-api-key"] = str(auth_credential).removeprefix("Bearer ")
+        else:
+            service_headers["Authorization"] = str(auth_credential)
     service_headers.update(headers)
     return service_headers

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -221,7 +221,11 @@ class TrackerService:
             harness_config = yaml.safe_load(f) or {}
 
         auth = harness_config.get("benchmark_auth") or {}
-        return auth.get(benchmark_name)
+        if credential := auth.get(benchmark_name):
+            return credential
+        if benchmark_name == "cyber-range" and harness_config.get("api_key"):
+            return f"Bearer {harness_config['api_key']}"
+        return None
 
     @staticmethod
     def get_webhook_secret() -> str | None:

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -48,6 +48,7 @@ from valkyrie.cli.runtime_config import (
     VALKYRIE_ENV_ENV_VAR,
 )
 from valkyrie.cli.tracker_client import TrackerService, TrackerServiceError
+import valkyrie.cli.tracker_client as tracker_client
 
 run_resume = import_module("valkyrie.cli.run.resume")
 run_start = import_module("valkyrie.cli.run.start")
@@ -1084,6 +1085,29 @@ def test_run_start_sends_configured_service_auth_and_cli_headers(
         start_kwargs = mock_tracker_service.start_calls[-1]["kwargs"]
         assert isinstance(start_kwargs, dict)
         assert start_kwargs["service_headers"] == expected_headers
+
+
+def test_cyber_range_auth_uses_descope_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        service_headers.TrackerService,
+        "get_benchmark_auth",
+        staticmethod(lambda _benchmark_name: "Bearer configured"),
+    )
+
+    assert service_headers.benchmark_service_headers("cyber-range") == {"x-descope-api-key": "configured"}
+
+
+def test_cyber_range_auth_falls_back_to_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "dev.yaml"
+    config_path.write_text("api_key: managed\n")
+    monkeypatch.setattr(tracker_client, "config_location", lambda: config_path)
+
+    assert TrackerService.get_benchmark_auth("cyber-range") == "Bearer managed"
 
 
 def test_run_label_cli_options_and_client_requests(


### PR DESCRIPTION
## Summary
Cyber Range uses managed AWS and no longer stores a service-specific credential in the normal config. The CLI must still authenticate the Cyber Range benchmark service with the managed `api_key`.

## Changes
- Fall back to `api_key` when `benchmark_auth.cyber-range` is absent.
- Send the Cyber Range credential as `x-descope-api-key`.
- Keep `Authorization` behavior for other benchmarks.
- Add a focused header regression test.

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing
- [x] Added/updated unit tests
- [x] Manually tested managed task listing: 43 Cyber Range task IDs returned.

## Checklist
- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [ ] Docs updated if needed
