### PR TITLE
Allow Lambda overrides when retrying runs

### DIFF
--- a/docs/reference/cli/run.mdx
+++ b/docs/reference/cli/run.mdx
@@ -387,7 +387,8 @@ valkyrie run resume \
   [--update-agent|-u] \
   [--from-scratch] \
   [--benchmark-url <TEXT>] \
-  [--connect]
+  [--connect] \
+  [--lambda <TEXT>]
 ```
 
 ```bash Example
@@ -456,6 +457,11 @@ valkyrie run resume \
   <p className="mb-0 mt-1">{"Connect to the tracker service to stream run updates after resuming"}</p>
 </div>
 
+<div className="border-b border-gray-200 py-3 dark:border-gray-800">
+  <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"><span className="break-all font-mono text-sm">{"--lambda"}</span><span className="min-w-0 break-words text-sm text-gray-500 dark:text-gray-400">optional · <code>{"text"}</code> · default: <code>{"None"}</code></span></div>
+  <p className="mb-0 mt-1">{"Replace the post-run Lambda for this retry or resume."}</p>
+</div>
+
 Task guidance: [Run guides](/runs/start).
 
 ---
@@ -475,7 +481,8 @@ valkyrie run retry \
   [--update-agent|-u] \
   [--from-scratch] \
   [--benchmark-url <TEXT>] \
-  [--connect]
+  [--connect] \
+  [--lambda <TEXT>]
 ```
 
 ```bash Example
@@ -538,6 +545,11 @@ valkyrie run retry \
 <div className="border-b border-gray-200 py-3 dark:border-gray-800">
   <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"><span className="break-all font-mono text-sm">{"--connect"}</span><span className="min-w-0 break-words text-sm text-gray-500 dark:text-gray-400">optional · <code>{"boolean"}</code> · default: <code>{"False"}</code></span></div>
   <p className="mb-0 mt-1">{"Connect to the tracker service to stream run updates after resuming"}</p>
+</div>
+
+<div className="border-b border-gray-200 py-3 dark:border-gray-800">
+  <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1"><span className="break-all font-mono text-sm">{"--lambda"}</span><span className="min-w-0 break-words text-sm text-gray-500 dark:text-gray-400">optional · <code>{"text"}</code> · default: <code>{"None"}</code></span></div>
+  <p className="mb-0 mt-1">{"Replace the post-run Lambda for this retry or resume."}</p>
 </div>
 
 Task guidance: [Run guides](/runs/start).

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -1238,6 +1238,7 @@ async def retry_or_resume_benchmark(
     service_headers: dict[str, str] = Body(default={}),
     secrets: dict[str, str] = Body(default={}),
     benchmark_url: str | None = Body(default=None),
+    lambda_function: str | None = Body(default=None, min_length=1),
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
 ) -> RetryOrResumeBenchmarkResponse:
@@ -1452,6 +1453,9 @@ async def retry_or_resume_benchmark(
                 concurrency=concurrency,
                 benchmark_url=benchmark_url,
             )
+
+        if lambda_function is not None:
+            benchmark_row.arguments = benchmark_row.arguments.model_copy(update={"lambda_function": lambda_function})
 
         if benchmark_row.aws_managed:
             resume_request = benchmark_row.managed_start_benchmark_request(

--- a/services/tracker/main.py
+++ b/services/tracker/main.py
@@ -5,7 +5,7 @@ import tarfile
 from collections.abc import AsyncGenerator, AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
-from typing import Any, cast
+from typing import Annotated, Any, cast
 from uuid import UUID, uuid4
 
 import httpx
@@ -1238,7 +1238,7 @@ async def retry_or_resume_benchmark(
     service_headers: dict[str, str] = Body(default={}),
     secrets: dict[str, str] = Body(default={}),
     benchmark_url: str | None = Body(default=None),
-    lambda_function: str | None = Body(default=None, min_length=1),
+    lambda_function: Annotated[str | None, Body(min_length=1)] = None,
     session: Session = Depends(get_session),
     org: Org = Depends(get_current_org),
 ) -> RetryOrResumeBenchmarkResponse:

--- a/services/tracker/openapi.json
+++ b/services/tracker/openapi.json
@@ -938,6 +938,18 @@
             ],
             "title": "Benchmark Url"
           },
