### PR TITLE
feat: correlate task execution telemetry

### DIFF
--- a/services/executor_artifact/pyproject.toml
+++ b/services/executor_artifact/pyproject.toml
@@ -10,4 +10,4 @@ prerelease = "allow"
 
 [tool.uv.sources]
 tracker = { path = "../tracker" }
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.38.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.39.1" }

--- a/services/executor_artifact/uv.lock
+++ b/services/executor_artifact/uv.lock
@@ -355,8 +355,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.38.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
+version = "0.39.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.39.1#4c4f1e299f31b8bc3025643c5026d18e6a947da1" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -1839,7 +1839,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.39.1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/services/tracker/pyproject.toml
+++ b/services/tracker/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "sentry-sdk[fastapi]==2.58.0",
   "python-json-logger>=3.2.1",
   "python-dotenv>=1.2.2",
-  "create-benchmark-service>=0.38.0",
+  "create-benchmark-service>=0.39.1",
   "aioboto3>=7.0.0",
 ]
 
@@ -52,7 +52,7 @@ build-backend = "hatchling.build"
 prerelease = "allow"
 
 [tool.uv.sources]
-create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.38.0" }
+create-benchmark-service = { git = "https://github.com/vals-ai/create-benchmark-service.git", rev = "v0.39.1" }
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/services/tracker/src/tracker/executor/entrypoint.py
+++ b/services/tracker/src/tracker/executor/entrypoint.py
@@ -23,6 +23,7 @@ from executor_protocol import (
 )
 from tracker.config import ENVIRONMENT
 from tracker.logging import benchmark_id_var, request_id_var, task_id_var
+from tracker.logging.context import attempt_started_at_var, executor_dispatch_id_var
 from tracker.observability import configure_observability
 from tracker.observability.sentry import capture_exception
 from tracker.utils.run_orchestration import process_benchmark
@@ -38,6 +39,8 @@ def _executor_context(payload: Mapping[str, object]) -> Generator[None, None, No
         request_id_var.set(telemetry_context["request_id"]),
         benchmark_id_var.set(executor_payload_benchmark_id(payload)),
         task_id_var.set(""),
+        executor_dispatch_id_var.set(cast(str, payload["executor_dispatch_id"])),
+        attempt_started_at_var.set(""),
     ]
     trace_headers = telemetry_context["trace_headers"]
     otel_token = attach(extract(trace_headers)) if trace_headers else None

--- a/services/tracker/src/tracker/logging/context.py
+++ b/services/tracker/src/tracker/logging/context.py
@@ -6,14 +6,18 @@ import logging
 request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="")
 benchmark_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("benchmark_id", default="")
 task_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("task_id", default="")
+executor_dispatch_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("executor_dispatch_id", default="")
+attempt_started_at_var: contextvars.ContextVar[str] = contextvars.ContextVar("attempt_started_at", default="")
 
 
 def get_context_tags() -> dict[str, str]:
-    """Current request/benchmark/task context vars. Values may be empty strings if unset."""
+    """Current execution context vars. Values may be empty strings if unset."""
     return {
         "request_id": request_id_var.get(""),
         "benchmark_id": benchmark_id_var.get(""),
         "task_id": task_id_var.get(""),
+        "executor_dispatch_id": executor_dispatch_id_var.get(""),
+        "attempt_started_at": attempt_started_at_var.get(""),
     }
 
 

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -15,19 +15,21 @@ from sentry_sdk.types import Event, Hint, Log
 
 from tracker.exceptions import SSLConnectionError
 from tracker.logging import task_id_var
-from tracker.logging.context import get_context_tags
+from tracker.logging.context import attempt_started_at_var, get_context_tags
 
 logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def task_scope(task_id: str) -> Iterator[None]:
-    """Isolate Sentry events and logging context for one tracked task."""
+def task_scope(task_id: str, *, attempt_started_at: str) -> Iterator[None]:
+    """Isolate Sentry events and logging context for one tracked task execution epoch."""
     with sentry_sdk.isolation_scope():
         token = task_id_var.set(task_id)
+        attempt_token = attempt_started_at_var.set(attempt_started_at)
         try:
             yield
         finally:
+            attempt_started_at_var.reset(attempt_token)
             task_id_var.reset(token)
 
 

