### PR TITLE
ci: publish dev and production Sentry deployment metadata

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -675,6 +675,43 @@ jobs:
         working-directory: infra
         run: make deploy STAGE=dev SCOPE=core DEV_ACCOUNT_ID="$DEV_ACCOUNT_ID" AWS_REGION="$AWS_REGION"
 
+      - name: Publish dev core Sentry release
+        if: env.OPERATION == 'deploy'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from urllib.parse import quote
+          from urllib.request import Request, urlopen
+
+          release = os.environ["GITHUB_SHA"]
+          base = "https://sentry.io/api/0/organizations/vals-ai"
+          for url, payload in (
+              (f"{base}/releases/", {
+                  "version": release,
+                  "projects": ["valkyrie"],
+                  "commits": [{"id": release, "repository": os.environ["GITHUB_REPOSITORY"]}],
+              }),
+              (f"{base}/releases/{quote(release, safe='')}/deploys/", {
+                  "environment": "dev",
+                  "projects": ["valkyrie"],
+              }),
+          ):
+              request = Request(
+                  url,
+                  data=json.dumps(payload).encode(),
+                  headers={
+                      "Authorization": f"Bearer {os.environ['SENTRY_AUTH_TOKEN']}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              with urlopen(request):
+                  pass
+          PY
+
   executor-development:
     if: >-
       always() && github.event_name == 'push' && github.ref == 'refs/heads/dev' &&
@@ -896,6 +933,47 @@ jobs:
           --region "$AWS_REGION"
           --stage dev
           --target-sha "$GITHUB_SHA"
+
+      - name: Publish dev executor Sentry release
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_release_required == 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from urllib.parse import quote
+          from urllib.request import Request, urlopen
+
+          manifest = json.loads((Path(os.environ["GITHUB_WORKSPACE"]) / "executor-release/manifest.json").read_text())
+          release = manifest["release_id"]
+          base = "https://sentry.io/api/0/organizations/vals-ai"
+          for url, payload in (
+              (f"{base}/releases/", {
+                  "version": release,
+                  "projects": ["valkyrie"],
+                  "commits": [{"id": manifest["source_revision"], "repository": os.environ["GITHUB_REPOSITORY"]}],
+              }),
+              (f"{base}/releases/{quote(release, safe='')}/deploys/", {
+                  "environment": "dev",
+                  "projects": ["valkyrie"],
+              }),
+          ):
+              request = Request(
+                  url,
+                  data=json.dumps(payload).encode(),
+                  headers={
+                      "Authorization": f"Bearer {os.environ['SENTRY_AUTH_TOKEN']}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              with urlopen(request):
+                  pass
+          PY
 
   executor-bench:
     if: >-

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -214,6 +214,42 @@ jobs:
           SCOPE=core
           AWS_REGION="$AWS_REGION"
 
+      - name: Publish prod core Sentry release
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from urllib.parse import quote
+          from urllib.request import Request, urlopen
+
+          release = os.environ["GITHUB_SHA"]
+          base = "https://sentry.io/api/0/organizations/vals-ai"
+          for url, payload in (
+              (f"{base}/releases/", {
+                  "version": release,
+                  "projects": ["valkyrie"],
+                  "commits": [{"id": release, "repository": os.environ["GITHUB_REPOSITORY"]}],
+              }),
+              (f"{base}/releases/{quote(release, safe='')}/deploys/", {
+                  "environment": "production",
+                  "projects": ["valkyrie"],
+              }),
+          ):
+              request = Request(
+                  url,
+                  data=json.dumps(payload).encode(),
+                  headers={
+                      "Authorization": f"Bearer {os.environ['SENTRY_AUTH_TOKEN']}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              with urlopen(request):
+                  pass
+          PY
+
   executor-prod:
     if: >-
       always() && github.event_name == 'push' && github.ref == 'refs/heads/prod' &&
@@ -456,6 +492,47 @@ jobs:
           --region "$AWS_REGION"
           --stage prod
           --target-sha "$GITHUB_SHA"
+
+      - name: Publish prod executor Sentry release
+        if: >-
+          steps.freshness.outputs.current == 'true' &&
+          needs.classify-deployment.outputs.executor_release_required == 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          from urllib.parse import quote
+          from urllib.request import Request, urlopen
+
+          manifest = json.loads((Path(os.environ["GITHUB_WORKSPACE"]) / "executor-release/manifest.json").read_text())
+          release = manifest["release_id"]
+          base = "https://sentry.io/api/0/organizations/vals-ai"
+          for url, payload in (
+              (f"{base}/releases/", {
+                  "version": release,
+                  "projects": ["valkyrie"],
+                  "commits": [{"id": manifest["source_revision"], "repository": os.environ["GITHUB_REPOSITORY"]}],
+              }),
+              (f"{base}/releases/{quote(release, safe='')}/deploys/", {
+                  "environment": "production",
+                  "projects": ["valkyrie"],
+              }),
+          ):
+              request = Request(
+                  url,
+                  data=json.dumps(payload).encode(),
+                  headers={
+                      "Authorization": f"Bearer {os.environ['SENTRY_AUTH_TOKEN']}",
+                      "Content-Type": "application/json",
+                  },
+                  method="POST",
+              )
+              with urlopen(request):
+                  pass
+          PY
 
   deploy-bench-core:
     if: >-

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -3,9 +3,17 @@
 Run: cd infra && PYTHONPATH=. uv run python -m unittest tests/test_deploy_workflow.py
 """
 
+import json
+import os
 import re
 import unittest
+from email.message import Message
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError
+from urllib.request import Request
 
 ROOT = Path(__file__).parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "deploy.yaml"
@@ -586,6 +594,95 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertEqual(workflow.count("services/executor_artifact/build.py"), 1)
         self.assertIn("services/executor_artifact/uv.lock", workflow)
         self.assertIn("uv lock --project services/executor_artifact --check", workflow)
+
+    def test_dev_sentry_publication_requires_successful_component_deployment(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        core = _job(workflow, "run-dev-operation")
+        executor = _job(workflow, "executor-development")
+        core_publication = _step(core, "Publish dev core Sentry release")
+        executor_publication = _step(executor, "Publish dev executor Sentry release")
+
+        self.assertIn("if: env.OPERATION == 'deploy'", core_publication)
+        self.assertLess(core.index("Deploy dev core stacks"), core.index("Publish dev core Sentry release"))
+        activation = _step(executor, "Publish and activate dev executor release")
+        activation_condition = activation.split("        if: >-\n", maxsplit=1)[1].split(
+            "        working-directory:", maxsplit=1
+        )[0]
+        self.assertIn(activation_condition, executor_publication)
+        self.assertLess(
+            executor.index("Publish and activate dev executor release"), executor.index("Finish dev maintenance")
+        )
+        self.assertLess(executor.index("Finish dev maintenance"), executor.index("Publish dev executor Sentry release"))
+        for publication in (core_publication, executor_publication):
+            self.assertIn("SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}", publication)
+            self.assertNotIn("always()", publication)
+            self.assertNotIn("continue-on-error:", publication)
+
+    def test_dev_sentry_publication_sends_deployed_identity_and_propagates_http_errors(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        core_revision = "4c2e9bc458e6ab0e458b95bc40bb38375802eabc"
+        executor_revision = "81ecdaa948195d5d407287d09ff980951bc6d514"
+        executor_release = f"git-{executor_revision[:12]}-{'a' * 16}"
+        cases = (
+            ("run-dev-operation", "Publish dev core Sentry release", core_revision, core_revision),
+            ("executor-development", "Publish dev executor Sentry release", executor_release, executor_revision),
+        )
+        with TemporaryDirectory() as workspace:
+            manifest = Path(workspace) / "executor-release" / "manifest.json"
+            manifest.parent.mkdir()
+            manifest.write_text(
+                json.dumps({"release_id": executor_release, "source_revision": executor_revision}),
+                encoding="utf-8",
+            )
+            environment = {
+                "GITHUB_SHA": core_revision,
+                "GITHUB_REPOSITORY": "vals-ai/Valkyrie",
+                "GITHUB_WORKSPACE": workspace,
+                "SENTRY_AUTH_TOKEN": "test-release-token",
+            }
+            for job_id, step_name, release, revision in cases:
+                step = _step(_job(workflow, job_id), step_name)
+                source = dedent(step.split("python - <<'PY'\n", maxsplit=1)[1].rsplit("\n          PY", maxsplit=1)[0])
+                expected_urls = [
+                    "https://sentry.io/api/0/organizations/vals-ai/releases/",
+                    f"https://sentry.io/api/0/organizations/vals-ai/releases/{release}/deploys/",
+                ]
+                expected_payloads = [
+                    {
+                        "version": release,
+                        "projects": ["valkyrie"],
+                        "commits": [{"id": revision, "repository": "vals-ai/Valkyrie"}],
+                    },
+                    {"environment": "dev", "projects": ["valkyrie"]},
+                ]
+                for failing_request in (None, 0, 1):
+                    with self.subTest(component=job_id, failing_request=failing_request):
+                        response = MagicMock()
+                        outcomes: list[object] = [response, response]
+                        error = HTTPError(expected_urls[failing_request or 0], 403, "Forbidden", Message(), None)
+                        if failing_request is not None:
+                            outcomes[failing_request] = error
+                        with patch.dict(os.environ, environment, clear=True), patch(
+                            "urllib.request.urlopen", side_effect=outcomes
+                        ) as transport:
+                            if failing_request is None:
+                                exec(compile(source, str(WORKFLOW), "exec"), {})
+                            else:
+                                with self.assertRaises(HTTPError) as raised:
+                                    exec(compile(source, str(WORKFLOW), "exec"), {})
+                                self.assertIs(raised.exception, error)
+
+                        expected_count = 2 if failing_request is None else failing_request + 1
+                        self.assertEqual(transport.call_count, expected_count)
+                        for index, call in enumerate(transport.call_args_list):
+                            request = call.args[0]
+                            assert isinstance(request, Request)
+                            self.assertEqual(request.full_url, expected_urls[index])
+                            self.assertEqual(request.get_method(), "POST")
+                            self.assertEqual(request.get_header("Authorization"), "Bearer test-release-token")
+                            self.assertEqual(request.get_header("Content-type"), "application/json")
+                            assert isinstance(request.data, bytes)
+                            self.assertEqual(json.loads(request.data), expected_payloads[index])
 
     def test_deployment_tools_are_pinned_and_release_dependencies_are_isolated(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -662,9 +662,10 @@ class DeployWorkflowTest(unittest.TestCase):
                         error = HTTPError(expected_urls[failing_request or 0], 403, "Forbidden", Message(), None)
                         if failing_request is not None:
                             outcomes[failing_request] = error
-                        with patch.dict(os.environ, environment, clear=True), patch(
-                            "urllib.request.urlopen", side_effect=outcomes
-                        ) as transport:
+                        with (
+                            patch.dict(os.environ, environment, clear=True),
+                            patch("urllib.request.urlopen", side_effect=outcomes) as transport,
+                        ):
                             if failing_request is None:
                                 exec(compile(source, str(WORKFLOW), "exec"), {})
                             else:

--- a/infra/tests/test_deploy_workflow.py
+++ b/infra/tests/test_deploy_workflow.py
@@ -595,37 +595,67 @@ class DeployWorkflowTest(unittest.TestCase):
         self.assertIn("services/executor_artifact/uv.lock", workflow)
         self.assertIn("uv lock --project services/executor_artifact --check", workflow)
 
-    def test_dev_sentry_publication_requires_successful_component_deployment(self) -> None:
+    def test_sentry_publication_requires_successful_component_deployment(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        core = _job(workflow, "run-dev-operation")
-        executor = _job(workflow, "executor-development")
-        core_publication = _step(core, "Publish dev core Sentry release")
-        executor_publication = _step(executor, "Publish dev executor Sentry release")
+        for stage, core_job, executor_job, github_environment in (
+            ("dev", "run-dev-operation", "executor-development", "dev"),
+            ("prod", "deploy-prod-core", "executor-prod", "prod-external"),
+        ):
+            with self.subTest(stage=stage):
+                core = _job(workflow, core_job)
+                executor = _job(workflow, executor_job)
+                core_publication = _step(core, f"Publish {stage} core Sentry release")
+                executor_publication = _step(executor, f"Publish {stage} executor Sentry release")
 
-        self.assertIn("if: env.OPERATION == 'deploy'", core_publication)
-        self.assertLess(core.index("Deploy dev core stacks"), core.index("Publish dev core Sentry release"))
-        activation = _step(executor, "Publish and activate dev executor release")
-        activation_condition = activation.split("        if: >-\n", maxsplit=1)[1].split(
-            "        working-directory:", maxsplit=1
-        )[0]
-        self.assertIn(activation_condition, executor_publication)
-        self.assertLess(
-            executor.index("Publish and activate dev executor release"), executor.index("Finish dev maintenance")
-        )
-        self.assertLess(executor.index("Finish dev maintenance"), executor.index("Publish dev executor Sentry release"))
-        for publication in (core_publication, executor_publication):
-            self.assertIn("SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}", publication)
-            self.assertNotIn("always()", publication)
-            self.assertNotIn("continue-on-error:", publication)
+                self.assertIn(f"    environment: {github_environment}\n", core)
+                self.assertIn(f"    environment: {github_environment}\n", executor)
+                if stage == "dev":
+                    self.assertIn("if: env.OPERATION == 'deploy'", core_publication)
+                else:
+                    self.assertNotIn("        if:", core_publication)
+                self.assertLess(
+                    core.index(f"Deploy {stage} core stacks"), core.index(f"Publish {stage} core Sentry release")
+                )
+                activation = _step(executor, f"Publish and activate {stage} executor release")
+                activation_condition = activation.split("        if: >-\n", maxsplit=1)[1].split(
+                    "        working-directory:", maxsplit=1
+                )[0]
+                self.assertIn(activation_condition, executor_publication)
+                self.assertLess(
+                    executor.index(f"Publish and activate {stage} executor release"),
+                    executor.index(f"Finish {stage} maintenance"),
+                )
+                self.assertLess(
+                    executor.index(f"Finish {stage} maintenance"),
+                    executor.index(f"Publish {stage} executor Sentry release"),
+                )
+                for publication in (core_publication, executor_publication):
+                    self.assertIn("SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}", publication)
+                    self.assertNotIn("always()", publication)
+                    self.assertNotIn("continue-on-error:", publication)
 
-    def test_dev_sentry_publication_sends_deployed_identity_and_propagates_http_errors(self) -> None:
+    def test_sentry_publication_sends_deployed_identity_and_propagates_http_errors(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         core_revision = "4c2e9bc458e6ab0e458b95bc40bb38375802eabc"
         executor_revision = "81ecdaa948195d5d407287d09ff980951bc6d514"
         executor_release = f"git-{executor_revision[:12]}-{'a' * 16}"
         cases = (
-            ("run-dev-operation", "Publish dev core Sentry release", core_revision, core_revision),
-            ("executor-development", "Publish dev executor Sentry release", executor_release, executor_revision),
+            ("run-dev-operation", "Publish dev core Sentry release", core_revision, core_revision, "dev"),
+            (
+                "executor-development",
+                "Publish dev executor Sentry release",
+                executor_release,
+                executor_revision,
+                "dev",
+            ),
+            ("deploy-prod-core", "Publish prod core Sentry release", core_revision, core_revision, "production"),
+            (
+                "executor-prod",
+                "Publish prod executor Sentry release",
+                executor_release,
+                executor_revision,
+                "production",
+            ),
         )
         with TemporaryDirectory() as workspace:
             manifest = Path(workspace) / "executor-release" / "manifest.json"
@@ -640,7 +670,7 @@ class DeployWorkflowTest(unittest.TestCase):
                 "GITHUB_WORKSPACE": workspace,
                 "SENTRY_AUTH_TOKEN": "test-release-token",
             }
-            for job_id, step_name, release, revision in cases:
+            for job_id, step_name, release, revision, sentry_environment in cases:
                 step = _step(_job(workflow, job_id), step_name)
                 source = dedent(step.split("python - <<'PY'\n", maxsplit=1)[1].rsplit("\n          PY", maxsplit=1)[0])
                 expected_urls = [
@@ -653,7 +683,7 @@ class DeployWorkflowTest(unittest.TestCase):
                         "projects": ["valkyrie"],
                         "commits": [{"id": revision, "repository": "vals-ai/Valkyrie"}],
                     },
-                    {"environment": "dev", "projects": ["valkyrie"]},
+                    {"environment": sentry_environment, "projects": ["valkyrie"]},
                 ]
                 for failing_request in (None, 0, 1):
                     with self.subTest(component=job_id, failing_request=failing_request):


### PR DESCRIPTION
## What changed

Add required Sentry release/commit/deployment publication after successful normal core deployments and immutable executor activation/maintenance completion in both dev and production.

- Core uses its deployed workflow SHA.
- Executor uses its immutable manifest release ID and source revision.
- Ordinary inline standard-library steps; HTTP failures fail the job. No retries, fallback, optional skip, separate job, or new dependency.
- Tests execute the exact inline Python with mocked HTTP transport and verify workflow ordering.

## Why

Link deployed errors to their source commits and successful deployments in `vals-ai/valkyrie`, preserving distinct core and executor release identities. Environment labels match runtime telemetry: `dev` and `production` (not the GitHub environment name `prod-external`).

## How tested

The existing tests cover four dev/production core/PEX paths: actual inline Python execution with mocked HTTP transport, captured release/commit identity, environment payload, authorization, request order, post-deployment/freshness gates and raw errors. ShellCheck and targeted primary LSP passed. Six-angle independent delta review completed with no remaining required findings. Final head `295d4bee29b583dd6c38352f60e3818db33bfa8c` passed 26 remote checks; one maintenance-approval check skipped, zero failures or pending checks. Infrastructure CI ran unittest discovery over `tests/test_*.py`: 127 tests passed. No local tests/typechecks/linters/formatters/builds, Sentry publication or AWS deployment were run.

## Remaining coverage and rollout notes

- Credential setup completed separately with explicit approval on 2026-09-12: the existing authorized token is stored as `SENTRY_AUTH_TOKEN` in the GitHub `dev` and `prod-external` environments; secret metadata was verified. No credential value is included in this PR.
- Maintenance-core release input and ExecutorHost original build-source provenance remain unresolved. They are not fabricated or covered by this partial PR.
- Deployment triggers/classification, infrastructure/runtime release identities, maintenance operations and bench remain unchanged. No merge or deployment was performed as part of this PR work.
