### PR TITLE
build(tracker): upgrade CBS to v0.38.0

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -10,4 +10,4 @@ prerelease = "allow"
 
 [tool.uv.sources]
 tracker = { path = "../tracker" }
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.2" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.38.0" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.37.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2#74d5398dc3805ac67ccaadc77225c21c0b764feb" }
+version = "0.38.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -368,8 +368,10 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "modal" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "starlette" },
     { name = "tenacity" },
     { name = "websockets" },
@@ -1837,7 +1839,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "sentry-sdk[fastapi]==2.58.0",
   "python-json-logger>=3.2.1",
   "python-dotenv>=1.2.2",
-  "create-benchmark-service>=0.37.2",
+  "create-benchmark-service>=0.38.0",
   "aioboto3>=7.0.0",
 ]
 
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.37.2" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.38.0" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.37.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2#74d5398dc3805ac67ccaadc77225c21c0b764feb" }
+version = "0.38.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -407,8 +407,10 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "modal" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "starlette" },
     { name = "tenacity" },
     { name = "websockets" },
@@ -2116,7 +2118,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.37.2"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2#74d5398dc3805ac67ccaadc77225c21c0b764feb" }
+version = "0.38.0"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -438,8 +438,10 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "modal" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "starlette" },
     { name = "tenacity" },
     { name = "websockets" },
@@ -2312,7 +2314,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.37.2" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## What changed
- Upgrade Tracker's CBS requirement/source from `v0.37.2` to `v0.38.0`.
- Upgrade the separate immutable executor-artifact CBS source to the same tag.
- Regenerate Tracker, executor-artifact, and root locks; all resolve CBS to `de2a82eea283942d290e136cec4c80d5072e2fb7`. Existing Sentry SDK pin remains `2.58.0`.

## Why
Enable the released CBS client correlation headers and WebSocket spans from https://github.com/vals-ai/create-benchmark-service/pull/160 alongside task/attempt isolation from https://github.com/vals-ai/Valkyrie/pull/772.

The executor PEX uses its own lock, so both the core and executor dependency owners must be upgraded. The approved rollout is **dev core and dev executor release only**; no production, source fault hooks, or executor-routing changes.

## How tested
- `uv lock` completed in the Tracker, executor-artifact, and root projects.
- Deterministic version/commit assertions for all three locks and `git diff --check` passed.
- Local suites were not run. Remote CI and independent dependency review are pending.
- Coordinated deployed telemetry probes follow the Tracker and SWE-bench dev rollouts; live validation has not run yet.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vals-ai/valkyrie/pull/786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->