### PR TITLE
fix(tracker): Keep fresh generations separate from recovery

### DIFF
--- a/services/tracker/src/tracker/database/migrations/versions/61d4162227ab_add_task_generation_id.py
+++ b/services/tracker/src/tracker/database/migrations/versions/61d4162227ab_add_task_generation_id.py
@@ -1,0 +1,17 @@
+"""Keep explicit fresh generations separate from automatic recovery."""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "61d4162227ab"
+down_revision = "50c3051116fa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("task", sa.Column("generation_id", sa.Uuid(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("task", "generation_id")

--- a/services/tracker/src/tracker/database/models.py
+++ b/services/tracker/src/tracker/database/models.py
@@ -567,6 +567,7 @@ class Task(SQLModel, table=True):
     started_at: datetime = Field(default_factory=lambda: datetime.now(ZoneInfo("UTC")))
     finished_at: datetime | None = None
     eval_resume_state: dict[str, Any] | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    generation_id: UUID | None = Field(default=None)
     benchmark: UUID = Field(foreign_key="benchmark.id")
     task_breakdown: UUID | None = Field(default=None, foreign_key="taskbreakdown.id")
 

--- a/services/tracker/src/tracker/utils/run_control.py
+++ b/services/tracker/src/tracker/utils/run_control.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import AsyncGenerator
 from datetime import datetime, timedelta
 from typing import Any