--- a/services/tracker/src/tracker/observability/sentry.py
+++ b/services/tracker/src/tracker/observability/sentry.py
@@ -51,6 +51,15 @@ def _before_send(
     return event
 
 
+def _before_send_transaction(event: Event, _hint: Hint) -> Event | None:
+    """Expose captured root identities as tags without using finishing-scope values."""
+    attributes = event.get("contexts", {}).get("otel", {}).get("attributes", {})
+    for key in get_context_tags():
+        if key in attributes:
+            event.setdefault("tags", {})[key] = attributes[key]
+    return event
+
+
 def _apply_current_otel_trace_context(telemetry: dict[str, Any]) -> None:
     span_context = get_current_span().get_span_context()
     if not span_context.is_valid:
@@ -91,6 +100,7 @@ def init_sentry(service_name: str, environment: str) -> None:
             enable_logs=True,
             send_default_pii=False,
             before_send=_before_send,
+            before_send_transaction=_before_send_transaction,
             before_send_log=_before_send_log,
             integrations=[
                 # INFO records become both searchable logs and breadcrumbs. Explicit exception

--- a/services/tracker/src/tracker/observability/tracing.py
+++ b/services/tracker/src/tracker/observability/tracing.py
@@ -76,7 +76,7 @@ def error_span(name: str, exc: BaseException, **attributes: Any) -> Generator[No
 
 
 class _ContextVarSpanProcessor(SpanProcessor):
-    """Attaches request/benchmark/task context vars to every span as attributes."""
+    """Attaches execution context vars to every span as attributes."""
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         existing = span.attributes or {}

--- a/services/tracker/src/tracker/sandbox.py
+++ b/services/tracker/src/tracker/sandbox.py
@@ -226,7 +226,7 @@ async def _create_sandbox(
     _reject_plaintext_secret_collisions(env_vars, sandbox_secrets)
     provider_source = _provider_source(source)
     _set_sandbox_create_span_attributes(sandbox_name, provider_source, resources)
-    return await provider.create_sandbox(
+    sandbox = await provider.create_sandbox(
         SandboxCreateRequest(
             source=provider_source,
             resources=resources,
@@ -239,6 +239,8 @@ async def _create_sandbox(
             create_timeout=SANDBOX_CREATE_TIMEOUT,
         )
     )
+    _set_sandbox_span_attributes(sandbox)
+    return sandbox
 
 
 @asynccontextmanager

--- a/services/tracker/src/tracker/utils/task_execution.py
+++ b/services/tracker/src/tracker/utils/task_execution.py
@@ -277,7 +277,7 @@ class TrackedTask:
                 self._status = TrackedTaskStatus.RUNNING
                 return await self._coro
 
-        with task_scope(task_row.task_id):
+        with task_scope(task_row.task_id, attempt_started_at=self.attempt_started_at.isoformat()):
             try:
                 self._task = asyncio.create_task(_wrap_coro())
                 return await self._task

--- a/services/tracker/tests/unit/executor/test_entrypoint.py
+++ b/services/tracker/tests/unit/executor/test_entrypoint.py
@@ -21,6 +21,7 @@ from pytest import MonkeyPatch
 from tracker.config import ENVIRONMENT
 from tracker.executor import entrypoint as executor_entrypoint
 from tracker.logging import benchmark_id_var, request_id_var, task_id_var
+from tracker.logging.context import attempt_started_at_var, executor_dispatch_id_var
 
 
 @pytest.fixture(autouse=True)
@@ -89,6 +90,7 @@ async def test_unhandled_executor_error_is_captured_with_run_context(monkeypatch
         assert captured_error is error
         captured_context["benchmark_id"] = benchmark_id_var.get()
         captured_context["request_id"] = request_id_var.get()
+        captured_context["executor_dispatch_id"] = executor_dispatch_id_var.get()
 
     monkeypatch.setattr(executor_entrypoint, "process_benchmark", process_benchmark)
     monkeypatch.setattr(sentry_sdk, "capture_exception", capture_exception)
@@ -102,7 +104,11 @@ async def test_unhandled_executor_error_is_captured_with_run_context(monkeypatch
             }
         )
 
-    assert captured_context == {"benchmark_id": "benchmark-id", "request_id": "request-id"}
+    assert captured_context == {
+        "benchmark_id": "benchmark-id",
+        "request_id": "request-id",
+        "executor_dispatch_id": "dispatch-id",
+    }
 
 
 def test_main_forwards_executor_payload(
@@ -179,11 +185,14 @@ def test_executor_context_restores_run_and_trace_context(monkeypatch: MonkeyPatc
     request_token = request_id_var.set("outer-request")
     benchmark_token = benchmark_id_var.set("outer-benchmark")
     task_token = task_id_var.set("outer-task")
+    dispatch_token = executor_dispatch_id_var.set("outer-dispatch")
+    attempt_token = attempt_started_at_var.set("outer-attempt")
 
     try:
         with executor_entrypoint._executor_context(  # pyright: ignore[reportPrivateUsage]
             {
                 "execution_context_json": {"benchmark_id": "benchmark-id"},
+                "executor_dispatch_id": "dispatch-id",
                 "telemetry_context_json": {
                     "request_id": "request-id",
                     "trace_headers": {"sentry-trace": "trace-header", "baggage": "baggage-header"},
@@ -193,13 +202,19 @@ def test_executor_context_restores_run_and_trace_context(monkeypatch: MonkeyPatc
             assert request_id_var.get() == "request-id"
             assert benchmark_id_var.get() == "benchmark-id"
             assert task_id_var.get() == ""
+            assert executor_dispatch_id_var.get() == "dispatch-id"
+            assert attempt_started_at_var.get() == ""
             assert trace.get_current_span().get_span_context() == parent_span.get_span_context()
 
         assert request_id_var.get() == "outer-request"
         assert benchmark_id_var.get() == "outer-benchmark"
         assert task_id_var.get() == "outer-task"
+        assert executor_dispatch_id_var.get() == "outer-dispatch"
+        assert attempt_started_at_var.get() == "outer-attempt"
         assert not trace.get_current_span().get_span_context().is_valid
     finally:
+        attempt_started_at_var.reset(attempt_token)
+        executor_dispatch_id_var.reset(dispatch_token)
         task_id_var.reset(task_token)
         benchmark_id_var.reset(benchmark_token)
         request_id_var.reset(request_token)

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 from collections.abc import Callable
 from contextlib import nullcontext
+from copy import deepcopy
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
@@ -30,7 +31,13 @@ import tracker.utils.task_execution as task_execution
 from tracker.database.models import Org, Task
 from tracker.executor.execution_authority import ExecutionAuthority
 from tracker.exceptions import SandboxError, SandboxSetupError, SSLConnectionError
-from tracker.logging.context import benchmark_id_var, request_id_var
+from tracker.logging.context import (
+    attempt_started_at_var,
+    benchmark_id_var,
+    executor_dispatch_id_var,
+    request_id_var,
+    task_id_var,
+)
 
 BeforeSend = Callable[[Event, Hint], Event | None]
 BeforeSendLog = Callable[[Log, Hint], Log | None]
@@ -85,6 +92,50 @@ class TestBeforeSend:
         assert event == {"message": "log event", "tags": {}}
 
 
+class TestBeforeSendTransaction:
+    """Only captured OTel root identities are promoted."""
+
+    def test_promotes_only_captured_owned_attributes_and_preserves_other_tags(self) -> None:
+        event: Event = {
+            "type": "transaction",
+            "contexts": {"otel": {"attributes": {"request_id": "captured-request", "http.method": "POST"}}},
+            "tags": {"request_id": "stale-request", "component": "tracker"},
+        }
+
+        with sentry_module.task_scope("late-task", attempt_started_at="2026-04-01T13:00:00+00:00"):
+            result = sentry_module._before_send_transaction(event, {})
+
+        assert result is event
+        assert event["tags"] == {"request_id": "captured-request", "component": "tracker"}
+        assert event["contexts"]["otel"]["attributes"] == {
+            "request_id": "captured-request",
+            "http.method": "POST",
+        }
+
+    @pytest.mark.parametrize(
+        "event",
+        [
+            {"type": "transaction"},
+            {
+                "type": "transaction",
+                "contexts": {
+                    "trace": {"trace_id": "019e04c6fbf0397e32a8d9601f98e45c00", "span_id": "a1f0f4fc15b83e82"},
+                },
+                "tags": {"component": "tracker"},
+            },
+        ],
+        ids=["without-contexts", "native-trace-context"],
+    )
+    def test_native_transactions_without_otel_context_are_unchanged(self, event: Event) -> None:
+        expected = deepcopy(event)
+
+        with sentry_module.task_scope("late-task", attempt_started_at="2026-04-01T13:00:00+00:00"):
+            result = sentry_module._before_send_transaction(event, {})
+
+        assert result is event
+        assert event == expected
+
+
 class TestSentrySetup:
     """Sentry initialization and log context behavior."""
 
@@ -101,6 +152,7 @@ class TestSentrySetup:
         sentry_module.init_sentry("valkyrie-worker", environment="test")
 
         assert init_mock.call_args.kwargs["environment"] == "bench"
+        assert init_mock.call_args.kwargs["before_send_transaction"] is sentry_module._before_send_transaction
         integrations = init_mock.call_args.kwargs["integrations"]
         otlp_integrations = [i for i in integrations if isinstance(i, OTLPIntegration)]
         assert len(otlp_integrations) == 1, "expected exactly one OTLPIntegration in integrations="
@@ -200,10 +252,23 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
         traces_sample_rate=1.0,
         instrumenter=INSTRUMENTER.OTEL,
         before_send=sentry_module._before_send,
+        before_send_transaction=sentry_module._before_send_transaction,
     )
     identities = {
-        "task-a": {"request_id": "request-a", "benchmark_id": "benchmark-a", "task_id": "task-a"},
-        "task-b": {"request_id": "request-b", "benchmark_id": "benchmark-b", "task_id": "task-b"},
+        "task-a": {
+            "request_id": "request-a",
+            "benchmark_id": "benchmark-a",
+            "task_id": "task-a",
+            "executor_dispatch_id": "dispatch-a",
+            "attempt_started_at": "2026-04-01T12:00:00+00:00",
+        },
+        "task-b": {
+            "request_id": "request-b",
+            "benchmark_id": "benchmark-b",
+            "task_id": "task-b",
+            "executor_dispatch_id": "dispatch-b",
+            "attempt_started_at": "2026-04-01T12:01:00+00:00",
+        },
     }
     client_ids: dict[str, str] = {}
     response_ids: dict[str, str] = {}
@@ -215,8 +280,9 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
         identity = identities[task_id]
         request_token = request_id_var.set(identity["request_id"])
         benchmark_token = benchmark_id_var.set(identity["benchmark_id"])
+        dispatch_token = executor_dispatch_id_var.set(identity["executor_dispatch_id"])
         try:
-            with sentry_module.task_scope(task_id, attempt_started_at="2026-04-01T12:00:00+00:00"):
+            with sentry_module.task_scope(task_id, attempt_started_at=identity["attempt_started_at"]):
                 with tracer.start_as_current_span(
                     "POST /execute",
                     context=Context() if client_is_root else None,
@@ -230,13 +296,22 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
                     await release.wait()
                     with tracer.start_as_current_span("response.process") as response:
                         response_ids[task_id] = f"{response.get_span_context().span_id:016x}"
+                    # Root export must use the captured identities, not this later context.
+                    request_id_var.set("finishing-request")
+                    benchmark_id_var.set("finishing-benchmark")
+                    executor_dispatch_id_var.set("finishing-dispatch")
+                    task_id_var.set("finishing-scope-task")
+                    attempt_started_at_var.set("2026-04-01T13:00:00+00:00")
+                    sentry_sdk.set_tag("task_id", "finishing-scope-task")
         finally:
+            executor_dispatch_id_var.reset(dispatch_token)
             benchmark_id_var.reset(benchmark_token)
             request_id_var.reset(request_token)
 
     try:
         with sentry_sdk.new_scope() as scope:
             scope.set_client(client)
+            scope.set_tag("component", "tracker")
             parent = nullcontext() if client_is_root else tracer.start_as_current_span("dispatch", context=Context())
             with parent:
                 await asyncio.gather(request("task-a"), request("task-b"))
@@ -257,7 +332,8 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
             )
             captured_client = event["contexts"]["otel"]["attributes"]
             assert event["contexts"]["trace"]["op"] == "http.client"
-            assert set(identity).isdisjoint(event.get("tags", {}))
+            assert {key: event["tags"][key] for key in identity} == identity
+            assert "http.url" not in event["tags"]
             trace_id = event["contexts"]["trace"]["trace_id"]
         else:
             event = transactions[0]
@@ -265,7 +341,6 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
             captured_client = client_span["data"]
             assert client_span["parent_span_id"] == event["contexts"]["trace"]["span_id"]
             assert client_span["op"] == "http.client"
-            assert set(identity).isdisjoint(client_span.get("tags", {}))
             trace_id = client_span["trace_id"]
             assert trace_id == event["contexts"]["trace"]["trace_id"]
 
@@ -275,7 +350,7 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
         for key, value in identity.items():
             assert captured_client[key] == value
             assert response["data"][key] == value
-        assert set(identity).isdisjoint(response.get("tags", {}))
+        assert event["tags"]["component"] == "tracker"
 
     if not client_is_root:
         assert transactions[0]["tags"]["task_id"] == "finishing-scope-task"

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -4,8 +4,10 @@ Run: uv run pytest tests/unit/observability/test_sentry.py
 """
 
 import asyncio
+import json
 
 from collections.abc import Callable
+from contextlib import nullcontext
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
@@ -13,14 +15,23 @@ from unittest.mock import Mock
 
 import pytest
 import sentry_sdk
+import sentry_sdk.scope as sentry_scope
+from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import TracerProvider
+from sentry_sdk.consts import INSTRUMENTER
+from sentry_sdk.envelope import Envelope
 from sentry_sdk.integrations.otlp import OTLPIntegration
+from sentry_sdk.transport import Transport
 from sentry_sdk.types import Event, Hint, Log
 
 import tracker.observability.sentry as sentry_module
+import tracker.observability.tracing as tracing_module
 import tracker.utils.task_execution as task_execution
 from tracker.database.models import Org, Task
 from tracker.executor.execution_authority import ExecutionAuthority
 from tracker.exceptions import SandboxError, SandboxSetupError, SSLConnectionError
+from tracker.logging.context import benchmark_id_var, request_id_var
 
 BeforeSend = Callable[[Event, Hint], Event | None]
 BeforeSendLog = Callable[[Log, Hint], Log | None]
@@ -158,6 +169,114 @@ class TestSentrySetup:
         sentry_module.init_sentry("valkyrie-worker", environment="production")
 
         init_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_is_root", [True, False], ids=["client-root", "client-child"])
+async def test_sentry_export_captures_task_identities_on_roots_and_children(
+    monkeypatch: pytest.MonkeyPatch,
+    client_is_root: bool,
+) -> None:
+    """Characterize SDK serialization, not Logfire registration or backend indexing."""
+    transactions: list[dict[str, Any]] = []
+
+    class CaptureTransport(Transport):
+        def capture_envelope(self, envelope: Envelope) -> None:
+            for item in envelope.items:
+                if item.type == "transaction":
+                    transactions.append(json.loads(item.get_bytes()))
+
+    # SentrySpanProcessor registers a global error processor on construction.
+    # Keep that registration local to this test; all test-owned spans finish normally.
+    monkeypatch.setattr(sentry_scope, "global_event_processors", list(sentry_scope.global_event_processors))
+    provider = TracerProvider()
+    provider.add_span_processor(tracing_module._ContextVarSpanProcessor())
+    provider.add_span_processor(tracing_module._FilteredSentrySpanProcessor())
+    tracer = provider.get_tracer(__name__)
+    client = sentry_sdk.Client(
+        dsn="https://public@example.com/1",
+        transport=CaptureTransport(),
+        default_integrations=False,
+        traces_sample_rate=1.0,
+        instrumenter=INSTRUMENTER.OTEL,
+        before_send=sentry_module._before_send,
+    )
+    identities = {
+        "task-a": {"request_id": "request-a", "benchmark_id": "benchmark-a", "task_id": "task-a"},
+        "task-b": {"request_id": "request-b", "benchmark_id": "benchmark-b", "task_id": "task-b"},
+    }
+    client_ids: dict[str, str] = {}
+    response_ids: dict[str, str] = {}
+    ready = 0
+    release = asyncio.Event()
+
+    async def request(task_id: str) -> None:
+        nonlocal ready
+        identity = identities[task_id]
+        request_token = request_id_var.set(identity["request_id"])
+        benchmark_token = benchmark_id_var.set(identity["benchmark_id"])
+        try:
+            with sentry_module.task_scope(task_id, attempt_started_at="2026-04-01T12:00:00+00:00"):
+                with tracer.start_as_current_span(
+                    "POST /execute",
+                    context=Context() if client_is_root else None,
+                    kind=trace.SpanKind.CLIENT,
+                    attributes={"http.method": "POST", "http.url": "https://benchmark.example/execute"},
+                ) as span:
+                    client_ids[task_id] = f"{span.get_span_context().span_id:016x}"
+                    ready += 1
+                    if ready == 2:
+                        release.set()
+                    await release.wait()
+                    with tracer.start_as_current_span("response.process") as response:
+                        response_ids[task_id] = f"{response.get_span_context().span_id:016x}"
+        finally:
+            benchmark_id_var.reset(benchmark_token)
+            request_id_var.reset(request_token)
+
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.set_client(client)
+            parent = nullcontext() if client_is_root else tracer.start_as_current_span("dispatch", context=Context())
+            with parent:
+                await asyncio.gather(request("task-a"), request("task-b"))
+                # A shared transaction finishes after both isolated tasks have left.
+                # Its finishing scope must not replace the identities captured on children.
+                scope.set_tag("task_id", "finishing-scope-task")
+    finally:
+        provider.shutdown()
+        client.close()
+
+    assert len(transactions) == (2 if client_is_root else 1)
+    children = {span["span_id"]: span for event in transactions for span in event["spans"]}
+    assert len(children) == (2 if client_is_root else 4)
+    for task_id, identity in identities.items():
+        if client_is_root:
+            event = next(event for event in transactions if event["contexts"]["trace"]["span_id"] == client_ids[task_id])
+            captured_client = event["contexts"]["otel"]["attributes"]
+            assert event["contexts"]["trace"]["op"] == "http.client"
+            assert set(identity).isdisjoint(event.get("tags", {}))
+            trace_id = event["contexts"]["trace"]["trace_id"]
+        else:
+            event = transactions[0]
+            client_span = children[client_ids[task_id]]
+            captured_client = client_span["data"]
+            assert client_span["parent_span_id"] == event["contexts"]["trace"]["span_id"]
+            assert client_span["op"] == "http.client"
+            assert set(identity).isdisjoint(client_span.get("tags", {}))
+            trace_id = client_span["trace_id"]
+            assert trace_id == event["contexts"]["trace"]["trace_id"]
+
+        response = children[response_ids[task_id]]
+        assert response["parent_span_id"] == client_ids[task_id]
+        assert response["trace_id"] == trace_id
+        for key, value in identity.items():
+            assert captured_client[key] == value
+            assert response["data"][key] == value
+        assert set(identity).isdisjoint(response.get("tags", {}))
+
+    if not client_is_root:
+        assert transactions[0]["tags"]["task_id"] == "finishing-scope-task"
 
 
 @pytest.mark.asyncio

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -5,7 +5,6 @@ Run: uv run pytest tests/unit/observability/test_sentry.py
 
 import asyncio
 import json
-
 from collections.abc import Callable
 from contextlib import nullcontext
 from datetime import UTC, datetime
@@ -195,7 +194,8 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
     tracer = provider.get_tracer(__name__)
     client = sentry_sdk.Client(
         dsn="https://public@example.com/1",
-        transport=CaptureTransport(),
+        # Let the SDK pass DSN options into Transport.__init__; the processor checks parsed_dsn.
+        transport=CaptureTransport,
         default_integrations=False,
         traces_sample_rate=1.0,
         instrumenter=INSTRUMENTER.OTEL,
@@ -252,7 +252,9 @@ async def test_sentry_export_captures_task_identities_on_roots_and_children(
     assert len(children) == (2 if client_is_root else 4)
     for task_id, identity in identities.items():
         if client_is_root:
-            event = next(event for event in transactions if event["contexts"]["trace"]["span_id"] == client_ids[task_id])
+            event = next(
+                event for event in transactions if event["contexts"]["trace"]["span_id"] == client_ids[task_id]
+            )
             captured_client = event["contexts"]["otel"]["attributes"]
             assert event["contexts"]["trace"]["op"] == "http.client"
             assert set(identity).isdisjoint(event.get("tags", {}))
@@ -343,7 +345,10 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
             cast(ExecutionAuthority, object()),
             attempt_starts["task-b"],
         )
-        await asyncio.gather(task_a.run(None, cast(Task, rows["task-a"])), task_b.run(None, cast(Task, rows["task-b"])))
+        await asyncio.gather(
+            task_a.run(None, cast(Task, rows["task-a"])),
+            task_b.run(None, cast(Task, rows["task-b"])),
+        )
 
     with sentry_sdk.init(
         dsn="https://public@example.com/1",
@@ -358,14 +363,14 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
     assert len(task_events) == 3
     task_tags = [cast(dict[str, str], event.get("tags", {})) for event in task_events]
     assert {(tags["task_id"], tags["sandbox_id"], tags["attempt_started_at"]) for tags in task_tags} == {
-        ("task-a", "sandbox-a", attempt_starts["task-a"].isoformat()),
-        ("task-b", "sandbox-b", attempt_starts["task-b"].isoformat()),
+        ("task-a", "sandbox-a", "2026-04-01T12:00:00"),
+        ("task-b", "sandbox-b", "2026-04-01T13:00:00"),
     }
     exception_events = [event for event in task_events if "exception" in event]
     assert len(exception_events) == 1
     assert cast(dict[str, str], exception_events[0].get("tags")) == {
         "task_id": "task-b",
-        "attempt_started_at": attempt_starts["task-b"].isoformat(),
+        "attempt_started_at": "2026-04-01T13:00:00",
         "sandbox_id": "sandbox-b",
         "sandbox_name": "sandbox-b-name",
     }

--- a/services/tracker/tests/unit/observability/test_sentry.py
+++ b/services/tracker/tests/unit/observability/test_sentry.py
@@ -167,6 +167,11 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
     events: list[Event] = []
     rows: dict[str, SimpleNamespace] = {}
 
+    attempt_starts = {
+        "task-a": datetime(2026, 4, 1, 12, tzinfo=UTC),
+        "task-b": datetime(2026, 4, 1, 13, tzinfo=UTC),
+    }
+
     class FakeSession:
         def __init__(self, **_kwargs: object) -> None:
             pass
@@ -204,20 +209,20 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
             rows[task_id] = SimpleNamespace(
                 id=task_id,
                 task_id=task_id,
-                started_at=datetime.now(UTC),
+                started_at=attempt_starts[task_id],
             )
 
         task_a = task_execution.TrackedTask(
             body("task-a", "sandbox-a", fail=False),
             cast(Org, object()),
             cast(ExecutionAuthority, object()),
-            datetime.now(UTC),
+            attempt_starts["task-a"],
         )
         task_b = task_execution.TrackedTask(
             body("task-b", "sandbox-b", fail=True),
             cast(Org, object()),
             cast(ExecutionAuthority, object()),
-            datetime.now(UTC),
+            attempt_starts["task-b"],
         )
         await asyncio.gather(task_a.run(None, cast(Task, rows["task-a"])), task_b.run(None, cast(Task, rows["task-b"])))
 
@@ -233,14 +238,15 @@ async def test_task_scope_isolates_concurrent_sandbox_events_and_outer_capture(
     task_events = [event for event in events if event.get("tags", {}).get("task_id")]
     assert len(task_events) == 3
     task_tags = [cast(dict[str, str], event.get("tags", {})) for event in task_events]
-    assert {(tags["task_id"], tags["sandbox_id"]) for tags in task_tags} == {
-        ("task-a", "sandbox-a"),
-        ("task-b", "sandbox-b"),
+    assert {(tags["task_id"], tags["sandbox_id"], tags["attempt_started_at"]) for tags in task_tags} == {
+        ("task-a", "sandbox-a", attempt_starts["task-a"].isoformat()),
+        ("task-b", "sandbox-b", attempt_starts["task-b"].isoformat()),
     }
     exception_events = [event for event in task_events if "exception" in event]
     assert len(exception_events) == 1
     assert cast(dict[str, str], exception_events[0].get("tags")) == {
         "task_id": "task-b",
+        "attempt_started_at": attempt_starts["task-b"].isoformat(),
         "sandbox_id": "sandbox-b",
         "sandbox_name": "sandbox-b-name",
     }
@@ -282,7 +288,7 @@ async def test_retry_attempt_clears_previous_sandbox_identity(
         default_integrations=False,
         before_send=_before_send(),
     ):
-        with sentry_module.task_scope("task-0"):
+        with sentry_module.task_scope("task-0", attempt_started_at="2026-04-01T12:00:00+00:00"):
             result = await task_execution.process_task(
                 task_row=cast(Any, object()),
                 start_benchmark_request=cast(
@@ -306,5 +312,5 @@ async def test_retry_attempt_clears_previous_sandbox_identity(
     assert result == {"task-0": {"ok": True}}
     retry_event = next(event for event in events if "exception" in event)
     retry_tags = cast(dict[str, str], retry_event.get("tags", {}))
-    assert retry_tags == {"task_id": "task-0"}
+    assert retry_tags == {"task_id": "task-0", "attempt_started_at": "2026-04-01T12:00:00+00:00"}
     assert "sandbox" not in retry_event.get("contexts", {})

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1095,9 +1095,10 @@ class TestSandboxLifecycle:
         monkeypatch.setattr(sandbox_module, "_set_sandbox_create_span_attributes", fake_create_span_attrs)
 
         span_attributes: dict[str, str] = {}
-        span = Mock()
+        span = Mock(spec=sandbox_module.trace.Span)
+        span.get_span_context.return_value = sandbox_module.trace.INVALID_SPAN_CONTEXT
         span.set_attribute.side_effect = lambda key, value: span_attributes.update({key: value})
-        monkeypatch.setattr(sandbox_module.trace, "get_current_span", lambda: span)
+        monkeypatch.setattr(sandbox_module.trace, "get_current_span", lambda context=None: span)
 
         mock_sandbox = AsyncMock()
         mock_sandbox.id = "sandbox-created-123"

--- a/services/tracker/tests/unit/test_sandbox.py
+++ b/services/tracker/tests/unit/test_sandbox.py
@@ -1084,7 +1084,9 @@ class TestSandboxLifecycle:
             "valkyrie.sandbox_state": "started",
         }
 
-    async def test_create_sandbox_passes_request_to_provider(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_create_sandbox_passes_request_and_records_returned_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         span_calls: list[tuple[str, str, int]] = []
 
         def fake_create_span_attrs(sandbox_name: str, source: Any, resources: Any) -> None:
@@ -1092,7 +1094,15 @@ class TestSandboxLifecycle:
 
         monkeypatch.setattr(sandbox_module, "_set_sandbox_create_span_attributes", fake_create_span_attrs)
 
+        span_attributes: dict[str, str] = {}
+        span = Mock()
+        span.set_attribute.side_effect = lambda key, value: span_attributes.update({key: value})
+        monkeypatch.setattr(sandbox_module.trace, "get_current_span", lambda: span)
+
         mock_sandbox = AsyncMock()
+        mock_sandbox.id = "sandbox-created-123"
+        mock_sandbox.name = "provider-returned-name"
+        mock_sandbox.state = "started"
         provider = AsyncMock()
         provider.create_sandbox = AsyncMock(return_value=mock_sandbox)
 
@@ -1118,6 +1128,11 @@ class TestSandboxLifecycle:
 
         assert sandbox is mock_sandbox
         assert span_calls == [("task-alias", "ghcr.io/vals/swebench:latest", 2)]
+        assert span_attributes == {
+            "valkyrie.sandbox_id": "sandbox-created-123",
+            "valkyrie.sandbox_name": "provider-returned-name",
+            "valkyrie.sandbox_state": "started",
+        }
         request = provider.create_sandbox.await_args.args[0]
         assert request.name == "task-alias"
         assert request.resources == resources

--- a/services/tracker/uv.lock
+++ b/services/tracker/uv.lock
@@ -394,8 +394,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.38.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
+version = "0.39.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.39.1#4c4f1e299f31b8bc3025643c5026d18e6a947da1" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2118,7 +2118,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.39.1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/tests/integration/observability/test_run_correlation.py
+++ b/tests/integration/observability/test_run_correlation.py
@@ -174,6 +174,7 @@ def _run_executor(dsn: str, context_path: str) -> None:
         {
             "benchmark_id_str": _RUN_ID,
             "telemetry_context_json": telemetry_context,
+            "executor_dispatch_id": _DISPATCH_ID,
         }
     ):
         with logfire.span("observability.smoke.executor"):

--- a/uv.lock
+++ b/uv.lock
@@ -425,8 +425,8 @@ wheels = [
 
 [[package]]
 name = "create-benchmark-service"
-version = "0.38.0"
-source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0#de2a82eea283942d290e136cec4c80d5072e2fb7" }
+version = "0.39.1"
+source = { git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.39.1#4c4f1e299f31b8bc3025643c5026d18e6a947da1" }
 dependencies = [
     { name = "boto3" },
     { name = "cachetools" },
@@ -2314,7 +2314,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.42.20" },
     { name = "boto3-stubs", extras = ["s3"] },
     { name = "cachetools", specifier = ">=7.1.1,<8" },
-    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.38.0" },
+    { name = "create-benchmark-service", git = "https://github.com/vals-ai/create-benchmark-service.git?rev=v0.39.1" },
     { name = "descope", specifier = ">=0.9.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.135.3" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## What changed

- Record returned sandbox ID/name/state on the existing creation span.
- Carry the existing executor dispatch ID and task execution epoch through isolated span/log/error context.
- Promote captured OTel transaction-root identity fields to Sentry tags. No late ambient values or parent-to-child identity copying.
- Upgrade Tracker, root and immutable executor dependency owners to released CBS v0.39.1 at `4c4f1e299f31b8bc3025643c5026d18e6a947da1`; other package version/source identities are unchanged.

## Why

Connect telemetry to actual resources and distinguish execution attempts. A known live client span was found by exact ID but not by its independently established task/run filters. Sentry confirmed it was a transaction root; SDK 2.58 stores its OTel attributes separately from tags. The new hook maps only the existing captured identity fields.

The approved CBS upgrade also includes v0.39.0 admission changes, including rejecting non-finite or negative capacity metadata on Tracker's image-admission path. No Tracker admission source changes are included.

## How tested

- Real Sentry SDK/OTel capture tests exercise root and child serialization, concurrent identities, stale finishing scope, unrelated tag preservation, and native transaction pass-through.
- Existing resource creation, executor cross-process correlation, context restoration and retry-clear tests cover resource/attempt/dispatch enrichment.
- Three `uv lock` resolutions succeeded; every non-CBS package version/source identity was compared and remains unchanged.
- Six-angle independent reviews completed with no remaining required code findings. Remote CI is being checked on the final head.
- No local tests/typechecks/linters/formatters/builds or live fault probes were run.

## Boundaries

No retry/counter/lifecycle/metric-dimension changes, new identifiers, exporter migration, deployment or production configuration changes. The root mapping has SDK serialization proof; post-deployment Sentry search/indexing remains unverified. This PR has not been merged or deployed.
