### PR TITLE
Preserve typed task outcomes and evaluation recovery

### DIFF
--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.38.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "04ecfbd14202459626947afd92b450f54674cca1" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/utils/run_orchestration.py
+++ b/services/tracker/src/tracker/utils/run_orchestration.py
@@ -13,6 +13,7 @@ from uuid import UUID
 import sentry_sdk
 from benchmark_service import SandboxProvider, SandboxProviderConfig
 from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceUnauthenticatedError
+from benchmark_service.schemas import ErrorTaskOutcome, EvaluatedTaskOutcome, TaskOutcome, UnavailableTaskOutcome
 from botocore.config import Config
 from pydantic import ValidationError
 from sqlmodel import Session, col, desc, func, select
@@ -68,7 +69,7 @@ logger = get_logger(__name__)
 _SANDBOX_CREATION_CAP: int = 10
 _RUNNABLE_TASK_STATUSES = [TaskStatus.PENDING, TaskStatus.BUILDING, TaskStatus.IN_PROGRESS, TaskStatus.EVALUATING]
 _TERMINAL_BENCHMARK_STATUSES = (BenchmarkStatus.FINISHED, BenchmarkStatus.ERROR, BenchmarkStatus.STOPPED)
-_TaskFingerprint = tuple[tuple[UUID, datetime, TaskStatus, UUID | None], ...]
+_TaskFingerprint = tuple[tuple[UUID, datetime, TaskStatus, UUID | None, UUID | None], ...]
 
 
 async def _run_queued_tasks(
@@ -424,7 +425,7 @@ def _fetch_final_score_state(
     org: Org,
     *,
     for_update: bool = False,
-) -> tuple[dict[str, dict[str, Any] | None], _TaskFingerprint]:
+) -> tuple[dict[str, dict[str, Any] | None], _TaskFingerprint, dict[str, TaskOutcome]]:
     # Fetch task rows which belong to the benchmark we are running
     task_rows_query = (
         select(Task.id, Task.task_id, Task.started_at, Task.status)
@@ -455,6 +456,36 @@ def _fetch_final_score_state(
     for task_row_id, result_id, result in result_rows:
         latest_results.setdefault(task_row_id, (result_id, result))
 
+    latest_errors: dict[UUID, ErrorResult] = {}
+    for error in session.exec(
+        select(ErrorResult)
+        .where(col(ErrorResult.task).in_(task_row_ids))
+        .where(ErrorResult.org_id == org.id)
+        .where(ErrorResult.retry_scheduled == False)  # noqa: E712
+        .order_by(desc(ErrorResult.created_at), desc(ErrorResult.id))
+    ).all():
+        latest_errors.setdefault(error.task, error)
+
+    outcomes: dict[str, TaskOutcome] = {}
+    for task_row_id, task_id, started_at, status in task_rows:
+        error = latest_errors.get(task_row_id)
+        if status == TaskStatus.ERROR:
+            # Previous attempts cannot supply provenance for the current failure.
+            if error is not None and error.created_at < started_at:
+                error = None
+            outcomes[task_id] = ErrorTaskOutcome(
+                producer=error.producer if error else None,
+                operation=error.operation if error else None,
+                error_type=error.error_type if error else None,
+                cause_code=error.cause_code if error else None,
+            )
+        elif status == TaskStatus.FINISHED and task_row_id in latest_results:
+            outcomes[task_id] = EvaluatedTaskOutcome()
+        else:
+            outcomes[task_id] = UnavailableTaskOutcome(
+                reason="missing_result" if status == TaskStatus.FINISHED else "not_finished"
+            )
+
     inputs = {
         task_id: latest_results[task_row_id][1]
         if status == TaskStatus.FINISHED and task_row_id in latest_results
@@ -467,10 +498,11 @@ def _fetch_final_score_state(
             started_at,
             status,
             latest_results[task_row_id][0] if task_row_id in latest_results else None,
+            latest_errors[task_row_id].id if task_row_id in latest_errors else None,
         )
         for task_row_id, _task_id, started_at, status in task_rows
     )
-    return inputs, fingerprint
+    return inputs, fingerprint, outcomes
 
 
 def fetch_final_score_inputs(session: Session, benchmark_row: Benchmark, org: Org) -> dict[str, dict[str, Any] | None]:
@@ -508,7 +540,7 @@ async def finalize_all_error_run(
         if has_stopped_tasks(session, benchmark_row, org):
             set_benchmark_final_status(benchmark_row, session, org, authority=authority)
             return False
-        _evaluation_results, task_fingerprint = _fetch_final_score_state(
+        _evaluation_results, task_fingerprint, _outcomes = _fetch_final_score_state(
             session,
             benchmark_row,
             org,
@@ -528,7 +560,7 @@ async def finalize_all_error_run(
         if has_stopped_tasks(session, benchmark_row, org):
             set_benchmark_final_status(benchmark_row, session, org, authority=authority)
             return False
-        _evaluation_results, current_fingerprint = _fetch_final_score_state(
+        _evaluation_results, current_fingerprint, _outcomes = _fetch_final_score_state(
             session,
             benchmark_row,
             org,
@@ -903,7 +935,7 @@ async def process_benchmark(
                 benchmark_id,
                 except_dispatch_id=authority.dispatch_id,
             )
-            evaluation_results, task_fingerprint = _fetch_final_score_state(
+            evaluation_results, task_fingerprint, task_outcomes = _fetch_final_score_state(
                 session,
                 benchmark_row,
                 org,
@@ -917,7 +949,7 @@ async def process_benchmark(
 
         # Calculate the final score based off the tasks that were ran
         final_score_response = await benchmark_service.final_score(
-            evaluation_results=evaluation_results, dataset=start_benchmark_request.dataset
+            evaluation_results=evaluation_results, dataset=start_benchmark_request.dataset, task_outcomes=task_outcomes
         )
 
         with Session(bind=engine) as session:
@@ -941,7 +973,7 @@ async def process_benchmark(
                 finalization_deferred = True
                 return
             lock_execution_authority(session, authority)
-            _current_results, current_fingerprint = _fetch_final_score_state(
+            _current_results, current_fingerprint, _outcomes = _fetch_final_score_state(
                 session,
                 benchmark_row,
                 org,

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -25,7 +25,12 @@ from benchmark_service import (
     SandboxProviderConfig,
     SandboxRecoveryAttempt,
 )
-from benchmark_service.client import BenchmarkServiceClient, BenchmarkServiceError, BenchmarkServiceStreamError
+from benchmark_service.client import (
+    BenchmarkServiceClient,
+    BenchmarkServiceError,
+    BenchmarkServiceResumableEvaluationError,
+    BenchmarkServiceStreamError,
+)
 from pydantic import ValidationError
 from sqlalchemy.engine import Connection
 from sqlmodel import Session, col, select, update
@@ -870,6 +875,9 @@ async def _process_task_attempt(
                 terminal_error,
                 producer="benchmark_service",
                 operation="resume_evaluation",
+                cause_code="resumable_evaluation_infrastructure"
+                if isinstance(resume_error, BenchmarkServiceResumableEvaluationError)
+                else None,
             )
 
         finished_at = time.perf_counter()
@@ -1334,6 +1342,20 @@ async def _process_task_attempt(
             producer="benchmark_service",
             operation="websocket",
             cause_code="websocket_connection_closed",
+        )
+    except BenchmarkServiceResumableEvaluationError as e:
+        if task_is_stopped():
+            return {task_id: None}
+        error_message = _exception_message(e)
+        recovered = await recover_evaluation_stream_failure(error_message)
+        if recovered is not None:
+            return recovered
+        return commit_terminal_error(
+            e,
+            error_message,
+            producer="benchmark_service",
+            operation="evaluate_instance",
+            cause_code="resumable_evaluation_infrastructure",
         )
     except BenchmarkServiceStreamError as e:
         if task_is_stopped():

--- a/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
+++ b/services/tracker/tests/unit/utils/test_benchmark_service_failures.py
@@ -15,6 +15,7 @@ from benchmark_service import ExecResult
 from benchmark_service.client import (
     BenchmarkServiceClient,
     BenchmarkServiceError,
+    BenchmarkServiceResumableEvaluationError,
     BenchmarkServiceStreamClosedError,
 )
 from benchmark_service.schemas import RetrieveTaskResponse
@@ -142,7 +143,7 @@ class TestBenchmarkServiceFailures:
         assert reason in error_message
         assert "last application message received" in error_message
 
-    @pytest.mark.parametrize("stream_failure", ["wrapped", "raw"])
+    @pytest.mark.parametrize("stream_failure", ["wrapped", "raw", "infrastructure", "candidate"])
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_stream_close_with_saved_state_resumes_evaluation(
         self,
@@ -161,8 +162,12 @@ class TestBenchmarkServiceFailures:
 
         async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
             on_eval_resume_state(saved_state)
+            if stream_failure == "candidate":
+                raise BenchmarkServiceError("Candidate packaging failed")
             if stream_failure == "raw":
                 raise ConnectionClosedError(None, None)
+            if stream_failure == "infrastructure":
+                raise BenchmarkServiceResumableEvaluationError("Evaluation sandbox unavailable")
             raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
 
         async def _mock_resume_evaluation(
@@ -178,6 +183,12 @@ class TestBenchmarkServiceFailures:
 
         result = await run_process_task(start_benchmark_request, task_row, benchmark_id, aws_runtime, authority)
 
+        if stream_failure == "candidate":
+            assert result == {"task_0": None}
+            assert resume_calls == 0
+            database_session.refresh(task_row)
+            assert task_row.status == TaskStatus.ERROR
+            return
         assert result == {"task_0": {"status": "success", "score": 1.0}}
         assert resume_calls == 1
         database_session.refresh(task_row)
@@ -273,9 +284,11 @@ class TestBenchmarkServiceFailures:
         assert database_session.exec(select(EvaluationResult).where(EvaluationResult.task == task_row.id)).one()
         assert not database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).first()
 
+    @pytest.mark.parametrize("typed", [False, True])
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_stream_close_without_saved_state_produces_stream_error(
         self,
+        typed: bool,
         contract: AgentContractRequest,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
@@ -287,6 +300,8 @@ class TestBenchmarkServiceFailures:
         )
 
         async def _mock_evaluate_instance(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            if typed:
+                raise BenchmarkServiceResumableEvaluationError("Evaluation sandbox unavailable")
             raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
 
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
@@ -297,12 +312,19 @@ class TestBenchmarkServiceFailures:
         database_session.refresh(task_row)
         assert task_row.status == TaskStatus.ERROR
         error_message = self._latest_task_error(database_session, task_row)
-        assert "Benchmark service WebSocket stream failed" in error_message
-        assert "keepalive timeout" in error_message
+        if typed:
+            assert "Evaluation sandbox unavailable" in error_message
+            error = database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).one()
+            assert error.cause_code == "resumable_evaluation_infrastructure"
+        else:
+            assert "Benchmark service WebSocket stream failed" in error_message
+            assert "keepalive timeout" in error_message
 
+    @pytest.mark.parametrize("typed", [False, True])
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_stream_resume_failure_produces_terminal_error(
         self,
+        typed: bool,
         contract: AgentContractRequest,
         database_session: Session,
         monkeypatch: pytest.MonkeyPatch,
@@ -313,13 +335,17 @@ class TestBenchmarkServiceFailures:
             contract, database_session, harness_config
         )
         saved_state = {"artifact_prefix": "s3://bucket/run", "job_id": "job-1"}
+        resume_calls = 0
 
         async def _mock_evaluate_instance(*_args: Any, on_eval_resume_state: Any, **_kwargs: Any) -> dict[str, Any]:
             on_eval_resume_state(saved_state)
             raise BenchmarkServiceStreamClosedError(close_code=1011, close_reason="keepalive timeout", idle_s=30.0)
 
         async def _mock_resume_evaluation(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
-            raise BenchmarkServiceError("resume endpoint unavailable")
+            nonlocal resume_calls
+            resume_calls += 1
+            error = BenchmarkServiceResumableEvaluationError if typed else BenchmarkServiceError
+            raise error("resume endpoint unavailable")
 
         monkeypatch.setattr(BenchmarkServiceClient, "evaluate_instance", _mock_evaluate_instance)
         monkeypatch.setattr(BenchmarkServiceClient, "resume_evaluation", _mock_resume_evaluation, raising=False)
@@ -332,6 +358,10 @@ class TestBenchmarkServiceFailures:
         error_message = self._latest_task_error(database_session, task_row)
         assert "resuming evaluation from durable benchmark state" in error_message
         assert "resume failed: resume endpoint unavailable" in error_message
+        assert resume_calls == 1
+        if typed:
+            error = database_session.exec(select(ErrorResult).where(ErrorResult.task == task_row.id)).one()
+            assert error.cause_code == "resumable_evaluation_infrastructure"
 
     @pytest.mark.usefixtures("process_benchmark_env")
     async def test_stream_resume_stops_when_task_is_stopped_during_retry(

--- a/services/tracker/tests/unit/utils/test_run_state.py
+++ b/services/tracker/tests/unit/utils/test_run_state.py
@@ -3,7 +3,7 @@
 Run: uv run pytest tests/unit/utils/test_run_state.py
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Sequence, cast
 from unittest.mock import AsyncMock, MagicMock
 from uuid import UUID, uuid4
@@ -51,6 +51,7 @@ from tracker.utils import (
     set_benchmark_final_status,
     start_benchmark_request_to_benchmark,
 )
+from tracker.utils.run_orchestration import _fetch_final_score_state
 
 _parse_log_retention_policy = getattr(harness_config_module, "_parse_log_retention_policy")
 
@@ -578,6 +579,42 @@ class TestRunState:
             "task_stopped": None,
             "task_pending": None,
         }
+        database_session.add(
+            ErrorResult(
+                org_id=TEST_ORG_ID,
+                task=error_task.id,
+                error_message="Not used for attribution",
+                producer="tracker",
+                operation="evaluate",
+                error_type="EvaluationError",
+                cause_code="resumable_evaluation_infrastructure",
+            )
+        )
+        database_session.commit()
+        inputs, _, outcomes = _fetch_final_score_state(database_session, benchmark_row, self._test_org)
+        assert inputs["task_error"] is None
+        assert outcomes["task_finished"].kind == "evaluated"
+        assert outcomes["task_stopped"].kind == "unavailable"
+        error_outcome = outcomes["task_error"]
+        assert error_outcome.kind == "error"
+        assert error_outcome.cause_code == "resumable_evaluation_infrastructure"
+        unknown_outcome = outcomes["task_pending"]
+        assert unknown_outcome.kind == "error"
+        assert unknown_outcome.cause_code is None
+        database_session.add(
+            ErrorResult(
+                org_id=TEST_ORG_ID,
+                task=pending_task.id,
+                created_at=pending_task.started_at - timedelta(seconds=1),
+                error_message="Previous attempt",
+                cause_code="resumable_evaluation_infrastructure",
+            )
+        )
+        database_session.commit()
+        _, _, outcomes = _fetch_final_score_state(database_session, benchmark_row, self._test_org)
+        previous_attempt = outcomes["task_pending"]
+        assert previous_attempt.kind == "error"
+        assert previous_attempt.cause_code is None
 
     def test_commit_task_error_spans_status_transition(
         self,

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.38.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
+version = "0.38.1.dev2+g04ecfbd14"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=04ecfbd14202459626947afd92b450f54674cca1#04ecfbd14202459626947afd92b450f54674cca1" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2118,7 +2118,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=04ecfbd14202459626947afd92b450f54674cca1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
Consume the combined CBS contract in vals-ai/create-benchmark-service#163 at 04ecfbd14202459626947afd92b450f54674cca1. Pass structured task outcome provenance to final scoring without changing legacy score values. Resume explicitly typed evaluation infrastructure failures once from saved state; generic candidate errors remain terminal.

Verification: 28 aggregation tests pass with the pinned dependency. Recovery cases passed individually in worker testing, but test runner teardown has hung; combined recovery suite and live qualification are not complete. No production deployment, automatic historical rescoring, or lost-prefix reconstruction.