+from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from benchmark_service import (
@@ -241,6 +242,7 @@ async def reset_to_in_progress_status(
             task.finished_at = None
             if retry_mode == RetryMode.FROM_SCRATCH:
                 task.eval_resume_state = None
+                task.generation_id = uuid4()
             session.add(task)
 
         for task_id in new_task_ids:

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -1041,6 +1041,7 @@ async def _process_task_attempt(
             **resolve_secrets(start_benchmark_request.contract.secrets, SecretsManagerStore(aws_runtime.clients)),
             "RUN_ID": str(benchmark_id),
             "TASK_ID": task_row.task_id,
+            "TASK_GENERATION_ID": str(task_row.generation_id) if task_row.generation_id else "",
             **_attested_inference_settings(start_benchmark_request.contract),
             "IDENTITY": json.dumps(identity),
             # Tags sandbox-internal OTel telemetry with our IDs + environment so traces/logs/metrics

--- a/services/tracker/tests/integration/local/database/test_migrations.py
+++ b/services/tracker/tests/integration/local/database/test_migrations.py
@@ -43,6 +43,21 @@ def test_migration_graph_has_single_head() -> None:
     assert len(heads) == 1, f"Expected one Alembic head, found {heads}"
 
 
+def test_task_generation_migration_round_trip(migration_database_url: str) -> None:
+    upgrade = _run_alembic(migration_database_url, "upgrade", "61d4162227ab")
+    assert upgrade.returncode == 0, upgrade.stderr
+    engine = create_engine(migration_database_url)
+    columns = {column["name"]: column for column in inspect(engine).get_columns("task")}
+    assert columns["generation_id"]["nullable"] is True
+    assert str(columns["generation_id"]["type"]) == "UUID"
+    downgrade = _run_alembic(migration_database_url, "downgrade", "50c3051116fa")
+    assert downgrade.returncode == 0, downgrade.stderr
+    assert "generation_id" not in {column["name"] for column in inspect(engine).get_columns("task")}
+    upgrade = _run_alembic(migration_database_url, "upgrade", "head")
+    assert upgrade.returncode == 0, upgrade.stderr
+    engine.dispose()
+
+
 @pytest.fixture
 def migration_database_url() -> Generator[str, None, None]:
     with PostgresContainer("postgres:16-alpine") as postgres:

--- a/services/tracker/tests/unit/utils/test_run_recovery.py
+++ b/services/tracker/tests/unit/utils/test_run_recovery.py
@@ -723,8 +723,10 @@ class TestRunRecovery:
             (RetryMode.FROM_SCRATCH, {"artifact_prefix": "s3://bucket/run"}, TaskStatus.PENDING, None),
         ],
     )
+    @pytest.mark.parametrize("has_generation", [False, True])
     async def test_reset_handles_eval_resume_state(
         self,
+        has_generation: bool,
         retry_mode: RetryMode,
         eval_resume_state: dict[str, str] | None,
         expected_status: TaskStatus,
@@ -741,9 +743,13 @@ class TestRunRecovery:
             benchmark=benchmark_row.id,
             status=TaskStatus.STOPPED,
             eval_resume_state=eval_resume_state,
+            generation_id=UUID("00000000-0000-0000-0000-000000000001") if has_generation else None,
         )
+        old_generation = task_row.generation_id
+        other_task = Task(org_id=TEST_ORG_ID, task_id="unselected", benchmark=benchmark_row.id, status=TaskStatus.ERROR)
         database_session.add(benchmark_row)
         database_session.add(task_row)
+        database_session.add(other_task)
         database_session.commit()
 
         async def _mock_request_verify_task_ids(*_args: Any, **_kwargs: Any) -> VerifyTaskIdsResponse:
@@ -766,6 +772,12 @@ class TestRunRecovery:
         assert verified_task_ids == [task_row.task_id]
         assert task_row.status == expected_status
         assert task_row.eval_resume_state == expected_state
+        if retry_mode == RetryMode.FROM_SCRATCH:
+            assert task_row.generation_id is not None and task_row.generation_id != old_generation
+        else:
+            assert task_row.generation_id == old_generation
+        database_session.refresh(other_task)
+        assert other_task.status == TaskStatus.ERROR and other_task.generation_id is None
 
     async def test_retry_preserves_previous_task_history_for_export(
         self,
@@ -2079,8 +2091,10 @@ class TestRunRecovery:
             assert persisted_task.status == TaskStatus.ERROR
             assert fresh_session.exec(select(ExecutorDispatch)).all() == []
 
+    @pytest.mark.parametrize("retry_mode", [RetryMode.AUTO, RetryMode.FROM_SCRATCH])
     async def test_release_resolution_failure_rolls_back_retry_mutation(
         self,
+        retry_mode: RetryMode,
         example_benchmark_object: Benchmark,
         database_session: Session,
         monkeypatch: MonkeyPatch,
@@ -2108,7 +2122,10 @@ class TestRunRecovery:
             _fail_release_resolution,
         )
 
-        response = client.post(f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true", headers=harness_headers)
+        response = client.post(
+            f"/retry-or-resume-benchmark/{benchmark_row.id}?retry=true&retry_mode={retry_mode.value}",
+            headers=harness_headers,
+        )
 
         assert response.status_code == 409
         with Session(bind=database_session.get_bind()) as fresh_session:
@@ -2119,6 +2136,7 @@ class TestRunRecovery:
             assert persisted_benchmark.current_execution_release_id == "test-release"
             assert persisted_task is not None
             assert persisted_task.status == TaskStatus.ERROR
+            assert persisted_task.generation_id is None
             assert fresh_session.get(FinalEvaluation, old_evaluation_id) is not None
             assert persisted_benchmark.final_evaluation is not None
             assert persisted_benchmark.final_evaluation.id == old_evaluation_id

--- a/services/tracker/tests/unit/utils/test_task_execution_env.py
+++ b/services/tracker/tests/unit/utils/test_task_execution_env.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from functools import partial
 from types import SimpleNamespace
 from typing import Any
+from uuid import UUID
 
 import pytest
 from benchmark_service.client import BenchmarkServiceClient
@@ -48,8 +49,10 @@ class TestProcessTaskEnvironment:
     """Tracker-owned environment variables passed to agent tasks."""
 
     @pytest.mark.usefixtures("process_benchmark_env")
+    @pytest.mark.parametrize("generation_id", [None, UUID("00000000-0000-0000-0000-000000000001")])
     async def test_process_task_injects_tracker_owned_attribution_env(
         self,
+        generation_id: UUID | None,
         contract: AgentContractRequest,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
@@ -82,12 +85,16 @@ class TestProcessTaskEnvironment:
                 "contract": contract.model_copy(update={"name": "transient-agent-name"}),
             }
         )
+        task_row.generation_id = generation_id
+        database_session.add(task_row)
+        database_session.commit()
         captured_env_vars: list[dict[str, str]] = []
 
         def _mock_resolve_secrets(*_args: Any, **_kwargs: Any) -> dict[str, str]:
             return {
                 "RUN_ID": "secret-run-id",
                 "TASK_ID": "secret-task-id",
+                "TASK_GENERATION_ID": "secret-generation-id",
                 "VALKYRIE_AGENT_MODEL": "secret-model",
                 "VALKYRIE_AGENT_VARIANT": "secret-variant",
                 "IDENTITY": '{"source":"secret"}',
@@ -111,6 +118,7 @@ class TestProcessTaskEnvironment:
         assert env_vars["RUN_ID"] == str(benchmark_id)
         assert "QUESTION_ID" not in env_vars
         assert env_vars["TASK_ID"] == "task_0"
+        assert env_vars["TASK_GENERATION_ID"] == (str(generation_id) if generation_id else "")
         assert env_vars["VALKYRIE_AGENT_MODEL"] == "provider/model"
         assert env_vars["VALKYRIE_AGENT_VARIANT"] == "xhigh"
         assert json.loads(env_vars["IDENTITY"]) == {


### PR DESCRIPTION
## Summary

Explicit from-scratch retries must not restore an earlier VCB generation. Automatic recovery must keep the current generation.

## Changes

- Add nullable task generation UUIDs with migration `61d4162227ab`.
- Rotate the UUID only for selected `FROM_SCRATCH` tasks.
- Pass the persisted UUID through `TASK_GENERATION_ID`. Keep legacy tasks compatible with an empty value.
- Keep retry changes in the existing admission transaction.

## Related Issues

Requires https://github.com/vals-ai/vcb-1-100-benchmark-service/pull/422 before enabling fresh-generation retries.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Docs / config

## Testing

- [x] Added/updated unit tests
- [ ] Manually tested

57 recovery and environment tests passed. Tests cover automatic recovery, UUID rotation, unselected tasks, rejected admission rollback, and secret override protection. PostgreSQL migration upgrade/downgrade/upgrade and the single-head check passed.

## Checklist

- [x] Self-reviewed the diff
- [x] No debug/dead code left in
- [x] Docs updated if needed

## Release gate

No merge, deployment, live retry, historical deletion, IAM change, or production change was performed. Deploy the matching VCB consumer before enabling this behavior. Qualify from-scratch and automatic recovery through the deployed dev service before release.