+          "lambda_function": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lambda Function"
+          },
           "secrets": {
             "additionalProperties": {
               "type": "string"

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -2015,11 +2015,14 @@ class TestRunRecovery:
 
         response = client.post(
             f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true",
+            json={"lambda_function": "vals-format-lambda"},
             headers=harness_headers,
         )
 
         assert response.status_code == 200
         admitted_payload = mock_kicker.queued_calls[0]
+        assert benchmark_row.arguments.lambda_function == "vals-format-lambda"
+        assert admitted_payload["start_benchmark_request_json"]["lambda_function"] == "vals-format-lambda"
         assert admitted_payload["verified_task_ids"] == ["task_error"]
         dispatch_id = UUID(admitted_payload["executor_dispatch_id"])
         dispatch = database_session.get(ExecutorDispatch, dispatch_id)

--- a/src/valkyrie/cli/run/resume.py
+++ b/src/valkyrie/cli/run/resume.py
@@ -89,6 +89,7 @@ from valkyrie.cli.tracker_client import TrackerService
     required=False,
     help="Connect to the tracker service to stream run updates after resuming",
 )
+@click.option("--lambda", "lambda_function", type=str, default=None, help="Replace the post-run Lambda for this retry or resume.")
 @click.pass_context
 def resume(
     ctx: click.Context,
@@ -102,6 +103,7 @@ def resume(
     update_agent: bool,
     from_scratch: bool,
     benchmark_url: str | None,
+    lambda_function: str | None,
     connect: bool,
 ):
     """
@@ -137,6 +139,7 @@ def resume(
                 service_headers=service_headers,
                 secrets={key: value for key, value in secrets},
                 benchmark_url=benchmark_url,
+                lambda_function=lambda_function,
             )
             action_label = "retried" if retry else "resumed"
             click.echo(click.style(f"✓ Run {action_label} successfully!", fg="green", bold=True))

--- a/src/valkyrie/cli/run/resume.py
+++ b/src/valkyrie/cli/run/resume.py
@@ -89,7 +89,9 @@ from valkyrie.cli.tracker_client import TrackerService
     required=False,
     help="Connect to the tracker service to stream run updates after resuming",
 )
-@click.option("--lambda", "lambda_function", type=str, default=None, help="Replace the post-run Lambda for this retry or resume.")
+@click.option(
+    "--lambda", "lambda_function", type=str, default=None, help="Replace the post-run Lambda for this retry or resume."
+)
 @click.pass_context
 def resume(
     ctx: click.Context,

--- a/src/valkyrie/cli/tracker_client.py
+++ b/src/valkyrie/cli/tracker_client.py
@@ -718,6 +718,7 @@ class TrackerService:
         service_headers: dict[str, str] | None = None,
         secrets: dict[str, str] | None = None,
         benchmark_url: str | None = None,
+        lambda_function: str | None = None,
     ) -> RetryOrResumeBenchmarkResponse:
         """
         Run a benchmark that has already been created by its benchmark id.
@@ -746,6 +747,8 @@ class TrackerService:
                 body["secrets"] = secrets
             if benchmark_url is not None:
                 body["benchmark_url"] = benchmark_url
+            if lambda_function is not None:
+                body["lambda_function"] = lambda_function
 
             response = self._client.post(
                 f"{self._base_url}/retry-or-resume-benchmark/{benchmark_id}",

--- a/tests/contract/test_sdk_tracker_contract.py
+++ b/tests/contract/test_sdk_tracker_contract.py
@@ -399,7 +399,7 @@ def test_tracker_routes_match_the_sdk_http_contract() -> None:
     retry_schema_ref = retry["requestBody"]["content"]["application/json"]["schema"]["$ref"]
     retry_schema = schema["components"]["schemas"][retry_schema_ref.rsplit("/", 1)[-1]]
     retry_fixture = load_fixture("retry_resume.json")
-    assert set(retry_schema["properties"]) == {*retry_fixture["body"], "benchmark_url"}
+    assert set(retry_schema["properties"]) == {*retry_fixture["body"], "benchmark_url", "lambda_function"}
     retry_properties = retry_schema["properties"]
     assert {
         name: (retry_properties[name]["type"], retry_properties[name]["default"])
@@ -410,6 +410,7 @@ def test_tracker_routes_match_the_sdk_http_contract() -> None:
         "secrets": ("object", {}),
     }
     assert retry_properties["benchmark_url"]["anyOf"] == [{"type": "string"}, {"type": "null"}]
+    assert retry_properties["lambda_function"]["anyOf"] == [{"type": "string", "minLength": 1}, {"type": "null"}]
 
     retry_parameters = {parameter["name"]: parameter for parameter in retry["parameters"]}
     assert retry_parameters["retry"]["schema"]["default"] == retry_fixture["query"]["retry"]

--- a/tests/unit/cli/run/test_resume.py
+++ b/tests/unit/cli/run/test_resume.py
@@ -43,6 +43,7 @@ class MockTrackerService:
         service_headers: dict[str, str] | None = None,
         secrets: dict[str, str] | None = None,
         benchmark_url: str | None = None,
+        lambda_function: str | None = None,
     ) -> RetryOrResumeBenchmarkResponse:
         self.calls.append({"benchmark_id": benchmark_id, "service_headers": service_headers})
         return RetryOrResumeBenchmarkResponse(status="success")

--- a/tests/unit/cli/test_tracker_client.py
+++ b/tests/unit/cli/test_tracker_client.py
@@ -695,6 +695,7 @@ def test_retry_or_resume_sends_retry_mode(
         task_ids=["task-1"],
         secrets={"ANTHROPIC_API_KEY": "new-secret"},
         benchmark_url="https://new.example",
+        lambda_function="vals-format-lambda",
     )
 
     assert result.status == "success"
@@ -704,6 +705,7 @@ def test_retry_or_resume_sends_retry_mode(
         "service_headers": {},
         "secrets": {"ANTHROPIC_API_KEY": "new-secret"},
         "benchmark_url": "https://new.example",
+        "lambda_function": "vals-format-lambda",
     }
 
     tracker.retry_or_resume_benchmark(
@@ -1018,11 +1020,12 @@ def test_run_retry_benchmark_url_reaches_tracker(
 
     result = CliRunner().invoke(
         cli_main.cli,
-        ["run", "retry", str(run_id), "--benchmark-url", "https://new.example"],
+        ["run", "retry", str(run_id), "--benchmark-url", "https://new.example", "--lambda", "vals-format-lambda"],
     )
 
     assert result.exit_code == 0, result.output
     assert mock_tracker_service.retry_or_resume_calls[0]["kwargs"]["benchmark_url"] == "https://new.example"
+    assert mock_tracker_service.retry_or_resume_calls[0]["kwargs"]["lambda_function"] == "vals-format-lambda"
 
 
 def test_run_start_provider_option_reaches_tracker(


### PR DESCRIPTION
Add --lambda to run retry/resume and forward it to Tracker. Persist the override within the accepted dispatch transaction, after active-run no-op paths. Omission preserves the stored value. Existing managed executor Lambda preflight remains before task creation and sandbox work; no IAM expansion or Tracker-side credential change.

Repairs the configuration path for run 54e72bc8-ac08-49b0-a1c3-ba1a4635ca45, which selected nonexistent vcb-final-view-lambda. Correct dev function vals-format-lambda exists and the managed executor policy allows invocation.

Verification: 33 CLI/client tests and 59 Tracker recovery/managed-execution tests passed. One existing Starlette deprecation warning. No production changes, direct database edits, or live retry. Deploy Tracker dev and the updated CLI before retrying the affected run.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/778" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->